### PR TITLE
Fix DNS caching for NGINX requests

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -25,6 +25,7 @@ services:
     environment:
       NGINX_HOST: ${NGINX_HOST:-hmis-frontend.127.0.0.1.nip.io}
       NGINX_PORT: ${NGINX_PORT:-8080}
+      NGINX_RESOLVER: ${NGINX_RESOLVER:-1.1.1.1}
       HMIS_BACKEND: ${HMIS_BACKEND:-qa-hmis-warehouse.openpath.host}
     labels:
       - "traefik.http.routers.hmis-frontend.rule=Host(`hmis-frontend.127.0.0.1.nip.io`)"

--- a/docker/templates/default.conf.template
+++ b/docker/templates/default.conf.template
@@ -4,6 +4,8 @@ server {
 
     server_tokens off;
 
+    resolver ${NGINX_RESOLVER} valid=10s;
+
     location /nginx_status {
         stub_status;
         allow 127.0.0.1;  # Only allow requests from localhost
@@ -30,25 +32,25 @@ server {
     }
 
     location /hmis {
-      # proxy destination
-      proxy_pass https://${HMIS_BACKEND};
+      set $backend_server ${HMIS_BACKEND};
+      proxy_pass https://$backend_server;
 
       # include default proxy headers
       include /etc/nginx/conf.d/proxy_headers.conf;
 
       # add location specific headers
-      proxy_set_header Host ${HMIS_BACKEND};
+      proxy_set_header Host $backend_server;
     }
 
     location /rails/active_storage/blob {
-      # proxy destination
-      proxy_pass https://${HMIS_BACKEND};
+      set $backend_server ${HMIS_BACKEND};
+      proxy_pass https://$backend_server;
 
       # include default proxy headers
       include /etc/nginx/conf.d/proxy_headers.conf;
 
       # add location specific headers
-      proxy_set_header Host ${HMIS_BACKEND};
+      proxy_set_header Host $backend_server;
     }
 
     # FIXME: how to add cache policy only for these files?
@@ -58,14 +60,14 @@ server {
     #}
 
     location /assets/theme {
-      # proxy destination
-      proxy_pass https://${HMIS_BACKEND};
+      set $backend_server ${HMIS_BACKEND};
+      proxy_pass https://$backend_server;
 
       # include default proxy headers
       include /etc/nginx/conf.d/proxy_headers.conf;
 
       # add location specific headers
-      proxy_set_header Host ${HMIS_BACKEND};
+      proxy_set_header Host $backend_server;
 
       # Long-lived caching for fingerprinted file names (logo image assets)
       add_header Cache-Control "public, max-age=31536000";

--- a/docker/templates/proxy_headers.conf.template
+++ b/docker/templates/proxy_headers.conf.template
@@ -14,6 +14,7 @@ proxy_set_header X-Forwarded-Host $host;
 # proxy_send_timeout          30;
 # proxy_read_timeout          30;
 
-# Some things to try
-# proxy_set_header Connection "";
-# proxy_set_header Connection "keep-alive";
+# enable upstream caching
+proxy_http_version 1.1;
+proxy_set_header Connection "";
+


### PR DESCRIPTION
Nginx does not refresh static hostnames when used along with proxy_pass. Set the backend in a variable to force DNS to be resolved more frequently.