### PR TITLE
Audit bug fix and perm fix

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -550,18 +550,6 @@
             "deprecationReason": null
           },
           {
-            "name": "enrollmentCoc",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "exit",
             "description": null,
             "args": [],
@@ -3548,6 +3536,22 @@
         "name": "ClientAccess",
         "description": null,
         "fields": [
+          {
+            "name": "canAuditClients",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "canDeleteAssessments",
             "description": null,
@@ -12760,6 +12764,22 @@
           },
           {
             "name": "canEditEnrollments",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "canSplitHouseholds",
             "description": null,
             "args": [],
             "type": {
@@ -28630,6 +28650,54 @@
           },
           {
             "name": "canManageOwnClientFiles",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "canMergeClients",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "canSplitHouseholds",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "canTransferEnrollments",
             "description": null,
             "args": [],
             "type": {

--- a/src/api/operations/access.fragments.graphql
+++ b/src/api/operations/access.fragments.graphql
@@ -4,7 +4,6 @@ fragment RootPermissions on QueryAccess {
   canEditClients
   canViewClients
   canDeleteClients
-  canAuditClients
   canEditOrganization
   canDeleteOrganization
   canViewDob
@@ -26,6 +25,9 @@ fragment RootPermissions on QueryAccess {
   canManageDeniedReferrals
   canManageIncomingReferrals
   canManageOutgoingReferrals
+  canMergeClients
+  canTransferEnrollments
+  canSplitHouseholds
 }
 
 fragment ClientAccessFields on ClientAccess {
@@ -43,6 +45,7 @@ fragment ClientAccessFields on ClientAccess {
   canManageOwnClientFiles
   canViewAnyConfidentialClientFiles
   canViewAnyNonconfidentialClientFiles
+  canAuditClients
 }
 
 fragment EnrollmentAccessFields on EnrollmentAccess {

--- a/src/components/clientDashboard/AuditHistory.tsx
+++ b/src/components/clientDashboard/AuditHistory.tsx
@@ -80,6 +80,8 @@ const columns: ColumnDef<AssessmentType>[] = [
   {
     header: 'Fields Changed',
     render: (e) => {
+      if (!e.objectChanges) return null;
+
       return (
         <SimpleTable
           TableCellProps={{

--- a/src/modules/client/components/ClientProfileCard.tsx
+++ b/src/modules/client/components/ClientProfileCard.tsx
@@ -32,10 +32,7 @@ import {
   lastUpdated,
   pronouns,
 } from '@/modules/hmis/hmisUtil';
-import {
-  ClientPermissionsFilter,
-  RootPermissionsFilter,
-} from '@/modules/permissions/PermissionsFilters';
+import { ClientPermissionsFilter } from '@/modules/permissions/PermissionsFilters';
 import { useHasRootPermissions } from '@/modules/permissions/useHasPermissionsHooks';
 import { ClientDashboardRoutes } from '@/routes/routes';
 import { HmisEnums } from '@/types/gqlEnums';
@@ -505,7 +502,10 @@ const ClientProfileCard: React.FC<Props> = ({ client, onlyCard = false }) => {
                 </ClientPermissionsFilter>
                 <Typography variant='body2' sx={{ fontStyle: 'italic', mt: 1 }}>
                   Last Updated on {lastUpdated(client, true)}.{' '}
-                  <RootPermissionsFilter permissions='canAuditClients'>
+                  <ClientPermissionsFilter
+                    id={client.id}
+                    permissions='canAuditClients'
+                  >
                     <RouterLink
                       to={generateSafePath(
                         ClientDashboardRoutes.AUDIT_HISTORY,
@@ -516,7 +516,7 @@ const ClientProfileCard: React.FC<Props> = ({ client, onlyCard = false }) => {
                     >
                       View client audit history
                     </RouterLink>
-                  </RootPermissionsFilter>
+                  </ClientPermissionsFilter>
                 </Typography>
               </Stack>
             </Box>

--- a/src/routes/protected.tsx
+++ b/src/routes/protected.tsx
@@ -475,12 +475,12 @@ export const protectedRoutes: RouteNode[] = [
           {
             path: ClientDashboardRoutes.AUDIT_HISTORY,
             element: (
-              <RootPermissionsFilter
+              <ClientRoute
                 permissions='canAuditClients'
-                otherwise={<Navigate to='profile' replace />}
+                redirectRoute={ClientDashboardRoutes.PROFILE}
               >
                 <AuditHistory />
-              </RootPermissionsFilter>
+              </ClientRoute>
             ),
           },
 

--- a/src/test/__mocks__/requests.ts
+++ b/src/test/__mocks__/requests.ts
@@ -34,6 +34,7 @@ const CLIENT_ACCESS_MOCK = {
   canManageOwnClientFiles: true,
   canViewAnyConfidentialClientFiles: true,
   canViewAnyNonconfidentialClientFiles: true,
+  canAuditClients: true,
 };
 
 export const RITA_ACKROYD = {

--- a/src/types/gqlObjects.ts
+++ b/src/types/gqlObjects.ts
@@ -120,10 +120,6 @@ export const HmisObjectSchemas: GqlSchema[] = [
         type: { kind: 'SCALAR', name: 'ISO8601DateTime', ofType: null },
       },
       {
-        name: 'enrollmentCoc',
-        type: { kind: 'SCALAR', name: 'String', ofType: null },
-      },
-      {
         name: 'id',
         type: {
           kind: 'NON_NULL',
@@ -595,6 +591,14 @@ export const HmisObjectSchemas: GqlSchema[] = [
   {
     name: 'ClientAccess',
     fields: [
+      {
+        name: 'canAuditClients',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'Boolean', ofType: null },
+        },
+      },
       {
         name: 'canDeleteAssessments',
         type: {
@@ -1992,6 +1996,14 @@ export const HmisObjectSchemas: GqlSchema[] = [
       },
       {
         name: 'canEditEnrollments',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'Boolean', ofType: null },
+        },
+      },
+      {
+        name: 'canSplitHouseholds',
         type: {
           kind: 'NON_NULL',
           name: null,
@@ -4084,6 +4096,30 @@ export const HmisObjectSchemas: GqlSchema[] = [
       },
       {
         name: 'canManageOwnClientFiles',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'Boolean', ofType: null },
+        },
+      },
+      {
+        name: 'canMergeClients',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'Boolean', ofType: null },
+        },
+      },
+      {
+        name: 'canSplitHouseholds',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'Boolean', ofType: null },
+        },
+      },
+      {
+        name: 'canTransferEnrollments',
         type: {
           kind: 'NON_NULL',
           name: null,

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -137,7 +137,6 @@ export type Assessment = {
   disabilityGroup?: Maybe<DisabilityGroup>;
   employmentEducation?: Maybe<EmploymentEducation>;
   enrollment: Enrollment;
-  enrollmentCoc?: Maybe<Scalars['String']['output']>;
   exit?: Maybe<Exit>;
   healthAndDv?: Maybe<HealthAndDv>;
   id: Scalars['ID']['output'];
@@ -516,6 +515,7 @@ export type ClientYouthEducationStatusesArgs = {
 
 export type ClientAccess = {
   __typename?: 'ClientAccess';
+  canAuditClients: Scalars['Boolean']['output'];
   canDeleteAssessments: Scalars['Boolean']['output'];
   canDeleteClient: Scalars['Boolean']['output'];
   canDeleteEnrollments: Scalars['Boolean']['output'];
@@ -1943,6 +1943,7 @@ export type EnrollmentAccess = {
   __typename?: 'EnrollmentAccess';
   canDeleteEnrollments: Scalars['Boolean']['output'];
   canEditEnrollments: Scalars['Boolean']['output'];
+  canSplitHouseholds: Scalars['Boolean']['output'];
   id: Scalars['ID']['output'];
 };
 
@@ -4752,6 +4753,9 @@ export type QueryAccess = {
   canManageInventory: Scalars['Boolean']['output'];
   canManageOutgoingReferrals: Scalars['Boolean']['output'];
   canManageOwnClientFiles: Scalars['Boolean']['output'];
+  canMergeClients: Scalars['Boolean']['output'];
+  canSplitHouseholds: Scalars['Boolean']['output'];
+  canTransferEnrollments: Scalars['Boolean']['output'];
   canViewAnyConfidentialClientFiles: Scalars['Boolean']['output'];
   canViewAnyNonconfidentialClientFiles: Scalars['Boolean']['output'];
   canViewClients: Scalars['Boolean']['output'];
@@ -6397,7 +6401,6 @@ export type RootPermissionsFragment = {
   canEditClients: boolean;
   canViewClients: boolean;
   canDeleteClients: boolean;
-  canAuditClients: boolean;
   canEditOrganization: boolean;
   canDeleteOrganization: boolean;
   canViewDob: boolean;
@@ -6419,6 +6422,9 @@ export type RootPermissionsFragment = {
   canManageDeniedReferrals: boolean;
   canManageIncomingReferrals: boolean;
   canManageOutgoingReferrals: boolean;
+  canMergeClients: boolean;
+  canTransferEnrollments: boolean;
+  canSplitHouseholds: boolean;
 };
 
 export type ClientAccessFieldsFragment = {
@@ -6437,6 +6443,7 @@ export type ClientAccessFieldsFragment = {
   canManageOwnClientFiles: boolean;
   canViewAnyConfidentialClientFiles: boolean;
   canViewAnyNonconfidentialClientFiles: boolean;
+  canAuditClients: boolean;
 };
 
 export type EnrollmentAccessFieldsFragment = {
@@ -6491,7 +6498,6 @@ export type GetRootPermissionsQuery = {
     canEditClients: boolean;
     canViewClients: boolean;
     canDeleteClients: boolean;
-    canAuditClients: boolean;
     canEditOrganization: boolean;
     canDeleteOrganization: boolean;
     canViewDob: boolean;
@@ -6513,6 +6519,9 @@ export type GetRootPermissionsQuery = {
     canManageDeniedReferrals: boolean;
     canManageIncomingReferrals: boolean;
     canManageOutgoingReferrals: boolean;
+    canMergeClients: boolean;
+    canTransferEnrollments: boolean;
+    canSplitHouseholds: boolean;
   };
 };
 
@@ -11201,6 +11210,7 @@ export type ClientSearchResultFieldsFragment = {
     canManageOwnClientFiles: boolean;
     canViewAnyConfidentialClientFiles: boolean;
     canViewAnyNonconfidentialClientFiles: boolean;
+    canAuditClients: boolean;
   };
 };
 
@@ -11265,6 +11275,7 @@ export type ClientFieldsFragment = {
     canManageOwnClientFiles: boolean;
     canViewAnyConfidentialClientFiles: boolean;
     canViewAnyNonconfidentialClientFiles: boolean;
+    canAuditClients: boolean;
   };
   customDataElements: Array<{
     __typename?: 'CustomDataElement';
@@ -11556,6 +11567,7 @@ export type SearchClientsQuery = {
         canManageOwnClientFiles: boolean;
         canViewAnyConfidentialClientFiles: boolean;
         canViewAnyNonconfidentialClientFiles: boolean;
+        canAuditClients: boolean;
       };
     }>;
   };
@@ -11628,6 +11640,7 @@ export type GetClientQuery = {
       canManageOwnClientFiles: boolean;
       canViewAnyConfidentialClientFiles: boolean;
       canViewAnyNonconfidentialClientFiles: boolean;
+      canAuditClients: boolean;
     };
     customDataElements: Array<{
       __typename?: 'CustomDataElement';
@@ -11760,6 +11773,7 @@ export type GetClientPermissionsQuery = {
       canManageOwnClientFiles: boolean;
       canViewAnyConfidentialClientFiles: boolean;
       canViewAnyNonconfidentialClientFiles: boolean;
+      canAuditClients: boolean;
     };
   } | null;
 };
@@ -12174,6 +12188,7 @@ export type GetClientHouseholdMemberCandidatesQuery = {
                 canManageOwnClientFiles: boolean;
                 canViewAnyConfidentialClientFiles: boolean;
                 canViewAnyNonconfidentialClientFiles: boolean;
+                canAuditClients: boolean;
               };
               externalIds: Array<{
                 __typename?: 'ExternalIdentifier';
@@ -12765,6 +12780,7 @@ export type AllEnrollmentDetailsFragment = {
       canManageOwnClientFiles: boolean;
       canViewAnyConfidentialClientFiles: boolean;
       canViewAnyNonconfidentialClientFiles: boolean;
+      canAuditClients: boolean;
     };
   };
   openEnrollmentSummary: Array<{
@@ -13745,6 +13761,7 @@ export type GetEnrollmentDetailsQuery = {
         canManageOwnClientFiles: boolean;
         canViewAnyConfidentialClientFiles: boolean;
         canViewAnyNonconfidentialClientFiles: boolean;
+        canAuditClients: boolean;
       };
     };
     openEnrollmentSummary: Array<{
@@ -14331,6 +14348,7 @@ export type GetEnrollmentWithHouseholdQuery = {
             canManageOwnClientFiles: boolean;
             canViewAnyConfidentialClientFiles: boolean;
             canViewAnyNonconfidentialClientFiles: boolean;
+            canAuditClients: boolean;
           };
           externalIds: Array<{
             __typename?: 'ExternalIdentifier';
@@ -16781,6 +16799,7 @@ export type SubmitFormMutation = {
             canManageOwnClientFiles: boolean;
             canViewAnyConfidentialClientFiles: boolean;
             canViewAnyNonconfidentialClientFiles: boolean;
+            canAuditClients: boolean;
           };
           customDataElements: Array<{
             __typename?: 'CustomDataElement';
@@ -17434,6 +17453,7 @@ export type HouseholdFieldsFragment = {
         canManageOwnClientFiles: boolean;
         canViewAnyConfidentialClientFiles: boolean;
         canViewAnyNonconfidentialClientFiles: boolean;
+        canAuditClients: boolean;
       };
       externalIds: Array<{
         __typename?: 'ExternalIdentifier';
@@ -17488,6 +17508,7 @@ export type HouseholdClientFieldsFragment = {
       canManageOwnClientFiles: boolean;
       canViewAnyConfidentialClientFiles: boolean;
       canViewAnyNonconfidentialClientFiles: boolean;
+      canAuditClients: boolean;
     };
     externalIds: Array<{
       __typename?: 'ExternalIdentifier';
@@ -17622,6 +17643,7 @@ export type GetHouseholdQuery = {
           canManageOwnClientFiles: boolean;
           canViewAnyConfidentialClientFiles: boolean;
           canViewAnyNonconfidentialClientFiles: boolean;
+          canAuditClients: boolean;
         };
         externalIds: Array<{
           __typename?: 'ExternalIdentifier';
@@ -19952,6 +19974,7 @@ export type GetReferralPostingQuery = {
           canManageOwnClientFiles: boolean;
           canViewAnyConfidentialClientFiles: boolean;
           canViewAnyNonconfidentialClientFiles: boolean;
+          canAuditClients: boolean;
         };
         externalIds: Array<{
           __typename?: 'ExternalIdentifier';
@@ -20065,6 +20088,7 @@ export type UpdateReferralPostingMutation = {
             canManageOwnClientFiles: boolean;
             canViewAnyConfidentialClientFiles: boolean;
             canViewAnyNonconfidentialClientFiles: boolean;
+            canAuditClients: boolean;
           };
           externalIds: Array<{
             __typename?: 'ExternalIdentifier';
@@ -20192,6 +20216,7 @@ export type CreateOutgoingReferralPostingMutation = {
             canManageOwnClientFiles: boolean;
             canViewAnyConfidentialClientFiles: boolean;
             canViewAnyNonconfidentialClientFiles: boolean;
+            canAuditClients: boolean;
           };
           externalIds: Array<{
             __typename?: 'ExternalIdentifier';
@@ -20377,6 +20402,7 @@ export type ReferralPostingDetailFieldsFragment = {
         canManageOwnClientFiles: boolean;
         canViewAnyConfidentialClientFiles: boolean;
         canViewAnyNonconfidentialClientFiles: boolean;
+        canAuditClients: boolean;
       };
       externalIds: Array<{
         __typename?: 'ExternalIdentifier';
@@ -21257,7 +21283,6 @@ export const RootPermissionsFragmentDoc = gql`
     canEditClients
     canViewClients
     canDeleteClients
-    canAuditClients
     canEditOrganization
     canDeleteOrganization
     canViewDob
@@ -21279,6 +21304,9 @@ export const RootPermissionsFragmentDoc = gql`
     canManageDeniedReferrals
     canManageIncomingReferrals
     canManageOutgoingReferrals
+    canMergeClients
+    canTransferEnrollments
+    canSplitHouseholds
   }
 `;
 export const OrganizationAccessFieldsFragmentDoc = gql`
@@ -21824,6 +21852,7 @@ export const ClientAccessFieldsFragmentDoc = gql`
     canManageOwnClientFiles
     canViewAnyConfidentialClientFiles
     canViewAnyNonconfidentialClientFiles
+    canAuditClients
   }
 `;
 export const ClientSearchResultFieldsFragmentDoc = gql`


### PR DESCRIPTION
- don't crash when audit object changes are null
- check audit history perm at the client level instead of globally