### PR TITLE
adds some possible fixes for nginx freezing up

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -42,6 +42,7 @@ WORKDIR /usr/share/nginx/html
 
 COPY --from=builder --chown=app:app /app/dist .
 COPY ./docker/nginx.conf /etc/nginx/nginx.conf
+COPY --chown=app:app ./docker/nginx-reload ./docker/docker-entrypoint.sh /
 COPY ./docker/templates/*.template /etc/nginx/templates/
 
 RUN addgroup --gid ${GROUPID} --system app \

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+# vim:sw=4:ts=4:et
+
+set -e
+
+entrypoint_log() {
+    if [ -z "${NGINX_ENTRYPOINT_QUIET_LOGS:-}" ]; then
+        echo "$@"
+    fi
+}
+
+/nginx-reload &
+
+if [ "$1" = "nginx" -o "$1" = "nginx-debug" ]; then
+    if /usr/bin/find "/docker-entrypoint.d/" -mindepth 1 -maxdepth 1 -type f -print -quit 2>/dev/null | read v; then
+        entrypoint_log "$0: /docker-entrypoint.d/ is not empty, will attempt to perform configuration"
+
+        entrypoint_log "$0: Looking for shell scripts in /docker-entrypoint.d/"
+        find "/docker-entrypoint.d/" -follow -type f -print | sort -V | while read -r f; do
+            case "$f" in
+                *.envsh)
+                    if [ -x "$f" ]; then
+                        entrypoint_log "$0: Sourcing $f";
+                        . "$f"
+                    else
+                        # warn on shell scripts without exec bit
+                        entrypoint_log "$0: Ignoring $f, not executable";
+                    fi
+                    ;;
+                *.sh)
+                    if [ -x "$f" ]; then
+                        entrypoint_log "$0: Launching $f";
+                        "$f"
+                    else
+                        # warn on shell scripts without exec bit
+                        entrypoint_log "$0: Ignoring $f, not executable";
+                    fi
+                    ;;
+                *) entrypoint_log "$0: Ignoring $f";;
+            esac
+        done
+
+        entrypoint_log "$0: Configuration complete; ready for start up"
+    else
+        entrypoint_log "$0: No files found in /docker-entrypoint.d/, skipping configuration"
+    fi
+fi
+
+exec "$@"

--- a/docker/nginx-reload
+++ b/docker/nginx-reload
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+while true
+do
+  sleep 3600
+  if [[ -e "/tmp/nginx.pid" ]]; then
+    echo gracefully reloading nginx workers then sleeping
+    kill -HUP $(cat /tmp/nginx.pid)
+  else
+    echo no nginx pid file found. sleeping for a while
+  fi
+done

--- a/docker/nginx-reload
+++ b/docker/nginx-reload
@@ -2,7 +2,7 @@
 
 while true
 do
-  sleep 3600
+  sleep 7200
   if [[ -e "/tmp/nginx.pid" ]]; then
     echo gracefully reloading nginx workers then sleeping
     kill -HUP $(cat /tmp/nginx.pid)

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,9 +1,13 @@
-worker_processes  auto;
+# This needs to be explicit or else the number of workers will match the host's
+# number of cores. We can scale the number of pods to achieve horizontal scaling.
+# This could be a different number, but I think it shouldn't be "auto"
+worker_processes  2;
 
 error_log  /var/log/nginx/error.log notice;
 pid        /tmp/nginx.pid;
 
 events {
+    # maximum simultanious connetions for each of the workers.
     worker_connections  1024;
 }
 
@@ -36,7 +40,33 @@ http {
     sendfile        on;
     #tcp_nopush     on;
 
-    keepalive_timeout  60;
+    # The first parameter sets a timeout during which a keep-alive client
+    # connection will stay open on the server side. The zero value disables
+    # keep-alive client connections. The optional second parameter sets a value
+    # in the “Keep-Alive: timeout=time” response header field. Two parameters
+    # may differ.
+    # The “Keep-Alive: timeout=time” header field is recognized by Mozilla and
+    # Konqueror. MSIE closes keep-alive connections by itself in about 60
+    # seconds. Defaults to 75s
+    keepalive_timeout  60 60;
+
+    # Limits the maximum time during which requests can be processed through
+    # one keep-alive connection. After this time is reached, the connection is
+    # closed following the subsequent request processing. Defaults to 1h
+    keepalive_time 10m;
+
+    # Sets the maximum number of requests that can be served through one
+    # keep-alive connection. After the maximum number of requests are made, the
+    # connection is closed.
+    # Closing connections periodically is necessary to free per-connection
+    # memory allocations. Therefore, using too high maximum number of requests
+    # could result in excessive memory usage and not recommended. Defaults to
+    # 1000
+    keepalive_requests 100;
+
+    # Maybe safari is misbehaving? I don't know if this is still a thing or
+    # something from the past.
+    # keepalive_disable safari;
 
     ########################
     # Compression Settings #

--- a/docker/templates/proxy_headers.conf.template
+++ b/docker/templates/proxy_headers.conf.template
@@ -5,9 +5,9 @@ proxy_set_header X-Forwarded-Port $server_port;
 proxy_set_header X-Forwarded-Host $host;
 
 # Defaults to 60 seconds.
-proxy_connect_timeout       30;
-proxy_send_timeout          30;
-proxy_read_timeout          30;
+# proxy_connect_timeout       30;
+# proxy_send_timeout          30;
+# proxy_read_timeout          30;
 
 # Some things to try
 # proxy_set_header Connection "";

--- a/docker/templates/proxy_headers.conf.template
+++ b/docker/templates/proxy_headers.conf.template
@@ -5,9 +5,9 @@ proxy_set_header X-Forwarded-Port $server_port;
 proxy_set_header X-Forwarded-Host $host;
 
 # Defaults to 60 seconds.
-#proxy_connect_timeout       300;
-#proxy_send_timeout          300;
-#proxy_read_timeout          300;
+proxy_connect_timeout       30;
+proxy_send_timeout          30;
+proxy_read_timeout          30;
 
 # Some things to try
 # proxy_set_header Connection "";


### PR DESCRIPTION
Sending the HUP signal to nginx fixed things immediately, so this PR is a mix of trying to solve the real problem and having that as the backup plan.

* Limits keep-alives in a few ways since something was occupying all 1024 connections of all the workers when this freezes up. Maybe it was these.
* explicitly set number of workers. Might have been too little CPU given the number of workers.
* run nginx-reload script which gracefully lets connections finish and starts up new workers every hour. This is a backup plan if we didn't actually solve the problem with the other settings.
* fails faster if proxy connections take too long. 30 seconds instead of 60 seconds