### PR TITLE
Add toggle to show all household member assessments on enrollment page

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -1243,6 +1243,68 @@
         "possibleTypes": null
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "AssessmentsForEnrollmentFilterOptions",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "type",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AssessmentRole",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "AssessmentsForHouseholdFilterOptions",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "type",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AssessmentRole",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "OBJECT",
         "name": "AssessmentsPaginated",
         "description": null,
@@ -11606,7 +11668,7 @@
                 "description": null,
                 "type": {
                   "kind": "INPUT_OBJECT",
-                  "name": "AssessmentFilterOptions",
+                  "name": "AssessmentsForEnrollmentFilterOptions",
                   "ofType": null
                 },
                 "defaultValue": null,
@@ -18345,8 +18407,85 @@
       {
         "kind": "OBJECT",
         "name": "Household",
-        "description": "HUD Household",
+        "description": null,
         "fields": [
+          {
+            "name": "assessments",
+            "description": null,
+            "args": [
+              {
+                "name": "filters",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "AssessmentsForHouseholdFilterOptions",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "inProgress",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "sortOrder",
+                "description": null,
+                "type": {
+                  "kind": "ENUM",
+                  "name": "AssessmentSortOption",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AssessmentsPaginated",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "householdClients",
             "description": null,

--- a/src/api/operations/assessment.fragments.graphql
+++ b/src/api/operations/assessment.fragments.graphql
@@ -1,3 +1,4 @@
+# fragment for resolving batch of assessments on a client/enrollment/household
 fragment AssessmentFields on Assessment {
   id
   lockVersion
@@ -10,17 +11,6 @@ fragment AssessmentFields on Assessment {
   role
   user {
     ...UserFields
-  }
-  access {
-    ...AssessmentAccessFields
-  }
-}
-
-fragment AssessmentWithValuesAndRecords on Assessment {
-  ...AssessmentWithValues
-  ...AssessmentWithRecords
-  enrollment {
-    id
   }
 }
 
@@ -63,6 +53,10 @@ fragment AssessmentWithRecords on Assessment {
   customDataElements {
     ...CustomDataElementFields
   }
+  # resolve access so we know if user can delete the assessment
+  access {
+    ...AssessmentAccessFields
+  }
 }
 
 fragment AssessmentWithValues on Assessment {
@@ -70,6 +64,7 @@ fragment AssessmentWithValues on Assessment {
   wipValues
 }
 
+# fragment for resolving a single assessment for viewing/editing (or a group of assessments in a household)
 fragment FullAssessment on Assessment {
   ...AssessmentWithRecords
   ...AssessmentWithValues

--- a/src/api/operations/assessment.queries.graphql
+++ b/src/api/operations/assessment.queries.graphql
@@ -41,7 +41,7 @@ query GetEnrollmentAssessments(
   $offset: Int = 0
   $inProgress: Boolean
   $sortOrder: AssessmentSortOption = ASSESSMENT_DATE
-  $filters: AssessmentFilterOptions
+  $filters: AssessmentsForEnrollmentFilterOptions
 ) {
   enrollment(id: $id) {
     id
@@ -72,7 +72,44 @@ query GetHouseholdAssessments(
     assessmentRole: $assessmentRole
     assessmentId: $assessmentId
   ) {
-    ...AssessmentWithValuesAndRecords
+    ...FullAssessment
+    enrollment {
+      id
+    }
+  }
+}
+
+query GetAllHouseholdAssessments(
+  $id: ID!
+  $limit: Int = 10
+  $offset: Int = 0
+  $inProgress: Boolean
+  $sortOrder: AssessmentSortOption = ASSESSMENT_DATE
+  $filters: AssessmentsForHouseholdFilterOptions
+) {
+  household(id: $id) {
+    id
+    assessments(
+      limit: $limit
+      offset: $offset
+      inProgress: $inProgress
+      sortOrder: $sortOrder
+      filters: $filters
+    ) {
+      offset
+      limit
+      nodesCount
+      nodes {
+        ...AssessmentFields
+        enrollment {
+          id
+          relationshipToHoH
+          client {
+            ...ClientName
+          }
+        }
+      }
+    }
   }
 }
 

--- a/src/api/operations/assessment.queries.graphql
+++ b/src/api/operations/assessment.queries.graphql
@@ -63,23 +63,6 @@ query GetEnrollmentAssessments(
 }
 
 query GetHouseholdAssessments(
-  $householdId: ID!
-  $assessmentRole: AssessmentRole!
-  $assessmentId: ID
-) {
-  householdAssessments(
-    householdId: $householdId
-    assessmentRole: $assessmentRole
-    assessmentId: $assessmentId
-  ) {
-    ...FullAssessment
-    enrollment {
-      id
-    }
-  }
-}
-
-query GetAllHouseholdAssessments(
   $id: ID!
   $limit: Int = 10
   $offset: Int = 0

--- a/src/components/clientDashboard/enrollments/ClientAssessments.tsx
+++ b/src/components/clientDashboard/enrollments/ClientAssessments.tsx
@@ -28,12 +28,12 @@ const columns: ColumnDef<AssessmentType>[] = [
   {
     header: 'Assessment Date',
     render: (a) => <AssessmentDateWithStatusIndicator assessment={a} />,
+    linkTreatment: true,
+    ariaLabel: (row) => assessmentDescription(row),
   },
   {
     header: 'Assessment Type',
     render: (assessment) => formRoleDisplay(assessment),
-    linkTreatment: true,
-    ariaLabel: (row) => assessmentDescription(row),
   },
   {
     header: 'Project Name',

--- a/src/modules/assessments/components/DeleteAssessmentButton.tsx
+++ b/src/modules/assessments/components/DeleteAssessmentButton.tsx
@@ -9,11 +9,11 @@ import {
   EnrollmentDashboardRoutes,
 } from '@/routes/routes';
 import {
-  AssessmentFieldsFragment,
   AssessmentRole,
   DeleteAssessmentDocument,
   DeleteAssessmentMutation,
   DeleteAssessmentMutationVariables,
+  FullAssessmentFragment,
 } from '@/types/gqlTypes';
 import { evictDeletedEnrollment } from '@/utils/cacheUtil';
 import { generateSafePath } from '@/utils/pathEncoding';
@@ -24,7 +24,7 @@ const DeleteAssessmentButton = ({
   onSuccess,
   enrollmentId,
 }: {
-  assessment: AssessmentFieldsFragment;
+  assessment: FullAssessmentFragment;
   clientId: string;
   enrollmentId: string;
   onSuccess?: VoidFunction;

--- a/src/modules/assessments/components/household/HouseholdAssessments.tsx
+++ b/src/modules/assessments/components/household/HouseholdAssessments.tsx
@@ -36,9 +36,9 @@ import { clientBriefName, enrollmentName } from '@/modules/hmis/hmisUtil';
 import { useHouseholdMembers } from '@/modules/household/hooks/useHouseholdMembers';
 import { router } from '@/routes/router';
 import {
+  AssessmentFieldsFragment,
   AssessmentRole,
   EnrollmentFieldsFragment,
-  GetHouseholdAssessmentsQuery,
   RelationshipToHoH,
 } from '@/types/gqlTypes';
 
@@ -48,12 +48,8 @@ interface HouseholdAssessmentsProps {
   assessmentId?: string;
 }
 
-type HhmAssessmentType = NonNullable<
-  GetHouseholdAssessmentsQuery['householdAssessments']
->[0];
-
 const calculateAssessmentStatus = (
-  assessment: HhmAssessmentType | undefined
+  assessment: AssessmentFieldsFragment | undefined
 ): AssessmentStatus => {
   if (!assessment) {
     return AssessmentStatus.NotStarted;

--- a/src/modules/assessments/components/household/HouseholdAssessments.tsx
+++ b/src/modules/assessments/components/household/HouseholdAssessments.tsx
@@ -37,8 +37,8 @@ import { useHouseholdMembers } from '@/modules/household/hooks/useHouseholdMembe
 import { router } from '@/routes/router';
 import {
   AssessmentRole,
-  AssessmentWithValuesAndRecordsFragment,
   EnrollmentFieldsFragment,
+  GetHouseholdAssessmentsQuery,
   RelationshipToHoH,
 } from '@/types/gqlTypes';
 
@@ -48,8 +48,12 @@ interface HouseholdAssessmentsProps {
   assessmentId?: string;
 }
 
+type HhmAssessmentType = NonNullable<
+  GetHouseholdAssessmentsQuery['householdAssessments']
+>[0];
+
 const calculateAssessmentStatus = (
-  assessment: AssessmentWithValuesAndRecordsFragment | undefined
+  assessment: HhmAssessmentType | undefined
 ): AssessmentStatus => {
   if (!assessment) {
     return AssessmentStatus.NotStarted;

--- a/src/modules/enrollment/components/EnrollmentAssessmentsTable.tsx
+++ b/src/modules/enrollment/components/EnrollmentAssessmentsTable.tsx
@@ -1,0 +1,78 @@
+import { useCallback } from 'react';
+
+import { ColumnDef } from '@/components/elements/table/types';
+import GenericTableWithData from '@/modules/dataFetching/components/GenericTableWithData';
+import AssessmentDateWithStatusIndicator from '@/modules/hmis/components/AssessmentDateWithStatusIndicator';
+import {
+  formRoleDisplay,
+  parseAndFormatDateTime,
+} from '@/modules/hmis/hmisUtil';
+import { EnrollmentDashboardRoutes } from '@/routes/routes';
+import {
+  AssessmentFieldsFragment,
+  GetEnrollmentAssessmentsDocument,
+  GetEnrollmentAssessmentsQuery,
+  GetEnrollmentAssessmentsQueryVariables,
+} from '@/types/gqlTypes';
+import { generateSafePath } from '@/utils/pathEncoding';
+
+const columns: ColumnDef<AssessmentFieldsFragment>[] = [
+  {
+    header: 'Assessment Date',
+    render: (a) => <AssessmentDateWithStatusIndicator assessment={a} />,
+    linkTreatment: true,
+  },
+  {
+    header: 'Assessment Type',
+    render: (assessment) => formRoleDisplay(assessment),
+  },
+  {
+    header: 'Last Updated',
+    render: (e) =>
+      `${
+        e.dateUpdated ? parseAndFormatDateTime(e.dateUpdated) : 'Unknown Date'
+      } by ${e.user?.name || 'Unknown User'}`,
+  },
+];
+
+interface Props {
+  enrollmentId: string;
+  clientId: string;
+}
+
+const EnrollmentAssessmentsTable: React.FC<Props> = ({
+  clientId,
+  enrollmentId,
+}) => {
+  const rowLinkTo = useCallback(
+    (assessment: AssessmentFieldsFragment) =>
+      generateSafePath(EnrollmentDashboardRoutes.ASSESSMENT, {
+        clientId,
+        enrollmentId,
+        assessmentId: assessment.id,
+        formRole: assessment.role,
+      }),
+    [clientId, enrollmentId]
+  );
+
+  return (
+    <GenericTableWithData<
+      GetEnrollmentAssessmentsQuery,
+      GetEnrollmentAssessmentsQueryVariables,
+      AssessmentFieldsFragment
+    >
+      showFilters
+      queryVariables={{ id: enrollmentId }}
+      queryDocument={GetEnrollmentAssessmentsDocument}
+      rowLinkTo={rowLinkTo}
+      columns={columns}
+      pagePath='enrollment.assessments'
+      noData='No assessments'
+      recordType='Assessment'
+      headerCellSx={() => ({ color: 'text.secondary' })}
+      filterInputType='AssessmentsForEnrollmentFilterOptions'
+    />
+  );
+};
+
+export default EnrollmentAssessmentsTable;

--- a/src/modules/enrollment/components/HouseholdAssessmentsTable.tsx
+++ b/src/modules/enrollment/components/HouseholdAssessmentsTable.tsx
@@ -10,14 +10,14 @@ import {
 } from '@/modules/hmis/hmisUtil';
 import { EnrollmentDashboardRoutes } from '@/routes/routes';
 import {
-  GetAllHouseholdAssessmentsDocument,
-  GetAllHouseholdAssessmentsQuery,
-  GetAllHouseholdAssessmentsQueryVariables,
+  GetHouseholdAssessmentsDocument,
+  GetHouseholdAssessmentsQuery,
+  GetHouseholdAssessmentsQueryVariables,
 } from '@/types/gqlTypes';
 import { generateSafePath } from '@/utils/pathEncoding';
 
 type HhmAssessmentType = NonNullable<
-  NonNullable<GetAllHouseholdAssessmentsQuery['household']>['assessments']
+  NonNullable<GetHouseholdAssessmentsQuery['household']>['assessments']
 >['nodes'][0];
 
 const columns: ColumnDef<HhmAssessmentType>[] = [
@@ -61,13 +61,13 @@ const HouseholdAssessmentsTable: React.FC<Props> = ({ householdId }) => {
 
   return (
     <GenericTableWithData<
-      GetAllHouseholdAssessmentsQuery,
-      GetAllHouseholdAssessmentsQueryVariables,
+      GetHouseholdAssessmentsQuery,
+      GetHouseholdAssessmentsQueryVariables,
       HhmAssessmentType
     >
       showFilters
       queryVariables={{ id: householdId }}
-      queryDocument={GetAllHouseholdAssessmentsDocument}
+      queryDocument={GetHouseholdAssessmentsDocument}
       rowLinkTo={rowLinkTo}
       columns={columns}
       pagePath='household.assessments'

--- a/src/modules/enrollment/components/HouseholdAssessmentsTable.tsx
+++ b/src/modules/enrollment/components/HouseholdAssessmentsTable.tsx
@@ -1,0 +1,82 @@
+import { useCallback } from 'react';
+
+import { ColumnDef } from '@/components/elements/table/types';
+import GenericTableWithData from '@/modules/dataFetching/components/GenericTableWithData';
+import AssessmentDateWithStatusIndicator from '@/modules/hmis/components/AssessmentDateWithStatusIndicator';
+import {
+  clientBriefName,
+  formRoleDisplay,
+  parseAndFormatDateTime,
+} from '@/modules/hmis/hmisUtil';
+import { EnrollmentDashboardRoutes } from '@/routes/routes';
+import {
+  GetAllHouseholdAssessmentsDocument,
+  GetAllHouseholdAssessmentsQuery,
+  GetAllHouseholdAssessmentsQueryVariables,
+} from '@/types/gqlTypes';
+import { generateSafePath } from '@/utils/pathEncoding';
+
+type HhmAssessmentType = NonNullable<
+  NonNullable<GetAllHouseholdAssessmentsQuery['household']>['assessments']
+>['nodes'][0];
+
+const columns: ColumnDef<HhmAssessmentType>[] = [
+  {
+    header: 'Client Name',
+    render: (a) => clientBriefName(a.enrollment.client),
+  },
+  {
+    header: 'Assessment Date',
+    render: (a) => <AssessmentDateWithStatusIndicator assessment={a} />,
+    linkTreatment: true,
+  },
+  {
+    header: 'Assessment Type',
+    render: (assessment) => formRoleDisplay(assessment),
+  },
+  {
+    header: 'Last Updated',
+    render: (e) =>
+      `${
+        e.dateUpdated ? parseAndFormatDateTime(e.dateUpdated) : 'Unknown Date'
+      } by ${e.user?.name || 'Unknown User'}`,
+  },
+];
+
+interface Props {
+  householdId: string;
+}
+
+const HouseholdAssessmentsTable: React.FC<Props> = ({ householdId }) => {
+  const rowLinkTo = useCallback(
+    (assessment: HhmAssessmentType) =>
+      generateSafePath(EnrollmentDashboardRoutes.ASSESSMENT, {
+        clientId: assessment.enrollment.client.id,
+        enrollmentId: assessment.enrollment.id,
+        assessmentId: assessment.id,
+        formRole: assessment.role,
+      }),
+    []
+  );
+
+  return (
+    <GenericTableWithData<
+      GetAllHouseholdAssessmentsQuery,
+      GetAllHouseholdAssessmentsQueryVariables,
+      HhmAssessmentType
+    >
+      showFilters
+      queryVariables={{ id: householdId }}
+      queryDocument={GetAllHouseholdAssessmentsDocument}
+      rowLinkTo={rowLinkTo}
+      columns={columns}
+      pagePath='household.assessments'
+      noData='No assessments'
+      recordType='Assessment'
+      headerCellSx={() => ({ color: 'text.secondary' })}
+      filterInputType='AssessmentsForHouseholdFilterOptions'
+    />
+  );
+};
+
+export default HouseholdAssessmentsTable;

--- a/src/modules/enrollment/components/dashboardPages/EnrollmentAssessmentsPage.tsx
+++ b/src/modules/enrollment/components/dashboardPages/EnrollmentAssessmentsPage.tsx
@@ -1,91 +1,84 @@
-import { useCallback } from 'react';
-
+import PeopleIcon from '@mui/icons-material/People';
+import PersonIcon from '@mui/icons-material/Person';
+import { Stack, ToggleButton, ToggleButtonGroup } from '@mui/material';
+import { useCallback, useState } from 'react';
 import EnrollmentAssessmentActionButtons from '../EnrollmentAssessmentActionButtons';
-import { ColumnDef } from '@/components/elements/table/types';
+import EnrollmentAssessmentsTable from '../EnrollmentAssessmentsTable';
+import HouseholdAssessmentsTable from '../HouseholdAssessmentsTable';
 import TitleCard from '@/components/elements/TitleCard';
 import { useEnrollmentDashboardContext } from '@/components/pages/EnrollmentDashboard';
 import NotFound from '@/components/pages/NotFound';
-import GenericTableWithData from '@/modules/dataFetching/components/GenericTableWithData';
-import AssessmentDateWithStatusIndicator from '@/modules/hmis/components/AssessmentDateWithStatusIndicator';
-import {
-  clientBriefName,
-  formRoleDisplay,
-  parseAndFormatDateTime,
-} from '@/modules/hmis/hmisUtil';
-import { EnrollmentDashboardRoutes } from '@/routes/routes';
-import {
-  AssessmentFieldsFragment,
-  GetEnrollmentAssessmentsDocument,
-  GetEnrollmentAssessmentsQuery,
-  GetEnrollmentAssessmentsQueryVariables,
-} from '@/types/gqlTypes';
-import { generateSafePath } from '@/utils/pathEncoding';
+import { clientBriefName } from '@/modules/hmis/hmisUtil';
 
-// FIXME: share configuration with AllAssesments component
-const columns: ColumnDef<AssessmentFieldsFragment>[] = [
-  {
-    header: 'Assessment Date',
-    render: (a) => <AssessmentDateWithStatusIndicator assessment={a} />,
-  },
-  {
-    header: 'Assessment Type',
-    render: (assessment) => formRoleDisplay(assessment),
-    linkTreatment: true,
-  },
-  {
-    header: 'Last Updated',
-    render: (e) =>
-      `${
-        e.dateUpdated ? parseAndFormatDateTime(e.dateUpdated) : 'Unknown Date'
-      } by ${e.user?.name || 'Unknown User'}`,
-  },
-];
+type Mode = 'current_client' | 'household';
 
 const AssessmentsTable = () => {
   const { enrollment } = useEnrollmentDashboardContext();
+  const [mode, setMode] = useState<Mode>('current_client');
   const enrollmentId = enrollment?.id;
   const clientId = enrollment?.client.id;
-  const rowLinkTo = useCallback(
-    (assessment: AssessmentFieldsFragment) =>
-      generateSafePath(EnrollmentDashboardRoutes.ASSESSMENT, {
-        clientId,
-        enrollmentId,
-        assessmentId: assessment.id,
-        formRole: assessment.role,
-      }),
-    [clientId, enrollmentId]
+  const onChangeMode = useCallback(
+    (event: React.MouseEvent<HTMLElement>, value: Mode) =>
+      value && setMode(value),
+    []
   );
 
   if (!enrollment || !enrollmentId || !clientId) return <NotFound />;
 
   return (
     <TitleCard
-      title={`${
-        enrollment.householdSize > 1 ? clientBriefName(enrollment.client) : ''
-      } Assessments`}
+      title={
+        mode === 'current_client'
+          ? `${clientBriefName(enrollment.client)} Assessments`
+          : 'Household Assessments'
+      }
       actions={
-        enrollment.access.canEditEnrollments && (
-          <EnrollmentAssessmentActionButtons enrollment={enrollment} />
-        )
+        <Stack direction='row' gap={4}>
+          {enrollment.householdSize > 1 && (
+            <ToggleButtonGroup
+              value={mode}
+              exclusive
+              onChange={onChangeMode}
+              aria-label='view assessments by'
+            >
+              <ToggleButton
+                value='current_client'
+                aria-label='Assessments for Client'
+                size='small'
+                sx={{ px: 2 }}
+              >
+                <PersonIcon fontSize='small' sx={{ mr: 0.5 }} />
+                Client
+              </ToggleButton>
+              <ToggleButton
+                value='household'
+                aria-label='Assessments for Household'
+                size='small'
+                sx={{ px: 2 }}
+              >
+                <PeopleIcon fontSize='small' sx={{ mr: 0.5 }} />
+                Household
+              </ToggleButton>
+            </ToggleButtonGroup>
+          )}
+
+          {enrollment.access.canEditEnrollments && (
+            <EnrollmentAssessmentActionButtons enrollment={enrollment} />
+          )}
+        </Stack>
       }
       headerVariant='border'
       data-testid='enrollmentAssessmentsCard'
     >
-      <GenericTableWithData<
-        GetEnrollmentAssessmentsQuery,
-        GetEnrollmentAssessmentsQueryVariables,
-        AssessmentFieldsFragment
-      >
-        showFilters
-        queryVariables={{ id: enrollmentId }}
-        queryDocument={GetEnrollmentAssessmentsDocument}
-        rowLinkTo={rowLinkTo}
-        columns={columns}
-        pagePath='enrollment.assessments'
-        noData='No assessments'
-        recordType='Assessment'
-        headerCellSx={() => ({ color: 'text.secondary' })}
-      />
+      {mode === 'current_client' && (
+        <EnrollmentAssessmentsTable
+          enrollmentId={enrollmentId}
+          clientId={clientId}
+        />
+      )}
+      {mode === 'household' && (
+        <HouseholdAssessmentsTable householdId={enrollment.householdId} />
+      )}
     </TitleCard>
   );
 };

--- a/src/types/gqlObjects.ts
+++ b/src/types/gqlObjects.ts
@@ -5112,6 +5112,40 @@ export const HmisInputObjectSchemas: GqlInputObjectSchema[] = [
     ],
   },
   {
+    name: 'AssessmentsForEnrollmentFilterOptions',
+    args: [
+      {
+        name: 'type',
+        type: {
+          kind: 'LIST',
+          name: null,
+          ofType: {
+            kind: 'NON_NULL',
+            name: null,
+            ofType: { kind: 'ENUM', name: 'AssessmentRole', ofType: null },
+          },
+        },
+      },
+    ],
+  },
+  {
+    name: 'AssessmentsForHouseholdFilterOptions',
+    args: [
+      {
+        name: 'type',
+        type: {
+          kind: 'LIST',
+          name: null,
+          ofType: {
+            kind: 'NON_NULL',
+            name: null,
+            ofType: { kind: 'ENUM', name: 'AssessmentRole', ofType: null },
+          },
+        },
+      },
+    ],
+  },
+  {
     name: 'BulkMergeClientsInput',
     args: [
       {

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -8555,430 +8555,6 @@ export type GetEnrollmentAssessmentsQuery = {
 };
 
 export type GetHouseholdAssessmentsQueryVariables = Exact<{
-  householdId: Scalars['ID']['input'];
-  assessmentRole: AssessmentRole;
-  assessmentId?: InputMaybe<Scalars['ID']['input']>;
-}>;
-
-export type GetHouseholdAssessmentsQuery = {
-  __typename?: 'Query';
-  householdAssessments?: Array<{
-    __typename?: 'Assessment';
-    wipValues?: any | null;
-    id: string;
-    lockVersion: number;
-    inProgress: boolean;
-    assessmentDate: string;
-    dataCollectionStage?: DataCollectionStage | null;
-    dateCreated?: string | null;
-    dateUpdated?: string | null;
-    dateDeleted?: string | null;
-    role: AssessmentRole;
-    enrollment: {
-      __typename?: 'Enrollment';
-      id: string;
-      lockVersion: number;
-      entryDate: string;
-      exitDate?: string | null;
-      disablingCondition?: NoYesReasonsForMissingData | null;
-      dateOfEngagement?: string | null;
-      moveInDate?: string | null;
-      livingSituation?: PriorLivingSituation | null;
-      rentalSubsidyType?: RentalSubsidyType | null;
-      lengthOfStay?: ResidencePriorLengthOfStay | null;
-      losUnderThreshold?: NoYesMissing | null;
-      previousStreetEssh?: NoYesMissing | null;
-      dateToStreetEssh?: string | null;
-      timesHomelessPastThreeYears?: TimesHomelessPastThreeYears | null;
-      monthsHomelessPastThreeYears?: MonthsHomelessPastThreeYears | null;
-      enrollmentCoc?: string | null;
-      dateOfPathStatus?: string | null;
-      clientEnrolledInPath?: NoYesMissing | null;
-      reasonNotEnrolled?: ReasonNotEnrolled | null;
-      percentAmi?: PercentAmi | null;
-      referralSource?: ReferralSource | null;
-      countOutreachReferralApproaches?: number | null;
-      dateOfBcpStatus?: string | null;
-      eligibleForRhy?: NoYesMissing | null;
-      reasonNoServices?: ReasonNoServices | null;
-      runawayYouth?: NoYesReasonsForMissingData | null;
-      sexualOrientation?: SexualOrientation | null;
-      sexualOrientationOther?: string | null;
-      formerWardChildWelfare?: NoYesReasonsForMissingData | null;
-      childWelfareYears?: RhyNumberofYears | null;
-      childWelfareMonths?: number | null;
-      formerWardJuvenileJustice?: NoYesReasonsForMissingData | null;
-      juvenileJusticeYears?: RhyNumberofYears | null;
-      juvenileJusticeMonths?: number | null;
-      unemploymentFam?: NoYesMissing | null;
-      mentalHealthDisorderFam?: NoYesMissing | null;
-      physicalDisabilityFam?: NoYesMissing | null;
-      alcoholDrugUseDisorderFam?: NoYesMissing | null;
-      insufficientIncome?: NoYesMissing | null;
-      incarceratedParent?: NoYesMissing | null;
-      targetScreenReqd?: NoYesMissing | null;
-      timeToHousingLoss?: TimeToHousingLoss | null;
-      annualPercentAmi?: AnnualPercentAmi | null;
-      literalHomelessHistory?: LiteralHomelessHistory | null;
-      clientLeaseholder?: NoYesMissing | null;
-      hohLeaseholder?: NoYesMissing | null;
-      subsidyAtRisk?: NoYesMissing | null;
-      evictionHistory?: EvictionHistory | null;
-      criminalRecord?: NoYesMissing | null;
-      incarceratedAdult?: IncarceratedAdult | null;
-      prisonDischarge?: NoYesMissing | null;
-      sexOffender?: NoYesMissing | null;
-      disabledHoh?: NoYesMissing | null;
-      currentPregnant?: NoYesMissing | null;
-      singleParent?: NoYesMissing | null;
-      dependentUnder6?: DependentUnder6 | null;
-      hh5Plus?: NoYesMissing | null;
-      cocPrioritized?: NoYesMissing | null;
-      hpScreeningScore?: number | null;
-      thresholdScore?: number | null;
-      vamcStation?: VamcStationNumber | null;
-      translationNeeded?: NoYesReasonsForMissingData | null;
-      preferredLanguage?: PreferredLanguage | null;
-      preferredLanguageDifferent?: string | null;
-      customDataElements: Array<{
-        __typename?: 'CustomDataElement';
-        id: string;
-        key: string;
-        label: string;
-        fieldType: CustomDataElementType;
-        repeats: boolean;
-        value?: {
-          __typename?: 'CustomDataElementValue';
-          id: string;
-          valueBoolean?: boolean | null;
-          valueDate?: string | null;
-          valueFloat?: number | null;
-          valueInteger?: number | null;
-          valueJson?: any | null;
-          valueString?: string | null;
-          valueText?: string | null;
-          dateCreated?: string | null;
-          dateUpdated?: string | null;
-          user?: { __typename: 'User'; id: string; name: string } | null;
-        } | null;
-        values?: Array<{
-          __typename?: 'CustomDataElementValue';
-          id: string;
-          valueBoolean?: boolean | null;
-          valueDate?: string | null;
-          valueFloat?: number | null;
-          valueInteger?: number | null;
-          valueJson?: any | null;
-          valueString?: string | null;
-          valueText?: string | null;
-          dateCreated?: string | null;
-          dateUpdated?: string | null;
-          user?: { __typename: 'User'; id: string; name: string } | null;
-        }> | null;
-      }>;
-      client: { __typename?: 'Client'; id: string };
-    };
-    incomeBenefit?: {
-      __typename: 'IncomeBenefit';
-      adap?: NoYesReasonsForMissingData | null;
-      alimony?: NoYesMissing | null;
-      alimonyAmount?: number | null;
-      benefitsFromAnySource?: NoYesReasonsForMissingData | null;
-      childSupport?: NoYesMissing | null;
-      childSupportAmount?: number | null;
-      cobra?: NoYesMissing | null;
-      connectionWithSoar?: NoYesReasonsForMissingData | null;
-      dataCollectionStage: DataCollectionStage;
-      dateCreated?: string | null;
-      dateDeleted?: string | null;
-      dateUpdated?: string | null;
-      earned?: NoYesMissing | null;
-      earnedAmount?: number | null;
-      employerProvided?: NoYesMissing | null;
-      ga?: NoYesMissing | null;
-      gaAmount?: number | null;
-      id: string;
-      incomeFromAnySource?: NoYesReasonsForMissingData | null;
-      indianHealthServices?: NoYesMissing | null;
-      informationDate?: string | null;
-      insuranceFromAnySource?: NoYesReasonsForMissingData | null;
-      medicaid?: NoYesMissing | null;
-      medicare?: NoYesMissing | null;
-      noAdapReason?: NoAssistanceReason | null;
-      noCobraReason?: ReasonNotInsured | null;
-      noEmployerProvidedReason?: ReasonNotInsured | null;
-      noIndianHealthServicesReason?: ReasonNotInsured | null;
-      noMedicaidReason?: ReasonNotInsured | null;
-      noMedicareReason?: ReasonNotInsured | null;
-      noPrivatePayReason?: ReasonNotInsured | null;
-      noRyanWhiteReason?: NoAssistanceReason | null;
-      noSchipReason?: ReasonNotInsured | null;
-      noStateHealthInsReason?: ReasonNotInsured | null;
-      noVhaReason?: ReasonNotInsured | null;
-      otherBenefitsSource?: NoYesMissing | null;
-      otherBenefitsSourceIdentify?: string | null;
-      otherIncomeAmount?: number | null;
-      otherIncomeSource?: NoYesMissing | null;
-      otherIncomeSourceIdentify?: string | null;
-      otherInsurance?: NoYesMissing | null;
-      otherInsuranceIdentify?: string | null;
-      otherTanf?: NoYesMissing | null;
-      pension?: NoYesMissing | null;
-      pensionAmount?: number | null;
-      privateDisability?: NoYesMissing | null;
-      privateDisabilityAmount?: number | null;
-      privatePay?: NoYesMissing | null;
-      ryanWhiteMedDent?: NoYesReasonsForMissingData | null;
-      schip?: NoYesMissing | null;
-      snap?: NoYesMissing | null;
-      socSecRetirement?: NoYesMissing | null;
-      socSecRetirementAmount?: number | null;
-      ssdi?: NoYesMissing | null;
-      ssdiAmount?: number | null;
-      ssi?: NoYesMissing | null;
-      ssiAmount?: number | null;
-      stateHealthIns?: NoYesMissing | null;
-      tanf?: NoYesMissing | null;
-      tanfAmount?: number | null;
-      tanfChildCare?: NoYesMissing | null;
-      tanfTransportation?: NoYesMissing | null;
-      totalMonthlyIncome?: string | null;
-      unemployment?: NoYesMissing | null;
-      unemploymentAmount?: number | null;
-      vaDisabilityNonService?: NoYesMissing | null;
-      vaDisabilityNonServiceAmount?: number | null;
-      vaDisabilityService?: NoYesMissing | null;
-      vaDisabilityServiceAmount?: number | null;
-      vhaServices?: NoYesMissing | null;
-      wic?: NoYesMissing | null;
-      workersComp?: NoYesMissing | null;
-      workersCompAmount?: number | null;
-      customDataElements: Array<{
-        __typename?: 'CustomDataElement';
-        id: string;
-        key: string;
-        label: string;
-        fieldType: CustomDataElementType;
-        repeats: boolean;
-        value?: {
-          __typename?: 'CustomDataElementValue';
-          id: string;
-          valueBoolean?: boolean | null;
-          valueDate?: string | null;
-          valueFloat?: number | null;
-          valueInteger?: number | null;
-          valueJson?: any | null;
-          valueString?: string | null;
-          valueText?: string | null;
-          dateCreated?: string | null;
-          dateUpdated?: string | null;
-          user?: { __typename: 'User'; id: string; name: string } | null;
-        } | null;
-        values?: Array<{
-          __typename?: 'CustomDataElementValue';
-          id: string;
-          valueBoolean?: boolean | null;
-          valueDate?: string | null;
-          valueFloat?: number | null;
-          valueInteger?: number | null;
-          valueJson?: any | null;
-          valueString?: string | null;
-          valueText?: string | null;
-          dateCreated?: string | null;
-          dateUpdated?: string | null;
-          user?: { __typename: 'User'; id: string; name: string } | null;
-        }> | null;
-      }>;
-    } | null;
-    disabilityGroup?: {
-      __typename: 'DisabilityGroup';
-      id: string;
-      dataCollectionStage: DataCollectionStage;
-      informationDate: string;
-      disablingCondition: NoYesReasonsForMissingData;
-      chronicHealthCondition?: NoYesReasonsForMissingData | null;
-      chronicHealthConditionIndefiniteAndImpairs?: NoYesReasonsForMissingData | null;
-      developmentalDisability?: NoYesReasonsForMissingData | null;
-      hivAids?: NoYesReasonsForMissingData | null;
-      mentalHealthDisorder?: NoYesReasonsForMissingData | null;
-      mentalHealthDisorderIndefiniteAndImpairs?: NoYesReasonsForMissingData | null;
-      physicalDisability?: NoYesReasonsForMissingData | null;
-      physicalDisabilityIndefiniteAndImpairs?: NoYesReasonsForMissingData | null;
-      substanceUseDisorder?: DisabilityResponse | null;
-      substanceUseDisorderIndefiniteAndImpairs?: NoYesReasonsForMissingData | null;
-      dateCreated?: string | null;
-      dateUpdated?: string | null;
-      tCellCountAvailable?: NoYesReasonsForMissingData | null;
-      tCellCount?: number | null;
-      tCellSource?: TCellSourceViralLoadSource | null;
-      viralLoadAvailable?: ViralLoadAvailable | null;
-      viralLoad?: number | null;
-      antiRetroviral?: NoYesReasonsForMissingData | null;
-    } | null;
-    healthAndDv?: {
-      __typename: 'HealthAndDv';
-      currentlyFleeing?: NoYesReasonsForMissingData | null;
-      dataCollectionStage: DataCollectionStage;
-      dateCreated?: string | null;
-      dateDeleted?: string | null;
-      dateUpdated?: string | null;
-      dentalHealthStatus?: HealthStatus | null;
-      domesticViolenceSurvivor?: NoYesReasonsForMissingData | null;
-      dueDate?: string | null;
-      generalHealthStatus?: HealthStatus | null;
-      id: string;
-      informationDate?: string | null;
-      mentalHealthStatus?: HealthStatus | null;
-      pregnancyStatus?: NoYesReasonsForMissingData | null;
-      whenOccurred?: WhenDvOccurred | null;
-    } | null;
-    exit?: {
-      __typename?: 'Exit';
-      id: string;
-      aftercareDate?: string | null;
-      aftercareProvided?: AftercareProvided | null;
-      aftercareMethods?: Array<AftercareMethod> | null;
-      askedOrForcedToExchangeForSex?: NoYesReasonsForMissingData | null;
-      askedOrForcedToExchangeForSexPastThreeMonths?: NoYesReasonsForMissingData | null;
-      cmExitReason?: CmExitReason | null;
-      coercedToContinueWork?: NoYesReasonsForMissingData | null;
-      counselingReceived?: NoYesMissing | null;
-      counselingMethods?: Array<CounselingMethod> | null;
-      countOfExchangeForSex?: CountExchangeForSex | null;
-      dateCreated?: string | null;
-      dateDeleted?: string | null;
-      dateUpdated?: string | null;
-      destination: Destination;
-      destinationSafeClient?: NoYesReasonsForMissingData | null;
-      destinationSafeWorker?: WorkerResponse | null;
-      destinationSubsidyType?: RentalSubsidyType | null;
-      earlyExitReason?: ExpelledReason | null;
-      exchangeForSex?: NoYesReasonsForMissingData | null;
-      exchangeForSexPastThreeMonths?: NoYesReasonsForMissingData | null;
-      exitDate: string;
-      housingAssessment?: HousingAssessmentAtExit | null;
-      laborExploitPastThreeMonths?: NoYesReasonsForMissingData | null;
-      otherDestination?: string | null;
-      posAdultConnections?: WorkerResponse | null;
-      posCommunityConnections?: WorkerResponse | null;
-      posPeerConnections?: WorkerResponse | null;
-      postExitCounselingPlan?: NoYesMissing | null;
-      projectCompletionStatus?: ProjectCompletionStatus | null;
-      sessionCountAtExit?: number | null;
-      sessionsInPlan?: number | null;
-      subsidyInformation?: SubsidyInformation | null;
-      workPlaceViolenceThreats?: NoYesReasonsForMissingData | null;
-      workplacePromiseDifference?: NoYesReasonsForMissingData | null;
-      customDataElements: Array<{
-        __typename?: 'CustomDataElement';
-        id: string;
-        key: string;
-        label: string;
-        fieldType: CustomDataElementType;
-        repeats: boolean;
-        value?: {
-          __typename?: 'CustomDataElementValue';
-          id: string;
-          valueBoolean?: boolean | null;
-          valueDate?: string | null;
-          valueFloat?: number | null;
-          valueInteger?: number | null;
-          valueJson?: any | null;
-          valueString?: string | null;
-          valueText?: string | null;
-          dateCreated?: string | null;
-          dateUpdated?: string | null;
-          user?: { __typename: 'User'; id: string; name: string } | null;
-        } | null;
-        values?: Array<{
-          __typename?: 'CustomDataElementValue';
-          id: string;
-          valueBoolean?: boolean | null;
-          valueDate?: string | null;
-          valueFloat?: number | null;
-          valueInteger?: number | null;
-          valueJson?: any | null;
-          valueString?: string | null;
-          valueText?: string | null;
-          dateCreated?: string | null;
-          dateUpdated?: string | null;
-          user?: { __typename: 'User'; id: string; name: string } | null;
-        }> | null;
-      }>;
-    } | null;
-    youthEducationStatus?: {
-      __typename?: 'YouthEducationStatus';
-      currentEdStatus?: CurrentEdStatus | null;
-      currentSchoolAttend?: CurrentSchoolAttended | null;
-      dataCollectionStage: DataCollectionStage;
-      dateCreated?: string | null;
-      dateDeleted?: string | null;
-      dateUpdated?: string | null;
-      id: string;
-      informationDate?: string | null;
-      mostRecentEdStatus?: MostRecentEdStatus | null;
-    } | null;
-    employmentEducation?: {
-      __typename?: 'EmploymentEducation';
-      dataCollectionStage: DataCollectionStage;
-      dateCreated?: string | null;
-      dateDeleted?: string | null;
-      employed?: NoYesReasonsForMissingData | null;
-      employmentType?: EmploymentType | null;
-      id: string;
-      informationDate?: string | null;
-      lastGradeCompleted?: LastGradeCompleted | null;
-      notEmployedReason?: NotEmployedReason | null;
-      schoolStatus?: SchoolStatus | null;
-    } | null;
-    customDataElements: Array<{
-      __typename?: 'CustomDataElement';
-      id: string;
-      key: string;
-      label: string;
-      fieldType: CustomDataElementType;
-      repeats: boolean;
-      value?: {
-        __typename?: 'CustomDataElementValue';
-        id: string;
-        valueBoolean?: boolean | null;
-        valueDate?: string | null;
-        valueFloat?: number | null;
-        valueInteger?: number | null;
-        valueJson?: any | null;
-        valueString?: string | null;
-        valueText?: string | null;
-        dateCreated?: string | null;
-        dateUpdated?: string | null;
-        user?: { __typename: 'User'; id: string; name: string } | null;
-      } | null;
-      values?: Array<{
-        __typename?: 'CustomDataElementValue';
-        id: string;
-        valueBoolean?: boolean | null;
-        valueDate?: string | null;
-        valueFloat?: number | null;
-        valueInteger?: number | null;
-        valueJson?: any | null;
-        valueString?: string | null;
-        valueText?: string | null;
-        dateCreated?: string | null;
-        dateUpdated?: string | null;
-        user?: { __typename: 'User'; id: string; name: string } | null;
-      }> | null;
-    }>;
-    access: {
-      __typename?: 'AssessmentAccess';
-      id: string;
-      canDeleteAssessments: boolean;
-      canDeleteEnrollments: boolean;
-      canEditEnrollments: boolean;
-    };
-    user?: { __typename: 'User'; id: string; name: string } | null;
-  }> | null;
-};
-
-export type GetAllHouseholdAssessmentsQueryVariables = Exact<{
   id: Scalars['ID']['input'];
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
@@ -8987,7 +8563,7 @@ export type GetAllHouseholdAssessmentsQueryVariables = Exact<{
   filters?: InputMaybe<AssessmentsForHouseholdFilterOptions>;
 }>;
 
-export type GetAllHouseholdAssessmentsQuery = {
+export type GetHouseholdAssessmentsQuery = {
   __typename?: 'Query';
   household?: {
     __typename?: 'Household';
@@ -23561,78 +23137,6 @@ export type GetEnrollmentAssessmentsQueryResult = Apollo.QueryResult<
 >;
 export const GetHouseholdAssessmentsDocument = gql`
   query GetHouseholdAssessments(
-    $householdId: ID!
-    $assessmentRole: AssessmentRole!
-    $assessmentId: ID
-  ) {
-    householdAssessments(
-      householdId: $householdId
-      assessmentRole: $assessmentRole
-      assessmentId: $assessmentId
-    ) {
-      ...FullAssessment
-      enrollment {
-        id
-      }
-    }
-  }
-  ${FullAssessmentFragmentDoc}
-`;
-
-/**
- * __useGetHouseholdAssessmentsQuery__
- *
- * To run a query within a React component, call `useGetHouseholdAssessmentsQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetHouseholdAssessmentsQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetHouseholdAssessmentsQuery({
- *   variables: {
- *      householdId: // value for 'householdId'
- *      assessmentRole: // value for 'assessmentRole'
- *      assessmentId: // value for 'assessmentId'
- *   },
- * });
- */
-export function useGetHouseholdAssessmentsQuery(
-  baseOptions: Apollo.QueryHookOptions<
-    GetHouseholdAssessmentsQuery,
-    GetHouseholdAssessmentsQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<
-    GetHouseholdAssessmentsQuery,
-    GetHouseholdAssessmentsQueryVariables
-  >(GetHouseholdAssessmentsDocument, options);
-}
-export function useGetHouseholdAssessmentsLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetHouseholdAssessmentsQuery,
-    GetHouseholdAssessmentsQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<
-    GetHouseholdAssessmentsQuery,
-    GetHouseholdAssessmentsQueryVariables
-  >(GetHouseholdAssessmentsDocument, options);
-}
-export type GetHouseholdAssessmentsQueryHookResult = ReturnType<
-  typeof useGetHouseholdAssessmentsQuery
->;
-export type GetHouseholdAssessmentsLazyQueryHookResult = ReturnType<
-  typeof useGetHouseholdAssessmentsLazyQuery
->;
-export type GetHouseholdAssessmentsQueryResult = Apollo.QueryResult<
-  GetHouseholdAssessmentsQuery,
-  GetHouseholdAssessmentsQueryVariables
->;
-export const GetAllHouseholdAssessmentsDocument = gql`
-  query GetAllHouseholdAssessments(
     $id: ID!
     $limit: Int = 10
     $offset: Int = 0
@@ -23670,16 +23174,16 @@ export const GetAllHouseholdAssessmentsDocument = gql`
 `;
 
 /**
- * __useGetAllHouseholdAssessmentsQuery__
+ * __useGetHouseholdAssessmentsQuery__
  *
- * To run a query within a React component, call `useGetAllHouseholdAssessmentsQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetAllHouseholdAssessmentsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useGetHouseholdAssessmentsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetHouseholdAssessmentsQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useGetAllHouseholdAssessmentsQuery({
+ * const { data, loading, error } = useGetHouseholdAssessmentsQuery({
  *   variables: {
  *      id: // value for 'id'
  *      limit: // value for 'limit'
@@ -23690,39 +23194,39 @@ export const GetAllHouseholdAssessmentsDocument = gql`
  *   },
  * });
  */
-export function useGetAllHouseholdAssessmentsQuery(
+export function useGetHouseholdAssessmentsQuery(
   baseOptions: Apollo.QueryHookOptions<
-    GetAllHouseholdAssessmentsQuery,
-    GetAllHouseholdAssessmentsQueryVariables
+    GetHouseholdAssessmentsQuery,
+    GetHouseholdAssessmentsQueryVariables
   >
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<
-    GetAllHouseholdAssessmentsQuery,
-    GetAllHouseholdAssessmentsQueryVariables
-  >(GetAllHouseholdAssessmentsDocument, options);
+    GetHouseholdAssessmentsQuery,
+    GetHouseholdAssessmentsQueryVariables
+  >(GetHouseholdAssessmentsDocument, options);
 }
-export function useGetAllHouseholdAssessmentsLazyQuery(
+export function useGetHouseholdAssessmentsLazyQuery(
   baseOptions?: Apollo.LazyQueryHookOptions<
-    GetAllHouseholdAssessmentsQuery,
-    GetAllHouseholdAssessmentsQueryVariables
+    GetHouseholdAssessmentsQuery,
+    GetHouseholdAssessmentsQueryVariables
   >
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useLazyQuery<
-    GetAllHouseholdAssessmentsQuery,
-    GetAllHouseholdAssessmentsQueryVariables
-  >(GetAllHouseholdAssessmentsDocument, options);
+    GetHouseholdAssessmentsQuery,
+    GetHouseholdAssessmentsQueryVariables
+  >(GetHouseholdAssessmentsDocument, options);
 }
-export type GetAllHouseholdAssessmentsQueryHookResult = ReturnType<
-  typeof useGetAllHouseholdAssessmentsQuery
+export type GetHouseholdAssessmentsQueryHookResult = ReturnType<
+  typeof useGetHouseholdAssessmentsQuery
 >;
-export type GetAllHouseholdAssessmentsLazyQueryHookResult = ReturnType<
-  typeof useGetAllHouseholdAssessmentsLazyQuery
+export type GetHouseholdAssessmentsLazyQueryHookResult = ReturnType<
+  typeof useGetHouseholdAssessmentsLazyQuery
 >;
-export type GetAllHouseholdAssessmentsQueryResult = Apollo.QueryResult<
-  GetAllHouseholdAssessmentsQuery,
-  GetAllHouseholdAssessmentsQueryVariables
+export type GetHouseholdAssessmentsQueryResult = Apollo.QueryResult<
+  GetHouseholdAssessmentsQuery,
+  GetHouseholdAssessmentsQueryVariables
 >;
 export const GetRelatedAnnualsDocument = gql`
   query GetRelatedAnnuals($householdId: ID!, $assessmentId: ID) {

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -239,6 +239,14 @@ export enum AssessmentType {
   Virtual = 'VIRTUAL',
 }
 
+export type AssessmentsForEnrollmentFilterOptions = {
+  type?: InputMaybe<Array<AssessmentRole>>;
+};
+
+export type AssessmentsForHouseholdFilterOptions = {
+  type?: InputMaybe<Array<AssessmentRole>>;
+};
+
 export type AssessmentsPaginated = {
   __typename?: 'AssessmentsPaginated';
   hasMoreAfter: Scalars['Boolean']['output'];
@@ -1927,7 +1935,7 @@ export type Enrollment = {
 
 /** HUD Enrollment */
 export type EnrollmentAssessmentsArgs = {
-  filters?: InputMaybe<AssessmentFilterOptions>;
+  filters?: InputMaybe<AssessmentsForEnrollmentFilterOptions>;
   inProgress?: InputMaybe<Scalars['Boolean']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
@@ -2773,13 +2781,21 @@ export type HmisParticipationsPaginated = {
   pagesCount: Scalars['Int']['output'];
 };
 
-/** HUD Household */
 export type Household = {
   __typename?: 'Household';
+  assessments: AssessmentsPaginated;
   householdClients: Array<HouseholdClient>;
   householdSize: Scalars['Int']['output'];
   id: Scalars['ID']['output'];
   shortId: Scalars['ID']['output'];
+};
+
+export type HouseholdAssessmentsArgs = {
+  filters?: InputMaybe<AssessmentsForHouseholdFilterOptions>;
+  inProgress?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  sortOrder?: InputMaybe<AssessmentSortOption>;
 };
 
 /** HUD Client within a Household */
@@ -6710,428 +6726,6 @@ export type AssessmentFieldsFragment = {
   dateDeleted?: string | null;
   role: AssessmentRole;
   user?: { __typename: 'User'; id: string; name: string } | null;
-  access: {
-    __typename?: 'AssessmentAccess';
-    id: string;
-    canDeleteAssessments: boolean;
-    canDeleteEnrollments: boolean;
-    canEditEnrollments: boolean;
-  };
-};
-
-export type AssessmentWithValuesAndRecordsFragment = {
-  __typename?: 'Assessment';
-  wipValues?: any | null;
-  id: string;
-  lockVersion: number;
-  inProgress: boolean;
-  assessmentDate: string;
-  dataCollectionStage?: DataCollectionStage | null;
-  dateCreated?: string | null;
-  dateUpdated?: string | null;
-  dateDeleted?: string | null;
-  role: AssessmentRole;
-  enrollment: {
-    __typename?: 'Enrollment';
-    id: string;
-    lockVersion: number;
-    entryDate: string;
-    exitDate?: string | null;
-    disablingCondition?: NoYesReasonsForMissingData | null;
-    dateOfEngagement?: string | null;
-    moveInDate?: string | null;
-    livingSituation?: PriorLivingSituation | null;
-    rentalSubsidyType?: RentalSubsidyType | null;
-    lengthOfStay?: ResidencePriorLengthOfStay | null;
-    losUnderThreshold?: NoYesMissing | null;
-    previousStreetEssh?: NoYesMissing | null;
-    dateToStreetEssh?: string | null;
-    timesHomelessPastThreeYears?: TimesHomelessPastThreeYears | null;
-    monthsHomelessPastThreeYears?: MonthsHomelessPastThreeYears | null;
-    enrollmentCoc?: string | null;
-    dateOfPathStatus?: string | null;
-    clientEnrolledInPath?: NoYesMissing | null;
-    reasonNotEnrolled?: ReasonNotEnrolled | null;
-    percentAmi?: PercentAmi | null;
-    referralSource?: ReferralSource | null;
-    countOutreachReferralApproaches?: number | null;
-    dateOfBcpStatus?: string | null;
-    eligibleForRhy?: NoYesMissing | null;
-    reasonNoServices?: ReasonNoServices | null;
-    runawayYouth?: NoYesReasonsForMissingData | null;
-    sexualOrientation?: SexualOrientation | null;
-    sexualOrientationOther?: string | null;
-    formerWardChildWelfare?: NoYesReasonsForMissingData | null;
-    childWelfareYears?: RhyNumberofYears | null;
-    childWelfareMonths?: number | null;
-    formerWardJuvenileJustice?: NoYesReasonsForMissingData | null;
-    juvenileJusticeYears?: RhyNumberofYears | null;
-    juvenileJusticeMonths?: number | null;
-    unemploymentFam?: NoYesMissing | null;
-    mentalHealthDisorderFam?: NoYesMissing | null;
-    physicalDisabilityFam?: NoYesMissing | null;
-    alcoholDrugUseDisorderFam?: NoYesMissing | null;
-    insufficientIncome?: NoYesMissing | null;
-    incarceratedParent?: NoYesMissing | null;
-    targetScreenReqd?: NoYesMissing | null;
-    timeToHousingLoss?: TimeToHousingLoss | null;
-    annualPercentAmi?: AnnualPercentAmi | null;
-    literalHomelessHistory?: LiteralHomelessHistory | null;
-    clientLeaseholder?: NoYesMissing | null;
-    hohLeaseholder?: NoYesMissing | null;
-    subsidyAtRisk?: NoYesMissing | null;
-    evictionHistory?: EvictionHistory | null;
-    criminalRecord?: NoYesMissing | null;
-    incarceratedAdult?: IncarceratedAdult | null;
-    prisonDischarge?: NoYesMissing | null;
-    sexOffender?: NoYesMissing | null;
-    disabledHoh?: NoYesMissing | null;
-    currentPregnant?: NoYesMissing | null;
-    singleParent?: NoYesMissing | null;
-    dependentUnder6?: DependentUnder6 | null;
-    hh5Plus?: NoYesMissing | null;
-    cocPrioritized?: NoYesMissing | null;
-    hpScreeningScore?: number | null;
-    thresholdScore?: number | null;
-    vamcStation?: VamcStationNumber | null;
-    translationNeeded?: NoYesReasonsForMissingData | null;
-    preferredLanguage?: PreferredLanguage | null;
-    preferredLanguageDifferent?: string | null;
-    customDataElements: Array<{
-      __typename?: 'CustomDataElement';
-      id: string;
-      key: string;
-      label: string;
-      fieldType: CustomDataElementType;
-      repeats: boolean;
-      value?: {
-        __typename?: 'CustomDataElementValue';
-        id: string;
-        valueBoolean?: boolean | null;
-        valueDate?: string | null;
-        valueFloat?: number | null;
-        valueInteger?: number | null;
-        valueJson?: any | null;
-        valueString?: string | null;
-        valueText?: string | null;
-        dateCreated?: string | null;
-        dateUpdated?: string | null;
-        user?: { __typename: 'User'; id: string; name: string } | null;
-      } | null;
-      values?: Array<{
-        __typename?: 'CustomDataElementValue';
-        id: string;
-        valueBoolean?: boolean | null;
-        valueDate?: string | null;
-        valueFloat?: number | null;
-        valueInteger?: number | null;
-        valueJson?: any | null;
-        valueString?: string | null;
-        valueText?: string | null;
-        dateCreated?: string | null;
-        dateUpdated?: string | null;
-        user?: { __typename: 'User'; id: string; name: string } | null;
-      }> | null;
-    }>;
-    client: { __typename?: 'Client'; id: string };
-  };
-  incomeBenefit?: {
-    __typename: 'IncomeBenefit';
-    adap?: NoYesReasonsForMissingData | null;
-    alimony?: NoYesMissing | null;
-    alimonyAmount?: number | null;
-    benefitsFromAnySource?: NoYesReasonsForMissingData | null;
-    childSupport?: NoYesMissing | null;
-    childSupportAmount?: number | null;
-    cobra?: NoYesMissing | null;
-    connectionWithSoar?: NoYesReasonsForMissingData | null;
-    dataCollectionStage: DataCollectionStage;
-    dateCreated?: string | null;
-    dateDeleted?: string | null;
-    dateUpdated?: string | null;
-    earned?: NoYesMissing | null;
-    earnedAmount?: number | null;
-    employerProvided?: NoYesMissing | null;
-    ga?: NoYesMissing | null;
-    gaAmount?: number | null;
-    id: string;
-    incomeFromAnySource?: NoYesReasonsForMissingData | null;
-    indianHealthServices?: NoYesMissing | null;
-    informationDate?: string | null;
-    insuranceFromAnySource?: NoYesReasonsForMissingData | null;
-    medicaid?: NoYesMissing | null;
-    medicare?: NoYesMissing | null;
-    noAdapReason?: NoAssistanceReason | null;
-    noCobraReason?: ReasonNotInsured | null;
-    noEmployerProvidedReason?: ReasonNotInsured | null;
-    noIndianHealthServicesReason?: ReasonNotInsured | null;
-    noMedicaidReason?: ReasonNotInsured | null;
-    noMedicareReason?: ReasonNotInsured | null;
-    noPrivatePayReason?: ReasonNotInsured | null;
-    noRyanWhiteReason?: NoAssistanceReason | null;
-    noSchipReason?: ReasonNotInsured | null;
-    noStateHealthInsReason?: ReasonNotInsured | null;
-    noVhaReason?: ReasonNotInsured | null;
-    otherBenefitsSource?: NoYesMissing | null;
-    otherBenefitsSourceIdentify?: string | null;
-    otherIncomeAmount?: number | null;
-    otherIncomeSource?: NoYesMissing | null;
-    otherIncomeSourceIdentify?: string | null;
-    otherInsurance?: NoYesMissing | null;
-    otherInsuranceIdentify?: string | null;
-    otherTanf?: NoYesMissing | null;
-    pension?: NoYesMissing | null;
-    pensionAmount?: number | null;
-    privateDisability?: NoYesMissing | null;
-    privateDisabilityAmount?: number | null;
-    privatePay?: NoYesMissing | null;
-    ryanWhiteMedDent?: NoYesReasonsForMissingData | null;
-    schip?: NoYesMissing | null;
-    snap?: NoYesMissing | null;
-    socSecRetirement?: NoYesMissing | null;
-    socSecRetirementAmount?: number | null;
-    ssdi?: NoYesMissing | null;
-    ssdiAmount?: number | null;
-    ssi?: NoYesMissing | null;
-    ssiAmount?: number | null;
-    stateHealthIns?: NoYesMissing | null;
-    tanf?: NoYesMissing | null;
-    tanfAmount?: number | null;
-    tanfChildCare?: NoYesMissing | null;
-    tanfTransportation?: NoYesMissing | null;
-    totalMonthlyIncome?: string | null;
-    unemployment?: NoYesMissing | null;
-    unemploymentAmount?: number | null;
-    vaDisabilityNonService?: NoYesMissing | null;
-    vaDisabilityNonServiceAmount?: number | null;
-    vaDisabilityService?: NoYesMissing | null;
-    vaDisabilityServiceAmount?: number | null;
-    vhaServices?: NoYesMissing | null;
-    wic?: NoYesMissing | null;
-    workersComp?: NoYesMissing | null;
-    workersCompAmount?: number | null;
-    customDataElements: Array<{
-      __typename?: 'CustomDataElement';
-      id: string;
-      key: string;
-      label: string;
-      fieldType: CustomDataElementType;
-      repeats: boolean;
-      value?: {
-        __typename?: 'CustomDataElementValue';
-        id: string;
-        valueBoolean?: boolean | null;
-        valueDate?: string | null;
-        valueFloat?: number | null;
-        valueInteger?: number | null;
-        valueJson?: any | null;
-        valueString?: string | null;
-        valueText?: string | null;
-        dateCreated?: string | null;
-        dateUpdated?: string | null;
-        user?: { __typename: 'User'; id: string; name: string } | null;
-      } | null;
-      values?: Array<{
-        __typename?: 'CustomDataElementValue';
-        id: string;
-        valueBoolean?: boolean | null;
-        valueDate?: string | null;
-        valueFloat?: number | null;
-        valueInteger?: number | null;
-        valueJson?: any | null;
-        valueString?: string | null;
-        valueText?: string | null;
-        dateCreated?: string | null;
-        dateUpdated?: string | null;
-        user?: { __typename: 'User'; id: string; name: string } | null;
-      }> | null;
-    }>;
-  } | null;
-  disabilityGroup?: {
-    __typename: 'DisabilityGroup';
-    id: string;
-    dataCollectionStage: DataCollectionStage;
-    informationDate: string;
-    disablingCondition: NoYesReasonsForMissingData;
-    chronicHealthCondition?: NoYesReasonsForMissingData | null;
-    chronicHealthConditionIndefiniteAndImpairs?: NoYesReasonsForMissingData | null;
-    developmentalDisability?: NoYesReasonsForMissingData | null;
-    hivAids?: NoYesReasonsForMissingData | null;
-    mentalHealthDisorder?: NoYesReasonsForMissingData | null;
-    mentalHealthDisorderIndefiniteAndImpairs?: NoYesReasonsForMissingData | null;
-    physicalDisability?: NoYesReasonsForMissingData | null;
-    physicalDisabilityIndefiniteAndImpairs?: NoYesReasonsForMissingData | null;
-    substanceUseDisorder?: DisabilityResponse | null;
-    substanceUseDisorderIndefiniteAndImpairs?: NoYesReasonsForMissingData | null;
-    dateCreated?: string | null;
-    dateUpdated?: string | null;
-    tCellCountAvailable?: NoYesReasonsForMissingData | null;
-    tCellCount?: number | null;
-    tCellSource?: TCellSourceViralLoadSource | null;
-    viralLoadAvailable?: ViralLoadAvailable | null;
-    viralLoad?: number | null;
-    antiRetroviral?: NoYesReasonsForMissingData | null;
-  } | null;
-  healthAndDv?: {
-    __typename: 'HealthAndDv';
-    currentlyFleeing?: NoYesReasonsForMissingData | null;
-    dataCollectionStage: DataCollectionStage;
-    dateCreated?: string | null;
-    dateDeleted?: string | null;
-    dateUpdated?: string | null;
-    dentalHealthStatus?: HealthStatus | null;
-    domesticViolenceSurvivor?: NoYesReasonsForMissingData | null;
-    dueDate?: string | null;
-    generalHealthStatus?: HealthStatus | null;
-    id: string;
-    informationDate?: string | null;
-    mentalHealthStatus?: HealthStatus | null;
-    pregnancyStatus?: NoYesReasonsForMissingData | null;
-    whenOccurred?: WhenDvOccurred | null;
-  } | null;
-  exit?: {
-    __typename?: 'Exit';
-    id: string;
-    aftercareDate?: string | null;
-    aftercareProvided?: AftercareProvided | null;
-    aftercareMethods?: Array<AftercareMethod> | null;
-    askedOrForcedToExchangeForSex?: NoYesReasonsForMissingData | null;
-    askedOrForcedToExchangeForSexPastThreeMonths?: NoYesReasonsForMissingData | null;
-    cmExitReason?: CmExitReason | null;
-    coercedToContinueWork?: NoYesReasonsForMissingData | null;
-    counselingReceived?: NoYesMissing | null;
-    counselingMethods?: Array<CounselingMethod> | null;
-    countOfExchangeForSex?: CountExchangeForSex | null;
-    dateCreated?: string | null;
-    dateDeleted?: string | null;
-    dateUpdated?: string | null;
-    destination: Destination;
-    destinationSafeClient?: NoYesReasonsForMissingData | null;
-    destinationSafeWorker?: WorkerResponse | null;
-    destinationSubsidyType?: RentalSubsidyType | null;
-    earlyExitReason?: ExpelledReason | null;
-    exchangeForSex?: NoYesReasonsForMissingData | null;
-    exchangeForSexPastThreeMonths?: NoYesReasonsForMissingData | null;
-    exitDate: string;
-    housingAssessment?: HousingAssessmentAtExit | null;
-    laborExploitPastThreeMonths?: NoYesReasonsForMissingData | null;
-    otherDestination?: string | null;
-    posAdultConnections?: WorkerResponse | null;
-    posCommunityConnections?: WorkerResponse | null;
-    posPeerConnections?: WorkerResponse | null;
-    postExitCounselingPlan?: NoYesMissing | null;
-    projectCompletionStatus?: ProjectCompletionStatus | null;
-    sessionCountAtExit?: number | null;
-    sessionsInPlan?: number | null;
-    subsidyInformation?: SubsidyInformation | null;
-    workPlaceViolenceThreats?: NoYesReasonsForMissingData | null;
-    workplacePromiseDifference?: NoYesReasonsForMissingData | null;
-    customDataElements: Array<{
-      __typename?: 'CustomDataElement';
-      id: string;
-      key: string;
-      label: string;
-      fieldType: CustomDataElementType;
-      repeats: boolean;
-      value?: {
-        __typename?: 'CustomDataElementValue';
-        id: string;
-        valueBoolean?: boolean | null;
-        valueDate?: string | null;
-        valueFloat?: number | null;
-        valueInteger?: number | null;
-        valueJson?: any | null;
-        valueString?: string | null;
-        valueText?: string | null;
-        dateCreated?: string | null;
-        dateUpdated?: string | null;
-        user?: { __typename: 'User'; id: string; name: string } | null;
-      } | null;
-      values?: Array<{
-        __typename?: 'CustomDataElementValue';
-        id: string;
-        valueBoolean?: boolean | null;
-        valueDate?: string | null;
-        valueFloat?: number | null;
-        valueInteger?: number | null;
-        valueJson?: any | null;
-        valueString?: string | null;
-        valueText?: string | null;
-        dateCreated?: string | null;
-        dateUpdated?: string | null;
-        user?: { __typename: 'User'; id: string; name: string } | null;
-      }> | null;
-    }>;
-  } | null;
-  youthEducationStatus?: {
-    __typename?: 'YouthEducationStatus';
-    currentEdStatus?: CurrentEdStatus | null;
-    currentSchoolAttend?: CurrentSchoolAttended | null;
-    dataCollectionStage: DataCollectionStage;
-    dateCreated?: string | null;
-    dateDeleted?: string | null;
-    dateUpdated?: string | null;
-    id: string;
-    informationDate?: string | null;
-    mostRecentEdStatus?: MostRecentEdStatus | null;
-  } | null;
-  employmentEducation?: {
-    __typename?: 'EmploymentEducation';
-    dataCollectionStage: DataCollectionStage;
-    dateCreated?: string | null;
-    dateDeleted?: string | null;
-    employed?: NoYesReasonsForMissingData | null;
-    employmentType?: EmploymentType | null;
-    id: string;
-    informationDate?: string | null;
-    lastGradeCompleted?: LastGradeCompleted | null;
-    notEmployedReason?: NotEmployedReason | null;
-    schoolStatus?: SchoolStatus | null;
-  } | null;
-  customDataElements: Array<{
-    __typename?: 'CustomDataElement';
-    id: string;
-    key: string;
-    label: string;
-    fieldType: CustomDataElementType;
-    repeats: boolean;
-    value?: {
-      __typename?: 'CustomDataElementValue';
-      id: string;
-      valueBoolean?: boolean | null;
-      valueDate?: string | null;
-      valueFloat?: number | null;
-      valueInteger?: number | null;
-      valueJson?: any | null;
-      valueString?: string | null;
-      valueText?: string | null;
-      dateCreated?: string | null;
-      dateUpdated?: string | null;
-      user?: { __typename: 'User'; id: string; name: string } | null;
-    } | null;
-    values?: Array<{
-      __typename?: 'CustomDataElementValue';
-      id: string;
-      valueBoolean?: boolean | null;
-      valueDate?: string | null;
-      valueFloat?: number | null;
-      valueInteger?: number | null;
-      valueJson?: any | null;
-      valueString?: string | null;
-      valueText?: string | null;
-      dateCreated?: string | null;
-      dateUpdated?: string | null;
-      user?: { __typename: 'User'; id: string; name: string } | null;
-    }> | null;
-  }>;
-  user?: { __typename: 'User'; id: string; name: string } | null;
-  access: {
-    __typename?: 'AssessmentAccess';
-    id: string;
-    canDeleteAssessments: boolean;
-    canDeleteEnrollments: boolean;
-    canEditEnrollments: boolean;
-  };
 };
 
 export type AssessmentWithRecordsFragment = {
@@ -7538,7 +7132,6 @@ export type AssessmentWithRecordsFragment = {
       user?: { __typename: 'User'; id: string; name: string } | null;
     }> | null;
   }>;
-  user?: { __typename: 'User'; id: string; name: string } | null;
   access: {
     __typename?: 'AssessmentAccess';
     id: string;
@@ -7546,6 +7139,7 @@ export type AssessmentWithRecordsFragment = {
     canDeleteEnrollments: boolean;
     canEditEnrollments: boolean;
   };
+  user?: { __typename: 'User'; id: string; name: string } | null;
 };
 
 export type AssessmentWithValuesFragment = {
@@ -7561,13 +7155,6 @@ export type AssessmentWithValuesFragment = {
   dateDeleted?: string | null;
   role: AssessmentRole;
   user?: { __typename: 'User'; id: string; name: string } | null;
-  access: {
-    __typename?: 'AssessmentAccess';
-    id: string;
-    canDeleteAssessments: boolean;
-    canDeleteEnrollments: boolean;
-    canEditEnrollments: boolean;
-  };
 };
 
 export type FullAssessmentFragment = {
@@ -7975,7 +7562,6 @@ export type FullAssessmentFragment = {
       user?: { __typename: 'User'; id: string; name: string } | null;
     }> | null;
   }>;
-  user?: { __typename: 'User'; id: string; name: string } | null;
   access: {
     __typename?: 'AssessmentAccess';
     id: string;
@@ -7983,6 +7569,7 @@ export type FullAssessmentFragment = {
     canDeleteEnrollments: boolean;
     canEditEnrollments: boolean;
   };
+  user?: { __typename: 'User'; id: string; name: string } | null;
 };
 
 export type GetAssessmentQueryVariables = Exact<{
@@ -8866,7 +8453,6 @@ export type GetAssessmentQuery = {
         user?: { __typename: 'User'; id: string; name: string } | null;
       }> | null;
     }>;
-    user?: { __typename: 'User'; id: string; name: string } | null;
     access: {
       __typename?: 'AssessmentAccess';
       id: string;
@@ -8874,6 +8460,7 @@ export type GetAssessmentQuery = {
       canDeleteEnrollments: boolean;
       canEditEnrollments: boolean;
     };
+    user?: { __typename: 'User'; id: string; name: string } | null;
   } | null;
 };
 
@@ -8926,13 +8513,6 @@ export type GetClientAssessmentsQuery = {
           };
         };
         user?: { __typename: 'User'; id: string; name: string } | null;
-        access: {
-          __typename?: 'AssessmentAccess';
-          id: string;
-          canDeleteAssessments: boolean;
-          canDeleteEnrollments: boolean;
-          canEditEnrollments: boolean;
-        };
       }>;
     };
   } | null;
@@ -8944,7 +8524,7 @@ export type GetEnrollmentAssessmentsQueryVariables = Exact<{
   offset?: InputMaybe<Scalars['Int']['input']>;
   inProgress?: InputMaybe<Scalars['Boolean']['input']>;
   sortOrder?: InputMaybe<AssessmentSortOption>;
-  filters?: InputMaybe<AssessmentFilterOptions>;
+  filters?: InputMaybe<AssessmentsForEnrollmentFilterOptions>;
 }>;
 
 export type GetEnrollmentAssessmentsQuery = {
@@ -8969,13 +8549,6 @@ export type GetEnrollmentAssessmentsQuery = {
         dateDeleted?: string | null;
         role: AssessmentRole;
         user?: { __typename: 'User'; id: string; name: string } | null;
-        access: {
-          __typename?: 'AssessmentAccess';
-          id: string;
-          canDeleteAssessments: boolean;
-          canDeleteEnrollments: boolean;
-          canEditEnrollments: boolean;
-        };
       }>;
     };
   } | null;
@@ -9394,7 +8967,6 @@ export type GetHouseholdAssessmentsQuery = {
         user?: { __typename: 'User'; id: string; name: string } | null;
       }> | null;
     }>;
-    user?: { __typename: 'User'; id: string; name: string } | null;
     access: {
       __typename?: 'AssessmentAccess';
       id: string;
@@ -9402,7 +8974,58 @@ export type GetHouseholdAssessmentsQuery = {
       canDeleteEnrollments: boolean;
       canEditEnrollments: boolean;
     };
+    user?: { __typename: 'User'; id: string; name: string } | null;
   }> | null;
+};
+
+export type GetAllHouseholdAssessmentsQueryVariables = Exact<{
+  id: Scalars['ID']['input'];
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  inProgress?: InputMaybe<Scalars['Boolean']['input']>;
+  sortOrder?: InputMaybe<AssessmentSortOption>;
+  filters?: InputMaybe<AssessmentsForHouseholdFilterOptions>;
+}>;
+
+export type GetAllHouseholdAssessmentsQuery = {
+  __typename?: 'Query';
+  household?: {
+    __typename?: 'Household';
+    id: string;
+    assessments: {
+      __typename?: 'AssessmentsPaginated';
+      offset: number;
+      limit: number;
+      nodesCount: number;
+      nodes: Array<{
+        __typename?: 'Assessment';
+        id: string;
+        lockVersion: number;
+        inProgress: boolean;
+        assessmentDate: string;
+        dataCollectionStage?: DataCollectionStage | null;
+        dateCreated?: string | null;
+        dateUpdated?: string | null;
+        dateDeleted?: string | null;
+        role: AssessmentRole;
+        enrollment: {
+          __typename?: 'Enrollment';
+          id: string;
+          relationshipToHoH: RelationshipToHoH;
+          client: {
+            __typename?: 'Client';
+            id: string;
+            lockVersion: number;
+            firstName?: string | null;
+            middleName?: string | null;
+            lastName?: string | null;
+            nameSuffix?: string | null;
+          };
+        };
+        user?: { __typename: 'User'; id: string; name: string } | null;
+      }>;
+    };
+  } | null;
 };
 
 export type GetRelatedAnnualsQueryVariables = Exact<{
@@ -9454,13 +9077,6 @@ export type SaveAssessmentMutation = {
       dateDeleted?: string | null;
       role: AssessmentRole;
       user?: { __typename: 'User'; id: string; name: string } | null;
-      access: {
-        __typename?: 'AssessmentAccess';
-        id: string;
-        canDeleteAssessments: boolean;
-        canDeleteEnrollments: boolean;
-        canEditEnrollments: boolean;
-      };
     } | null;
     errors: Array<{
       __typename?: 'ValidationError';
@@ -9891,7 +9507,6 @@ export type SubmitAssessmentMutation = {
           user?: { __typename: 'User'; id: string; name: string } | null;
         }> | null;
       }>;
-      user?: { __typename: 'User'; id: string; name: string } | null;
       access: {
         __typename?: 'AssessmentAccess';
         id: string;
@@ -9899,6 +9514,7 @@ export type SubmitAssessmentMutation = {
         canDeleteEnrollments: boolean;
         canEditEnrollments: boolean;
       };
+      user?: { __typename: 'User'; id: string; name: string } | null;
     } | null;
     errors: Array<{
       __typename?: 'ValidationError';
@@ -10329,7 +9945,6 @@ export type SubmitHouseholdAssessmentsMutation = {
           user?: { __typename: 'User'; id: string; name: string } | null;
         }> | null;
       }>;
-      user?: { __typename: 'User'; id: string; name: string } | null;
       access: {
         __typename?: 'AssessmentAccess';
         id: string;
@@ -10337,6 +9952,7 @@ export type SubmitHouseholdAssessmentsMutation = {
         canDeleteEnrollments: boolean;
         canEditEnrollments: boolean;
       };
+      user?: { __typename: 'User'; id: string; name: string } | null;
     }> | null;
     errors: Array<{
       __typename?: 'ValidationError';
@@ -10782,7 +10398,6 @@ export type GetAssessmentsForPopulationQuery = {
             user?: { __typename: 'User'; id: string; name: string } | null;
           }> | null;
         }>;
-        user?: { __typename: 'User'; id: string; name: string } | null;
         access: {
           __typename?: 'AssessmentAccess';
           id: string;
@@ -10790,6 +10405,7 @@ export type GetAssessmentsForPopulationQuery = {
           canDeleteEnrollments: boolean;
           canEditEnrollments: boolean;
         };
+        user?: { __typename: 'User'; id: string; name: string } | null;
       }>;
     };
   } | null;
@@ -21890,14 +21506,6 @@ export const UserFieldsFragmentDoc = gql`
     name
   }
 `;
-export const AssessmentAccessFieldsFragmentDoc = gql`
-  fragment AssessmentAccessFields on AssessmentAccess {
-    id
-    canDeleteAssessments
-    canDeleteEnrollments
-    canEditEnrollments
-  }
-`;
 export const AssessmentFieldsFragmentDoc = gql`
   fragment AssessmentFields on Assessment {
     id
@@ -21912,19 +21520,8 @@ export const AssessmentFieldsFragmentDoc = gql`
     user {
       ...UserFields
     }
-    access {
-      ...AssessmentAccessFields
-    }
   }
   ${UserFieldsFragmentDoc}
-  ${AssessmentAccessFieldsFragmentDoc}
-`;
-export const AssessmentWithValuesFragmentDoc = gql`
-  fragment AssessmentWithValues on Assessment {
-    ...AssessmentFields
-    wipValues
-  }
-  ${AssessmentFieldsFragmentDoc}
 `;
 export const EnrollmentValuesFragmentDoc = gql`
   fragment EnrollmentValues on Enrollment {
@@ -22223,6 +21820,14 @@ export const EmploymentEducationValuesFragmentDoc = gql`
     schoolStatus
   }
 `;
+export const AssessmentAccessFieldsFragmentDoc = gql`
+  fragment AssessmentAccessFields on AssessmentAccess {
+    id
+    canDeleteAssessments
+    canDeleteEnrollments
+    canEditEnrollments
+  }
+`;
 export const AssessmentWithRecordsFragmentDoc = gql`
   fragment AssessmentWithRecords on Assessment {
     ...AssessmentFields
@@ -22262,6 +21867,9 @@ export const AssessmentWithRecordsFragmentDoc = gql`
     customDataElements {
       ...CustomDataElementFields
     }
+    access {
+      ...AssessmentAccessFields
+    }
   }
   ${AssessmentFieldsFragmentDoc}
   ${EnrollmentValuesFragmentDoc}
@@ -22272,17 +21880,14 @@ export const AssessmentWithRecordsFragmentDoc = gql`
   ${ExitValuesFragmentDoc}
   ${YouthEducationStatusValuesFragmentDoc}
   ${EmploymentEducationValuesFragmentDoc}
+  ${AssessmentAccessFieldsFragmentDoc}
 `;
-export const AssessmentWithValuesAndRecordsFragmentDoc = gql`
-  fragment AssessmentWithValuesAndRecords on Assessment {
-    ...AssessmentWithValues
-    ...AssessmentWithRecords
-    enrollment {
-      id
-    }
+export const AssessmentWithValuesFragmentDoc = gql`
+  fragment AssessmentWithValues on Assessment {
+    ...AssessmentFields
+    wipValues
   }
-  ${AssessmentWithValuesFragmentDoc}
-  ${AssessmentWithRecordsFragmentDoc}
+  ${AssessmentFieldsFragmentDoc}
 `;
 export const FullAssessmentFragmentDoc = gql`
   fragment FullAssessment on Assessment {
@@ -23876,7 +23481,7 @@ export const GetEnrollmentAssessmentsDocument = gql`
     $offset: Int = 0
     $inProgress: Boolean
     $sortOrder: AssessmentSortOption = ASSESSMENT_DATE
-    $filters: AssessmentFilterOptions
+    $filters: AssessmentsForEnrollmentFilterOptions
   ) {
     enrollment(id: $id) {
       id
@@ -23965,10 +23570,13 @@ export const GetHouseholdAssessmentsDocument = gql`
       assessmentRole: $assessmentRole
       assessmentId: $assessmentId
     ) {
-      ...AssessmentWithValuesAndRecords
+      ...FullAssessment
+      enrollment {
+        id
+      }
     }
   }
-  ${AssessmentWithValuesAndRecordsFragmentDoc}
+  ${FullAssessmentFragmentDoc}
 `;
 
 /**
@@ -24022,6 +23630,99 @@ export type GetHouseholdAssessmentsLazyQueryHookResult = ReturnType<
 export type GetHouseholdAssessmentsQueryResult = Apollo.QueryResult<
   GetHouseholdAssessmentsQuery,
   GetHouseholdAssessmentsQueryVariables
+>;
+export const GetAllHouseholdAssessmentsDocument = gql`
+  query GetAllHouseholdAssessments(
+    $id: ID!
+    $limit: Int = 10
+    $offset: Int = 0
+    $inProgress: Boolean
+    $sortOrder: AssessmentSortOption = ASSESSMENT_DATE
+    $filters: AssessmentsForHouseholdFilterOptions
+  ) {
+    household(id: $id) {
+      id
+      assessments(
+        limit: $limit
+        offset: $offset
+        inProgress: $inProgress
+        sortOrder: $sortOrder
+        filters: $filters
+      ) {
+        offset
+        limit
+        nodesCount
+        nodes {
+          ...AssessmentFields
+          enrollment {
+            id
+            relationshipToHoH
+            client {
+              ...ClientName
+            }
+          }
+        }
+      }
+    }
+  }
+  ${AssessmentFieldsFragmentDoc}
+  ${ClientNameFragmentDoc}
+`;
+
+/**
+ * __useGetAllHouseholdAssessmentsQuery__
+ *
+ * To run a query within a React component, call `useGetAllHouseholdAssessmentsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetAllHouseholdAssessmentsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetAllHouseholdAssessmentsQuery({
+ *   variables: {
+ *      id: // value for 'id'
+ *      limit: // value for 'limit'
+ *      offset: // value for 'offset'
+ *      inProgress: // value for 'inProgress'
+ *      sortOrder: // value for 'sortOrder'
+ *      filters: // value for 'filters'
+ *   },
+ * });
+ */
+export function useGetAllHouseholdAssessmentsQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    GetAllHouseholdAssessmentsQuery,
+    GetAllHouseholdAssessmentsQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    GetAllHouseholdAssessmentsQuery,
+    GetAllHouseholdAssessmentsQueryVariables
+  >(GetAllHouseholdAssessmentsDocument, options);
+}
+export function useGetAllHouseholdAssessmentsLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GetAllHouseholdAssessmentsQuery,
+    GetAllHouseholdAssessmentsQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    GetAllHouseholdAssessmentsQuery,
+    GetAllHouseholdAssessmentsQueryVariables
+  >(GetAllHouseholdAssessmentsDocument, options);
+}
+export type GetAllHouseholdAssessmentsQueryHookResult = ReturnType<
+  typeof useGetAllHouseholdAssessmentsQuery
+>;
+export type GetAllHouseholdAssessmentsLazyQueryHookResult = ReturnType<
+  typeof useGetAllHouseholdAssessmentsLazyQuery
+>;
+export type GetAllHouseholdAssessmentsQueryResult = Apollo.QueryResult<
+  GetAllHouseholdAssessmentsQuery,
+  GetAllHouseholdAssessmentsQueryVariables
 >;
 export const GetRelatedAnnualsDocument = gql`
   query GetRelatedAnnuals($householdId: ID!, $assessmentId: ID) {


### PR DESCRIPTION
## Description

Add a new toggle to the enrollment dashboard assessment table for multi-member households. When toggled to "household" you can see one row per assessment for all assessments in the household. 

[//]: # 'remove if not applicable'
Depends on hmis-warehouse PR: https://github.com/greenriver/hmis-warehouse/pull/3745

## Type of change
[//]: # 'remove options that are not relevant'
- [x] New feature (adds functionality)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
