### PR TITLE
Throw error if bad app setting response

### DIFF
--- a/src/modules/hmisAppSettings/Provider.tsx
+++ b/src/modules/hmisAppSettings/Provider.tsx
@@ -10,6 +10,7 @@ interface Props {
   children: ReactNode;
 }
 export const HmisAppSettingsProvider: React.FC<Props> = ({ children }) => {
+  // TODO: use browser storage, don't need to fetch on each page load
   const [fetched, setFetched] = useState<HmisAppSettings>();
   const [error, setError] = useState<Error>();
   useEffect(() => {

--- a/src/modules/hmisAppSettings/api.tsx
+++ b/src/modules/hmisAppSettings/api.tsx
@@ -11,5 +11,10 @@ export const fetchHmisAppSettings = async (): Promise<HmisAppSettings> => {
       'X-CSRF-Token': getCsrfToken(),
     },
   });
-  return response.json();
+
+  if (response.ok) {
+    return response.json();
+  }
+
+  throw new Error('Failed to fetch app settings');
 };


### PR DESCRIPTION
Trying to debug a periodic issue I've seen on QA, where the page loads without the app settings (no Okta screen), and you need to hard refresh to get the correct settings. I can't reliably reproduce it.