### PR TITLE
Assessment refactor to pull up change handlers and assessment+definition fetching

### DIFF
--- a/src/components/clientDashboard/enrollments/AssessmentPage.tsx
+++ b/src/components/clientDashboard/enrollments/AssessmentPage.tsx
@@ -1,19 +1,11 @@
-import { useCallback } from 'react';
-import { useNavigate } from 'react-router-dom';
-
 import { useEnrollmentDashboardContext } from '@/components/pages/EnrollmentDashboard';
 import NotFound from '@/components/pages/NotFound';
 import useIsPrintView from '@/hooks/useIsPrintView';
 import useSafeParams from '@/hooks/useSafeParams';
 import HouseholdAssessments from '@/modules/assessments/components/household/HouseholdAssessments';
 import { isHouseholdAssesmentRole } from '@/modules/assessments/components/household/util';
-import IndividualAssessment from '@/modules/assessments/components/IndividualAssessment';
-import { FormActionTypes } from '@/modules/form/types';
-import { clientBriefName } from '@/modules/hmis/hmisUtil';
-import { cache } from '@/providers/apolloClient';
-import { EnrollmentDashboardRoutes } from '@/routes/routes';
+import IndividualAssessmentPage from '@/modules/assessments/components/IndividualAssessmentPage';
 import { EnrollmentFieldsFragment, FormRole } from '@/types/gqlTypes';
-import { generateSafePath } from '@/utils/pathEncoding';
 
 export const showAssessmentInHousehold = (
   enrollment?: EnrollmentFieldsFragment,
@@ -28,39 +20,14 @@ export const showAssessmentInHousehold = (
 };
 
 const AssessmentPage = () => {
-  const navigate = useNavigate();
-  const { client, enrollment } = useEnrollmentDashboardContext();
-  const { clientId, enrollmentId, assessmentId, formRole } =
-    useSafeParams() as {
-      clientId: string;
-      enrollmentId: string;
-      formRole: FormRole;
-      assessmentId?: string;
-    };
+  const { enrollment, client } = useEnrollmentDashboardContext();
+  const { assessmentId, formRole } = useSafeParams() as {
+    clientId: string;
+    enrollmentId: string;
+    formRole: FormRole;
+    assessmentId?: string;
+  };
   const isPrintView = useIsPrintView();
-  const clientName = clientBriefName(client);
-
-  const navigateToEnrollment = useCallback(
-    () =>
-      navigate(
-        generateSafePath(EnrollmentDashboardRoutes.ASSESSMENTS, {
-          enrollmentId,
-          clientId,
-        })
-      ),
-    [navigate, enrollmentId, clientId]
-  );
-
-  const onSuccess = useCallback(() => {
-    // We created a NEW assessment, clear assessment queries from cache before navigating so the table reloads
-    if (!assessmentId) {
-      cache.evict({
-        id: `Enrollment:${enrollmentId}`,
-        fieldName: 'assessments',
-      });
-    }
-    navigateToEnrollment();
-  }, [navigateToEnrollment, assessmentId, enrollmentId]);
 
   if (!enrollment) return <NotFound />;
   if (!formRole) return <NotFound />;
@@ -80,45 +47,7 @@ const AssessmentPage = () => {
     );
   }
 
-  return (
-    <IndividualAssessment
-      formRole={formRole}
-      enrollmentId={enrollmentId}
-      clientName={clientName}
-      assessmentId={assessmentId}
-      client={client}
-      relationshipToHoH={enrollment.relationshipToHoH}
-      getFormActionProps={(assessment) => ({
-        onDiscard: navigateToEnrollment,
-        config: [
-          {
-            id: 'submit',
-            label: 'Submit',
-            action: FormActionTypes.Submit,
-            buttonProps: { variant: 'contained' } as const,
-            onSuccess,
-          },
-          ...(assessment && !assessment.inProgress
-            ? []
-            : [
-                {
-                  id: 'saveDraft',
-                  label: 'Save and finish later',
-                  action: FormActionTypes.Save,
-                  buttonProps: { variant: 'outlined' } as const,
-                  onSuccess,
-                },
-              ]),
-          {
-            id: 'discard',
-            label: 'Cancel',
-            action: FormActionTypes.Discard,
-            buttonProps: { variant: 'gray' } as const,
-          },
-        ],
-      })}
-    />
-  );
+  return <IndividualAssessmentPage enrollment={enrollment} client={client} />;
 };
 
 export default AssessmentPage;

--- a/src/components/elements/LoadingButton.tsx
+++ b/src/components/elements/LoadingButton.tsx
@@ -1,6 +1,6 @@
 import { LoadingButton as MuiLoadingButton } from '@mui/lab';
 import { ButtonProps } from '@mui/material';
-import { forwardRef } from 'react';
+import { forwardRef, useMemo } from 'react';
 
 /**
  * Wrapper around LoadingButton to make tsc compilation faster.
@@ -14,9 +14,21 @@ export interface LoadingButtonProps extends ButtonProps {
   loadingPosition: 'start' | 'end' | 'center';
 }
 
-const LoadingButton = forwardRef<LoadingButtonProps, any>((props, ref) => (
-  <MuiLoadingButton ref={ref} {...props} />
-));
+const LoadingButton = forwardRef<LoadingButtonProps, any>((props, ref) => {
+  const extraSx = useMemo(() => {
+    if (props.loading && props.loadingPosition === 'start') {
+      return { pl: 5 };
+    }
+    if (props.loading && props.loadingPosition === 'end') {
+      return { pr: 5 };
+    }
+    return;
+  }, [props.loading, props.loadingPosition]);
+
+  return (
+    <MuiLoadingButton ref={ref} {...props} sx={{ ...props.sx, ...extraSx }} />
+  );
+});
 
 LoadingButton.displayName = 'LoadingButton';
 

--- a/src/modules/assessments/components/AssessmentForm.tsx
+++ b/src/modules/assessments/components/AssessmentForm.tsx
@@ -219,16 +219,24 @@ const AssessmentForm: React.FC<Props> = ({
     hold: pickListsLoading,
   });
 
-  // the form is locked, replace the submit button with an 'unlock' button
-  const formActionPropsWithLock = useMemo<typeof FormActionProps>(() => {
+  const formActionsPropsWithLastUpdated = useMemo<
+    typeof FormActionProps
+  >(() => {
     const formActionProps: typeof FormActionProps = { ...FormActionProps };
-
     // Add last saved / last submitted dates
     if (assessment?.inProgress) {
       formActionProps.lastSaved = assessment?.dateUpdated || undefined;
     } else if (assessment && !assessment.inProgress) {
       formActionProps.lastSubmitted = assessment?.dateUpdated || undefined;
     }
+    return formActionProps;
+  }, [FormActionProps, assessment]);
+
+  // the form is locked, replace the submit button with an 'unlock' button
+  const formActionPropsWithLock = useMemo<typeof FormActionProps>(() => {
+    const formActionProps: typeof FormActionProps = {
+      ...formActionsPropsWithLastUpdated,
+    };
 
     if (!locked || !canEdit) return formActionProps;
 
@@ -252,9 +260,8 @@ const AssessmentForm: React.FC<Props> = ({
       .filter((item) => item.action !== FormActionTypes.Discard);
     return { ...formActionProps, config };
   }, [
-    assessment,
+    formActionsPropsWithLastUpdated,
     locked,
-    FormActionProps,
     canEdit,
     embeddedInWorkflow,
     handleUnlock,
@@ -335,7 +342,7 @@ const AssessmentForm: React.FC<Props> = ({
             clientId={clientId}
             showSavePrompt
             alwaysShowSaveSlide={!!embeddedInWorkflow}
-            FormActionProps={FormActionProps}
+            FormActionProps={formActionsPropsWithLastUpdated}
             onDirty={handleDirty}
             ValidationDialogProps={{ onCancel: onCancelValidations }}
             // Only show "warn if empty" treatments if this is an existing assessment,

--- a/src/modules/assessments/components/IndividualAssessment.tsx
+++ b/src/modules/assessments/components/IndividualAssessment.tsx
@@ -36,61 +36,39 @@ import {
 } from '@/types/gqlTypes';
 
 export interface IndividualAssessmentProps {
-  /**
-   * FormDefiniton to use for rendering assessment
-   */
+  // FormDefiniton to use for rendering the assessment
   definition: FormDefinition;
