### PR TITLE
Adjusts proxy timeouts

### DIFF
--- a/docker/templates/proxy_headers.conf.template
+++ b/docker/templates/proxy_headers.conf.template
@@ -3,3 +3,12 @@ proxy_set_header X-Forwarded-Proto $scheme;
 proxy_set_header X-Forwarded-Ssl on;
 proxy_set_header X-Forwarded-Port $server_port;
 proxy_set_header X-Forwarded-Host $host;
+
+# These are normally 60 second. Trying these first to fix instability problems.
+proxy_connect_timeout       300;
+proxy_send_timeout          300;
+proxy_read_timeout          300;
+
+# Some things to try
+# proxy_set_header Connection "";
+# proxy_set_header Connection "keep-alive";


### PR DESCRIPTION
We've ruled out the instance sizing fixing the instability problem. We'll run with these longer proxy timeouts for a bit to see if the problem comes back. We're back down to two replicas as well. 

@gigxz Note that we think redeploying temporarily fixes this problem, so if you're in dire need, that's a stopgap.

I have commented out some other things we can try in the proxy config if the timeouts don't fix it.