### PR TITLE
Perform annual assessments individually

### DIFF
--- a/src/api/operations/assessment.queries.graphql
+++ b/src/api/operations/assessment.queries.graphql
@@ -76,6 +76,24 @@ query GetHouseholdAssessments(
   }
 }
 
+query GetRelatedAnnuals($householdId: ID!, $assessmentId: ID) {
+  householdAssessments(
+    householdId: $householdId
+    assessmentRole: ANNUAL
+    assessmentId: $assessmentId
+  ) {
+    id
+    assessmentDate
+    enrollment {
+      id
+      relationshipToHoH
+    }
+    client {
+      ...ClientName
+    }
+  }
+}
+
 mutation SaveAssessment($input: SaveAssessmentInput!) {
   saveAssessment(input: $input) {
     assessment {

--- a/src/components/pages/NotFound.tsx
+++ b/src/components/pages/NotFound.tsx
@@ -2,7 +2,7 @@ import * as Sentry from '@sentry/react';
 
 import { sentryUser } from '@/modules/auth/api/sessions';
 import useAuth from '@/modules/auth/hooks/useAuth';
-import ErrorFallback from '@/modules/errors/components/ErrorFallback';
+import { FullPageError } from '@/modules/errors/components/ErrorFallback';
 
 const NotFound = ({ text = 'Page not found.' }: { text?: string }) => {
   // Note: we may or may not have an AuthProvider
@@ -11,7 +11,7 @@ const NotFound = ({ text = 'Page not found.' }: { text?: string }) => {
     user: sentryUser(user),
   });
 
-  return <ErrorFallback text={text} />;
+  return <FullPageError text={text} />;
 };
 
 export default NotFound;

--- a/src/modules/assessments/components/AssessmentTitle.tsx
+++ b/src/modules/assessments/components/AssessmentTitle.tsx
@@ -1,36 +1,104 @@
-import { Typography } from '@mui/material';
+import { Alert, AlertTitle, Skeleton, Typography } from '@mui/material';
 import { Stack } from '@mui/system';
-import { ReactNode } from 'react';
+import { ReactNode, useState } from 'react';
+import { useRelatedAnnualAssessments } from '../hooks/useRelatedAnnualAssessments';
+import RouterLink from '@/components/elements/RouterLink';
+import { parseAndFormatDate } from '@/modules/hmis/hmisUtil';
+import { AssessmentRole } from '@/types/gqlTypes';
 
 export interface AssessmentTitleProps {
   projectName: string;
   assessmentTitle?: ReactNode;
-  clientName?: ReactNode;
+  assessmentRole: AssessmentRole;
+  clientName: ReactNode;
+  assessmentId?: string;
+  enrollmentId: string;
+  householdId: string;
+  embeddedInWorkflow?: boolean;
+  householdSize: number;
 }
 
 const AssessmentTitle = ({
   projectName,
   assessmentTitle,
   clientName,
+  householdId,
+  enrollmentId,
+  assessmentId,
+  embeddedInWorkflow,
+  assessmentRole,
+  householdSize,
 }: AssessmentTitleProps) => {
-  if (clientName) {
-    return (
-      <Stack sx={{ mb: 1 }} gap={1}>
-        <Typography variant='h4'>{clientName}</Typography>
-        <Typography variant='body1'>
-          <b>
-            {assessmentTitle}
-            {': '}
-          </b>
-          {projectName}
-        </Typography>
-      </Stack>
+  // const hhAssessments = useHouseholdAssessments(role, householdId, assessmentId)
+  const isAnnual = assessmentRole == AssessmentRole.Annual;
+  const { assessmentInfo, loading } = useRelatedAnnualAssessments({
+    householdId: householdId || '',
+    enrollmentId,
+    assessmentId,
+    skip:
+      !isAnnual || householdSize === 1 || embeddedInWorkflow || !householdId,
+  });
+  const [alertHidden, setAlertHidden] = useState(false);
+
+  let subtitle = null;
+  if (assessmentInfo && assessmentInfo.length > 0 && !alertHidden) {
+    const otherMembers = assessmentInfo.filter(
+      (m) => m.enrollmentId !== enrollmentId
     );
+    if (otherMembers.length > 0) {
+      subtitle = (
+        <Alert
+          severity='info'
+          sx={{ my: 1 }}
+          onClose={() => setAlertHidden(true)}
+          icon={false}
+        >
+          <AlertTitle>Other household member's annual assessments:</AlertTitle>
+          <Stack gap={0.5}>
+            {otherMembers.map(
+              ({
+                enrollmentId,
+                clientName,
+                firstName,
+                assessmentDate,
+                path,
+              }) => (
+                <Stack direction={'row'} gap={1} key={enrollmentId}>
+                  <Typography variant='body2'>
+                    {clientName}
+                    {':'}
+                  </Typography>
+                  <RouterLink to={path} openInNew>
+                    {assessmentDate
+                      ? parseAndFormatDate(assessmentDate)
+                      : 'Start new '}{' '}
+                    Annual Assessment for {firstName}
+                  </RouterLink>
+                </Stack>
+              )
+            )}
+          </Stack>
+        </Alert>
+      );
+    }
   }
+
+  if (!assessmentInfo && loading && !subtitle) {
+    subtitle = <Skeleton variant='rectangular' width='100%' height={50} />;
+  }
+
   return (
-    <Typography variant='h4' sx={{ mb: 1 }}>
-      {assessmentTitle}
-    </Typography>
+    <Stack sx={{ mb: 1 }} gap={1}>
+      <Typography variant='h4'>{clientName}</Typography>
+      <Typography variant='body1'>
+        <b>
+          {assessmentTitle}
+          {': '}
+        </b>
+        {projectName}
+      </Typography>
+      {subtitle}
+    </Stack>
   );
 };
 

--- a/src/modules/assessments/components/AssessmentTitle.tsx
+++ b/src/modules/assessments/components/AssessmentTitle.tsx
@@ -31,12 +31,12 @@ const AssessmentTitle = ({
 }: AssessmentTitleProps) => {
   // const hhAssessments = useHouseholdAssessments(role, householdId, assessmentId)
   const isAnnual = assessmentRole == AssessmentRole.Annual;
+  const skipQuery = !isAnnual || householdSize === 1 || embeddedInWorkflow;
   const { assessmentInfo, loading } = useRelatedAnnualAssessments({
     householdId: householdId || '',
     enrollmentId,
     assessmentId,
-    skip:
-      !isAnnual || householdSize === 1 || embeddedInWorkflow || !householdId,
+    skip: skipQuery,
   });
   const [alertHidden, setAlertHidden] = useState(false);
 
@@ -72,7 +72,7 @@ const AssessmentTitle = ({
     );
   }
 
-  if (!assessmentInfo && loading && !subtitle && !alertHidden) {
+  if (!skipQuery && !assessmentInfo && loading && !subtitle && !alertHidden) {
     subtitle = <Skeleton variant='rectangular' width='100%' height={50} />;
   }
 

--- a/src/modules/assessments/components/AssessmentTitle.tsx
+++ b/src/modules/assessments/components/AssessmentTitle.tsx
@@ -42,48 +42,37 @@ const AssessmentTitle = ({
 
   let subtitle = null;
   if (assessmentInfo && assessmentInfo.length > 0 && !alertHidden) {
-    const otherMembers = assessmentInfo.filter(
-      (m) => m.enrollmentId !== enrollmentId
+    subtitle = (
+      <Alert
+        severity='info'
+        sx={{ my: 1 }}
+        onClose={() => setAlertHidden(true)}
+        icon={false}
+      >
+        <AlertTitle>Related annual assessments in this household:</AlertTitle>
+        <Stack gap={0.5}>
+          {assessmentInfo.map(
+            ({ enrollmentId, clientName, firstName, assessmentDate, path }) => (
+              <Stack direction={'row'} gap={1} key={enrollmentId}>
+                <Typography variant='body2'>
+                  {clientName}
+                  {':'}
+                </Typography>
+                <RouterLink to={path} openInNew>
+                  {assessmentDate
+                    ? parseAndFormatDate(assessmentDate)
+                    : 'Start new '}{' '}
+                  Annual Assessment for {firstName}
+                </RouterLink>
+              </Stack>
+            )
+          )}
+        </Stack>
+      </Alert>
     );
-    if (otherMembers.length > 0) {
-      subtitle = (
-        <Alert
-          severity='info'
-          sx={{ my: 1 }}
-          onClose={() => setAlertHidden(true)}
-          icon={false}
-        >
-          <AlertTitle>Other household member's annual assessments:</AlertTitle>
-          <Stack gap={0.5}>
-            {otherMembers.map(
-              ({
-                enrollmentId,
-                clientName,
-                firstName,
-                assessmentDate,
-                path,
-              }) => (
-                <Stack direction={'row'} gap={1} key={enrollmentId}>
-                  <Typography variant='body2'>
-                    {clientName}
-                    {':'}
-                  </Typography>
-                  <RouterLink to={path} openInNew>
-                    {assessmentDate
-                      ? parseAndFormatDate(assessmentDate)
-                      : 'Start new '}{' '}
-                    Annual Assessment for {firstName}
-                  </RouterLink>
-                </Stack>
-              )
-            )}
-          </Stack>
-        </Alert>
-      );
-    }
   }
 
-  if (!assessmentInfo && loading && !subtitle) {
+  if (!assessmentInfo && loading && !subtitle && !alertHidden) {
     subtitle = <Skeleton variant='rectangular' width='100%' height={50} />;
   }
 

--- a/src/modules/assessments/components/IndividualAssessment.tsx
+++ b/src/modules/assessments/components/IndividualAssessment.tsx
@@ -147,6 +147,7 @@ const IndividualAssessment = ({
       assessmentRole={formRole as unknown as AssessmentRole}
       embeddedInWorkflow={embeddedInWorkflow}
       assessmentId={assessmentId}
+      householdSize={enrollment.householdSize}
     />
   );
 

--- a/src/modules/assessments/components/IndividualAssessment.tsx
+++ b/src/modules/assessments/components/IndividualAssessment.tsx
@@ -29,6 +29,7 @@ import { ClientNameDobVeteranFields } from '@/modules/form/util/formUtil';
 import { EnrollmentDashboardRoutes } from '@/routes/routes';
 import {
   AssessmentFieldsFragment,
+  AssessmentRole,
   FormRole,
   RelationshipToHoH,
 } from '@/types/gqlTypes';
@@ -38,7 +39,7 @@ export interface IndividualAssessmentProps {
   assessmentId?: string;
   formRole?: FormRole;
   embeddedInWorkflow?: boolean;
-  clientName?: string;
+  clientName: string;
   relationshipToHoH: RelationshipToHoH;
   client: ClientNameDobVeteranFields;
   assessmentStatus?: AssessmentStatus;
@@ -141,6 +142,11 @@ const IndividualAssessment = ({
       assessmentTitle={assessmentTitle}
       clientName={clientName || undefined}
       projectName={enrollment.project.projectName}
+      enrollmentId={enrollment.id}
+      householdId={enrollment.householdId}
+      assessmentRole={formRole as unknown as AssessmentRole}
+      embeddedInWorkflow={embeddedInWorkflow}
+      assessmentId={assessmentId}
     />
   );
 

--- a/src/modules/assessments/components/household/HouseholdAssessments.tsx
+++ b/src/modules/assessments/components/household/HouseholdAssessments.tsx
@@ -349,7 +349,9 @@ const HouseholdAssessments = ({
               {...tabDefinition}
             />
           ))}
-          {tabs.length === 0 ? (
+          {tabs.length === 0 &&
+          !fetchAssessmentsStatus.loading &&
+          !fetchMembersStatus.loading ? (
             <Alert severity='info'>
               {role === AssessmentRole.Intake ? (
                 <>No household members can be entered at this time</>

--- a/src/modules/assessments/components/household/util.ts
+++ b/src/modules/assessments/components/household/util.ts
@@ -23,7 +23,8 @@ export function isHouseholdAssesmentRole(
 ): keyInput is HouseholdAssesmentRole {
   return [
     AssessmentRole.Intake,
-    AssessmentRole.Annual,
+    // Turned off Annual grouping because of bugs. #186185565
+    // AssessmentRole.Annual,
     AssessmentRole.Exit,
   ].includes(keyInput as AssessmentRole);
 }

--- a/src/modules/assessments/hooks/useHouseholdAssessments.tsx
+++ b/src/modules/assessments/hooks/useHouseholdAssessments.tsx
@@ -4,7 +4,7 @@ import { useMemo } from 'react';
 import { HouseholdAssesmentRole } from '../components/household/util';
 
 import {
-  AssessmentWithValuesAndRecordsFragment,
+  GetHouseholdAssessmentsQuery,
   useGetHouseholdAssessmentsQuery,
 } from '@/types/gqlTypes';
 
@@ -12,12 +12,18 @@ interface Args {
   householdId: string;
   role: HouseholdAssesmentRole;
   assessmentId?: string;
+  skip?: boolean;
 }
+
+type AssessmentResultType = NonNullable<
+  NonNullable<GetHouseholdAssessmentsQuery['householdAssessments']>
+>[0];
 
 export function useHouseholdAssessments({
   role,
   householdId,
   assessmentId,
+  skip,
 }: Args) {
   const { data: { householdAssessments } = {}, ...status } =
     useGetHouseholdAssessmentsQuery({
@@ -26,6 +32,7 @@ export function useHouseholdAssessments({
         assessmentRole: role,
         assessmentId,
       },
+      skip,
       fetchPolicy: 'cache-and-network',
     });
 
@@ -35,10 +42,8 @@ export function useHouseholdAssessments({
       enrollment.id,
       assessment,
     ]);
-    return fromPairs(pairs) as Record<
-      string,
-      AssessmentWithValuesAndRecordsFragment | undefined
-    >;
+    return fromPairs(pairs) as Record<string, AssessmentResultType | undefined>;
   }, [householdAssessments]);
+
   return { householdAssessments, assessmentByEnrollmentId, ...status } as const;
 }

--- a/src/modules/assessments/hooks/useRelatedAnnualAssessments.tsx
+++ b/src/modules/assessments/hooks/useRelatedAnnualAssessments.tsx
@@ -1,0 +1,112 @@
+import { useMemo } from 'react';
+
+import { To } from 'react-router-dom';
+import {
+  clientBriefName,
+  relationshipToHohForDisplay,
+} from '@/modules/hmis/hmisUtil';
+import { useHouseholdMembers } from '@/modules/household/hooks/useHouseholdMembers';
+import { EnrollmentDashboardRoutes } from '@/routes/routes';
+import {
+  FormRole,
+  RelationshipToHoH,
+  useGetRelatedAnnualsQuery,
+} from '@/types/gqlTypes';
+import generateSafePath from '@/utils/generateSafePath';
+
+interface Args {
+  householdId: string;
+  enrollmentId: string;
+  assessmentId?: string;
+  skip?: boolean;
+}
+
+// type AssessmentResultType = NonNullable<
+//   NonNullable<GetRelatedAnnualsQuery['householdAssessments']>
+// >[0];
+
+type HouseholdMemberAnnualInfo = {
+  clientName: string;
+  firstName: string;
+  enrollmentId: string;
+  relationshipToHoH: RelationshipToHoH;
+  path: To;
+  assessmentId?: string;
+  assessmentDate?: string;
+};
+
+function relationshipSuffix(relationship: RelationshipToHoH) {
+  const formatted = relationshipToHohForDisplay(relationship, true);
+  return formatted ? ` (${formatted})` : '';
+}
+
+export function useRelatedAnnualAssessments({
+  enrollmentId,
+  householdId,
+  assessmentId,
+  skip,
+}: Args) {
+  const [householdMembers, { loading: hhmLoading }] =
+    useHouseholdMembers(enrollmentId);
+  const { data: { householdAssessments } = {}, loading: assmtsLoading } =
+    useGetRelatedAnnualsQuery({
+      variables: { householdId, assessmentId },
+      skip,
+      fetchPolicy: 'cache-and-network',
+    });
+
+  const assessmentInfo = useMemo(() => {
+    if (!householdAssessments || !householdMembers) return;
+
+    const annualInfo: HouseholdMemberAnnualInfo[] = [];
+
+    householdAssessments.forEach(({ enrollment, client, ...assessment }) => {
+      if (enrollment.id === enrollmentId) return; // skip current member
+
+      annualInfo.push({
+        clientName: `${clientBriefName(client)}${relationshipSuffix(
+          enrollment.relationshipToHoH
+        )}`,
+        firstName: client.firstName || 'Client',
+        assessmentDate: assessment.assessmentDate,
+        enrollmentId: enrollment.id,
+        relationshipToHoH: enrollment.relationshipToHoH,
+        path: generateSafePath(EnrollmentDashboardRoutes.ASSESSMENT, {
+          clientId: client.id,
+          enrollmentId: enrollment.id,
+          assessmentId: assessment.id,
+          formRole: FormRole.Annual,
+        }),
+      });
+    });
+
+    householdMembers.forEach(({ client, enrollment, ...hhm }) => {
+      if (enrollment.id === enrollmentId) return; // skip current member
+      const hasAssessment = !!householdAssessments.find(
+        (ha) => ha.enrollment.id === enrollment.id
+      );
+      if (hasAssessment) return; // skip if already included because they have an assessment
+
+      annualInfo.push({
+        clientName: `${clientBriefName(client)}${relationshipSuffix(
+          hhm.relationshipToHoH
+        )}`,
+        firstName: client.firstName || 'Client',
+        enrollmentId: enrollment.id,
+        relationshipToHoH: hhm.relationshipToHoH,
+        path: generateSafePath(EnrollmentDashboardRoutes.ASSESSMENT, {
+          clientId: client.id,
+          enrollmentId: enrollment.id,
+          formRole: FormRole.Annual,
+        }),
+      });
+    });
+
+    return annualInfo;
+  }, [enrollmentId, householdAssessments, householdMembers]);
+
+  return {
+    assessmentInfo,
+    loading: hhmLoading || assmtsLoading,
+  } as const;
+}

--- a/src/modules/enrollment/components/dashboardPages/EnrollmentAssessmentsPage.tsx
+++ b/src/modules/enrollment/components/dashboardPages/EnrollmentAssessmentsPage.tsx
@@ -15,6 +15,7 @@ import AssessmentDateWithStatusIndicator from '@/modules/hmis/components/Assessm
 import {
   formRoleDisplay,
   parseAndFormatDateTime,
+  clientBriefName,
 } from '@/modules/hmis/hmisUtil';
 import { useHouseholdMembers } from '@/modules/household/hooks/useHouseholdMembers';
 import { EnrollmentDashboardRoutes } from '@/routes/routes';
@@ -207,7 +208,9 @@ const AssessmentsTable = () => {
 
   return (
     <TitleCard
-      title='Assessments'
+      title={`${
+        enrollment.householdSize > 1 ? clientBriefName(enrollment.client) : ''
+      } Assessments`}
       actions={
         enrollment.access.canEditEnrollments && (
           <AssessmentActionButtons

--- a/src/modules/errors/components/SentryErrorBoundary.tsx
+++ b/src/modules/errors/components/SentryErrorBoundary.tsx
@@ -1,22 +1,17 @@
 import { ErrorBoundary } from '@sentry/react';
 import { ReactNode } from 'react';
 
-import { alertErrorFallback, fullPageErrorFallback } from './ErrorFallback';
+import { AlertErrorFallback } from './ErrorFallback';
 
 import { sentryUser } from '@/modules/auth/api/sessions';
 import useAuth from '@/modules/auth/hooks/useAuth';
 
-const SentryErrorBoundary = ({
-  children,
-  fullpage = false,
-}: {
-  children: ReactNode;
-  fullpage?: boolean;
-}) => {
+const SentryErrorBoundary = ({ children }: { children: ReactNode }) => {
   const { user } = useAuth();
+
   return (
     <ErrorBoundary
-      fallback={fullpage ? fullPageErrorFallback : alertErrorFallback}
+      fallback={(props) => <AlertErrorFallback {...props} />}
       beforeCapture={(scope) => {
         const userObj = sentryUser(user);
         if (userObj) scope.setUser(userObj);

--- a/src/modules/hmis/hmisUtil.ts
+++ b/src/modules/hmis/hmisUtil.ts
@@ -527,3 +527,18 @@ export const featureEnabledForEnrollment = (
     relationshipToHoH
   );
 };
+
+export const relationshipToHohForDisplay = (
+  relationship: RelationshipToHoH,
+  hideDataNotCollectedAndInvalid: boolean
+) => {
+  if (
+    hideDataNotCollectedAndInvalid &&
+    (relationship === RelationshipToHoH.DataNotCollected ||
+      relationship === RelationshipToHoH.Invalid)
+  ) {
+    return '';
+  }
+
+  return HmisEnums.RelationshipToHoH[relationship];
+};

--- a/src/modules/hmis/hmisUtil.ts
+++ b/src/modules/hmis/hmisUtil.ts
@@ -540,5 +540,7 @@ export const relationshipToHohForDisplay = (
     return '';
   }
 
+  if (relationship === RelationshipToHoH.SelfHeadOfHousehold) return 'HoH';
+
   return HmisEnums.RelationshipToHoH[relationship];
 };

--- a/src/providers/AppProvider.tsx
+++ b/src/providers/AppProvider.tsx
@@ -19,7 +19,7 @@ type AppProviderProps = {
 const AppProvider = ({ children }: AppProviderProps) => {
   return (
     <React.Suspense fallback={<Loading />}>
-      <SentryErrorBoundary fullpage>
+      <SentryErrorBoundary>
         <LocalizationProvider dateAdapter={AdapterDateFns}>
           <ApolloProvider client={apolloClient}>
             <BrowserRouter>

--- a/src/routes/protected.tsx
+++ b/src/routes/protected.tsx
@@ -74,7 +74,7 @@ const App = () => {
   return (
     <MainLayout>
       <Suspense fallback={<Loading />}>
-        <SentryErrorBoundary fullpage>
+        <SentryErrorBoundary>
           <Outlet />
         </SentryErrorBoundary>
       </Suspense>

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -9141,6 +9141,34 @@ export type GetHouseholdAssessmentsQuery = {
   }> | null;
 };
 
+export type GetRelatedAnnualsQueryVariables = Exact<{
+  householdId: Scalars['ID']['input'];
+  assessmentId?: InputMaybe<Scalars['ID']['input']>;
+}>;
+
+export type GetRelatedAnnualsQuery = {
+  __typename?: 'Query';
+  householdAssessments?: Array<{
+    __typename?: 'Assessment';
+    id: string;
+    assessmentDate: string;
+    enrollment: {
+      __typename?: 'Enrollment';
+      id: string;
+      relationshipToHoH: RelationshipToHoH;
+    };
+    client: {
+      __typename?: 'Client';
+      id: string;
+      lockVersion: number;
+      firstName?: string | null;
+      middleName?: string | null;
+      lastName?: string | null;
+      nameSuffix?: string | null;
+    };
+  }> | null;
+};
+
 export type SaveAssessmentMutationVariables = Exact<{
   input: SaveAssessmentInput;
 }>;
@@ -23035,6 +23063,78 @@ export type GetHouseholdAssessmentsLazyQueryHookResult = ReturnType<
 export type GetHouseholdAssessmentsQueryResult = Apollo.QueryResult<
   GetHouseholdAssessmentsQuery,
   GetHouseholdAssessmentsQueryVariables
+>;
+export const GetRelatedAnnualsDocument = gql`
+  query GetRelatedAnnuals($householdId: ID!, $assessmentId: ID) {
+    householdAssessments(
+      householdId: $householdId
+      assessmentRole: ANNUAL
+      assessmentId: $assessmentId
+    ) {
+      id
+      assessmentDate
+      enrollment {
+        id
+        relationshipToHoH
+      }
+      client {
+        ...ClientName
+      }
+    }
+  }
+  ${ClientNameFragmentDoc}
+`;
+
+/**
+ * __useGetRelatedAnnualsQuery__
+ *
+ * To run a query within a React component, call `useGetRelatedAnnualsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetRelatedAnnualsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetRelatedAnnualsQuery({
+ *   variables: {
+ *      householdId: // value for 'householdId'
+ *      assessmentId: // value for 'assessmentId'
+ *   },
+ * });
+ */
+export function useGetRelatedAnnualsQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    GetRelatedAnnualsQuery,
+    GetRelatedAnnualsQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    GetRelatedAnnualsQuery,
+    GetRelatedAnnualsQueryVariables
+  >(GetRelatedAnnualsDocument, options);
+}
+export function useGetRelatedAnnualsLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GetRelatedAnnualsQuery,
+    GetRelatedAnnualsQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    GetRelatedAnnualsQuery,
+    GetRelatedAnnualsQueryVariables
+  >(GetRelatedAnnualsDocument, options);
+}
+export type GetRelatedAnnualsQueryHookResult = ReturnType<
+  typeof useGetRelatedAnnualsQuery
+>;
+export type GetRelatedAnnualsLazyQueryHookResult = ReturnType<
+  typeof useGetRelatedAnnualsLazyQuery
+>;
+export type GetRelatedAnnualsQueryResult = Apollo.QueryResult<
+  GetRelatedAnnualsQuery,
+  GetRelatedAnnualsQueryVariables
 >;
 export const SaveAssessmentDocument = gql`
   mutation SaveAssessment($input: SaveAssessmentInput!) {


### PR DESCRIPTION
Turn off "household" view for annuals due to some bugs. Instead, perform them individually, with links to potentially "related" annuals. Annual workflow needs to be revisited.