### PR TITLE
Implement printable assessment

### DIFF
--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -9,10 +9,12 @@ import {
   OP_LINK_BAR_HEIGHT,
   SHOW_OP_LINK_BAR,
 } from './layoutConstants';
+import PrintViewButton from './PrintViewButton';
 import UserMenu from './UserMenu';
 import WarehouseLinkBar from './WarehouseLinkBar';
 
 import Loading from '@/components/elements/Loading';
+import useIsPrintView from '@/hooks/useIsPrintView';
 import useAuth from '@/modules/auth/hooks/useAuth';
 import { useHmisAppSettings } from '@/modules/hmisAppSettings/useHmisAppSettings';
 import { RootPermissionsFilter } from '@/modules/permissions/PermissionsFilters';
@@ -27,9 +29,36 @@ interface Props {
 const MainLayout: React.FC<Props> = ({ children }) => {
   const { user, loading } = useAuth();
   const { appName } = useHmisAppSettings();
+  const isPrint = useIsPrintView();
   // Load root permissions into the cache before loading the page
   const { loading: permissionsLoading } = useGetRootPermissionsQuery();
   if (loading || permissionsLoading || !user) return <Loading />;
+
+  if (isPrint)
+    return (
+      <>
+        <CssBaseline />
+        <Box
+          sx={(theme) => ({
+            position: 'fixed',
+            right: theme.spacing(1),
+            top: theme.spacing(1),
+            backgroundColor: theme.palette.background.paper,
+            '& > *': {
+              boxShadow: `${theme.shadows[2]} !important`,
+            },
+            '@media print': {
+              '&': {
+                display: 'none',
+              },
+            },
+          })}
+        >
+          <PrintViewButton exit />
+        </Box>
+        {children}
+      </>
+    );
 
   return (
     <React.Fragment>

--- a/src/components/layout/PrintViewButton.tsx
+++ b/src/components/layout/PrintViewButton.tsx
@@ -1,0 +1,44 @@
+import CancelPresentationIcon from '@mui/icons-material/CancelPresentation';
+import { Button, ButtonProps } from '@mui/material';
+import React, { useMemo } from 'react';
+import { useLocation, Link as RouterLink } from 'react-router-dom';
+
+export interface PrintViewButtonProps
+  extends Omit<
+    ButtonProps<typeof RouterLink, { component?: typeof RouterLink }>,
+    'to'
+  > {
+  exit?: boolean;
+}
+
+const PrintViewButton: React.FC<PrintViewButtonProps> = ({
+  exit = false,
+  children = exit ? 'Exit Print View' : 'Goto Print View',
+  ...props
+}) => {
+  const location = useLocation();
+
+  const backlinkUrl = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    if (exit) {
+      params.delete('print');
+    } else {
+      params.append('print', '');
+    }
+    return [location.pathname, params.toString()].join('?');
+  }, [location, exit]);
+
+  return (
+    <Button
+      startIcon={<CancelPresentationIcon />}
+      variant='outlined'
+      {...props}
+      component={RouterLink}
+      to={backlinkUrl}
+    >
+      {children}
+    </Button>
+  );
+};
+
+export default PrintViewButton;

--- a/src/components/pages/ClientDashboard.tsx
+++ b/src/components/pages/ClientDashboard.tsx
@@ -1,4 +1,4 @@
-import { Container } from '@mui/material';
+import { Container, Stack, Typography } from '@mui/material';
 import { useMemo, useState } from 'react';
 import { Outlet, useOutletContext } from 'react-router-dom';
 
@@ -13,11 +13,17 @@ import { useDashboardNavItems } from '../layout/dashboard/sideNav/useDashboardNa
 import NotFound from './NotFound';
 
 import { useDashboardState } from '@/hooks/useDashboardState';
+import useIsPrintView from '@/hooks/useIsPrintView';
 import useSafeParams from '@/hooks/useSafeParams';
 import ClientCardMini from '@/modules/client/components/ClientCardMini';
+import ClientName from '@/modules/client/components/ClientName';
+import HmisEnum from '@/modules/hmis/components/HmisEnum';
+import { enrollmentName, entryExitRange } from '@/modules/hmis/hmisUtil';
+import { HmisEnums } from '@/types/gqlEnums';
 import {
   ClientFieldsFragment,
   EnrollmentFieldsFragment,
+  RelationshipToHoH,
   useGetClientQuery,
 } from '@/types/gqlTypes';
 
@@ -26,6 +32,7 @@ const ClientDashboard: React.FC = () => {
     clientId: string;
     enrollmentId?: string;
   };
+  const isPrint = useIsPrintView();
 
   const [breadcrumbOverrides, overrideBreadcrumbTitles] = useState<
     Record<string, string> | undefined
@@ -65,6 +72,41 @@ const ClientDashboard: React.FC = () => {
   if (enrollment && enrollment.client.id !== params.clientId) {
     return <NotFound />;
   }
+
+  if (isPrint)
+    return (
+      <>
+        <Stack
+          direction='row'
+          gap={2}
+          sx={(theme) => ({
+            position: 'running(pageHeader)',
+            borderBottom: `1px solid ${theme.palette.divider}`,
+            p: 2,
+            mb: 2,
+          })}
+        >
+          <Typography>
+            <ClientName client={client} variant='body1' />
+          </Typography>
+          {enrollment && (
+            <>
+              <HmisEnum
+                variant='body1'
+                value={enrollment.relationshipToHoH}
+                enumMap={{
+                  ...HmisEnums.RelationshipToHoH,
+                  [RelationshipToHoH.SelfHeadOfHousehold]: 'Self (HoH)',
+                }}
+              />
+              <Typography>{enrollmentName(enrollment)}</Typography>
+              <Typography>{entryExitRange(enrollment)}</Typography>
+            </>
+          )}
+        </Stack>
+        <Outlet context={outletContext} />
+      </>
+    );
 
   return (
     <DashboardContentContainer

--- a/src/hooks/useIsPrintView.ts
+++ b/src/hooks/useIsPrintView.ts
@@ -1,6 +1,14 @@
 import { useLocation } from 'react-router-dom';
 
-const useIsPrintView = () =>
-  new URLSearchParams(useLocation().search).has('print');
+import useCurrentPath from './useCurrentPath';
+
+import { PRINTABLE_ROUTES } from '@/routes/routes';
+
+const useIsPrintView = () => {
+  const hasPrintParam = new URLSearchParams(useLocation().search).has('print');
+  const isPrintableRoute = PRINTABLE_ROUTES.includes(useCurrentPath() || '');
+
+  return hasPrintParam && isPrintableRoute;
+};
 
 export default useIsPrintView;

--- a/src/hooks/useIsPrintView.ts
+++ b/src/hooks/useIsPrintView.ts
@@ -1,0 +1,6 @@
+import { useLocation } from 'react-router-dom';
+
+const useIsPrintView = () =>
+  new URLSearchParams(useLocation().search).has('print');
+
+export default useIsPrintView;

--- a/src/hooks/usePrintTrigger.ts
+++ b/src/hooks/usePrintTrigger.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react';
+
+import useIsPrintView from './useIsPrintView';
+import usePrevious from './usePrevious';
+
+interface Args {
+  startReady?: boolean;
+  hold?: boolean;
+  timeout?: number;
+}
+
+const usePrintTrigger = ({
+  startReady = true,
+  hold = false,
+  timeout = 0,
+}: Args = {}) => {
+  const [shouldPrint, setShouldPrint] = useState<boolean>(startReady);
+  const isPrintView = useIsPrintView();
+  const prev = usePrevious(isPrintView);
+
+  useEffect(() => {
+    if (shouldPrint && !hold)
+      setTimeout(() => {
+        window.print();
+        setShouldPrint(false);
+      }, timeout);
+  }, [shouldPrint, hold, timeout]);
+
+  useEffect(() => {
+    if (isPrintView && !prev) setShouldPrint(true);
+  }, [isPrintView, prev]);
+};
+
+export default usePrintTrigger;

--- a/src/modules/assessments/components/AssessmentForm.tsx
+++ b/src/modules/assessments/components/AssessmentForm.tsx
@@ -15,6 +15,8 @@ import {
   STICKY_BAR_HEIGHT,
 } from '@/components/layout/layoutConstants';
 import NotFound from '@/components/pages/NotFound';
+import useIsPrintView from '@/hooks/useIsPrintView';
+import usePrintTrigger from '@/hooks/usePrintTrigger';
 import { useScrollToHash } from '@/hooks/useScrollToHash';
 import { hasAnyValue } from '@/modules/errors/util';
 import DynamicForm, {
@@ -88,6 +90,8 @@ const AssessmentForm = ({
     setDialogOpen(false);
     setReloadInitialValues((old) => !old);
   }, []);
+
+  const isPrintView = useIsPrintView();
 
   const { submitHandler, saveDraftHandler, mutationLoading, errors } =
     useAssessmentHandlers({
@@ -165,54 +169,64 @@ const AssessmentForm = ({
 
   const canEdit = enrollment?.access.canEditEnrollments;
 
+  usePrintTrigger({
+    startReady: isPrintView,
+    hold: !enrollment,
+    timeout: 3000,
+  });
+
   if (!enrollment) return <NotFound />;
+
+  const navigation = (
+    <Grid item xs={2.5} sx={{ pr: 2, pt: '0 !important' }}>
+      <Box
+        sx={{
+          position: 'sticky',
+          top: top + 16,
+        }}
+      >
+        <Paper sx={{ p: 2 }}>
+          {navigationTitle}
+          <FormStepper
+            items={definition.definition.item}
+            scrollOffset={top}
+            useUrlHash={!embeddedInWorkflow}
+          />
+        </Paper>
+        <Stack gap={2} sx={{ mt: 2 }}>
+          {!assessment && (
+            <ButtonTooltipContainer title='Choose a previous assessment to copy into this assessment'>
+              <Button
+                variant='outlined'
+                onClick={() => setDialogOpen(true)}
+                sx={{ height: 'fit-content' }}
+                fullWidth
+              >
+                Autofill Assessment
+              </Button>
+            </ButtonTooltipContainer>
+          )}
+          {assessment && (
+            <DeleteAssessmentButton
+              assessment={assessment}
+              clientId={enrollment.client.id}
+              enrollmentId={enrollment.id}
+              onSuccess={navigateToEnrollment}
+            />
+          )}
+          {import.meta.env.MODE === 'development' && assessment && (
+            <IdDisplay prefix='Assessment' value={assessment.id} />
+          )}
+        </Stack>
+      </Box>
+    </Grid>
+  );
 
   return (
     <Grid container spacing={2} sx={{ pb: 20, mt: 0 }}>
-      <Grid item xs={2.5} sx={{ pr: 2, pt: '0 !important' }}>
-        <Box
-          sx={{
-            position: 'sticky',
-            top: top + 16,
-          }}
-        >
-          <Paper sx={{ p: 2 }}>
-            {navigationTitle}
-            <FormStepper
-              items={definition.definition.item}
-              scrollOffset={top}
-              useUrlHash={!embeddedInWorkflow}
-            />
-          </Paper>
-          <Stack gap={2} sx={{ mt: 2 }}>
-            {!assessment && (
-              <ButtonTooltipContainer title='Choose a previous assessment to copy into this assessment'>
-                <Button
-                  variant='outlined'
-                  onClick={() => setDialogOpen(true)}
-                  sx={{ height: 'fit-content' }}
-                  fullWidth
-                >
-                  Autofill Assessment
-                </Button>
-              </ButtonTooltipContainer>
-            )}
-            {assessment && (
-              <DeleteAssessmentButton
-                assessment={assessment}
-                clientId={enrollment.client.id}
-                enrollmentId={enrollment.id}
-                onSuccess={navigateToEnrollment}
-              />
-            )}
-            {import.meta.env.MODE === 'development' && assessment && (
-              <IdDisplay prefix='Assessment' value={assessment.id} />
-            )}
-          </Stack>
-        </Box>
-      </Grid>
-      <Grid item xs={9} sx={{ pt: '0 !important' }}>
-        {assessment && !assessment.inProgress && locked && (
+      {!isPrintView && navigation}
+      <Grid item xs sx={{ pt: '0 !important' }}>
+        {!isPrintView && assessment && !assessment.inProgress && locked && (
           <LockedAssessmentAlert
             allowUnlock={canEdit}
             onUnlock={() => setLocked(false)}

--- a/src/modules/assessments/components/AssessmentForm.tsx
+++ b/src/modules/assessments/components/AssessmentForm.tsx
@@ -14,7 +14,6 @@ import {
   CONTEXT_HEADER_HEIGHT,
   STICKY_BAR_HEIGHT,
 } from '@/components/layout/layoutConstants';
-import NotFound from '@/components/pages/NotFound';
 import useIsPrintView from '@/hooks/useIsPrintView';
 import usePrintTrigger from '@/hooks/usePrintTrigger';
 import { useScrollToHash } from '@/hooks/useScrollToHash';
@@ -171,11 +170,8 @@ const AssessmentForm = ({
 
   usePrintTrigger({
     startReady: isPrintView,
-    hold: !enrollment,
     timeout: 3000,
   });
-
-  if (!enrollment) return <NotFound />;
 
   const navigation = (
     <Grid item xs={2.5} sx={{ pr: 2, pt: '0 !important' }}>

--- a/src/modules/assessments/components/IndividualAssessment.tsx
+++ b/src/modules/assessments/components/IndividualAssessment.tsx
@@ -1,5 +1,5 @@
-import DownloadIcon from '@mui/icons-material/Download';
-import { Box, Button, Stack, Typography } from '@mui/material';
+import PrintIcon from '@mui/icons-material/Print';
+import { Box, Stack, Typography } from '@mui/material';
 import { isNil } from 'lodash-es';
 import { Ref, useEffect, useMemo, useState } from 'react';
 
@@ -14,8 +14,10 @@ import {
   HOUSEHOLD_ASSESSMENTS_HEADER_HEIGHT,
   STICKY_BAR_HEIGHT,
 } from '@/components/layout/layoutConstants';
+import PrintViewButton from '@/components/layout/PrintViewButton';
 import { useClientDashboardContext } from '@/components/pages/ClientDashboard';
 import NotFound from '@/components/pages/NotFound';
+import useIsPrintView from '@/hooks/useIsPrintView';
 import { useScrollToHash } from '@/hooks/useScrollToHash';
 import AssessmentForm from '@/modules/assessments/components/AssessmentForm';
 import { useAssessment } from '@/modules/assessments/components/useAssessment';
@@ -69,6 +71,8 @@ const IndividualAssessment = ({
   formRef,
 }: IndividualAssessmentProps) => {
   const { overrideBreadcrumbTitles } = useClientDashboardContext();
+
+  const isPrintView = useIsPrintView();
 
   // Fetch the enrollment, which may be different from the current context enrollment if this assessment is part of a workflow.
   const { enrollment, loading: enrollmentLoading } =
@@ -156,14 +160,14 @@ const IndividualAssessment = ({
           assessmentTitle={assessmentTitle}
           clientName={clientName || undefined}
           actions={
-            readOnly ? (
-              <Button
+            !isPrintView && readOnly ? (
+              <PrintViewButton
                 color='secondary'
                 variant='outlined'
-                startIcon={<DownloadIcon />}
+                startIcon={<PrintIcon />}
               >
-                Download PDF
-              </Button>
+                Print Assessment
+              </PrintViewButton>
             ) : undefined
           }
         />

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -98,3 +98,5 @@ export const FOCUS_MODE_ROUTES = [
     previous: ClientDashboardRoutes.VIEW_ENROLLMENT,
   },
 ];
+
+export const PRINTABLE_ROUTES = [ClientDashboardRoutes.VIEW_ASSESSMENT];


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/184629713

@gigxz This is my first shot at how to do this, very open to suggestions if you disagree with how I've done it here. Overall it was pretty smooth, but I do have one big thing to bring up:

I wanted to put the print trigger higher up in the component tree, but I needed it to fire only when the form was done loading. So I put it into the form and gave it a `hold` prop to handle the loading state. However, the actual dynamic view still needs to do queries to load pick lists. Those queries don't even trigger a re-render of `AssessmentForm`, so unless I use some kind of event listening I can't really get at when those are loaded. That all felt like a rabbit hole, and since the ticket said to timebox this work, I decided not to go down that road. My solution was just to add a configurable timeout and hope that that will work for now, but I don't love that solution long term.

What do you think?