### PR TITLE
185905983 better apollo error message fix

### DIFF
--- a/src/modules/errors/components/ApolloErrorAlert.tsx
+++ b/src/modules/errors/components/ApolloErrorAlert.tsx
@@ -101,7 +101,7 @@ const ApolloErrorAlert: React.FC<Props> = ({
   inline = false,
   ...props
 }) => {
-  const errors = useMemo<Error[]>(() => {
+  const displayErrors = useMemo<Error[]>(() => {
     if (!error) return [];
     if (isServerError(error.networkError)) {
       // looks like this maybe an array sometimes. Maybe related to batching
@@ -127,7 +127,7 @@ const ApolloErrorAlert: React.FC<Props> = ({
     return (
       <BaseAlert
         {...props}
-        errors={errors || []}
+        errors={displayErrors || []}
         isNetworkError={isNetworkError}
       />
     );
@@ -135,7 +135,7 @@ const ApolloErrorAlert: React.FC<Props> = ({
   return (
     <SnackbarAlert
       {...props}
-      errors={errors || []}
+      errors={displayErrors || []}
       isNetworkError={isNetworkError}
     />
   );

--- a/src/modules/search/components/OmniSearch.tsx
+++ b/src/modules/search/components/OmniSearch.tsx
@@ -226,7 +226,7 @@ const OmniSearch: React.FC = () => {
         name='Client and Project search'
         inputProps={{
           ...values.getInputProps(),
-          value,
+          value: value ? value : '',
         }}
         placeholder='Search'
         size='small'


### PR DESCRIPTION
Sorry for the long tail on this issue. Fixes a few small issues I noticed
- display graphql errors in development mode (fixed accidental array wrap, added conditional)
- fixed issue where stack trace wasn't shown in the snackbar (networkError.result is an array sometimes)
- adjusted error variable name to be more descriptive
- fix warning in browser console when typing into omnisearch (controlled vs uncontrolled input)