### PR TITLE
Split JS into vendor chunk & app chunk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+bundle_analysis*
 untracked
 docker-compose.yml
 docker-dev

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,12 +3,14 @@ import { resolve } from 'path';
 
 import { sentryVitePlugin } from '@sentry/vite-plugin';
 import react from '@vitejs/plugin-react';
-// import { visualizer } from 'rollup-plugin-visualizer';
+import { visualizer } from 'rollup-plugin-visualizer';
 import { defineConfig, loadEnv } from 'vite';
+
 import mkcert from 'vite-plugin-mkcert';
 
 dns.setDefaultResultOrder('ipv4first');
 
+const VISUALIZER = false; // enable to generate bundle visualization on build
 const DEFAULT_WAREHOUSE_SERVER = 'https://hmis-warehouse.dev.test';
 
 // https://github.com/vitejs/vite/issues/2433#issuecomment-1487472995
@@ -81,11 +83,18 @@ export default defineConfig(({ command, mode }) => {
     build: {
       rollupOptions: {
         plugins: [
-          // visualizer({ filename: 'bundle_analysis.html' })
+          VISUALIZER && visualizer({ filename: 'bundle_analysis.html' }),
         ],
+        output: {
+          manualChunks(id) {
+            if (id.includes('node_modules')) {
+              return 'vendor';
+            }
+          },
+        },
       },
       sourcemap: true,
-      minify: mode === 'development' ? false : true,
+      minify: mode === 'development' ? false : 'esbuild',
     },
     ...(command !== 'build' && {
       preview: {


### PR DESCRIPTION
## Description

Split out npm dependencies into a vendor chunk. Should still be further split and optimized as both bundles are large. [PT: further improvements](https://www.pivotaltracker.com/story/show/186701612)

## Type of change
- [x] Code clean-up / housekeeping

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (eslint)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