-  /**
-   * Assessment to render, if one exists.
-   */
+  // Assessment to render. Omit if starting a new assessment.
   assessment?: FullAssessmentFragment;
-  /**
-   * Assessment Title
-   */
   title: string;
-  /**
-   * ID of related Enrollment
-   */
   enrollmentId: string;
-  /**
-   * Assessment Role (Intake, Exit, etc.)
-   */
+  // Assessment Role (Intake, Exit, etc.)
   formRole?: FormRole;
-  /**
-   * Whether the assessment is embedded in a household workflow
-   */
+  // Whether the assessment is embedded in a household workflow
   embeddedInWorkflow?: boolean;
-  /**
-   * Client information
-   */
   client: ClientNameFragment;
-  /**
-   * Current status of the assessment
-   */
+  // Assessment status to use for indicator
   assessmentStatus?: AssessmentStatus;
-  /**
-   * Whether the form is currently visible on the page.
-   * Used for household workflow when the assessment is on an inactive tab.
-   */
+  // Whether the form is currently visible on the page. Used for household workflow when the assessment is on an inactive tab.
   visible?: boolean;
-  /**
-   * Reference to the form
-   */
+  // Reference to the form element
   formRef?: Ref<DynamicFormRef>;
-  /**
-   * Callback to handle changes to form state
-   */
+  // Callback to handle changes to form state
   onFormStateChange?: (
     enrollmentId: string,
     action: HouseholdAssessmentFormAction
   ) => void;
-
-  // DynamicForm props
+  // Props to pass to the FormActions component to specify button layout and actions
   FormActionProps?: DynamicFormProps['FormActionProps'];
+  // Submit handler
   onSubmit: DynamicFormProps['onSubmit'];
+  // Save handler (unsubmitted assessments only)
   onSaveDraft?: DynamicFormProps['onSaveDraft'];
+  // Error state
   errors: ErrorState;
+  // Whether Submit or Save mutation is loading
   mutationLoading?: boolean;
+  // Callback for clicking "cancel" on warning validation modal
   onCancelValidations?: VoidFunction;
 }
 

--- a/src/modules/assessments/components/IndividualAssessmentPage.tsx
+++ b/src/modules/assessments/components/IndividualAssessmentPage.tsx
@@ -1,0 +1,130 @@
+import { useCallback, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { useAssessment } from '../hooks/useAssessment';
+import { useAssessmentHandlers } from '../hooks/useAssessmentHandlers';
+import MissingDefinitionAlert from './MissingDefinitionAlert';
+import Loading from '@/components/elements/Loading';
+import NotFound from '@/components/pages/NotFound';
+import useSafeParams from '@/hooks/useSafeParams';
+import IndividualAssessment from '@/modules/assessments/components/IndividualAssessment';
+import { FormActionTypes } from '@/modules/form/types';
+import { DashboardEnrollment } from '@/modules/hmis/types';
+import { cache } from '@/providers/apolloClient';
+import { EnrollmentDashboardRoutes } from '@/routes/routes';
+import { ClientNameDobVetFragment, FormRole } from '@/types/gqlTypes';
+import { generateSafePath } from '@/utils/pathEncoding';
+
+interface Props {
+  enrollment: DashboardEnrollment;
+  client: ClientNameDobVetFragment;
+}
+
+const IndividualAssessmentPage: React.FC<Props> = ({ client, enrollment }) => {
+  const navigate = useNavigate();
+  const { clientId, enrollmentId, assessmentId, formRole } =
+    useSafeParams() as {
+      clientId: string;
+      enrollmentId: string;
+      formRole: FormRole;
+      assessmentId?: string;
+    };
+
+  const navigateToEnrollment = useCallback(
+    () =>
+      navigate(
+        generateSafePath(EnrollmentDashboardRoutes.ASSESSMENTS, {
+          enrollmentId,
+          clientId,
+        })
+      ),
+    [navigate, enrollmentId, clientId]
+  );
+
+  const onSuccess = useCallback(() => {
+    // We created a NEW assessment, clear assessment queries from cache before navigating so the table reloads
+    if (!assessmentId) {
+      cache.evict({
+        id: `Enrollment:${enrollmentId}`,
+        fieldName: 'assessments',
+      });
+    }
+    navigateToEnrollment();
+  }, [navigateToEnrollment, assessmentId, enrollmentId]);
+
+  const {
+    definition,
+    assessment,
+    loading: dataLoading,
+    assessmentTitle,
+    formRole: role,
+  } = useAssessment({
+    enrollmentId,
+    assessmentId,
+    formRoleParam: formRole,
+    client,
+    relationshipToHoH: enrollment?.relationshipToHoH,
+  });
+
+  const { submitHandler, saveDraftHandler, mutationLoading, errors } =
+    useAssessmentHandlers({
+      definition,
+      enrollmentId: enrollment.id,
+      assessmentId: assessment?.id,
+      assessmentLockVersion: assessment?.lockVersion,
+    });
+
+  const FormActionProps = useMemo(() => {
+    return {
+      onDiscard: navigateToEnrollment,
+      config: [
+        {
+          id: 'submit',
+          label: 'Submit',
+          action: FormActionTypes.Submit,
+          buttonProps: { variant: 'contained' } as const,
+          onSuccess,
+        },
+        ...(assessment && !assessment.inProgress
+          ? []
+          : [
+              {
+                id: 'saveDraft',
+                label: 'Save and finish later',
+                action: FormActionTypes.Save,
+                buttonProps: { variant: 'outlined' } as const,
+                onSuccess,
+              },
+            ]),
+        {
+          id: 'discard',
+          label: 'Cancel',
+          action: FormActionTypes.Discard,
+          buttonProps: { variant: 'gray' } as const,
+        },
+      ],
+    };
+  }, [assessment, navigateToEnrollment, onSuccess]);
+
+  if (!formRole) return <NotFound />;
+  if (dataLoading) return <Loading />;
+  if (!definition) return <MissingDefinitionAlert />;
+
+  return (
+    <IndividualAssessment
+      definition={definition}
+      assessment={assessment}
+      formRole={role}
+      enrollmentId={enrollmentId}
+      title={assessmentTitle}
+      client={client}
+      onSubmit={submitHandler}
+      onSaveDraft={saveDraftHandler}
+      errors={errors}
+      mutationLoading={mutationLoading}
+      FormActionProps={FormActionProps}
+    />
+  );
+};
+
+export default IndividualAssessmentPage;

--- a/src/modules/assessments/components/household/HouseholdAssessmentTabPanel.tsx
+++ b/src/modules/assessments/components/household/HouseholdAssessmentTabPanel.tsx
@@ -1,9 +1,15 @@
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
-import { memo, useCallback, useEffect, useRef } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef } from 'react';
 
