### PR TITLE
Audit UI improvements

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -34292,6 +34292,18 @@
             "deprecationReason": null
           },
           {
+            "name": "recordType",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "ENUM",
+              "name": "RecordType",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "referralOutcome",
             "description": null,
             "args": [],
@@ -34326,6 +34338,18 @@
             "type": {
               "kind": "ENUM",
               "name": "ServiceSubTypeProvided",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "typeProvided",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "ENUM",
+              "name": "ServiceTypeProvided",
               "ofType": null
             },
             "isDeprecated": false,

--- a/src/components/elements/YesNoDisplay.tsx
+++ b/src/components/elements/YesNoDisplay.tsx
@@ -18,6 +18,7 @@ interface Props extends TypographyProps {
     | DisabilityResponse
     | null;
   fallback?: ReactElement;
+  showIcon?: boolean;
 }
 
 const YES_VALUES: string[] = [
@@ -36,6 +37,7 @@ const YesNoDisplay: React.FC<Props> = ({
   booleanValue,
   enumValue,
   fallback,
+  showIcon = false,
   ...props
 }) => {
   let Icon;
@@ -64,8 +66,14 @@ const YesNoDisplay: React.FC<Props> = ({
 
   return (
     <Stack direction='row' gap={0.8}>
-      {Icon && <Icon fontSize='small' sx={{ alignSelf: 'center' }} />}
-      <Typography variant='body2' color='text.secondary' {...props}>
+      {showIcon && Icon && (
+        <Icon fontSize='small' sx={{ alignSelf: 'center' }} />
+      )}
+      <Typography
+        variant='body2'
+        color={showIcon && Icon ? 'text.secondary' : 'text.primary'}
+        {...props}
+      >
         {text}
       </Typography>
     </Stack>

--- a/src/modules/audit/components/AuditObjectChangesSummary.tsx
+++ b/src/modules/audit/components/AuditObjectChangesSummary.tsx
@@ -6,6 +6,7 @@ import { filter, isNil } from 'lodash-es';
 import SimpleTable from '@/components/elements/SimpleTable';
 import { hasMeaningfulValue } from '@/modules/form/util/formUtil';
 import HmisField from '@/modules/hmis/components/HmisField';
+import { AuditEventType } from '@/types/gqlTypes';
 
 // expected shape of JSON 'objectChanges' field
 export type ObjectChangesType = {
@@ -19,6 +20,7 @@ export type ObjectChangesType = {
 interface Props {
   objectChanges: ObjectChangesType;
   recordType: string;
+  eventType: AuditEventType;
 }
 
 const nullText = (
@@ -47,6 +49,7 @@ const changedText = (
 const AuditObjectChangesSummary: React.FC<Props> = ({
   objectChanges,
   recordType,
+  eventType,
 }) => {
   return (
     <SimpleTable
@@ -89,13 +92,19 @@ const AuditObjectChangesSummary: React.FC<Props> = ({
 
             return (
               <Stack gap={1} direction='row' alignItems='center'>
-                <Typography variant='body2' component='div'>
-                  {isNil(from) ? nullText : from}
-                </Typography>
-                <ArrowForwardIcon fontSize='inherit' />
-                <Typography variant='body2' component='div'>
-                  {isNil(to) ? nullText : to}
-                </Typography>
+                {['destroy', 'update'].includes(eventType) && (
+                  <Typography variant='body2' component='div'>
+                    {isNil(from) ? nullText : from}
+                  </Typography>
+                )}
+                {eventType === 'update' && (
+                  <ArrowForwardIcon fontSize='inherit' />
+                )}
+                {['update', 'create'].includes(eventType) && (
+                  <Typography variant='body2' component='div'>
+                    {isNil(to) ? nullText : to}
+                  </Typography>
+                )}
               </Stack>
             );
           },

--- a/src/modules/audit/components/ClientAuditHistory.tsx
+++ b/src/modules/audit/components/ClientAuditHistory.tsx
@@ -1,5 +1,5 @@
 import { Paper, Stack, Typography } from '@mui/material';
-import { capitalize, filter } from 'lodash-es';
+import { filter } from 'lodash-es';
 import AuditObjectChangesSummary, {
   ObjectChangesType,
 } from './AuditObjectChangesSummary';
@@ -13,7 +13,10 @@ import PageTitle from '@/components/layout/PageTitle';
 import useSafeParams from '@/hooks/useSafeParams';
 import GenericTableWithData from '@/modules/dataFetching/components/GenericTableWithData';
 import { hasMeaningfulValue } from '@/modules/form/util/formUtil';
-import { formatDateTimeForDisplay } from '@/modules/hmis/hmisUtil';
+import {
+  auditActionForDisplay,
+  formatDateTimeForDisplay,
+} from '@/modules/hmis/hmisUtil';
 import {
   GetClientAuditEventsDocument,
   GetClientAuditEventsQuery,
@@ -39,7 +42,7 @@ const columns: ColumnDef<AuditHistoryType>[] = [
   {
     header: 'Action',
     width: '100px',
-    render: ({ event }) => capitalize(event),
+    render: ({ event }) => auditActionForDisplay(event),
   },
   {
     header: 'Record Type',

--- a/src/modules/audit/components/ClientAuditHistory.tsx
+++ b/src/modules/audit/components/ClientAuditHistory.tsx
@@ -81,6 +81,7 @@ const columns: ColumnDef<AuditHistoryType>[] = [
           <AuditObjectChangesSummary
             objectChanges={e.objectChanges as ObjectChangesType}
             recordType={e.graphqlType}
+            eventType={e.event}
           />
         </ContextualCollapsibleList>
       );

--- a/src/modules/audit/components/EnrollmentAuditHistory.tsx
+++ b/src/modules/audit/components/EnrollmentAuditHistory.tsx
@@ -1,5 +1,5 @@
 import { Paper, Stack, Typography } from '@mui/material';
-import { capitalize, filter } from 'lodash-es';
+import { filter } from 'lodash-es';
 import AuditObjectChangesSummary, {
   ObjectChangesType,
 } from './AuditObjectChangesSummary';
@@ -13,7 +13,10 @@ import PageTitle from '@/components/layout/PageTitle';
 import useSafeParams from '@/hooks/useSafeParams';
 import GenericTableWithData from '@/modules/dataFetching/components/GenericTableWithData';
 import { hasMeaningfulValue } from '@/modules/form/util/formUtil';
-import { formatDateTimeForDisplay } from '@/modules/hmis/hmisUtil';
+import {
+  auditActionForDisplay,
+  formatDateTimeForDisplay,
+} from '@/modules/hmis/hmisUtil';
 import {
   BaseAuditEventFilterOptions,
   GetEnrollmentAuditEventsDocument,
@@ -40,11 +43,11 @@ const columns: ColumnDef<AuditHistoryType>[] = [
   {
     header: 'Action',
     width: '100px',
-    render: ({ event }) => capitalize(event),
+    render: ({ event }) => auditActionForDisplay(event),
   },
   {
     header: 'Record Type',
-    width: '150px',
+    width: '180px',
     render: ({ recordName, recordId }) => {
       return (
         <Stack>

--- a/src/modules/audit/components/EnrollmentAuditHistory.tsx
+++ b/src/modules/audit/components/EnrollmentAuditHistory.tsx
@@ -82,6 +82,7 @@ const columns: ColumnDef<AuditHistoryType>[] = [
           <AuditObjectChangesSummary
             objectChanges={e.objectChanges as ObjectChangesType}
             recordType={e.graphqlType}
+            eventType={e.event}
           />
         </ContextualCollapsibleList>
       );

--- a/src/modules/hmis/components/HmisEnum.tsx
+++ b/src/modules/hmis/components/HmisEnum.tsx
@@ -11,7 +11,7 @@ const getLabelAndColor = (
   let color: TypographyProps['color'] = 'text.primary';
   let label = enumMap[value];
   if (!label) {
-    label = noValue || 'Not Specified'; // fixme handle invalid?
+    label = noValue || 'Not Specified';
     color = 'text.secondary';
   } else if (value === INVALID_ENUM) {
     color = 'error';

--- a/src/modules/hmis/components/HmisEnum.tsx
+++ b/src/modules/hmis/components/HmisEnum.tsx
@@ -11,7 +11,7 @@ const getLabelAndColor = (
   let color: TypographyProps['color'] = 'text.primary';
   let label = enumMap[value];
   if (!label) {
-    label = noValue || 'Not Specified';
+    label = noValue || 'Not Specified'; // fixme handle invalid?
     color = 'text.secondary';
   } else if (value === INVALID_ENUM) {
     color = 'error';

--- a/src/modules/hmis/components/HmisField.tsx
+++ b/src/modules/hmis/components/HmisField.tsx
@@ -56,6 +56,7 @@ const getPrimitiveDisplay = (value: any, type: GqlSchemaType['name']) => {
     case 'Float':
       return formatCurrency(value);
   }
+  // FIXME: attempt date formatting if it looks like a date
   return value;
 };
 

--- a/src/modules/hmis/components/HmisField.tsx
+++ b/src/modules/hmis/components/HmisField.tsx
@@ -6,6 +6,7 @@ import {
   getSchemaForType,
   parseAndFormatDate,
   parseAndFormatDateTime,
+  safeParseDateOrString,
 } from '../hmisUtil';
 
 import { hasCustomDataElements } from '../types';
@@ -45,6 +46,7 @@ const getPrimitiveDisplay = (value: any, type: GqlSchemaType['name']) => {
       <HmisEnum value={value} enumMap={enumMap} />
     );
   }
+
   switch (type) {
     case 'Boolean':
       if (!isNil(value)) return <YesNoDisplay booleanValue={value} />;
@@ -56,7 +58,12 @@ const getPrimitiveDisplay = (value: any, type: GqlSchemaType['name']) => {
     case 'Float':
       return formatCurrency(value);
   }
-  // FIXME: attempt date formatting if it looks like a date
+
+  // Attempt date formatting if it is a date
+  if (safeParseDateOrString(value)) {
+    return parseAndFormatDate(value);
+  }
+
   return value;
 };
 

--- a/src/modules/hmis/hmisUtil.ts
+++ b/src/modules/hmis/hmisUtil.ts
@@ -11,7 +11,7 @@ import {
   isYesterday,
   parseISO,
 } from 'date-fns';
-import { find, isNil, sortBy, startCase } from 'lodash-es';
+import { capitalize, find, isNil, sortBy, startCase } from 'lodash-es';
 
 import {
   ClientNameDobVeteranFields,
@@ -23,6 +23,7 @@ import { HmisEnums } from '@/types/gqlEnums';
 import { HmisInputObjectSchemas, HmisObjectSchemas } from '@/types/gqlObjects';
 import {
   AssessmentFieldsFragment,
+  AuditEventType,
   ClientEnrollmentFieldsFragment,
   ClientFieldsFragment,
   ClientNameDobVetFragment,
@@ -564,4 +565,11 @@ export const relationshipToHohForDisplay = (
   if (relationship === RelationshipToHoH.SelfHeadOfHousehold) return 'HoH';
 
   return HmisEnums.RelationshipToHoH[relationship];
+};
+
+export const auditActionForDisplay = (action: AuditEventType) => {
+  if (action === AuditEventType.Destroy) {
+    return 'Delete';
+  }
+  return capitalize(action);
 };

--- a/src/types/gqlObjects.ts
+++ b/src/types/gqlObjects.ts
@@ -4868,12 +4868,20 @@ export const HmisObjectSchemas: GqlSchema[] = [
         type: { kind: 'SCALAR', name: 'String', ofType: null },
       },
       {
+        name: 'recordType',
+        type: { kind: 'ENUM', name: 'RecordType', ofType: null },
+      },
+      {
         name: 'referralOutcome',
         type: { kind: 'ENUM', name: 'PATHReferralOutcome', ofType: null },
       },
       {
         name: 'subTypeProvided',
         type: { kind: 'ENUM', name: 'ServiceSubTypeProvided', ofType: null },
+      },
+      {
+        name: 'typeProvided',
+        type: { kind: 'ENUM', name: 'ServiceTypeProvided', ofType: null },
       },
     ],
   },

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -5589,9 +5589,11 @@ export type Service = {
   id: Scalars['ID']['output'];
   movingOnOtherType?: Maybe<Scalars['String']['output']>;
   otherTypeProvided?: Maybe<Scalars['String']['output']>;
+  recordType?: Maybe<RecordType>;
   referralOutcome?: Maybe<PathReferralOutcome>;
   serviceType: ServiceType;
   subTypeProvided?: Maybe<ServiceSubTypeProvided>;
+  typeProvided?: Maybe<ServiceTypeProvided>;
   user?: Maybe<ApplicationUser>;
 };
 


### PR DESCRIPTION
## Description

UI Improvements to Client and Enrollment audit interfaces:

* Only show one value on Create and Destroy actions
* Destroy=>Delete in the UI

Depends on hmis-warehouse PR: https://github.com/greenriver/hmis-warehouse/pull/3811

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Code clean-up / housekeeping

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
