### PR TITLE
revert to invalid autcomplete property

### DIFF
--- a/src/components/elements/input/TextInput.tsx
+++ b/src/components/elements/input/TextInput.tsx
@@ -13,6 +13,7 @@ import {
 import { useId } from 'react';
 
 import { DynamicInputCommonProps } from '@/modules/form/types';
+import { formAutoCompleteOff } from '@/modules/form/util/formUtil';
 
 interface Props extends Partial<Omit<TextFieldProps, 'error' | 'variant'>> {
   name?: string;
@@ -57,7 +58,7 @@ const TextInput = ({
       onKeyDown={(e) =>
         !props.multiline && e.key === 'Enter' && e.preventDefault()
       }
-      autoComplete='off'
+      autoComplete={formAutoCompleteOff}
       {...props}
       sx={sx}
       inputProps={{

--- a/src/modules/form/components/DynamicForm.tsx
+++ b/src/modules/form/components/DynamicForm.tsx
@@ -29,6 +29,7 @@ import ErrorAlert from '@/modules/errors/components/ErrorAlert';
 import { ValidationDialogProps } from '@/modules/errors/components/ValidationDialog';
 import { useValidationDialog } from '@/modules/errors/hooks/useValidationDialog';
 import { ErrorState, hasErrors } from '@/modules/errors/util';
+import { formAutoCompleteOff } from '@/modules/form/util/formUtil';
 import { FormDefinitionJson } from '@/types/gqlTypes';
 
 interface DynamicFormSubmitInput {
@@ -226,7 +227,7 @@ const DynamicForm = forwardRef(
     return (
       <form
         onSubmit={(e: React.FormEvent<HTMLFormElement>) => e.preventDefault()}
-        autoComplete='off'
+        autoComplete={formAutoCompleteOff}
       >
         <Grid container direction='column' spacing={2}>
           <div ref={errorRef} />

--- a/src/modules/form/util/formUtil.ts
+++ b/src/modules/form/util/formUtil.ts
@@ -74,6 +74,11 @@ import {
   ValueBound,
 } from '@/types/gqlTypes';
 
+// Chrome ignores autocomplete="off" in some cases, such street address fields. We use an
+// invalid value here that the browser doesn't understand to prevent this behavior. This
+// works in current versions of chrome as of 2023 but is not valid HTML.
+export const formAutoCompleteOff = 'do-not-autocomplete';
+
 export const maxWidthAtNestingLevel = (nestingLevel: number) =>
   600 - nestingLevel * 26;
 


### PR DESCRIPTION
## Description

Revert to using an invalid value for autocomplete (regression in ab5eabceef5a1). Add documentation.

## Testing:
In chrome, open a form containing and address, such as move-in form. The browser should not offer to autocomplete the form fields.


## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
