### PR TITLE
Fix tab scroll in assessment

### DIFF
--- a/src/modules/form/components/DynamicForm.tsx
+++ b/src/modules/form/components/DynamicForm.tsx
@@ -252,6 +252,7 @@ const DynamicForm = forwardRef(
           <SaveSlide
             in={alwaysShowSaveSlide || (promptSave && !isSaveButtonVisible)}
             appear
+            padBody
             timeout={300}
             direction='up'
             loading={loading}

--- a/src/modules/form/components/SaveSlide.tsx
+++ b/src/modules/form/components/SaveSlide.tsx
@@ -1,40 +1,72 @@
 import { Box, LinearProgress, Paper, Slide, SlideProps } from '@mui/material';
+import { first } from 'lodash-es';
+import { useEffect, useRef, useState } from 'react';
 
 interface Props extends SlideProps {
   loading?: boolean;
+  padBody?: boolean;
 }
 
-const SaveSlide = ({ children, loading = false, ...props }: Props) => (
-  <Slide {...props}>
-    <Paper
-      elevation={2}
-      square
-      sx={{
-        position: 'sticky',
-        bottom: 0,
-        display: 'flex',
-        alignItems: 'center',
-        flexDirection: 'row-reverse',
-        backgroundColor: 'white',
-        zIndex: (theme) => theme.zIndex.drawer,
-        boxShadow: '0 0 10px rgb(0 0 0 / 25%)',
-        clipPath: 'inset(-10px -1px 0px -1px)',
-      }}
-    >
-      <Box sx={{ width: '100%' }}>
-        {loading ? (
-          <LinearProgress
-            sx={{ height: 2 }}
-            aria-live='polite'
-            aria-busy='true'
-          />
-        ) : (
-          <Box sx={{ height: 2 }} />
-        )}
-        <Box sx={{ p: 2 }}>{children}</Box>
-      </Box>
-    </Paper>
-  </Slide>
-);
+const SaveSlide = ({
+  children,
+  loading = false,
+  padBody = false,
+  ...props
+}: Props) => {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const [height, setHeight] = useState(0);
+
+  useEffect(() => {
+    if (!padBody) return;
+    const currentElem = ref.current;
+    if (!currentElem) return;
+
+    const observer = new ResizeObserver((entries) => {
+      const entry = first(entries);
+      if (entry?.contentRect) setHeight(entry.contentRect.height);
+    });
+
+    observer.observe(currentElem);
+    return () => observer.unobserve(currentElem);
+  }, [padBody]);
+
+  return (
+    <>
+      {height > 0 && (
+        <style>{`html { scroll-padding-bottom: ${height}px }`}</style>
+      )}
+      <Slide {...props} ref={ref}>
+        <Paper
+          elevation={2}
+          square
+          sx={{
+            position: 'sticky',
+            bottom: 0,
+            display: 'flex',
+            alignItems: 'center',
+            flexDirection: 'row-reverse',
+            backgroundColor: 'white',
+            zIndex: (theme) => theme.zIndex.drawer,
+            boxShadow: '0 0 10px rgb(0 0 0 / 25%)',
+            clipPath: 'inset(-10px -1px 0px -1px)',
+          }}
+        >
+          <Box sx={{ width: '100%' }}>
+            {loading ? (
+              <LinearProgress
+                sx={{ height: 2 }}
+                aria-live='polite'
+                aria-busy='true'
+              />
+            ) : (
+              <Box sx={{ height: 2 }} />
+            )}
+            <Box sx={{ p: 2 }}>{children}</Box>
+          </Box>
+        </Paper>
+      </Slide>
+    </>
+  );
+};
 
 export default SaveSlide;


### PR DESCRIPTION
## Description

Adds a scroll bottom padding to the `html` element when `SaveSlide` has dimensions, which should fix the tabbing issue. Added a `ResizeObserver` to help deal with a potentially dynamic height of this element.

[//]: # 'remove if not applicable'
Depends on hmis-warehouse PR:

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