+import { useAssessment } from '../../hooks/useAssessment';
+import {
+  AssessmentResponseStatus,
+  useAssessmentHandlers,
+} from '../../hooks/useAssessmentHandlers';
 import IndividualAssessment from '../IndividualAssessment';
 
+import MissingDefinitionAlert from '../MissingDefinitionAlert';
 import AlwaysMountedTabPanel from './AlwaysMountedTabPanel';
 import {
   AssessmentStatus,
@@ -12,6 +18,7 @@ import {
   tabPanelA11yProps,
 } from './util';
 
+import Loading from '@/components/elements/Loading';
 import {
   HouseholdAssessmentFormAction,
   HouseholdAssessmentFormState,
@@ -19,7 +26,7 @@ import {
 import { DynamicFormRef } from '@/modules/form/components/DynamicForm';
 import { FormActionProps } from '@/modules/form/components/FormActions';
 import { FormActionTypes } from '@/modules/form/types';
-import { AssessmentFieldsFragment, FormRole } from '@/types/gqlTypes';
+import { FormRole } from '@/types/gqlTypes';
 
 interface HouseholdAssessmentTabPanelProps extends TabDefinition {
   active: boolean;
@@ -44,7 +51,7 @@ const HouseholdAssessmentTabPanel = memo(
     active,
     navigatingAway,
     id,
-    clientName,
+    // clientName,
     enrollmentId,
     assessmentId,
     client,
@@ -60,7 +67,7 @@ const HouseholdAssessmentTabPanel = memo(
     onFormStateChange,
     formState,
   }: HouseholdAssessmentTabPanelProps) => {
-    // console.debug('Rendering assessment panel for', clientName);
+    // if (active) console.debug(clientName, formState);
 
     const formRef = useRef<DynamicFormRef>(null);
 
@@ -70,23 +77,14 @@ const HouseholdAssessmentTabPanel = memo(
       if (!navigatingAway) return;
       // skip save if it's already happening
       if (formState.saving) return;
+      // skip save if there are errors. user must do an explicit save to resolve error before proceeding
+      if (formState.errors) return;
+
+      // perform background save or submit
       if (assessmentSubmitted) {
-        formRef.current.SubmitIfDirty(true, () => {
-          // TODO: Update tab status to 'error' if error?
-          // console.debug(`Submitted ${clientName}!`);
-          onFormStateChange(enrollmentId, 'saveCompleted');
-        });
+        formRef.current.SubmitIfDirty(false);
       } else {
-        formRef.current.SaveIfDirty(() => {
-          onFormStateChange(enrollmentId, 'saveCompleted');
-          // TODO: Update tab status to 'error' if error?
-          // console.debug(`Saved ${clientName}!`);
-          if (!assessmentId) {
-            // This was a NEW assessment; we need to re-fetch to get it
-            updateTabStatus(AssessmentStatus.Started, id);
-            refetch();
-          }
-        });
+        formRef.current.SaveIfDirty();
       }
     }, [
       onFormStateChange,
@@ -98,74 +96,126 @@ const HouseholdAssessmentTabPanel = memo(
       id,
       refetch,
       updateTabStatus,
+      formState.errors,
     ]);
 
-    const getFormActionProps = useCallback(
-      (assessment?: AssessmentFieldsFragment) => {
-        const config: NonNullable<FormActionProps['config']> = [];
-        const nextPreviousProps = {
-          variant: 'text',
-          sx: { height: '50px', alignSelf: 'center' },
-        } as const;
+    const {
+      definition,
+      assessment,
+      loading: definitionLoading,
+      assessmentTitle,
+      formRole,
+    } = useAssessment({
+      enrollmentId,
+      assessmentId,
+      formRoleParam: role as unknown as FormRole,
+      client,
+      relationshipToHoH,
+    });
 
-        config.push({
-          id: 'prev',
-          label: 'Previous',
-          action: FormActionTypes.Navigate,
-          buttonProps: {
-            disabled: !previousTab,
-            startIcon: <ArrowBackIcon fontSize='small' />,
-            ...nextPreviousProps,
-          } as const,
-          onSuccess: () => {
-            if (previousTab) navigateToTab(previousTab);
-          },
-        });
-
-        if (assessment && !assessment.inProgress) {
-          config.push({
-            id: 'submit',
-            label: 'Save & Submit',
-            centerAlign: true,
-            action: FormActionTypes.Submit,
-            buttonProps: { variant: 'outlined' } as const,
-            onSuccess: () => {
-              updateTabStatus(AssessmentStatus.Submitted, id);
-              refetch();
-            },
-          });
-        } else {
-          config.push({
-            id: 'save',
-            label: 'Save Assessment',
-            centerAlign: true,
-            action: FormActionTypes.Save,
-            buttonProps: { variant: 'contained', size: 'large' } as const,
-            onSuccess: () => {
-              if (!assessment) updateTabStatus(AssessmentStatus.Started, id);
-              refetch();
-            },
-          });
+    const onCompletedMutation = useCallback(
+      (status: AssessmentResponseStatus) => {
+        // console.debug('Completed with status', status);
+        if (['saved', 'submitted'].includes(status)) {
+          onFormStateChange?.(enrollmentId, 'saveCompleted');
+        } else if (['warning', 'error'].includes(status)) {
+          // Treat warning and errors the same right now. This should be expanded to treat them differently with visual indicators.
+          onFormStateChange?.(enrollmentId, 'saveFailed');
         }
 
-        config.push({
-          id: 'next',
-          label: 'Next',
-          action: FormActionTypes.Navigate,
-          buttonProps: {
-            disabled: !nextTab,
-            endIcon: <ArrowForwardIcon fontSize='small' />,
-            ...nextPreviousProps,
-          } as const,
-          onSuccess: () => {
-            if (nextTab) navigateToTab(nextTab);
-          },
-        });
-
-        return { config };
+        // If this was a brand new assessment being saved for the first time,
+        // we need to refetch to get it.
+        if (status === 'saved' && !assessmentId) {
+          updateTabStatus(AssessmentStatus.Started, id);
+          refetch();
+        }
       },
-      [navigateToTab, previousTab, nextTab, refetch, updateTabStatus, id]
+      [
+        assessmentId,
+        enrollmentId,
+        id,
+        onFormStateChange,
+        refetch,
+        updateTabStatus,
+      ]
     );
+
+    const { submitHandler, saveDraftHandler, mutationLoading, errors } =
+      useAssessmentHandlers({
+        definition,
+        enrollmentId,
+        assessmentId,
+        assessmentLockVersion: assessment?.lockVersion,
+        onCompletedMutation,
+      });
+
+    // disabling nav buttons while loading, and if there are errors
+    const disableNavigation = useMemo(
+      () => mutationLoading || formState.errors,
+      [formState.errors, mutationLoading]
+    );
+
+    const FormActionProps = useMemo(() => {
+      const config: NonNullable<FormActionProps['config']> = [];
+      const nextPreviousProps = {
+        variant: 'text',
+        sx: { height: '50px', alignSelf: 'center' },
+      } as const;
+
+      config.push({
+        id: 'prev',
+        label: 'Previous',
+        action: FormActionTypes.Navigate,
+        buttonProps: {
+          disabled: !previousTab || disableNavigation,
+          startIcon: <ArrowBackIcon fontSize='small' />,
+          ...nextPreviousProps,
+        } as const,
+        onClick: () => {
+          if (previousTab) navigateToTab(previousTab);
+        },
+      });
+
+      if (assessment && !assessment.inProgress) {
+        config.push({
+          id: 'submit',
+          label: 'Save & Submit',
+          centerAlign: true,
+          action: FormActionTypes.Submit,
+          buttonProps: { variant: 'outlined' } as const,
+        });
+      } else {
+        config.push({
+          id: 'save',
+          label: 'Save Assessment',
+          centerAlign: true,
+          action: FormActionTypes.Save,
+          buttonProps: { variant: 'contained', size: 'large' } as const,
+        });
+      }
+
+      config.push({
+        id: 'next',
+        label: 'Next',
+        action: FormActionTypes.Navigate,
+        buttonProps: {
+          disabled: !nextTab || disableNavigation,
+          endIcon: <ArrowForwardIcon fontSize='small' />,
+          ...nextPreviousProps,
+        } as const,
+        onClick: () => {
+          if (nextTab) navigateToTab(nextTab);
+        },
+      });
+
+      return { config };
+    }, [previousTab, disableNavigation, assessment, nextTab, navigateToTab]);
+
+    useEffect(() => {
+      if (mutationLoading) {
+        onFormStateChange?.(enrollmentId, 'saveStarted');
+      }
+    }, [enrollmentId, mutationLoading, onFormStateChange]);
 
     return (
       <AlwaysMountedTabPanel
@@ -173,20 +223,33 @@ const HouseholdAssessmentTabPanel = memo(
         key={id}
         {...tabPanelA11yProps(id)}
       >
-        <IndividualAssessment
-          clientName={clientName}
-          client={client}
-          relationshipToHoH={relationshipToHoH}
-          embeddedInWorkflow
-          enrollmentId={enrollmentId}
-          assessmentId={assessmentId}
-          assessmentStatus={assessmentStatus}
-          formRole={role as unknown as FormRole}
-          getFormActionProps={getFormActionProps}
-          visible={active}
-          formRef={formRef}
-          onFormStateChange={onFormStateChange}
-        />
+        {definitionLoading ? (
+          <Loading />
+        ) : !definition ? (
+          <MissingDefinitionAlert />
+        ) : (
+          <IndividualAssessment
+            definition={definition}
+            client={client}
+            embeddedInWorkflow
+            enrollmentId={enrollmentId}
+            assessment={assessment}
+            assessmentStatus={assessmentStatus}
+            formRole={formRole}
+            FormActionProps={FormActionProps}
+            visible={active}
+            formRef={formRef}
+            onFormStateChange={onFormStateChange}
+            title={assessmentTitle}
+            onSubmit={submitHandler}
+            onSaveDraft={saveDraftHandler}
+            errors={errors}
+            mutationLoading={mutationLoading}
+            onCancelValidations={() =>
+              onFormStateChange?.(enrollmentId, 'saveCanceled')
+            }
+          />
+        )}
       </AlwaysMountedTabPanel>
     );
   }

--- a/src/modules/assessments/components/household/HouseholdAssessmentTabPanel.tsx
+++ b/src/modules/assessments/components/household/HouseholdAssessmentTabPanel.tsx
@@ -164,7 +164,7 @@ const HouseholdAssessmentTabPanel = memo(
 
       config.push({
         id: 'prev',
-        label: 'Previous',
+        label: 'Previous Client',
         action: FormActionTypes.Navigate,
         buttonProps: {
           disabled: !previousTab || disableNavigation,
@@ -180,14 +180,16 @@ const HouseholdAssessmentTabPanel = memo(
         config.push({
           id: 'submit',
           label: 'Save & Submit',
+          loadingLabel: 'Submitting',
           centerAlign: true,
           action: FormActionTypes.Submit,
-          buttonProps: { variant: 'outlined' } as const,
+          buttonProps: { variant: 'contained', size: 'large' } as const,
         });
       } else {
         config.push({
           id: 'save',
           label: 'Save Assessment',
+          loadingLabel: 'Saving',
           centerAlign: true,
           action: FormActionTypes.Save,
           buttonProps: { variant: 'contained', size: 'large' } as const,
@@ -196,7 +198,7 @@ const HouseholdAssessmentTabPanel = memo(
 
       config.push({
         id: 'next',
-        label: 'Next',
+        label: 'Next Client',
         action: FormActionTypes.Navigate,
         buttonProps: {
           disabled: !nextTab || disableNavigation,

--- a/src/modules/assessments/components/household/HouseholdAssessmentTabPanel.tsx
+++ b/src/modules/assessments/components/household/HouseholdAssessmentTabPanel.tsx
@@ -150,10 +150,7 @@ const HouseholdAssessmentTabPanel = memo(
       });
 
     // disabling nav buttons while loading, and if there are errors
-    const disableNavigation = useMemo(
-      () => mutationLoading || formState.errors,
-      [formState.errors, mutationLoading]
-    );
+    const disableNavigation = mutationLoading || formState.errors 
 
     const FormActionProps = useMemo(() => {
       const config: NonNullable<FormActionProps['config']> = [];

--- a/src/modules/assessments/components/household/HouseholdAssessmentTabPanel.tsx
+++ b/src/modules/assessments/components/household/HouseholdAssessmentTabPanel.tsx
@@ -157,20 +157,25 @@ const HouseholdAssessmentTabPanel = memo(
 
     const FormActionProps = useMemo(() => {
       const config: NonNullable<FormActionProps['config']> = [];
-      const nextPreviousProps = {
-        variant: 'text',
-        sx: { height: '50px', alignSelf: 'center' },
-      } as const;
+      const navTooltip = formState.errors
+        ? 'Please fix errors and save changes before proceeding.'
+        : undefined;
 
       config.push({
         id: 'prev',
         label: 'Previous Client',
         action: FormActionTypes.Navigate,
         buttonProps: {
-          disabled: !previousTab || disableNavigation,
+          disabled: disableNavigation,
           startIcon: <ArrowBackIcon fontSize='small' />,
-          ...nextPreviousProps,
+          variant: 'text',
+          sx: {
+            display: !previousTab ? 'none' : undefined,
+            height: '50px',
+            alignSelf: 'center',
+          },
         } as const,
+        tooltip: navTooltip,
         onClick: () => {
           if (previousTab) navigateToTab(previousTab);
         },
@@ -203,15 +208,28 @@ const HouseholdAssessmentTabPanel = memo(
         buttonProps: {
           disabled: !nextTab || disableNavigation,
           endIcon: <ArrowForwardIcon fontSize='small' />,
-          ...nextPreviousProps,
+          variant: 'text',
+          sx: {
+            display: !nextTab ? 'none' : undefined,
+            height: '50px',
+            alignSelf: 'center',
+          },
         } as const,
+        tooltip: navTooltip,
         onClick: () => {
           if (nextTab) navigateToTab(nextTab);
         },
       });
 
       return { config };
-    }, [previousTab, disableNavigation, assessment, nextTab, navigateToTab]);
+    }, [
+      previousTab,
+      disableNavigation,
+      assessment,
+      nextTab,
+      formState.errors,
+      navigateToTab,
+    ]);
 
     useEffect(() => {
       if (mutationLoading) {

--- a/src/modules/assessments/components/household/HouseholdAssessments.tsx
+++ b/src/modules/assessments/components/household/HouseholdAssessments.tsx
@@ -193,14 +193,6 @@ const HouseholdAssessments: React.FC<Props> = ({
     setNextTab(newValue);
   }, []);
 
-  // const hasCurrentError = useMemo(() => {
-  //   if (!currentTab) return false;
-  //   const curr = tabs.find((t) => t.id === currentTab)?.enrollmentId;
-  //   if (!curr) return false;
-  //   const currState = formStates[curr];
-  //   return currState && currState.errors && !currState.dirty;
-  // }, [currentTab, formStates, tabs]);
-
   useEffect(() => {
     if (!nextTab) return;
     if (hasErrorAssessments) {

--- a/src/modules/assessments/components/household/HouseholdAssessments.tsx
+++ b/src/modules/assessments/components/household/HouseholdAssessments.tsx
@@ -91,6 +91,10 @@ const HouseholdAssessments: React.FC<Props> = ({
   const hasDirtyAssessments = Object.values(formStates).some(
     ({ dirty }) => dirty
   );
+  const hasErrorAssessments = Object.values(formStates).some(
+    ({ errors }) => errors
+  );
+
   const hasInflights = Object.values(formStates).some(({ saving }) => saving);
 
   const [householdMembers, fetchMembersStatus] = useHouseholdMembers(
@@ -144,11 +148,7 @@ const HouseholdAssessments: React.FC<Props> = ({
             assessmentInProgress,
             assessmentSubmitted: !!assessmentId && !assessmentInProgress,
             clientId: client.id,
-            client: {
-              id: client.id,
-              dob: client.dob,
-              veteranStatus: client.veteranStatus,
-            },
+            client,
             relationshipToHoH,
             assessmentDate,
             status: status,
@@ -193,18 +193,36 @@ const HouseholdAssessments: React.FC<Props> = ({
     setNextTab(newValue);
   }, []);
 
+  // const hasCurrentError = useMemo(() => {
+  //   if (!currentTab) return false;
+  //   const curr = tabs.find((t) => t.id === currentTab)?.enrollmentId;
+  //   if (!curr) return false;
+  //   const currState = formStates[curr];
+  //   return currState && currState.errors && !currState.dirty;
+  // }, [currentTab, formStates, tabs]);
+
   useEffect(() => {
+    if (!nextTab) return;
+    if (hasErrorAssessments) {
+      setNextTab(undefined); // clear out "next tab" state if there was an error
+      return;
+    }
     if (hasDirtyAssessments) return;
     if (hasInflights) return;
-    if (!nextTab) return;
     if (nextTab === currentTab) return;
-    // TODO: cancel navigation if errors
+
     setCurrentTab(nextTab);
     setNextTab(undefined);
     window.scrollTo(0, 0);
     router.navigate(`${pathname}#${nextTab}`, { replace: true });
-    // console.info('navigating')
-  }, [pathname, nextTab, currentTab, hasDirtyAssessments, hasInflights]);
+  }, [
+    pathname,
+    nextTab,
+    currentTab,
+    hasDirtyAssessments,
+    hasInflights,
+    hasErrorAssessments,
+  ]);
 
   // console.info({hasDirtyAssessments, hasInflights, nextTab, currentTab});
   // console.info(formStates);

--- a/src/modules/assessments/components/household/HouseholdSummaryTabPanel.tsx
+++ b/src/modules/assessments/components/household/HouseholdSummaryTabPanel.tsx
@@ -129,6 +129,7 @@ const HouseholdSummaryTabPanel = memo(
           )
           .filter((i): i is VersionedRecordInput => !!i);
 
+        setErrors(emptyErrorState);
         submitMutation({
           variables: {
             input: {

--- a/src/modules/assessments/components/household/formState.ts
+++ b/src/modules/assessments/components/household/formState.ts
@@ -1,32 +1,37 @@
 export interface HouseholdAssessmentFormState {
   dirty: boolean;
   saving: boolean;
-  // these are hard to track
-  // errors: boolean
+  errors: boolean;
 }
 
 export type HouseholdAssessmentFormAction =
   | 'saveStarted'
   | 'saveCompleted'
+  | 'saveFailed'
+  | 'saveCanceled'
   | 'formDirty';
 
 export const initialHouseholdAssessmentFormState: HouseholdAssessmentFormState =
   {
     dirty: false,
     saving: false,
+    errors: false,
   };
 
 export function householdAssessmentFormStateReducer(
   state: HouseholdAssessmentFormState,
   action: HouseholdAssessmentFormAction
 ): HouseholdAssessmentFormState {
-  // console.info('action', action);
   switch (action) {
     case 'saveStarted':
       return { ...state, saving: true };
     case 'saveCompleted':
-      return { ...state, saving: false, dirty: false };
+      return { saving: false, dirty: false, errors: false };
+    case 'saveFailed':
+      return { saving: false, dirty: false, errors: true };
+    case 'saveCanceled':
+      return { saving: false, dirty: true, errors: false };
     case 'formDirty':
-      return { ...state, dirty: true };
+      return { ...state, dirty: true, errors: false };
   }
 }

--- a/src/modules/assessments/components/household/util.ts
+++ b/src/modules/assessments/components/household/util.ts
@@ -1,5 +1,9 @@
-import { ClientNameDobVeteranFields } from '@/modules/form/util/formUtil';
-import { AssessmentRole, FormRole, RelationshipToHoH } from '@/types/gqlTypes';
+import {
+  AssessmentRole,
+  ClientNameDobVetFragment,
+  FormRole,
+  RelationshipToHoH,
+} from '@/types/gqlTypes';
 
 export enum AssessmentStatus {
   NotStarted,
@@ -32,7 +36,7 @@ export function isHouseholdAssesmentRole(
 export type TabDefinition = {
   id: string;
   clientName: string;
-  client: ClientNameDobVeteranFields;
+  client: ClientNameDobVetFragment;
   clientId: string;
   enrollmentId: string;
   entryOrExitCompleted?: boolean;

--- a/src/modules/assessments/hooks/useAssessmentHandlers.tsx
+++ b/src/modules/assessments/hooks/useAssessmentHandlers.tsx
@@ -169,7 +169,7 @@ export function useAssessmentHandlers({
   );
 
   const saveDraftHandler = useCallback(
-    (values: FormValues, onSuccessCallback: VoidFunction) => {
+    (values: FormValues, onSuccessCallback?: VoidFunction) => {
       if (!definition || !formDefinitionId) return;
 
       const input: AssessmentInput = {
@@ -205,10 +205,5 @@ export function useAssessmentHandlers({
     saveDraftHandler,
     mutationLoading: saveLoading || submitLoading,
     errors,
-  } as {
-    submitHandler: DynamicFormOnSubmit;
-    saveDraftHandler: (values: FormValues) => void; // wrong
-    mutationLoading: boolean;
-    errors: ErrorState;
-  };
+  } as const;
 }

--- a/src/modules/assessments/hooks/useAssessmentHandlers.tsx
+++ b/src/modules/assessments/hooks/useAssessmentHandlers.tsx
@@ -4,6 +4,9 @@ import { useCallback, useState } from 'react';
 import {
   emptyErrorState,
   ErrorState,
+  hasAnyValue,
+  hasErrors,
+  hasOnlyWarnings,
   partitionValidations,
 } from '@/modules/errors/util';
 import { DynamicFormOnSubmit } from '@/modules/form/components/DynamicForm';
@@ -13,7 +16,6 @@ import {
   transformSubmitValues,
 } from '@/modules/form/util/formUtil';
 import {
-  AssessmentFieldsFragment,
   AssessmentInput,
   FormDefinition,
   FormDefinitionJson,
@@ -23,14 +25,28 @@ import {
   useSubmitAssessmentMutation,
 } from '@/types/gqlTypes';
 
+export type AssessmentResponseStatus =
+  | 'saved'
+  | 'submitted'
+  | 'error'
+  | 'warning';
+
 type Args = {
-  definition: FormDefinition;
+  definition?: FormDefinition;
   enrollmentId: string;
   assessmentId?: string;
   assessmentLockVersion?: number;
-  onSuccessfulSubmit: (assessment: AssessmentFieldsFragment) => void;
-  onSuccessfulDraftSave: (assessment: AssessmentFieldsFragment) => void;
+  onCompletedMutation?: (
+    status: AssessmentResponseStatus,
+    data?: SubmitAssessmentMutation | SaveAssessmentMutation
+  ) => void;
 };
+
+function isSaveMutation(
+  data: SubmitAssessmentMutation | SaveAssessmentMutation
+): data is SaveAssessmentMutation {
+  return data && data.hasOwnProperty('saveAssessment');
+}
 
 export const createValuesForSubmit = (
   values: FormValues,
@@ -53,37 +69,54 @@ export function useAssessmentHandlers({
   enrollmentId,
   assessmentId,
   assessmentLockVersion,
-  onSuccessfulSubmit = () => null,
-  onSuccessfulDraftSave = () => null,
+  onCompletedMutation = () => null,
 }: Args) {
-  const formDefinitionId = definition.id;
+  const formDefinitionId = definition?.id;
 
   const [errors, setErrors] = useState<ErrorState>(emptyErrorState);
 
   const onCompleted = useCallback(
     (data: SubmitAssessmentMutation | SaveAssessmentMutation) => {
       let errs;
-      if (data.hasOwnProperty('saveAssessment')) {
-        errs = (data as SaveAssessmentMutation).saveAssessment?.errors || [];
+      if (isSaveMutation(data)) {
+        errs = data.saveAssessment?.errors || [];
       } else {
-        errs =
-          (data as SubmitAssessmentMutation).submitAssessment?.errors || [];
+        errs = data.submitAssessment?.errors || [];
+      }
+      const errorState = partitionValidations(errs || []);
+
+      let status: AssessmentResponseStatus;
+      if (hasErrors(errorState)) {
+        status = 'error';
+      } else if (hasOnlyWarnings(errorState)) {
+        status = 'warning';
+      } else if (isSaveMutation(data)) {
+        status = 'saved';
+      } else {
+        status = 'submitted';
       }
 
-      if (errs.length > 0) {
-        window.scrollTo(0, 0);
-        setErrors(partitionValidations(errs));
-        return;
+      if (hasAnyValue(errorState)) {
+        window.scrollTo(0, 0); // scroll to top to view errors
+        setErrors(errorState); // update error state
+        onCompletedMutation(status, data); // callback
+      } else {
+        setErrors(emptyErrorState); // clear error state
+        onCompletedMutation(status, data); // callback
       }
-      setErrors(emptyErrorState);
     },
-    [setErrors]
+    [onCompletedMutation]
   );
 
-  const onError = useCallback((apolloError: ApolloError) => {
-    window.scrollTo(0, 0);
-    setErrors({ ...emptyErrorState, apolloError });
-  }, []);
+  // Handle server error
+  const onError = useCallback(
+    (apolloError: ApolloError) => {
+      window.scrollTo(0, 0);
+      setErrors({ ...emptyErrorState, apolloError });
+      onCompletedMutation('error');
+    },
+    [onCompletedMutation]
+  );
 
   const [saveAssessmentMutation, { loading: saveLoading }] =
     useSaveAssessmentMutation({ onError });
@@ -93,7 +126,7 @@ export function useAssessmentHandlers({
 
   const submitHandler: DynamicFormOnSubmit = useCallback(
     ({ event, values, confirmed = false, onSuccess }) => {
-      if (!definition) return;
+      if (!definition || !formDefinitionId) return;
       if (
         event &&
         debugFormValues(
@@ -120,7 +153,6 @@ export function useAssessmentHandlers({
           onCompleted(data);
           if (data.submitAssessment?.assessment && onSuccess) {
             onSuccess();
-            onSuccessfulSubmit(data.submitAssessment?.assessment);
           }
         },
       });
@@ -133,13 +165,12 @@ export function useAssessmentHandlers({
       formDefinitionId,
       enrollmentId,
       onCompleted,
-      onSuccessfulSubmit,
     ]
   );
 
   const saveDraftHandler = useCallback(
     (values: FormValues, onSuccessCallback: VoidFunction) => {
-      if (!definition) return;
+      if (!definition || !formDefinitionId) return;
 
       const input: AssessmentInput = {
         assessmentId,
@@ -154,7 +185,6 @@ export function useAssessmentHandlers({
           onCompleted(data);
           if (data.saveAssessment?.assessment && onSuccessCallback) {
             onSuccessCallback();
-            onSuccessfulDraftSave(data.saveAssessment?.assessment);
           }
         },
       });
@@ -167,7 +197,6 @@ export function useAssessmentHandlers({
       formDefinitionId,
       enrollmentId,
       onCompleted,
-      onSuccessfulDraftSave,
     ]
   );
 
@@ -178,7 +207,7 @@ export function useAssessmentHandlers({
     errors,
   } as {
     submitHandler: DynamicFormOnSubmit;
-    saveDraftHandler: (values: FormValues) => void;
+    saveDraftHandler: (values: FormValues) => void; // wrong
     mutationLoading: boolean;
     errors: ErrorState;
   };

--- a/src/modules/form/components/FormActions.tsx
+++ b/src/modules/form/components/FormActions.tsx
@@ -1,11 +1,18 @@
 import { ButtonProps, Stack } from '@mui/material';
 import { findIndex, findLastIndex } from 'lodash-es';
-import { MouseEventHandler, useCallback, useMemo, useState } from 'react';
+import {
+  MouseEventHandler,
+  ReactNode,
+  useCallback,
+  useMemo,
+  useState,
+} from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { FormActionTypes } from '../types';
 
 import ButtonLink from '@/components/elements/ButtonLink';
+import ButtonTooltipContainer from '@/components/elements/ButtonTooltipContainer';
 import LoadingButton from '@/components/elements/LoadingButton';
 import AssessmentLastUpdated from '@/modules/hmis/components/AssessmentLastUpdated';
 
@@ -17,6 +24,7 @@ type ButtonConfig = {
   onClick?: VoidFunction;
   centerAlign?: boolean;
   buttonProps?: Omit<ButtonProps, 'ref'>;
+  tooltip?: ReactNode;
 };
 
 export interface FormActionProps {
@@ -111,7 +119,8 @@ const FormActions = ({
   );
 
   const renderButton = (buttonConfig: ButtonConfig) => {
-    const { id, label, action, loadingLabel, buttonProps } = buttonConfig;
+    const { id, label, action, loadingLabel, tooltip, buttonProps } =
+      buttonConfig;
     const isSubmit =
       action === FormActionTypes.Save || action === FormActionTypes.Submit;
 
@@ -137,18 +146,19 @@ const FormActions = ({
     const isLoading = loading && lastClicked === id;
 
     return (
-      <LoadingButton
-        key={id}
-        data-testid={`formButton-${id}`}
-        type={isSubmit ? 'submit' : undefined}
-        disabled={disabled || loading}
-        onClick={getClickHandler(buttonConfig)}
-        loading={isLoading}
-        loadingPosition={loadingLabel ? 'end' : 'center'}
-        {...buttonProps}
-      >
-        {isLoading && loadingLabel ? loadingLabel : label}
-      </LoadingButton>
+      <ButtonTooltipContainer key={id} title={tooltip}>
+        <LoadingButton
+          data-testid={`formButton-${id}`}
+          type={isSubmit ? 'submit' : undefined}
+          disabled={disabled || loading}
+          onClick={getClickHandler(buttonConfig)}
+          loading={isLoading}
+          loadingPosition={isLoading && loadingLabel ? 'end' : undefined}
+          {...buttonProps}
+        >
+          {isLoading && loadingLabel ? loadingLabel : label}
+        </LoadingButton>
+      </ButtonTooltipContainer>
     );
   };
 

--- a/src/modules/form/components/FormActions.tsx
+++ b/src/modules/form/components/FormActions.tsx
@@ -13,18 +13,15 @@ type ButtonConfig = {
   id: string;
   label: string;
   action: FormActionTypes;
-  onSuccess?: VoidFunction;
+  onClick?: VoidFunction;
   centerAlign?: boolean;
   buttonProps?: Omit<ButtonProps, 'ref'>;
 };
 
 export interface FormActionProps {
   config?: ButtonConfig[];
-  onSubmit: (
-    e: React.MouseEvent<HTMLButtonElement>,
-    onSuccess?: VoidFunction
-  ) => void;
-  onSaveDraft?: (onSuccess?: VoidFunction) => void;
+  onSubmit: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  onSaveDraft?: VoidFunction;
   onDiscard?: MouseEventHandler | string;
   submitButtonText?: string;
   discardButtonText?: string;
@@ -84,7 +81,7 @@ const FormActions = ({
   const [lastClicked, setLastClicked] = useState<string>();
 
   const getClickHandler = useCallback(
-    ({ action, onSuccess, id }: ButtonConfig) => {
+    ({ action, onClick, id }: ButtonConfig) => {
       if (action === FormActionTypes.Discard) {
         return (onDiscard as MouseEventHandler) || (() => navigate(-1));
       }
@@ -93,7 +90,7 @@ const FormActions = ({
         return (e: React.MouseEvent<HTMLButtonElement>) => {
           e.preventDefault();
           setLastClicked(id);
-          onSaveDraft(onSuccess);
+          onSaveDraft();
         };
       }
       if (action === FormActionTypes.Submit) {
@@ -101,12 +98,12 @@ const FormActions = ({
         return (e: React.MouseEvent<HTMLButtonElement>) => {
           e.preventDefault();
           setLastClicked(id);
-          onSubmit(e, onSuccess);
+          onSubmit(e);
         };
       }
 
       if (action === FormActionTypes.Navigate) {
-        return onSuccess;
+        return onClick;
       }
     },
     [onDiscard, onSaveDraft, onSubmit, navigate]

--- a/src/modules/form/components/FormActions.tsx
+++ b/src/modules/form/components/FormActions.tsx
@@ -12,6 +12,7 @@ import AssessmentLastUpdated from '@/modules/hmis/components/AssessmentLastUpdat
 type ButtonConfig = {
   id: string;
   label: string;
+  loadingLabel?: string;
   action: FormActionTypes;
   onClick?: VoidFunction;
   centerAlign?: boolean;
@@ -110,7 +111,7 @@ const FormActions = ({
   );
 
   const renderButton = (buttonConfig: ButtonConfig) => {
-    const { id, label, action, buttonProps } = buttonConfig;
+    const { id, label, action, loadingLabel, buttonProps } = buttonConfig;
     const isSubmit =
       action === FormActionTypes.Save || action === FormActionTypes.Submit;
 
@@ -133,6 +134,8 @@ const FormActions = ({
       );
     }
 
+    const isLoading = loading && lastClicked === id;
+
     return (
       <LoadingButton
         key={id}
@@ -140,10 +143,11 @@ const FormActions = ({
         type={isSubmit ? 'submit' : undefined}
         disabled={disabled || loading}
         onClick={getClickHandler(buttonConfig)}
-        loading={loading && lastClicked === id}
+        loading={isLoading}
+        loadingPosition={loadingLabel ? 'end' : 'center'}
         {...buttonProps}
       >
-        {label}
+        {isLoading && loadingLabel ? loadingLabel : label}
       </LoadingButton>
     );
   };

--- a/src/modules/hmis/hmisUtil.ts
+++ b/src/modules/hmis/hmisUtil.ts
@@ -25,6 +25,7 @@ import {
   AssessmentFieldsFragment,
   ClientEnrollmentFieldsFragment,
   ClientFieldsFragment,
+  ClientNameDobVetFragment,
   ClientNameFragment,
   CustomDataElementFieldsFragment,
   CustomDataElementValueFieldsFragment,
@@ -227,7 +228,9 @@ export const clientNameAllParts = (client: ClientNameFragment) => {
   );
 };
 
-export const clientBriefName = (client: ClientNameFragment) =>
+export const clientBriefName = (
+  client: ClientNameFragment | ClientNameDobVetFragment
+) =>
   [client.firstName, client.lastName].filter(Boolean).join(' ') ||
   anonymousClientName(client);
 


### PR DESCRIPTION
## Description

#### Bugs fixed
* Fixes a bug where a user could get "stuck" if they attempted to re-submit an assessment and then canceled the warning dialog. Repro steps:
  * Set up household assessments where at least 1 assessment has been Submitted
  * Unlock a submitted assessment
  * Make a change. Make sure some fields are left empty so you get a warning.
  * Click "save & submit"
  * Click "cancel" on the warning dialog
  * Try clicking Next/Prev or Tabs (Bug: nothing happens)
* Fixes a bug where a user could get "stuck" if they saved an assessment with an error. With this change, they still do get stuck, but they get a tooltip explaining that they have to fix errors before proceeding. (needs improvement). Repro steps
  *  Set up a household where at least 1 assessment is In Progress
  *  Update the Entry Date to be in the future (need to use text input, not picker)
  *  Hit "save" OR "next" or "previous" or any tab
  * Error message shows up. 
  * Fix the error by moving the date in range
  * Bug: "next"/"prev" don't do anything. "Save" resolves the error


#### Fetching Assessments and Definitions
- When an Assessment form is rendered, we need to fetch the Assessment (if editing an existing) and the Definition to use for rendering. These fetches are encapsulated in the `useAssessment` hook.
- The `useAssessment` hook was previously used by the `IndividualAssessment` component.
- With this PR, `useAssessment` is instead called by `IndividualAssessmentPage` (for single assmts) and `HouseholdAssessmentTabPanel` (for household assmts).


#### Assessment Mutation Handlers
- The assessment submission "handlers" are responsible for taking the raw form state and transforming it into values for submission (which requires knowledge of the definition), and calling the appropriate mutation. This is all encapsulated in the `useAssessmentHandlers` hook.
- The `useAssessmentHandlers` hook was previously used by the `AssessmentForm` component.
- With this PR, `useAssessmentHandlers` is instead called by `IndividualAssessmentPage` (for single assmts) and `HouseholdAssessmentTabPanel` (for household assmts). This allows each of those components to easily wrap the handlers to specify logic that should occur before/during/after a save occurs, and see the server response directly.
- This should help us with threading errors through the household assessments tab

#### Extra callbacks
- Now that the `useAssessmentHandlers` are pulled up to higher level components, I was able to get rid of some of the weird callbacks-in-callbacks that were around. 


## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [x] Code clean-up / housekeeping

## Checklist before requesting review
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (eslint)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
