### PR TITLE
186395195 stale object error when submitting household assessments

### DIFF
--- a/src/components/elements/Loading.tsx
+++ b/src/components/elements/Loading.tsx
@@ -8,6 +8,8 @@ const Loading = () => (
     height='100%'
     data-testid='loading'
     sx={{ p: 10 }}
+    aria-live='polite'
+    aria-busy='true'
   >
     <CircularProgress size={50} />
   </Box>

--- a/src/components/elements/LoadingSkeleton.tsx
+++ b/src/components/elements/LoadingSkeleton.tsx
@@ -1,6 +1,5 @@
 import { Box, Skeleton } from '@mui/material';
 import { BoxProps } from '@mui/system';
-import times from 'lodash-es/times';
 import React from 'react';
 
 interface Props extends BoxProps {
@@ -16,7 +15,7 @@ const LoadingSkeleton: React.FC<Props> = ({
 }) => {
   return (
     <Box aria-live='polite' aria-busy='true' {...props}>
-      {times(count, (i) => (
+      {Array.from({ length: count }, (x, i) => (
         <Skeleton
           animation={animation}
           key={i}

--- a/src/components/elements/LoadingSkeleton.tsx
+++ b/src/components/elements/LoadingSkeleton.tsx
@@ -1,0 +1,32 @@
+import { Box, Skeleton } from '@mui/material';
+import { BoxProps } from '@mui/system';
+import times from 'lodash-es/times';
+import React from 'react';
+
+interface Props extends BoxProps {
+  animation?: 'pulse' | 'wave' | false;
+  count?: number;
+  height?: number;
+}
+const LoadingSkeleton: React.FC<Props> = ({
+  animation = 'wave',
+  count = 6,
+  height = 50,
+  ...props
+}) => {
+  return (
+    <Box aria-live='polite' aria-busy='true' {...props}>
+      {times(count, (i) => (
+        <Skeleton
+          animation={animation}
+          key={i}
+          height={height}
+          variant='rounded'
+          sx={{ mb: 2 }}
+        />
+      ))}
+    </Box>
+  );
+};
+
+export default LoadingSkeleton;

--- a/src/modules/assessments/components/AssessmentForm.tsx
+++ b/src/modules/assessments/components/AssessmentForm.tsx
@@ -62,7 +62,7 @@ interface Props {
   FormActionProps?: DynamicFormProps['FormActionProps'];
   visible?: boolean;
   formRef?: Ref<DynamicFormRef>;
-  onInflight?: (clientId: string, value: boolean) => void;
+  onDirty?: (enrollmentId: string, value: boolean) => void;
 }
 
 const AssessmentForm: React.FC<Props> = ({
@@ -78,7 +78,7 @@ const AssessmentForm: React.FC<Props> = ({
   formRef,
   visible = true,
   top = STICKY_BAR_HEIGHT + CONTEXT_HEADER_HEIGHT,
-  onInflight,
+  onDirty,
 }) => {
   // Whether record picker dialog is open for autofill
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -127,9 +127,9 @@ const AssessmentForm: React.FC<Props> = ({
 
   const handleDirty = useCallback(
     (value: boolean) => {
-      onInflight?.(clientId, value);
+      onDirty?.(enrollment.id, value);
     },
-    [onInflight, clientId]
+    [onDirty, enrollment.id]
   );
 
   const itemMap = useMemo(

--- a/src/modules/assessments/components/AssessmentForm.tsx
+++ b/src/modules/assessments/components/AssessmentForm.tsx
@@ -62,7 +62,7 @@ interface Props {
   FormActionProps?: DynamicFormProps['FormActionProps'];
   visible?: boolean;
   formRef?: Ref<DynamicFormRef>;
-  onInflight: (clientId: string, value: boolean) => void;
+  onInflight?: (clientId: string, value: boolean) => void;
 }
 
 const AssessmentForm: React.FC<Props> = ({
@@ -127,7 +127,7 @@ const AssessmentForm: React.FC<Props> = ({
 
   const handleDirty = useCallback(
     (value: boolean) => {
-      onInflight(clientId, value);
+      onInflight?.(clientId, value);
     },
     [onInflight, clientId]
   );

--- a/src/modules/assessments/components/IndividualAssessment.tsx
+++ b/src/modules/assessments/components/IndividualAssessment.tsx
@@ -44,6 +44,7 @@ export interface IndividualAssessmentProps {
   client: ClientNameDobVeteranFields;
   assessmentStatus?: AssessmentStatus;
   visible?: boolean;
+  onInflight: (clientId: string, inFlight: boolean) => void;
   getFormActionProps?: (
     assessment?: AssessmentFieldsFragment
   ) => DynamicFormProps['FormActionProps'];
@@ -68,6 +69,7 @@ const IndividualAssessment = ({
   getFormActionProps,
   visible,
   formRef,
+  onInflight,
 }: IndividualAssessmentProps) => {
   const { overrideBreadcrumbTitles } = useClientDashboardContext();
 
@@ -181,6 +183,7 @@ const IndividualAssessment = ({
       FormActionProps={FormActionProps}
       visible={visible}
       formRef={formRef}
+      onInflight={onInflight}
     />
   );
 };

--- a/src/modules/assessments/components/IndividualAssessment.tsx
+++ b/src/modules/assessments/components/IndividualAssessment.tsx
@@ -44,11 +44,12 @@ export interface IndividualAssessmentProps {
   client: ClientNameDobVeteranFields;
   assessmentStatus?: AssessmentStatus;
   visible?: boolean;
-  onDirty?: (enrollmentId: string, inFlight: boolean) => void;
   getFormActionProps?: (
     assessment?: AssessmentFieldsFragment
   ) => DynamicFormProps['FormActionProps'];
   formRef?: Ref<DynamicFormRef>;
+  onDirty?: (enrollmentId: string, inFlight: boolean) => void;
+  onInflight?: (enrollmentId: string, inFlight: boolean) => void;
 }
 
 /**
@@ -70,6 +71,7 @@ const IndividualAssessment = ({
   visible,
   formRef,
   onDirty,
+  onInflight,
 }: IndividualAssessmentProps) => {
   const { overrideBreadcrumbTitles } = useClientDashboardContext();
 
@@ -184,6 +186,7 @@ const IndividualAssessment = ({
       visible={visible}
       formRef={formRef}
       onDirty={onDirty}
+      onInflight={onInflight}
     />
   );
 };

--- a/src/modules/assessments/components/IndividualAssessment.tsx
+++ b/src/modules/assessments/components/IndividualAssessment.tsx
@@ -44,7 +44,7 @@ export interface IndividualAssessmentProps {
   client: ClientNameDobVeteranFields;
   assessmentStatus?: AssessmentStatus;
   visible?: boolean;
-  onInflight: (clientId: string, inFlight: boolean) => void;
+  onInflight?: (clientId: string, inFlight: boolean) => void;
   getFormActionProps?: (
     assessment?: AssessmentFieldsFragment
   ) => DynamicFormProps['FormActionProps'];

--- a/src/modules/assessments/components/IndividualAssessment.tsx
+++ b/src/modules/assessments/components/IndividualAssessment.tsx
@@ -17,6 +17,7 @@ import NotFound from '@/components/pages/NotFound';
 import { useScrollToHash } from '@/hooks/useScrollToHash';
 import AssessmentForm from '@/modules/assessments/components/AssessmentForm';
 import AssessmentStatusIndicator from '@/modules/assessments/components/AssessmentStatusIndicator';
+import { HouseholdAssessmentFormAction } from '@/modules/assessments/components/household/formState';
 import { AssessmentStatus } from '@/modules/assessments/components/household/util';
 import { useAssessment } from '@/modules/assessments/hooks/useAssessment';
 import { useBasicEnrollment } from '@/modules/enrollment/hooks/useBasicEnrollment';
@@ -48,8 +49,10 @@ export interface IndividualAssessmentProps {
     assessment?: AssessmentFieldsFragment
   ) => DynamicFormProps['FormActionProps'];
   formRef?: Ref<DynamicFormRef>;
-  onDirty?: (enrollmentId: string, inFlight: boolean) => void;
-  onInflight?: (enrollmentId: string, inFlight: boolean) => void;
+  onFormStateChange?: (
+    enrollmentId: string,
+    action: HouseholdAssessmentFormAction
+  ) => void;
 }
 
 /**
@@ -70,8 +73,7 @@ const IndividualAssessment = ({
   getFormActionProps,
   visible,
   formRef,
-  onDirty,
-  onInflight,
+  onFormStateChange,
 }: IndividualAssessmentProps) => {
   const { overrideBreadcrumbTitles } = useClientDashboardContext();
 
@@ -185,8 +187,7 @@ const IndividualAssessment = ({
       FormActionProps={FormActionProps}
       visible={visible}
       formRef={formRef}
-      onDirty={onDirty}
-      onInflight={onInflight}
+      onFormStateChange={onFormStateChange}
     />
   );
 };

--- a/src/modules/assessments/components/IndividualAssessment.tsx
+++ b/src/modules/assessments/components/IndividualAssessment.tsx
@@ -44,7 +44,7 @@ export interface IndividualAssessmentProps {
   client: ClientNameDobVeteranFields;
   assessmentStatus?: AssessmentStatus;
   visible?: boolean;
-  onInflight?: (clientId: string, inFlight: boolean) => void;
+  onDirty?: (enrollmentId: string, inFlight: boolean) => void;
   getFormActionProps?: (
     assessment?: AssessmentFieldsFragment
   ) => DynamicFormProps['FormActionProps'];
@@ -69,7 +69,7 @@ const IndividualAssessment = ({
   getFormActionProps,
   visible,
   formRef,
-  onInflight,
+  onDirty,
 }: IndividualAssessmentProps) => {
   const { overrideBreadcrumbTitles } = useClientDashboardContext();
 
@@ -183,7 +183,7 @@ const IndividualAssessment = ({
       FormActionProps={FormActionProps}
       visible={visible}
       formRef={formRef}
-      onInflight={onInflight}
+      onDirty={onDirty}
     />
   );
 };

--- a/src/modules/assessments/components/household/HouseholdAssessmentTabPanel.tsx
+++ b/src/modules/assessments/components/household/HouseholdAssessmentTabPanel.tsx
@@ -27,8 +27,7 @@ interface HouseholdAssessmentTabPanelProps extends TabDefinition {
   navigateToTab: (t: string) => void;
   updateTabStatus: (status: AssessmentStatus, tabId: string) => void;
   assessmentStatus: AssessmentStatus;
-  onInflight: (clientId: string, inFlight: boolean) => void;
-  hasInflight: boolean;
+  onDirty: (enrollmentId: string, inFlight: boolean) => void;
 }
 
 // Memoized to only re-render when props change (shallow compare)
@@ -49,7 +48,7 @@ const HouseholdAssessmentTabPanel = memo(
     updateTabStatus,
     assessmentSubmitted,
     assessmentStatus,
-    onInflight,
+    onDirty,
   }: HouseholdAssessmentTabPanelProps) => {
     // console.debug('Rendering assessment panel for', clientName);
 
@@ -164,7 +163,7 @@ const HouseholdAssessmentTabPanel = memo(
           getFormActionProps={getFormActionProps}
           visible={active}
           formRef={formRef}
-          onInflight={onInflight}
+          onDirty={onDirty}
         />
       </AlwaysMountedTabPanel>
     );

--- a/src/modules/assessments/components/household/HouseholdAssessmentTabPanel.tsx
+++ b/src/modules/assessments/components/household/HouseholdAssessmentTabPanel.tsx
@@ -27,6 +27,8 @@ interface HouseholdAssessmentTabPanelProps extends TabDefinition {
   navigateToTab: (t: string) => void;
   updateTabStatus: (status: AssessmentStatus, tabId: string) => void;
   assessmentStatus: AssessmentStatus;
+  onInflight: (clientId: string, inFlight: boolean) => void;
+  hasInflight: boolean;
 }
 
 // Memoized to only re-render when props change (shallow compare)
@@ -47,6 +49,7 @@ const HouseholdAssessmentTabPanel = memo(
     updateTabStatus,
     assessmentSubmitted,
     assessmentStatus,
+    onInflight,
   }: HouseholdAssessmentTabPanelProps) => {
     // console.debug('Rendering assessment panel for', clientName);
 
@@ -161,6 +164,7 @@ const HouseholdAssessmentTabPanel = memo(
           getFormActionProps={getFormActionProps}
           visible={active}
           formRef={formRef}
+          onInflight={onInflight}
         />
       </AlwaysMountedTabPanel>
     );

--- a/src/modules/assessments/components/household/HouseholdAssessments.tsx
+++ b/src/modules/assessments/components/household/HouseholdAssessments.tsx
@@ -8,7 +8,7 @@ import {
   Typography,
 } from '@mui/material';
 import { findIndex } from 'lodash-es';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 
 import { useHouseholdAssessments } from '../../hooks/useHouseholdAssessments';
@@ -66,14 +66,16 @@ const HouseholdAssessments: React.FC<Props> = ({
   enrollment,
   assessmentId,
 }) => {
-  // inFlights track if there are any outstanding mutations
-  const [inFlights, setInFlights] = useState<Record<string, boolean>>({});
-  const handleInFlight = useCallback((clientId: string, value: boolean) => {
-    setInFlights((c) => ({ ...c, [clientId]: value }));
-  }, []);
-  const anyInFlight = useMemo(() => {
-    return Object.values(inFlights).some((value) => value);
-  }, [inFlights]);
+  // track if there are any dirty assessment forms
+  const [dirtyAssessments, setDirtyAssessments] = useState<
+    Record<string, boolean>
+  >({});
+  const handleDirtyAssessment = useCallback(
+    (enrollmentId: string, value: boolean) => {
+      setDirtyAssessments((c) => ({ ...c, [enrollmentId]: value }));
+    },
+    []
+  );
 
   const [householdMembers, fetchMembersStatus] = useHouseholdMembers(
     enrollment.id
@@ -355,8 +357,7 @@ const HouseholdAssessments: React.FC<Props> = ({
               role={role}
               updateTabStatus={updateTabStatus}
               assessmentStatus={tabDefinition.status}
-              onInflight={handleInFlight}
-              hasInflight={anyInFlight}
+              onDirty={handleDirtyAssessment}
               {...tabDefinition}
             />
           ))}
@@ -383,7 +384,7 @@ const HouseholdAssessments: React.FC<Props> = ({
                 projectName={enrollmentName(enrollment)}
                 refetch={refetch}
                 setCurrentTab={setCurrentTab}
-                hasInFlight={anyInFlight}
+                blocked={Object.values(dirtyAssessments).some((value) => value)}
               />
             )
           )}

--- a/src/modules/assessments/components/household/HouseholdSummaryTabPanel.tsx
+++ b/src/modules/assessments/components/household/HouseholdSummaryTabPanel.tsx
@@ -20,6 +20,7 @@ import {
 } from './util';
 
 import BackButton from '@/components/elements/BackButton';
+import Loading from '@/components/elements/Loading';
 import LoadingButton from '@/components/elements/LoadingButton';
 import TitleCard from '@/components/elements/TitleCard';
 import useSafeParams from '@/hooks/useSafeParams';
@@ -51,6 +52,7 @@ interface HouseholdSummaryTabPanelProps {
   projectName: string;
   refetch: () => Promise<any>;
   setCurrentTab: Dispatch<SetStateAction<string | undefined>>;
+  hasInFlight: boolean;
 }
 
 // Memoized to only re-render when props change (shallow compare)
@@ -63,6 +65,7 @@ const HouseholdSummaryTabPanel = memo(
     projectName,
     refetch,
     setCurrentTab,
+    hasInFlight,
   }: HouseholdSummaryTabPanelProps) => {
     const [errorState, setErrors] = useState<ErrorState>(emptyErrorState);
     const [submitMutation, { loading, data: submitResponseData }] =
@@ -153,6 +156,18 @@ const HouseholdSummaryTabPanel = memo(
       }
     );
 
+    if (hasInFlight) {
+      return (
+        <AlwaysMountedTabPanel
+          active={active}
+          key='summary'
+          {...tabPanelA11yProps(id)}
+        >
+          <Loading />
+        </AlwaysMountedTabPanel>
+      );
+    }
+
     return (
       <AlwaysMountedTabPanel
         active={active}
@@ -218,7 +233,7 @@ const HouseholdSummaryTabPanel = memo(
         </Grid>
         {renderValidationDialog({
           onConfirm: () => handleSubmit(true),
-          loading,
+          loading: loading,
           sectionLabels: mapValues(keyBy(tabs, 'assessmentId'), 'clientName'),
         })}
       </AlwaysMountedTabPanel>

--- a/src/modules/assessments/components/household/HouseholdSummaryTabPanel.tsx
+++ b/src/modules/assessments/components/household/HouseholdSummaryTabPanel.tsx
@@ -20,8 +20,8 @@ import {
 } from './util';
 
 import BackButton from '@/components/elements/BackButton';
-import Loading from '@/components/elements/Loading';
 import LoadingButton from '@/components/elements/LoadingButton';
+import LoadingSkeleton from '@/components/elements/LoadingSkeleton';
 import TitleCard from '@/components/elements/TitleCard';
 import useSafeParams from '@/hooks/useSafeParams';
 import HouseholdSummaryExitHelpCard from '@/modules/assessments/components/household/HouseholdSummaryExitHelpCard';
@@ -52,7 +52,7 @@ interface HouseholdSummaryTabPanelProps {
   projectName: string;
   refetch: () => Promise<any>;
   setCurrentTab: Dispatch<SetStateAction<string | undefined>>;
-  hasInFlight: boolean;
+  blocked: boolean;
 }
 
 // Memoized to only re-render when props change (shallow compare)
@@ -65,7 +65,7 @@ const HouseholdSummaryTabPanel = memo(
     projectName,
     refetch,
     setCurrentTab,
-    hasInFlight,
+    blocked,
   }: HouseholdSummaryTabPanelProps) => {
     const [errorState, setErrors] = useState<ErrorState>(emptyErrorState);
     const [submitMutation, { loading, data: submitResponseData }] =
@@ -156,18 +156,6 @@ const HouseholdSummaryTabPanel = memo(
       }
     );
 
-    if (hasInFlight) {
-      return (
-        <AlwaysMountedTabPanel
-          active={active}
-          key='summary'
-          {...tabPanelA11yProps(id)}
-        >
-          <Loading />
-        </AlwaysMountedTabPanel>
-      );
-    }
-
     return (
       <AlwaysMountedTabPanel
         active={active}
@@ -204,17 +192,21 @@ const HouseholdSummaryTabPanel = memo(
               </Grid>
             )}
             <TitleCard title='Select Household Members for Submission'>
-              <HouseholdSummaryTable
-                tabs={tabs}
-                role={role}
-                setAssessmentsToSubmit={setAssessmentsToSubmit}
-                setCurrentTab={setCurrentTab}
-              />
+              {blocked ? (
+                <LoadingSkeleton px={2} count={tabs.length} />
+              ) : (
+                <HouseholdSummaryTable
+                  tabs={tabs}
+                  role={role}
+                  setAssessmentsToSubmit={setAssessmentsToSubmit}
+                  setCurrentTab={setCurrentTab}
+                />
+              )}
               <Box sx={{ px: 2, py: 3 }}>
                 <LoadingButton
                   loading={loading}
                   onClick={() => handleSubmit(false)}
-                  disabled={assessmentsToSubmit.length === 0}
+                  disabled={assessmentsToSubmit.length === 0 || blocked}
                 >
                   {`Submit (${assessmentsToSubmit.length}) ${startCase(
                     role.toLowerCase()

--- a/src/modules/assessments/components/household/HouseholdSummaryTable.tsx
+++ b/src/modules/assessments/components/household/HouseholdSummaryTable.tsx
@@ -140,7 +140,7 @@ const HouseholdSummaryTable = ({
           ? undefined
           : (theme) => theme.palette.grey[50],
       })}
-      setSelectedRowIds={handleSetSelected}
+      onChangeSelectedRowIds={handleSetSelected}
     />
   );
 };

--- a/src/modules/assessments/components/household/formState.ts
+++ b/src/modules/assessments/components/household/formState.ts
@@ -1,0 +1,32 @@
+export interface HouseholdAssessmentFormState {
+  dirty: boolean;
+  saving: boolean;
+  // these are hard to track
+  // errors: boolean
+}
+
+export type HouseholdAssessmentFormAction =
+  | 'saveStarted'
+  | 'saveCompleted'
+  | 'formDirty';
+
+export const initialHouseholdAssessmentFormState: HouseholdAssessmentFormState =
+  {
+    dirty: false,
+    saving: false,
+  };
+
+export function householdAssessmentFormStateReducer(
+  state: HouseholdAssessmentFormState,
+  action: HouseholdAssessmentFormAction
+): HouseholdAssessmentFormState {
+  // console.info('action', action);
+  switch (action) {
+    case 'saveStarted':
+      return { ...state, saving: true };
+    case 'saveCompleted':
+      return { ...state, saving: false, dirty: false };
+    case 'formDirty':
+      return { ...state, dirty: true };
+  }
+}

--- a/src/modules/assessments/hooks/useAssessmentHandlers.tsx
+++ b/src/modules/assessments/hooks/useAssessmentHandlers.tsx
@@ -28,7 +28,8 @@ type Args = {
   enrollmentId: string;
   assessmentId?: string;
   assessmentLockVersion?: number;
-  onSuccessfulSubmit?: (assessment: AssessmentFieldsFragment) => void;
+  onSuccessfulSubmit: (assessment: AssessmentFieldsFragment) => void;
+  onSuccessfulDraftSave: (assessment: AssessmentFieldsFragment) => void;
 };
 
 export const createValuesForSubmit = (
@@ -53,6 +54,7 @@ export function useAssessmentHandlers({
   assessmentId,
   assessmentLockVersion,
   onSuccessfulSubmit = () => null,
+  onSuccessfulDraftSave = () => null,
 }: Args) {
   const formDefinitionId = definition.id;
 
@@ -152,6 +154,7 @@ export function useAssessmentHandlers({
           onCompleted(data);
           if (data.saveAssessment?.assessment && onSuccessCallback) {
             onSuccessCallback();
+            onSuccessfulDraftSave(data.saveAssessment?.assessment);
           }
         },
       });
@@ -164,6 +167,7 @@ export function useAssessmentHandlers({
       formDefinitionId,
       enrollmentId,
       onCompleted,
+      onSuccessfulDraftSave,
     ]
   );
 

--- a/src/modules/form/components/DynamicForm.tsx
+++ b/src/modules/form/components/DynamicForm.tsx
@@ -51,6 +51,7 @@ export interface DynamicFormProps
   definition: FormDefinitionJson;
   onSubmit: DynamicFormOnSubmit;
   onSaveDraft?: (values: FormValues, onSuccess?: VoidFunction) => void;
+  onDirty?: (value: boolean) => void;
   loading?: boolean;
   initialValues?: Record<string, any>;
   errors: ErrorState;
@@ -101,10 +102,14 @@ const DynamicForm = forwardRef(
       hideSubmit = false,
       localConstants,
       errorRef,
+      onDirty,
     }: DynamicFormProps,
     ref: Ref<DynamicFormRef>
   ) => {
     const [dirty, setDirty] = useState(false);
+    useEffect(() => {
+      onDirty?.(dirty);
+    }, [dirty, onDirty]);
     const [promptSave, setPromptSave] = useState<boolean | undefined>();
 
     const onFieldChange = useCallback((type: ChangeType) => {

--- a/src/modules/form/components/DynamicForm.tsx
+++ b/src/modules/form/components/DynamicForm.tsx
@@ -271,6 +271,7 @@ const DynamicForm = forwardRef(
             appear
             timeout={300}
             direction='up'
+            loading={loading}
           >
             {saveButtons}
           </SaveSlide>

--- a/src/modules/form/components/SaveSlide.tsx
+++ b/src/modules/form/components/SaveSlide.tsx
@@ -1,28 +1,37 @@
-import { Box, Paper, Slide, SlideProps } from '@mui/material';
+import { Box, LinearProgress, Paper, Slide, SlideProps } from '@mui/material';
 
-type Props = SlideProps;
+interface Props extends SlideProps {
+  loading?: boolean;
+}
 
-const SaveSlide = ({ children, ...props }: Props) => (
+const SaveSlide = ({ children, loading = false, ...props }: Props) => (
   <Slide {...props}>
-    <Paper
-      elevation={2}
-      square
-      sx={{
-        position: 'sticky',
-        bottom: 0,
-        display: 'flex',
-        alignItems: 'center',
-        flexDirection: 'row-reverse',
-        backgroundColor: 'white',
-        py: 2,
-        px: 2,
-        zIndex: (theme) => theme.zIndex.drawer,
-        boxShadow: '0 0 10px rgb(0 0 0 / 25%)',
-        clipPath: 'inset(-10px -1px 0px -1px)',
-      }}
-    >
-      <Box sx={{ width: '100%' }}>{children}</Box>
-    </Paper>
+    <div>
+      {loading ? (
+        <LinearProgress sx={{ height: 2 }} />
+      ) : (
+        <Box sx={{ height: 2 }} />
+      )}
+      <Paper
+        elevation={2}
+        square
+        sx={{
+          position: 'sticky',
+          bottom: 0,
+          display: 'flex',
+          alignItems: 'center',
+          flexDirection: 'row-reverse',
+          backgroundColor: 'white',
+          py: 2,
+          px: 2,
+          zIndex: (theme) => theme.zIndex.drawer,
+          boxShadow: '0 0 10px rgb(0 0 0 / 25%)',
+          clipPath: 'inset(-10px -1px 0px -1px)',
+        }}
+      >
+        <Box sx={{ width: '100%' }}>{children}</Box>
+      </Paper>
+    </div>
   </Slide>
 );
 

--- a/src/modules/form/components/SaveSlide.tsx
+++ b/src/modules/form/components/SaveSlide.tsx
@@ -8,7 +8,11 @@ const SaveSlide = ({ children, loading = false, ...props }: Props) => (
   <Slide {...props}>
     <div>
       {loading ? (
-        <LinearProgress sx={{ height: 2 }} />
+        <LinearProgress
+          sx={{ height: 2 }}
+          aria-live='polite'
+          aria-busy='true'
+        />
       ) : (
         <Box sx={{ height: 2 }} />
       )}

--- a/src/modules/form/components/SaveSlide.tsx
+++ b/src/modules/form/components/SaveSlide.tsx
@@ -6,36 +6,34 @@ interface Props extends SlideProps {
 
 const SaveSlide = ({ children, loading = false, ...props }: Props) => (
   <Slide {...props}>
-    <div>
-      {loading ? (
-        <LinearProgress
-          sx={{ height: 2 }}
-          aria-live='polite'
-          aria-busy='true'
-        />
-      ) : (
-        <Box sx={{ height: 2 }} />
-      )}
-      <Paper
-        elevation={2}
-        square
-        sx={{
-          position: 'sticky',
-          bottom: 0,
-          display: 'flex',
-          alignItems: 'center',
-          flexDirection: 'row-reverse',
-          backgroundColor: 'white',
-          py: 2,
-          px: 2,
-          zIndex: (theme) => theme.zIndex.drawer,
-          boxShadow: '0 0 10px rgb(0 0 0 / 25%)',
-          clipPath: 'inset(-10px -1px 0px -1px)',
-        }}
-      >
-        <Box sx={{ width: '100%' }}>{children}</Box>
-      </Paper>
-    </div>
+    <Paper
+      elevation={2}
+      square
+      sx={{
+        position: 'sticky',
+        bottom: 0,
+        display: 'flex',
+        alignItems: 'center',
+        flexDirection: 'row-reverse',
+        backgroundColor: 'white',
+        zIndex: (theme) => theme.zIndex.drawer,
+        boxShadow: '0 0 10px rgb(0 0 0 / 25%)',
+        clipPath: 'inset(-10px -1px 0px -1px)',
+      }}
+    >
+      <Box sx={{ width: '100%' }}>
+        {loading ? (
+          <LinearProgress
+            sx={{ height: 2 }}
+            aria-live='polite'
+            aria-busy='true'
+          />
+        ) : (
+          <Box sx={{ height: 2 }} />
+        )}
+        <Box sx={{ p: 2 }}>{children}</Box>
+      </Box>
+    </Paper>
   </Slide>
 );
 


### PR DESCRIPTION
## Description

[StaleObjectError when submitting household assessments
](https://www.pivotaltracker.com/story/show/186395195)

[Capybara Tests](https://github.com/greenriver/hmis-warehouse/pull/3767)

* prevent submission of assessment when there are in-flight mutations/dirty forms
* indicate a save is in progress on the form-action bar
* pauses navigation to next assessment tab while save completes
* add some missing accessibility attrs to loading indicators

## Testing
* create a multi-member household and start an intake 
* New function: clicking Save / Submit Assessment on the bottom bar should show a blue progress bar while the form is loading

* go to the last assessment in the household
* make a change the assessment and quickly hit 'next' to go to the "complete entry" tab. You may need to throttle your network connection in chrome
* New function: loading spinner is shown on the page if the previous save is still in progress. Once the saves are complete, the summary page is visible as usual

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [x] New feature (adds functionality)


## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
