### PR TITLE
Longer caching for fingerprinted assets

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -53,6 +53,8 @@ RUN addgroup --gid ${GROUPID} --system app \
  && chmod -R g+w /etc/nginx \
  && touch /tmp/nginx.pid \
  && chown -R app:app /tmp/nginx.pid \
+ && apk update \
+ && apk upgrade --no-cache \
  && apk add --no-cache dumb-init
 
 # Set entrypoint to handle signals

--- a/docker/templates/default.conf.template
+++ b/docker/templates/default.conf.template
@@ -18,15 +18,18 @@ server {
         # Always revalidate index.html before use
         add_header Cache-Control "no-cache";
 
-        # use INLINE_RUNTIME_CHECK=false yarn build and nonce / hash to apply a CSP
-        # Use add_header Content-Security-Policy "......." always;
-        add_header Content-Security-Policy "default-src 'none'; connect-src 'self' *.sentry.io *.s3.amazonaws.com; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' fonts.googleapis.com 'unsafe-inline'; img-src 'self' data: blob: *.s3.amazonaws.com; font-src 'self' fonts.gstatic.com; object-src 'none';" always;
+        # Include default headers
+        include /etc/nginx/conf.d/non_proxy_headers.conf;
+    }
 
-        add_header Referrer-Policy "strict-origin-when-cross-origin";
-        add_header X-Frame-Options "SAMEORIGIN" always;
-        add_header X-XSS-Protection "1; mode=block" always;
-        add_header X-Content-Type-Options "nosniff" always;
-        add_header Feature-Policy "geolocation 'none'; midi 'none'; notifications 'none'; push 'none'; sync-xhr 'none'; microphone 'none'; camera 'none'; magnetometer 'none'; gyroscope 'none'; speaker 'none'; vibrate 'none'; fullscreen 'none'; payment 'none'; usb 'none';";
+    location /assets {
+        root   /usr/share/nginx/html;
+
+        # Long-lived caching for assets, because they are fingerprinted
+        add_header Cache-Control "public, max-age=31536000";
+
+        # Include default headers
+        include /etc/nginx/conf.d/non_proxy_headers.conf;
     }
 
     location /hmis {
@@ -50,12 +53,6 @@ server {
       # add location specific headers
       proxy_set_header Host ${HMIS_BACKEND};
     }
-
-    # FIXME: how to add cache policy only for these files?
-    # location /assets {
-    #  # Long-lived caching for fingerprinted file names (CSS and JS)
-    #  add_header Cache-Control "public, max-age=31536000";
-    #}
 
     location /assets/theme {
       # proxy destination

--- a/docker/templates/non_proxy_headers.conf.template
+++ b/docker/templates/non_proxy_headers.conf.template
@@ -1,0 +1,9 @@
+# use INLINE_RUNTIME_CHECK=false yarn build and nonce / hash to apply a CSP
+# Use add_header Content-Security-Policy "......." always;
+add_header Content-Security-Policy "default-src 'none'; connect-src 'self' *.sentry.io *.s3.amazonaws.com; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' fonts.googleapis.com 'unsafe-inline'; img-src 'self' data: blob: *.s3.amazonaws.com; font-src 'self' fonts.gstatic.com; object-src 'none';" always;
+
+add_header Referrer-Policy "strict-origin-when-cross-origin";
+add_header X-Frame-Options "SAMEORIGIN" always;
+add_header X-XSS-Protection "1; mode=block" always;
+add_header X-Content-Type-Options "nosniff" always;
+add_header Feature-Policy "geolocation 'none'; midi 'none'; notifications 'none'; push 'none'; sync-xhr 'none'; microphone 'none'; camera 'none'; magnetometer 'none'; gyroscope 'none'; speaker 'none'; vibrate 'none'; fullscreen 'none'; payment 'none'; usb 'none';";


### PR DESCRIPTION
Add a new location block for assets, so that they can get a different `Cache-Control` header. Tested on QA. Required some refactoring to maintain all the existing headers.