### PR TITLE
Support custom client detail forms (for pathways)

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -15446,9 +15446,17 @@
             "name": "project",
             "description": null,
             "type": {
-              "kind": "SCALAR",
-              "name": "ID",
-              "ofType": null
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              }
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -19370,6 +19378,12 @@
           {
             "name": "CLIENT",
             "description": "Client",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "CLIENT_DETAIL",
+            "description": "Client detail",
             "isDeprecated": false,
             "deprecationReason": null
           },
@@ -32279,6 +32293,30 @@
               "kind": "OBJECT",
               "name": "Client",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "clientDetailForms",
+            "description": "Custom forms for collecting and/or displaying custom details for a Client (outside of the Client demographics form)",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "OccurrencePointForm",
+                    "ofType": null
+                  }
+                }
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/src/api/operations/client.queries.graphql
+++ b/src/api/operations/client.queries.graphql
@@ -200,3 +200,9 @@ query GetClientFiles($id: ID!, $limit: Int = 10, $offset: Int = 0) {
     }
   }
 }
+
+query ClientDetailForms {
+  clientDetailForms {
+    ...OccurrencePointFormFields
+  }
+}

--- a/src/components/clientDashboard/ProfileLayout.tsx
+++ b/src/components/clientDashboard/ProfileLayout.tsx
@@ -36,9 +36,7 @@ const ProfileLayout: React.FC<Props> = ({ client, notices = [] }) => {
         )}
         <Grid item md={12} lg={canViewEnrollments ? 6 : 8}>
           <Stack gap={2}>
-            <Box>
-              <ClientProfileCard client={client} />
-            </Box>
+            <ClientProfileCard client={client} />
             <ClientCustomDataElementsCard client={client} />
           </Stack>
         </Grid>

--- a/src/components/clientDashboard/ProfileLayout.tsx
+++ b/src/components/clientDashboard/ProfileLayout.tsx
@@ -1,6 +1,7 @@
-import { Alert, AlertProps, AlertTitle, Box, Grid } from '@mui/material';
+import { Alert, AlertProps, AlertTitle, Box, Grid, Stack } from '@mui/material';
 import { isEmpty } from 'lodash-es';
 
+import ClientCustomDataElementsCard from '@/modules/client/components/ClientCustomDataElementsCard';
 import ClientEnrollmentCard from '@/modules/client/components/ClientEnrollmentCard';
 import ClientProfileCard from '@/modules/client/components/ClientProfileCard';
 import { ClientFieldsFragment } from '@/types/gqlTypes';
@@ -34,7 +35,12 @@ const ProfileLayout: React.FC<Props> = ({ client, notices = [] }) => {
           </Grid>
         )}
         <Grid item md={12} lg={canViewEnrollments ? 6 : 8}>
-          <ClientProfileCard client={client} />
+          <Stack gap={2}>
+            <Box>
+              <ClientProfileCard client={client} />
+            </Box>
+            <ClientCustomDataElementsCard client={client} />
+          </Stack>
         </Grid>
         {canViewEnrollments && (
           <Grid item md={12} lg={6}>

--- a/src/components/elements/CommonDetailGrid.tsx
+++ b/src/components/elements/CommonDetailGrid.tsx
@@ -1,12 +1,12 @@
 import { Grid, Typography } from '@mui/material';
 
-import React, { ReactNode } from 'react';
+import React, { ReactNode, useId } from 'react';
 
 // Grid of Key/Value pairs that has the specific styling used for Enrollment Details and custom client attributes
 
-export const CommonDetailGridContainer: React.FC<{ children: ReactNode }> = ({
-  children,
-}) => {
+export const CommonDetailGridContainer: React.FC<{
+  children: ReactNode;
+}> = ({ children }) => {
   return (
     <Grid
       container
@@ -34,20 +34,40 @@ export const CommonDetailGridItem: React.FC<{
   label: string | ReactNode;
   children: ReactNode;
 }> = ({ label, children }) => {
+  const labelId = useId();
   const itemSx = {
     py: 1.5,
     px: 2,
     display: 'flex',
     alignItems: 'center',
   };
+
   return (
     <>
-      <Grid item xs={12} md={4} lg={5} xl={4} sx={{ ...itemSx }} key='label'>
+      <Grid
+        key='label'
+        id={labelId}
+        item
+        xs={12}
+        md={4}
+        lg={5}
+        xl={4}
+        sx={itemSx}
+      >
         <Typography fontWeight={600} variant='body2'>
           {label}
         </Typography>
       </Grid>
-      <Grid item xs={12} md={8} lg={7} xl={8} sx={{ ...itemSx }} key='value'>
+      <Grid
+        key='value'
+        item
+        xs={12}
+        md={8}
+        lg={7}
+        xl={8}
+        sx={itemSx}
+        aria-labelledby={labelId}
+      >
         <Typography variant='body2' component='div' sx={{ width: '100%' }}>
           {children}
         </Typography>

--- a/src/components/elements/CommonDetailGrid.tsx
+++ b/src/components/elements/CommonDetailGrid.tsx
@@ -1,0 +1,57 @@
+import { Grid, Typography } from '@mui/material';
+
+import React, { ReactNode } from 'react';
+
+// Grid of Key/Value pairs that has the specific styling used for Enrollment Details and custom client attributes
+
+export const CommonDetailGridContainer: React.FC<{ children: ReactNode }> = ({
+  children,
+}) => {
+  return (
+    <Grid
+      container
+      rowGap={0}
+      sx={{
+        '> .MuiGrid-item': {
+          borderBottomColor: 'borders.light',
+          borderBottomWidth: 1,
+          borderBottomStyle: 'solid',
+        },
+        '> .MuiGrid-item:nth-last-of-type(2)': {
+          border: 'unset',
+        },
+        '> .MuiGrid-item:nth-last-of-type(1)': {
+          border: 'unset',
+        },
+      }}
+    >
+      {children}
+    </Grid>
+  );
+};
+
+export const CommonDetailGridItem: React.FC<{
+  label: string | ReactNode;
+  children: ReactNode;
+}> = ({ label, children }) => {
+  const itemSx = {
+    py: 1.5,
+    px: 2,
+    display: 'flex',
+    alignItems: 'center',
+  };
+  return (
+    <>
+      <Grid item xs={12} md={4} lg={5} xl={4} sx={{ ...itemSx }} key='label'>
+        <Typography fontWeight={600} variant='body2'>
+          {label}
+        </Typography>
+      </Grid>
+      <Grid item xs={12} md={8} lg={7} xl={8} sx={{ ...itemSx }} key='value'>
+        <Typography variant='body2' component='div' sx={{ width: '100%' }}>
+          {children}
+        </Typography>
+      </Grid>
+    </>
+  );
+};

--- a/src/components/elements/input/ClientImageUploadDialog.tsx
+++ b/src/components/elements/input/ClientImageUploadDialog.tsx
@@ -17,7 +17,7 @@ import CommonDialog from '../CommonDialog';
 import LoadingButton from '../LoadingButton';
 import Uploader from '../upload/UploaderBase';
 
-import { ClientCardImageElement } from '@/modules/client/components/ClientProfileCard';
+import ClientCardImageElement from '@/modules/client/components/ClientCardImageElement';
 import {
   useDeleteClientImageMutation,
   useGetClientImageQuery,

--- a/src/modules/client/components/ClientCardImageElement.tsx
+++ b/src/modules/client/components/ClientCardImageElement.tsx
@@ -1,0 +1,63 @@
+import { Box, BoxProps, Typography } from '@mui/material';
+import React from 'react';
+
+import { ClientImageFragment } from '@/types/gqlTypes';
+
+type Props = {
+  client?: ClientImageFragment;
+  base64?: string;
+  url?: string;
+  size?: number;
+} & BoxProps<'img'>;
+
+const ClientCardImageElement: React.FC<Props> = ({
+  client,
+  base64,
+  url,
+  size = 150,
+  ...props
+}) => {
+  // let src = 'https://dummyimage.com/150x150/e8e8e8/aaa';
+  let src;
+
+  if (client?.image?.base64)
+    src = `data:image/jpeg;base64,${client.image.base64}`;
+  if (base64) src = `data:image/jpeg;base64,${base64}`;
+  if (url) src = url;
+
+  return (
+    <Box
+      alt='client'
+      src={src}
+      {...props}
+      sx={{
+        height: size,
+        width: size,
+        backgroundColor: (theme) => theme.palette.grey[100],
+        borderRadius: (theme) => `${theme.shape.borderRadius}px`,
+        ...props.sx,
+      }}
+      component={src ? 'img' : undefined}
+    >
+      {src ? undefined : (
+        <Typography
+          sx={{
+            color: (theme) => theme.palette.text.disabled,
+            borderBottom: 0,
+            display: 'flex',
+            flexGrow: 1,
+            height: '100%',
+            justifyContent: 'center',
+            alignItems: 'center',
+          }}
+          variant='body2'
+          component='span'
+        >
+          No Client Photo
+        </Typography>
+      )}
+    </Box>
+  );
+};
+
+export default ClientCardImageElement;

--- a/src/modules/client/components/ClientCustomDataElementsCard.tsx
+++ b/src/modules/client/components/ClientCustomDataElementsCard.tsx
@@ -1,0 +1,62 @@
+import React, { useMemo } from 'react';
+import {
+  CommonDetailGridContainer,
+  CommonDetailGridItem,
+} from '@/components/elements/CommonDetailGrid';
+import TitleCard from '@/components/elements/TitleCard';
+import OccurrencePointForm from '@/modules/form/components/OccurrencePointForm';
+import { useClientDetailForms } from '@/modules/form/hooks/useClientDetailForms';
+import { parseOccurrencePointFormDefinition } from '@/modules/form/util/formUtil';
+import { ClientFieldsFragment } from '@/types/gqlTypes';
+
+interface Props {
+  client: ClientFieldsFragment;
+}
+
+const ClientCustomDataElementsCard: React.FC<Props> = ({ client }) => {
+  const { forms, loading } = useClientDetailForms();
+
+  const rows = useMemo(
+    () =>
+      forms.map((form) => {
+        const { displayTitle, isEditable, readOnlyDefinition } =
+          parseOccurrencePointFormDefinition(form.definition);
+
+        return {
+          id: form.id,
+          label: displayTitle,
+          value: (
+            <OccurrencePointForm
+              record={client}
+              definition={form.definition}
+              readOnlyDefinition={readOnlyDefinition}
+              editable={isEditable && client.access.canEditClient}
+              dialogTitle={displayTitle}
+            />
+          ),
+        };
+      }),
+    [client, forms]
+  );
+
+  if (loading) return null;
+  if (rows.length === 0) return null;
+
+  return (
+    <TitleCard
+      title='Custom Fields'
+      headerVariant='border'
+      headerTypographyVariant='body1'
+    >
+      <CommonDetailGridContainer>
+        {rows.map(({ id, label, value }) => (
+          <CommonDetailGridItem label={label} key={id}>
+            {value}
+          </CommonDetailGridItem>
+        ))}
+      </CommonDetailGridContainer>
+    </TitleCard>
+  );
+};
+
+export default ClientCustomDataElementsCard;

--- a/src/modules/client/components/ClientCustomDataElementsCard.tsx
+++ b/src/modules/client/components/ClientCustomDataElementsCard.tsx
@@ -48,7 +48,7 @@ const ClientCustomDataElementsCard: React.FC<Props> = ({ client }) => {
       headerVariant='border'
       headerTypographyVariant='body1'
     >
-      <CommonDetailGridContainer>
+      <CommonDetailGridContainer ariaLabel='Custom Client Fields'>
         {rows.map(({ id, label, value }) => (
           <CommonDetailGridItem label={label} key={id}>
             {value}

--- a/src/modules/client/components/ClientCustomDataElementsCard.tsx
+++ b/src/modules/client/components/ClientCustomDataElementsCard.tsx
@@ -48,7 +48,7 @@ const ClientCustomDataElementsCard: React.FC<Props> = ({ client }) => {
       headerVariant='border'
       headerTypographyVariant='body1'
     >
-      <CommonDetailGridContainer ariaLabel='Custom Client Fields'>
+      <CommonDetailGridContainer>
         {rows.map(({ id, label, value }) => (
           <CommonDetailGridItem label={label} key={id}>
             {value}

--- a/src/modules/client/components/ClientProfileCard.stories.tsx
+++ b/src/modules/client/components/ClientProfileCard.stories.tsx
@@ -21,7 +21,6 @@ Default.args = {
 
 export const WithFewerDetails = Template.bind({});
 WithFewerDetails.args = {
-  onlyCard: true,
   client: {
     ...RITA_ACKROYD,
     pronouns: [],

--- a/src/modules/client/components/ClientProfileCard.tsx
+++ b/src/modules/client/components/ClientProfileCard.tsx
@@ -3,7 +3,6 @@ import PersonIcon from '@mui/icons-material/Person';
 import PhotoCameraIcon from '@mui/icons-material/PhotoCamera';
 import {
   Box,
-  BoxProps,
   Card,
   Chip,
   Grid,
@@ -16,6 +15,7 @@ import {
 import { useCallback, useRef, useState } from 'react';
 
 import ClientAddress from './ClientAddress';
+import ClientCardImageElement from './ClientCardImageElement';
 import ClientContactPoint from './ClientContactPoint';
 import ButtonLink from '@/components/elements/ButtonLink';
 import ExternalIdDisplay from '@/components/elements/ExternalIdDisplay';
@@ -44,10 +44,9 @@ import { generateSafePath } from '@/utils/pathEncoding';
 
 interface Props {
   client: ClientFieldsFragment;
-  onlyCard?: boolean;
 }
 
-export const ClientProfileCardTextTable = ({
+const ClientProfileCardTextTable = ({
   content,
   condensed = true,
 }: {
@@ -111,7 +110,7 @@ const LabelWithSubtitle = ({
   </Stack>
 );
 
-export const ClientProfileCardAccordion = ({ client }: Props): JSX.Element => {
+const ClientProfileCardAccordion = ({ client }: Props): JSX.Element => {
   const hasContactInformation =
     client.addresses.length > 0 ||
     client.phoneNumbers.length > 0 ||
@@ -130,7 +129,7 @@ export const ClientProfileCardAccordion = ({ client }: Props): JSX.Element => {
         renderHeader={(header) => <Typography>{header}</Typography>}
         renderContent={(content) => content}
         AccordionProps={{
-          sx: { '&.MuiAccordion-root': { my: 0 } },
+          sx: { '&.MuiAccordion-root': { mb: 0, mt: '-1px' } },
         }}
         items={[
           {
@@ -251,62 +250,7 @@ export const ClientProfileCardAccordion = ({ client }: Props): JSX.Element => {
   );
 };
 
-export const ClientCardImageElement = ({
-  client,
-  base64,
-  url,
-  size = 150,
-  ...props
-}: {
-  client?: ClientImageFragment;
-  base64?: string;
-  url?: string;
-  size?: number;
-} & BoxProps<'img'>) => {
-  // let src = 'https://dummyimage.com/150x150/e8e8e8/aaa';
-  let src;
-
-  if (client?.image?.base64)
-    src = `data:image/jpeg;base64,${client.image.base64}`;
-  if (base64) src = `data:image/jpeg;base64,${base64}`;
-  if (url) src = url;
-
-  return (
-    <Box
-      alt='client'
-      src={src}
-      {...props}
-      sx={{
-        height: size,
-        width: size,
-        backgroundColor: (theme) => theme.palette.grey[100],
-        borderRadius: (theme) => `${theme.shape.borderRadius}px`,
-        ...props.sx,
-      }}
-      component={src ? 'img' : undefined}
-    >
-      {src ? undefined : (
-        <Typography
-          sx={{
-            color: (theme) => theme.palette.text.disabled,
-            borderBottom: 0,
-            display: 'flex',
-            flexGrow: 1,
-            height: '100%',
-            justifyContent: 'center',
-            alignItems: 'center',
-          }}
-          variant='body2'
-          component='span'
-        >
-          No Client Photo
-        </Typography>
-      )}
-    </Box>
-  );
-};
-
-export const ClientCardImage = ({
+const ClientCardImage = ({
   client,
   size = 150,
 }: {
@@ -395,7 +339,14 @@ export const ClientCardImage = ({
   );
 };
 
-const ClientProfileCard: React.FC<Props> = ({ client, onlyCard = false }) => {
+/**
+ * Profile card displayed on the Client Dashboard Overview, with:
+ * - Image
+ * - Client Name
+ * - Action to Edit
+ * - Accordions with IDs, Demographics, and Contact Information
+ */
+const ClientProfileCard: React.FC<Props> = ({ client }) => {
   const {
     data: { client: clientImageData } = {},
     loading: imageLoading = false,
@@ -409,13 +360,12 @@ const ClientProfileCard: React.FC<Props> = ({ client, onlyCard = false }) => {
   ]);
 
   return (
-    <>
+    <Box>
       <Card
         sx={{
           p: 2,
-          ...(!onlyCard
-            ? { borderBottomRightRadius: 0, borderBottomLeftRadius: 0 }
-            : {}),
+          borderBottomRightRadius: 0,
+          borderBottomLeftRadius: 0,
         }}
       >
         <Grid container spacing={2}>
@@ -494,16 +444,10 @@ const ClientProfileCard: React.FC<Props> = ({ client, onlyCard = false }) => {
           </Grid>
         </Grid>
       </Card>
-      {!onlyCard && (
-        <Box
-          sx={{
-            mt: '-1px',
-          }}
-        >
-          <ClientProfileCardAccordion client={client} />
-        </Box>
-      )}
-    </>
+      <Box sx={{ mt: '-1px' }}>
+        <ClientProfileCardAccordion client={client} />
+      </Box>
+    </Box>
   );
 };
 

--- a/src/modules/client/components/ClientProfileCard.tsx
+++ b/src/modules/client/components/ClientProfileCard.tsx
@@ -117,7 +117,6 @@ export const ClientProfileCardAccordion = ({ client }: Props): JSX.Element => {
     client.phoneNumbers.length > 0 ||
     client.emailAddresses.length > 0;
 
-  // const hasCustomDataElements = client.customDataElements.length > 0;
   return (
     <Box
       sx={{
@@ -246,27 +245,6 @@ export const ClientProfileCardAccordion = ({ client }: Props): JSX.Element => {
               />
             ),
           },
-          // NOTE: disabling for now because we may need to apply a permission
-          // ...(hasCustomDataElements
-          //   ? [
-          //       {
-          //         key: 'Other Attributes',
-          //         defaultExpanded: false,
-          //         content: (
-          //           <ClientProfileCardTextTable
-          //             content={fromPairs(
-          //               client.customDataElements.map((cde) => [
-          //                 cde.label,
-          //                 customDataElementValueAsString(cde) || (
-          //                   <NotCollectedText />
-          //                 ),
-          //               ])
-          //             )}
-          //           />
-          //         ),
-          //       },
-          //     ]
-          //   : []),
         ]}
       />
     </Box>

--- a/src/modules/client/components/ClientSearchResultCard.stories.tsx
+++ b/src/modules/client/components/ClientSearchResultCard.stories.tsx
@@ -1,17 +1,17 @@
 import { ComponentStory, Meta } from '@storybook/react';
 
-import ClientCard from './ClientCard';
+import ClientSearchResultCard from './ClientSearchResultCard';
 
 import { RITA_ACKROYD } from '@/test/__mocks__/requests';
 import { ClientFieldsFragment } from '@/types/gqlTypes';
 
 export default {
-  title: 'ClientCard',
-  component: ClientCard,
-} as Meta<typeof ClientCard>;
+  title: 'ClientSearchResultCard',
+  component: ClientSearchResultCard,
+} as Meta<typeof ClientSearchResultCard>;
 
-const Template: ComponentStory<typeof ClientCard> = (args) => (
-  <ClientCard {...args} />
+const Template: ComponentStory<typeof ClientSearchResultCard> = (args) => (
+  <ClientSearchResultCard {...args} />
 );
 
 export const Default = Template.bind({});

--- a/src/modules/client/components/ClientSearchResultCard.tsx
+++ b/src/modules/client/components/ClientSearchResultCard.tsx
@@ -7,8 +7,8 @@ import {
   ContextualClientDobAge,
   ContextualClientSsn,
 } from '../providers/ClientSsnDobVisibility';
-import { ClientCardImageElement } from './ClientProfileCard';
 
+import ClientCardImageElement from './ClientCardImageElement';
 import ButtonLink from '@/components/elements/ButtonLink';
 import { CommonLabeledTextBlock } from '@/components/elements/CommonLabeledTextBlock';
 import { LabeledExternalIdDisplay } from '@/components/elements/ExternalIdDisplay';
@@ -85,7 +85,7 @@ interface Props {
   hideImage?: boolean;
 }
 
-const ClientCard: React.FC<Props> = ({
+const ClientSearchResultCard: React.FC<Props> = ({
   client,
   linkTargetBlank = false,
   hideImage = false,
@@ -251,4 +251,4 @@ const ClientCard: React.FC<Props> = ({
   );
 };
 
-export default ClientCard;
+export default ClientSearchResultCard;

--- a/src/modules/enrollment/components/EnrollmentDetails.tsx
+++ b/src/modules/enrollment/components/EnrollmentDetails.tsx
@@ -118,7 +118,7 @@ const EnrollmentDetails = ({
   if (!enrollment || !rows) return <Loading />;
 
   return (
-    <CommonDetailGridContainer ariaLabel='Enrollment Details'>
+    <CommonDetailGridContainer>
       {rows.map(({ id, label, value }) => (
         <CommonDetailGridItem label={label} key={id}>
           {value}

--- a/src/modules/enrollment/components/EnrollmentDetails.tsx
+++ b/src/modules/enrollment/components/EnrollmentDetails.tsx
@@ -1,13 +1,17 @@
 import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
-import { Box, Grid, Tooltip, Typography } from '@mui/material';
-import { Fragment, ReactNode, useMemo } from 'react';
+import { Tooltip } from '@mui/material';
+import { ReactNode, useMemo } from 'react';
+import EnrollmentOccurrencePointForm from './EnrollmentOccurrencePointForm';
 import EnrollmentSummaryCount from './EnrollmentSummaryCount';
 import EntryExitDatesWithAssessmentLinks from './EntryExitDatesWithAssessmentLinks';
-import OccurrencePointValue, {
-  parseOccurrencePointFormDefinition,
-} from './OccurrencePointValue';
+import {
+  CommonDetailGridContainer,
+  CommonDetailGridItem,
+} from '@/components/elements/CommonDetailGrid';
 import Loading from '@/components/elements/Loading';
 import NotCollectedText from '@/components/elements/NotCollectedText';
+
+import { parseOccurrencePointFormDefinition } from '@/modules/form/util/formUtil';
 import EnrollmentStatus from '@/modules/hmis/components/EnrollmentStatus';
 import HmisEnum from '@/modules/hmis/components/HmisEnum';
 import {
@@ -66,7 +70,7 @@ const EnrollmentDetails = ({
           parseOccurrencePointFormDefinition(definition);
 
         content[displayTitle] = (
-          <OccurrencePointValue
+          <EnrollmentOccurrencePointForm
             enrollment={enrollment}
             definition={definition}
             readOnlyDefinition={readOnlyDefinition}
@@ -113,59 +117,14 @@ const EnrollmentDetails = ({
 
   if (!enrollment || !rows) return <Loading />;
 
-  const itemSx = {
-    py: 1.5,
-    px: 2,
-    display: 'flex',
-    alignItems: 'center',
-  };
-
   return (
-    <Box>
-      <Grid
-        container
-        rowGap={0}
-        sx={{
-          '> .MuiGrid-item': {
-            borderBottomColor: 'borders.light',
-            borderBottomWidth: 1,
-            borderBottomStyle: 'solid',
-          },
-          '> .MuiGrid-item:nth-last-of-type(2)': {
-            border: 'unset',
-          },
-          '> .MuiGrid-item:nth-last-of-type(1)': {
-            border: 'unset',
-          },
-        }}
-      >
-        {rows.map(({ id, label, value }) => (
-          <Fragment key={id + 'label'}>
-            <Grid item xs={12} md={4} lg={5} sx={{ ...itemSx }}>
-              <Typography fontWeight={600} variant='body2'>
-                {label}
-              </Typography>
-            </Grid>
-            <Grid
-              item
-              xs={12}
-              md={8}
-              lg={7}
-              sx={{ ...itemSx }}
-              key={id + 'value'}
-            >
-              <Typography
-                variant='body2'
-                component='div'
-                sx={{ width: '100%' }}
-              >
-                {value}
-              </Typography>
-            </Grid>
-          </Fragment>
-        ))}
-      </Grid>
-    </Box>
+    <CommonDetailGridContainer>
+      {rows.map(({ id, label, value }) => (
+        <CommonDetailGridItem label={label} key={id}>
+          {value}
+        </CommonDetailGridItem>
+      ))}
+    </CommonDetailGridContainer>
   );
 };
 

--- a/src/modules/enrollment/components/EnrollmentDetails.tsx
+++ b/src/modules/enrollment/components/EnrollmentDetails.tsx
@@ -118,7 +118,7 @@ const EnrollmentDetails = ({
   if (!enrollment || !rows) return <Loading />;
 
   return (
-    <CommonDetailGridContainer>
+    <CommonDetailGridContainer ariaLabel='Enrollment Details'>
       {rows.map(({ id, label, value }) => (
         <CommonDetailGridItem label={label} key={id}>
           {value}

--- a/src/modules/enrollment/components/EnrollmentOccurrencePointForm.tsx
+++ b/src/modules/enrollment/components/EnrollmentOccurrencePointForm.tsx
@@ -1,0 +1,46 @@
+import React, { useMemo } from 'react';
+import OccurrencePointForm, {
+  OccurrencePointFormProps,
+} from '@/modules/form/components/OccurrencePointForm';
+import { AlwaysPresentLocalConstants } from '@/modules/form/util/formUtil';
+import { DashboardEnrollment } from '@/modules/hmis/types';
+
+const EnrollmentOccurrencePointForm: React.FC<
+  Omit<OccurrencePointFormProps, 'record'> & { enrollment: DashboardEnrollment }
+> = ({ enrollment, ...props }) => {
+  const localConstants = useMemo(
+    () => ({
+      entryDate: enrollment.entryDate,
+      exitDate: enrollment.exitDate,
+      projectType: enrollment.project.projectType,
+      ...AlwaysPresentLocalConstants,
+    }),
+    [enrollment.entryDate, enrollment.exitDate, enrollment.project.projectType]
+  );
+
+  // Pick list args for form and display
+  const pickListArgs = useMemo(
+    () => ({
+      projectId: enrollment.project.id,
+      householdId: enrollment.householdId,
+    }),
+    [enrollment]
+  );
+
+  const submitFormInputVariables = {
+    clientId: enrollment.client.id,
+    enrollmentId: enrollment.id,
+  };
+
+  return (
+    <OccurrencePointForm
+      submitFormInputVariables={submitFormInputVariables}
+      pickListArgs={pickListArgs}
+      localConstants={localConstants}
+      record={enrollment}
+      {...props}
+    />
+  );
+};
+
+export default EnrollmentOccurrencePointForm;

--- a/src/modules/enrollment/components/IconButtonContainer.tsx
+++ b/src/modules/enrollment/components/IconButtonContainer.tsx
@@ -1,5 +1,5 @@
 import { SvgIconComponent } from '@mui/icons-material';
-import { IconButton, IconButtonProps, Stack } from '@mui/material';
+import { ButtonProps, IconButton, IconButtonProps, Stack } from '@mui/material';
 import { ReactNode } from 'react';
 import ButtonTooltipContainer from '@/components/elements/ButtonTooltipContainer';
 
@@ -8,17 +8,20 @@ const IconButtonContainer = ({
   Icon,
   onClick,
   tooltip,
+  ButtonProps,
 }: {
   children?: ReactNode;
   Icon: SvgIconComponent;
   onClick: IconButtonProps['onClick'];
   tooltip?: ReactNode;
+  ButtonProps?: ButtonProps;
 }) => {
   const button = (
     <IconButton
       sx={{ padding: 0.5, color: 'links' }}
       size='small'
       onClick={onClick}
+      {...ButtonProps}
     >
       <Icon fontSize='inherit' />
     </IconButton>

--- a/src/modules/form/components/OccurrencePointForm.tsx
+++ b/src/modules/form/components/OccurrencePointForm.tsx
@@ -8,7 +8,11 @@ import IconButtonContainer from '@/modules/enrollment/components/IconButtonConta
 import DynamicView from '@/modules/form/components/viewable/DynamicView';
 import { SubmitFormInputVariables } from '@/modules/form/hooks/useDynamicFormHandlersForRecord';
 import { useFormDialog } from '@/modules/form/hooks/useFormDialog';
-import { LocalConstants, PickListArgs } from '@/modules/form/types';
+import {
+  LocalConstants,
+  PickListArgs,
+  SubmitFormAllowedTypes,
+} from '@/modules/form/types';
 import {
   AlwaysPresentLocalConstants,
   createInitialValuesFromRecord,
@@ -16,9 +20,7 @@ import {
   getInitialValues,
   getItemMap,
 } from '@/modules/form/util/formUtil';
-import { DashboardEnrollment } from '@/modules/hmis/types';
 import {
-  ClientFieldsFragment,
   FormDefinitionFieldsFragment,
   FormDefinitionJson,
   FormRole,
@@ -26,7 +28,7 @@ import {
 } from '@/types/gqlTypes';
 
 export interface OccurrencePointFormProps {
-  record: DashboardEnrollment | ClientFieldsFragment; // coudl be anything
+  record: SubmitFormAllowedTypes;
   definition: FormDefinitionFieldsFragment;
   submitFormInputVariables?: SubmitFormInputVariables;
   readOnlyDefinition: FormDefinitionJson;
@@ -36,6 +38,15 @@ export interface OccurrencePointFormProps {
   pickListArgs?: PickListArgs;
 }
 
+/**
+ * This component renders the values from the `record` into the `definition` and displays
+ * it as a read-only view. If any of the `definition` items are not read-only, it shows
+ * a pencil icon button. When clicked, it brings up a modal that renders a form according to
+ * the `definition`, and submits changes using SubmitForm.
+ *
+ * This is currently primarily used for viewing/editing Custom Data Elements that are associated with
+ * a Client or an Enrollment, on the Client Dashboard and Enrollment Dashboard respectively.
+ */
 const OccurrencePointForm: React.FC<OccurrencePointFormProps> = ({
   record,
   localConstants: localConstantsProp,

--- a/src/modules/form/components/OccurrencePointForm.tsx
+++ b/src/modules/form/components/OccurrencePointForm.tsx
@@ -1,75 +1,50 @@
 import EditIcon from '@mui/icons-material/Edit';
 import { Box } from '@mui/material';
 import { assign, isEmpty, isNil, omit } from 'lodash-es';
-import { useMemo } from 'react';
-import IconButtonContainer from './IconButtonContainer';
+import React, { useMemo } from 'react';
+
 import NotCollectedText from '@/components/elements/NotCollectedText';
+import IconButtonContainer from '@/modules/enrollment/components/IconButtonContainer';
 import DynamicView from '@/modules/form/components/viewable/DynamicView';
+import { SubmitFormInputVariables } from '@/modules/form/hooks/useDynamicFormHandlersForRecord';
 import { useFormDialog } from '@/modules/form/hooks/useFormDialog';
-import { FormValues, isQuestionItem } from '@/modules/form/types';
+import { LocalConstants, PickListArgs } from '@/modules/form/types';
 import {
   AlwaysPresentLocalConstants,
   createInitialValuesFromRecord,
-  getItemMap,
-  getInitialValues,
-  modifyFormDefinition,
   getDisabledLinkIds,
+  getInitialValues,
+  getItemMap,
 } from '@/modules/form/util/formUtil';
 import { DashboardEnrollment } from '@/modules/hmis/types';
 import {
+  ClientFieldsFragment,
   FormDefinitionFieldsFragment,
   FormDefinitionJson,
-  FormItem,
   FormRole,
   InitialBehavior,
 } from '@/types/gqlTypes';
 
-function matchesTitle(item: FormItem, title: string) {
-  return !![item.text, item.readonlyText].find(
-    (s) => s && s.toLowerCase() === title.toLowerCase()
-  );
-}
-
-export const parseOccurrencePointFormDefinition = (
-  definition: FormDefinitionFieldsFragment
-) => {
-  let displayTitle = definition.title;
-  let isEditable = false;
-  const readOnlyDefinition = modifyFormDefinition(
-    definition.definition,
-    (item) => {
-      if (definition.title && matchesTitle(item, definition.title)) {
-        displayTitle = item.readonlyText || item.text || displayTitle;
-        delete item.text;
-        delete item.readonlyText;
-      }
-      if (isQuestionItem(item) && !item.readOnly) {
-        isEditable = true;
-      }
-    }
-  );
-
-  return { displayTitle, isEditable, readOnlyDefinition };
-};
-
-function hasAnyValues(object: FormValues) {
-  return !!Object.keys(object).find((k) => !isNil(object[k]));
-}
-
-interface OccurrencePointValueProps {
-  enrollment: DashboardEnrollment;
+export interface OccurrencePointFormProps {
+  record: DashboardEnrollment | ClientFieldsFragment; // coudl be anything
   definition: FormDefinitionFieldsFragment;
+  submitFormInputVariables?: SubmitFormInputVariables;
   readOnlyDefinition: FormDefinitionJson;
   editable?: boolean;
   dialogTitle?: string;
+  localConstants?: LocalConstants;
+  pickListArgs?: PickListArgs;
 }
 
-const OccurrencePointValue: React.FC<OccurrencePointValueProps> = ({
-  enrollment,
+const OccurrencePointForm: React.FC<OccurrencePointFormProps> = ({
+  record,
+  localConstants: localConstantsProp,
   definition,
   editable,
   readOnlyDefinition,
   dialogTitle,
+  pickListArgs,
+  submitFormInputVariables,
 }) => {
   const itemMap = useMemo(
     () => getItemMap(definition.definition, false),
@@ -78,12 +53,10 @@ const OccurrencePointValue: React.FC<OccurrencePointValueProps> = ({
 
   const localConstants = useMemo(
     () => ({
-      entryDate: enrollment.entryDate,
-      exitDate: enrollment.exitDate,
-      projectType: enrollment.project.projectType,
+      ...localConstantsProp,
       ...AlwaysPresentLocalConstants,
     }),
-    [enrollment.entryDate, enrollment.exitDate, enrollment.project.projectType]
+    [localConstantsProp]
   );
 
   // Build values for DynamicView
@@ -96,12 +69,15 @@ const OccurrencePointValue: React.FC<OccurrencePointValueProps> = ({
       InitialBehavior.IfEmpty
     );
     // Apply values from the Enrollment
-    const formValues = createInitialValuesFromRecord(itemMap, enrollment);
+    const formValues = createInitialValuesFromRecord(itemMap, record);
 
     return assign(initialsIfEmpty, formValues);
-  }, [itemMap, definition.definition, enrollment, localConstants]);
+  }, [itemMap, definition.definition, record, localConstants]);
 
-  const hasAnyContent = useMemo(() => hasAnyValues(values), [values]);
+  const hasAnyContent = useMemo(
+    () => !!Object.keys(values).find((k) => !isNil(values[k])),
+    [values]
+  );
 
   const hasAnyEditableContent = useMemo(() => {
     if (!editable) return false;
@@ -113,24 +89,12 @@ const OccurrencePointValue: React.FC<OccurrencePointValueProps> = ({
     return !isEmpty(omit(values, initiallyDisabledLinkIds));
   }, [itemMap, editable, localConstants, values]);
 
-  // Pick list args for form and display
-  const pickListArgs = useMemo(
-    () => ({
-      projectId: enrollment.project.id,
-      householdId: enrollment.householdId,
-    }),
-    [enrollment]
-  );
-
   // Form dialog for editing
   const { openFormDialog, renderFormDialog } = useFormDialog({
     formRole: FormRole.OccurrencePoint,
     localDefinition: definition,
-    record: enrollment,
-    inputVariables: {
-      clientId: enrollment.client.id,
-      enrollmentId: enrollment.id,
-    },
+    record,
+    inputVariables: submitFormInputVariables,
     localConstants,
   });
 
@@ -164,4 +128,4 @@ const OccurrencePointValue: React.FC<OccurrencePointValueProps> = ({
   );
 };
 
-export default OccurrencePointValue;
+export default OccurrencePointForm;

--- a/src/modules/form/components/OccurrencePointForm.tsx
+++ b/src/modules/form/components/OccurrencePointForm.tsx
@@ -127,7 +127,11 @@ const OccurrencePointForm: React.FC<OccurrencePointFormProps> = ({
 
   return (
     <>
-      <IconButtonContainer onClick={openFormDialog} Icon={EditIcon}>
+      <IconButtonContainer
+        onClick={openFormDialog}
+        Icon={EditIcon}
+        ButtonProps={{ 'aria-label': `Edit ${dialogTitle}` }}
+      >
         {dynamicView}
       </IconButtonContainer>
       {renderFormDialog({

--- a/src/modules/form/hooks/useClientDetailForms.tsx
+++ b/src/modules/form/hooks/useClientDetailForms.tsx
@@ -1,0 +1,12 @@
+import { useClientDetailFormsQuery } from '@/types/gqlTypes';
+
+export function useClientDetailForms() {
+  const { data, error, loading } = useClientDetailFormsQuery();
+
+  if (error) throw error;
+
+  return {
+    forms: data?.clientDetailForms || [],
+    loading,
+  } as const;
+}

--- a/src/modules/form/hooks/useDynamicFormHandlersForRecord.tsx
+++ b/src/modules/form/hooks/useDynamicFormHandlersForRecord.tsx
@@ -35,7 +35,7 @@ const recordLockVersion = (
   return undefined;
 };
 
-type SubmitFormInputVariables = Omit<
+export type SubmitFormInputVariables = Omit<
   FormInput,
   'confirmed' | 'formDefinitionId' | 'values' | 'hudValues' | 'recordId'
 >;

--- a/src/modules/form/util/formUtil.ts
+++ b/src/modules/form/util/formUtil.ts
@@ -1420,3 +1420,32 @@ export const itemDefaults = {
   hidden: false,
   repeats: false,
 };
+
+export const parseOccurrencePointFormDefinition = (
+  definition: FormDefinitionFieldsFragment
+) => {
+  let displayTitle = definition.title;
+  let isEditable = false;
+
+  function matchesTitle(item: FormItem, title: string) {
+    return !![item.text, item.readonlyText].find(
+      (s) => s && s.toLowerCase() === title.toLowerCase()
+    );
+  }
+
+  const readOnlyDefinition = modifyFormDefinition(
+    definition.definition,
+    (item) => {
+      if (definition.title && matchesTitle(item, definition.title)) {
+        displayTitle = item.readonlyText || item.text || displayTitle;
+        delete item.text;
+        delete item.readonlyText;
+      }
+      if (isQuestionItem(item) && !item.readOnly) {
+        isEditable = true;
+      }
+    }
+  );
+
+  return { displayTitle, isEditable, readOnlyDefinition };
+};

--- a/src/modules/search/components/ClientSearch.tsx
+++ b/src/modules/search/components/ClientSearch.tsx
@@ -17,8 +17,8 @@ import { externalIdColumn } from '@/components/elements/ExternalIdDisplay';
 import { ColumnDef } from '@/components/elements/table/types';
 import { useIsMobile } from '@/hooks/useIsMobile';
 
-import ClientCard from '@/modules/client/components/ClientCard';
 import ClientName from '@/modules/client/components/ClientName';
+import ClientSearchResultCard from '@/modules/client/components/ClientSearchResultCard';
 import {
   ContextualClientDobAge,
   ContextualClientSsn,
@@ -311,7 +311,10 @@ const ClientSearch = () => {
                 ? (client) => (
                     <TableRow key={client.id}>
                       <TableCell colSpan={columns.length} sx={{ py: 2 }}>
-                        <ClientCard key={client.id} client={client} />
+                        <ClientSearchResultCard
+                          key={client.id}
+                          client={client}
+                        />
                       </TableCell>
                     </TableRow>
                   )

--- a/src/test/__mocks__/requests.ts
+++ b/src/test/__mocks__/requests.ts
@@ -1,10 +1,13 @@
+import { v4 } from 'uuid';
 import MOCK_IMAGE from '@/components/elements/upload/MOCK_IMAGE';
 import { HmisEnums } from '@/types/gqlEnums';
 import { HmisObjectSchemas } from '@/types/gqlObjects';
 import {
   ClientAccess,
+  ClientDetailFormsDocument,
   CreateDirectUploadMutationDocument,
   DobDataQuality,
+  EnrollmentAccess,
   Gender,
   GetClientDocument,
   GetClientEnrollmentsDocument,
@@ -16,6 +19,7 @@ import {
   NameDataQuality,
   NoYesReasonsForMissingData,
   PickListOption,
+  ProjectType,
   Race,
   RelationshipToHoH,
   SearchClientsDocument,
@@ -30,6 +34,39 @@ const CLIENT_ACCESS_MOCK = {
   ),
   id: '9999:1',
 } as ClientAccess;
+
+const ENROLLMENT_ACCESS_MOCK = {
+  ...Object.fromEntries(
+    HmisObjectSchemas.find(
+      (obj) => obj.name === 'EnrollmentAccess'
+    )?.fields.map((f) => [f.name, true]) || []
+  ),
+  id: '9999:1',
+} as EnrollmentAccess;
+
+const fakeEnrollment = () => {
+  return {
+    __typename: 'Enrollment',
+    id: v4(),
+    relationshipToHoH: RelationshipToHoH.SelfHeadOfHousehold,
+    inProgress: false,
+    entryDate: '2022-06-18',
+    exitDate: null,
+    access: ENROLLMENT_ACCESS_MOCK,
+    householdSize: 1,
+    projectName: 'White Pine',
+    projectType: ProjectType.EsNbn,
+    organizationName: 'Blue Hills Organization',
+    lastBedNightDate: '2022-06-18',
+    moveInDate: null,
+    lockVersion: '1',
+    project: {
+      id: '1',
+      projectName: 'White Pine',
+      projectType: ProjectType.EsNbn,
+    },
+  };
+};
 
 export const RITA_ACKROYD = {
   __typename: 'Client',
@@ -89,44 +126,7 @@ export const RITA_ACKROYD = {
     nodesCount: 5,
     offset: 0,
     limit: 10,
-    nodes: [
-      {
-        __typename: 'Enrollment',
-        id: '5',
-        entryDate: '2022-06-18',
-        exitDate: null,
-        householdSize: 1,
-        project: { projectName: 'White Pine' },
-      },
-      {
-        __typename: 'Enrollment',
-        id: '6',
-        entryDate: '2021-02-10',
-        exitDate: '2021-02-10',
-        project: { projectName: 'Spruce Hill' },
-      },
-      {
-        __typename: 'Enrollment',
-        id: '7',
-        entryDate: '2013-02-10',
-        exitDate: '2013-02-10',
-        project: { projectName: 'White Pine Terrace' },
-      },
-      {
-        __typename: 'Enrollment',
-        id: '8',
-        entryDate: '2013-02-10',
-        exitDate: '2013-02-10',
-        project: { projectName: 'White Pine' },
-      },
-      {
-        __typename: 'Enrollment',
-        id: '9',
-        entryDate: '2013-02-10',
-        exitDate: '2013-02-10',
-        project: { projectName: 'White Pine' },
-      },
-    ],
+    nodes: [fakeEnrollment(), fakeEnrollment(), fakeEnrollment()],
   },
 };
 
@@ -347,18 +347,13 @@ const clientWithoutEnrollmentsMock = {
 const enrollmentWithHoHMock = {
   request: {
     query: GetEnrollmentWithHouseholdDocument,
-    variables: {
-      id: '5',
-    },
+    variables: { id: '5' },
   },
   result: {
     data: {
       enrollment: {
-        __typename: 'Enrollment',
-        id: '5',
-        entryDate: '2022-06-18',
-        exitDate: null,
-        project: { label: 'White Pine' },
+        ...fakeEnrollment(),
+        householdSize: 2,
         household: {
           id: '123',
           __typename: 'Household',
@@ -368,12 +363,7 @@ const enrollmentWithHoHMock = {
               id: RITA_ACKROYD.id,
               relationshipToHoH: RelationshipToHoH.SelfHeadOfHousehold,
               client: RITA_ACKROYD,
-              enrollment: {
-                __typename: 'Enrollment',
-                id: '5',
-                entryDate: '2022-06-18',
-                exitDate: null,
-              },
+              enrollment: { ...fakeEnrollment(), id: '5' },
             },
             {
               __typename: 'HouseholdClient',
@@ -386,12 +376,7 @@ const enrollmentWithHoHMock = {
                 lastName: 'Acker',
                 nameSuffix: null,
               },
-              enrollment: {
-                __typename: 'Enrollment',
-                id: '4',
-                entryDate: '2022-06-15',
-                exitDate: '2022-08-15',
-              },
+              enrollment: fakeEnrollment(),
             },
           ],
         },
@@ -470,12 +455,24 @@ const getClientPermissionMocks = {
   result: {
     data: {
       client: {
+        __typename: 'Client',
         id: RITA_ACKROYD.id,
         access: CLIENT_ACCESS_MOCK,
       },
     },
   },
 };
+
+const clientDetailFormsMock = {
+  request: {
+    query: ClientDetailFormsDocument,
+    variables: {},
+  },
+  result: {
+    data: {},
+  },
+};
+
 const mocks: any[] = [
   projectsForSelectMock,
   clientSearchMock,
@@ -496,6 +493,8 @@ const mocks: any[] = [
   getClientPermissionMocks,
   getClientPermissionMocks,
   getClientPermissionMocks,
+  clientDetailFormsMock,
+  clientDetailFormsMock,
 ];
 
 export default mocks;

--- a/src/types/gqlEnums.ts
+++ b/src/types/gqlEnums.ts
@@ -519,6 +519,7 @@ export const HmisEnums = {
     CE_EVENT: 'CE event',
     CE_PARTICIPATION: 'CE participation',
     CLIENT: 'Client',
+    CLIENT_DETAIL: 'Client detail',
     CURRENT_LIVING_SITUATION: 'Current living situation',
     ENROLLMENT: 'Enrollment',
     EXIT: 'Exit',

--- a/src/types/gqlObjects.ts
+++ b/src/types/gqlObjects.ts
@@ -6173,7 +6173,18 @@ export const HmisInputObjectSchemas: GqlInputObjectSchema[] = [
         name: 'onOrAfter',
         type: { kind: 'SCALAR', name: 'ISO8601Date', ofType: null },
       },
-      { name: 'project', type: { kind: 'SCALAR', name: 'ID', ofType: null } },
+      {
+        name: 'project',
+        type: {
+          kind: 'LIST',
+          name: null,
+          ofType: {
+            kind: 'NON_NULL',
+            name: null,
+            ofType: { kind: 'SCALAR', name: 'ID', ofType: null },
+          },
+        },
+      },
       {
         name: 'searchTerm',
         type: { kind: 'SCALAR', name: 'String', ofType: null },

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -2266,7 +2266,7 @@ export type EnrollmentAccessSummary = {
 
 export type EnrollmentAccessSummaryFilterOptions = {
   onOrAfter?: InputMaybe<Scalars['ISO8601Date']['input']>;
-  project?: InputMaybe<Scalars['ID']['input']>;
+  project?: InputMaybe<Array<Scalars['ID']['input']>>;
   searchTerm?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -2771,6 +2771,8 @@ export enum FormRole {
   CeParticipation = 'CE_PARTICIPATION',
   /** Client */
   Client = 'CLIENT',
+  /** Client detail */
+  ClientDetail = 'CLIENT_DETAIL',
   /** Current living situation */
   CurrentLivingSituation = 'CURRENT_LIVING_SITUATION',
   /** Enrollment */
@@ -5141,6 +5143,8 @@ export type Query = {
   autoExitConfigs: AutoExitConfigsPaginated;
   /** Client lookup */
   client?: Maybe<Client>;
+  /** Custom forms for collecting and/or displaying custom details for a Client (outside of the Client demographics form) */
+  clientDetailForms: Array<OccurrencePointForm>;
   /** Client omnisearch */
   clientOmniSearch: ClientsPaginated;
   /** Search for clients */
@@ -12885,6 +12889,488 @@ export type GetClientFilesQuery = {
       }>;
     };
   } | null;
+};
+
+export type ClientDetailFormsQueryVariables = Exact<{ [key: string]: never }>;
+
+export type ClientDetailFormsQuery = {
+  __typename?: 'Query';
+  clientDetailForms: Array<{
+    __typename?: 'OccurrencePointForm';
+    id: string;
+    dataCollectedAbout: DataCollectedAbout;
+    definition: {
+      __typename?: 'FormDefinition';
+      id: string;
+      role: FormRole;
+      title: string;
+      cacheKey: string;
+      identifier: string;
+      definition: {
+        __typename?: 'FormDefinitionJson';
+        item: Array<{
+          __typename: 'FormItem';
+          linkId: string;
+          type: ItemType;
+          component?: Component | null;
+          prefix?: string | null;
+          text?: string | null;
+          briefText?: string | null;
+          readonlyText?: string | null;
+          helperText?: string | null;
+          required: boolean;
+          warnIfEmpty: boolean;
+          hidden: boolean;
+          readOnly: boolean;
+          repeats: boolean;
+          pickListReference?: string | null;
+          serviceDetailType?: ServiceDetailType | null;
+          size?: InputSize | null;
+          assessmentDate?: boolean | null;
+          prefill: boolean;
+          dataCollectedAbout?: DataCollectedAbout | null;
+          disabledDisplay: DisabledDisplay;
+          enableBehavior: EnableBehavior;
+          item?: Array<{
+            __typename: 'FormItem';
+            linkId: string;
+            type: ItemType;
+            component?: Component | null;
+            prefix?: string | null;
+            text?: string | null;
+            briefText?: string | null;
+            readonlyText?: string | null;
+            helperText?: string | null;
+            required: boolean;
+            warnIfEmpty: boolean;
+            hidden: boolean;
+            readOnly: boolean;
+            repeats: boolean;
+            pickListReference?: string | null;
+            serviceDetailType?: ServiceDetailType | null;
+            size?: InputSize | null;
+            assessmentDate?: boolean | null;
+            prefill: boolean;
+            dataCollectedAbout?: DataCollectedAbout | null;
+            disabledDisplay: DisabledDisplay;
+            enableBehavior: EnableBehavior;
+            item?: Array<{
+              __typename: 'FormItem';
+              linkId: string;
+              type: ItemType;
+              component?: Component | null;
+              prefix?: string | null;
+              text?: string | null;
+              briefText?: string | null;
+              readonlyText?: string | null;
+              helperText?: string | null;
+              required: boolean;
+              warnIfEmpty: boolean;
+              hidden: boolean;
+              readOnly: boolean;
+              repeats: boolean;
+              pickListReference?: string | null;
+              serviceDetailType?: ServiceDetailType | null;
+              size?: InputSize | null;
+              assessmentDate?: boolean | null;
+              prefill: boolean;
+              dataCollectedAbout?: DataCollectedAbout | null;
+              disabledDisplay: DisabledDisplay;
+              enableBehavior: EnableBehavior;
+              item?: Array<{
+                __typename: 'FormItem';
+                linkId: string;
+                type: ItemType;
+                component?: Component | null;
+                prefix?: string | null;
+                text?: string | null;
+                briefText?: string | null;
+                readonlyText?: string | null;
+                helperText?: string | null;
+                required: boolean;
+                warnIfEmpty: boolean;
+                hidden: boolean;
+                readOnly: boolean;
+                repeats: boolean;
+                pickListReference?: string | null;
+                serviceDetailType?: ServiceDetailType | null;
+                size?: InputSize | null;
+                assessmentDate?: boolean | null;
+                prefill: boolean;
+                dataCollectedAbout?: DataCollectedAbout | null;
+                disabledDisplay: DisabledDisplay;
+                enableBehavior: EnableBehavior;
+                item?: Array<{
+                  __typename: 'FormItem';
+                  linkId: string;
+                  type: ItemType;
+                  component?: Component | null;
+                  prefix?: string | null;
+                  text?: string | null;
+                  briefText?: string | null;
+                  readonlyText?: string | null;
+                  helperText?: string | null;
+                  required: boolean;
+                  warnIfEmpty: boolean;
+                  hidden: boolean;
+                  readOnly: boolean;
+                  repeats: boolean;
+                  pickListReference?: string | null;
+                  serviceDetailType?: ServiceDetailType | null;
+                  size?: InputSize | null;
+                  assessmentDate?: boolean | null;
+                  prefill: boolean;
+                  dataCollectedAbout?: DataCollectedAbout | null;
+                  disabledDisplay: DisabledDisplay;
+                  enableBehavior: EnableBehavior;
+                  mapping?: {
+                    __typename?: 'FieldMapping';
+                    recordType?: RelatedRecordType | null;
+                    fieldName?: string | null;
+                    customFieldKey?: string | null;
+                  } | null;
+                  bounds?: Array<{
+                    __typename?: 'ValueBound';
+                    id: string;
+                    severity: ValidationSeverity;
+                    type: BoundType;
+                    question?: string | null;
+                    valueNumber?: number | null;
+                    valueDate?: string | null;
+                    valueLocalConstant?: string | null;
+                    offset?: number | null;
+                  }> | null;
+                  pickListOptions?: Array<{
+                    __typename?: 'PickListOption';
+                    code: string;
+                    label?: string | null;
+                    secondaryLabel?: string | null;
+                    groupLabel?: string | null;
+                    groupCode?: string | null;
+                    initialSelected?: boolean | null;
+                  }> | null;
+                  initial?: Array<{
+                    __typename?: 'InitialValue';
+                    valueCode?: string | null;
+                    valueBoolean?: boolean | null;
+                    valueNumber?: number | null;
+                    valueLocalConstant?: string | null;
+                    initialBehavior: InitialBehavior;
+                  }> | null;
+                  enableWhen?: Array<{
+                    __typename?: 'EnableWhen';
+                    question?: string | null;
+                    localConstant?: string | null;
+                    operator: EnableOperator;
+                    answerCode?: string | null;
+                    answerCodes?: Array<string> | null;
+                    answerNumber?: number | null;
+                    answerBoolean?: boolean | null;
+                    answerGroupCode?: string | null;
+                    compareQuestion?: string | null;
+                  }> | null;
+                  autofillValues?: Array<{
+                    __typename?: 'AutofillValue';
+                    valueCode?: string | null;
+                    valueQuestion?: string | null;
+                    valueBoolean?: boolean | null;
+                    valueNumber?: number | null;
+                    sumQuestions?: Array<string> | null;
+                    autofillBehavior: EnableBehavior;
+                    autofillReadonly?: boolean | null;
+                    autofillWhen: Array<{
+                      __typename?: 'EnableWhen';
+                      question?: string | null;
+                      localConstant?: string | null;
+                      operator: EnableOperator;
+                      answerCode?: string | null;
+                      answerCodes?: Array<string> | null;
+                      answerNumber?: number | null;
+                      answerBoolean?: boolean | null;
+                      answerGroupCode?: string | null;
+                      compareQuestion?: string | null;
+                    }>;
+                  }> | null;
+                }> | null;
+                mapping?: {
+                  __typename?: 'FieldMapping';
+                  recordType?: RelatedRecordType | null;
+                  fieldName?: string | null;
+                  customFieldKey?: string | null;
+                } | null;
+                bounds?: Array<{
+                  __typename?: 'ValueBound';
+                  id: string;
+                  severity: ValidationSeverity;
+                  type: BoundType;
+                  question?: string | null;
+                  valueNumber?: number | null;
+                  valueDate?: string | null;
+                  valueLocalConstant?: string | null;
+                  offset?: number | null;
+                }> | null;
+                pickListOptions?: Array<{
+                  __typename?: 'PickListOption';
+                  code: string;
+                  label?: string | null;
+                  secondaryLabel?: string | null;
+                  groupLabel?: string | null;
+                  groupCode?: string | null;
+                  initialSelected?: boolean | null;
+                }> | null;
+                initial?: Array<{
+                  __typename?: 'InitialValue';
+                  valueCode?: string | null;
+                  valueBoolean?: boolean | null;
+                  valueNumber?: number | null;
+                  valueLocalConstant?: string | null;
+                  initialBehavior: InitialBehavior;
+                }> | null;
+                enableWhen?: Array<{
+                  __typename?: 'EnableWhen';
+                  question?: string | null;
+                  localConstant?: string | null;
+                  operator: EnableOperator;
+                  answerCode?: string | null;
+                  answerCodes?: Array<string> | null;
+                  answerNumber?: number | null;
+                  answerBoolean?: boolean | null;
+                  answerGroupCode?: string | null;
+                  compareQuestion?: string | null;
+                }> | null;
+                autofillValues?: Array<{
+                  __typename?: 'AutofillValue';
+                  valueCode?: string | null;
+                  valueQuestion?: string | null;
+                  valueBoolean?: boolean | null;
+                  valueNumber?: number | null;
+                  sumQuestions?: Array<string> | null;
+                  autofillBehavior: EnableBehavior;
+                  autofillReadonly?: boolean | null;
+                  autofillWhen: Array<{
+                    __typename?: 'EnableWhen';
+                    question?: string | null;
+                    localConstant?: string | null;
+                    operator: EnableOperator;
+                    answerCode?: string | null;
+                    answerCodes?: Array<string> | null;
+                    answerNumber?: number | null;
+                    answerBoolean?: boolean | null;
+                    answerGroupCode?: string | null;
+                    compareQuestion?: string | null;
+                  }>;
+                }> | null;
+              }> | null;
+              mapping?: {
+                __typename?: 'FieldMapping';
+                recordType?: RelatedRecordType | null;
+                fieldName?: string | null;
+                customFieldKey?: string | null;
+              } | null;
+              bounds?: Array<{
+                __typename?: 'ValueBound';
+                id: string;
+                severity: ValidationSeverity;
+                type: BoundType;
+                question?: string | null;
+                valueNumber?: number | null;
+                valueDate?: string | null;
+                valueLocalConstant?: string | null;
+                offset?: number | null;
+              }> | null;
+              pickListOptions?: Array<{
+                __typename?: 'PickListOption';
+                code: string;
+                label?: string | null;
+                secondaryLabel?: string | null;
+                groupLabel?: string | null;
+                groupCode?: string | null;
+                initialSelected?: boolean | null;
+              }> | null;
+              initial?: Array<{
+                __typename?: 'InitialValue';
+                valueCode?: string | null;
+                valueBoolean?: boolean | null;
+                valueNumber?: number | null;
+                valueLocalConstant?: string | null;
+                initialBehavior: InitialBehavior;
+              }> | null;
+              enableWhen?: Array<{
+                __typename?: 'EnableWhen';
+                question?: string | null;
+                localConstant?: string | null;
+                operator: EnableOperator;
+                answerCode?: string | null;
+                answerCodes?: Array<string> | null;
+                answerNumber?: number | null;
+                answerBoolean?: boolean | null;
+                answerGroupCode?: string | null;
+                compareQuestion?: string | null;
+              }> | null;
+              autofillValues?: Array<{
+                __typename?: 'AutofillValue';
+                valueCode?: string | null;
+                valueQuestion?: string | null;
+                valueBoolean?: boolean | null;
+                valueNumber?: number | null;
+                sumQuestions?: Array<string> | null;
+                autofillBehavior: EnableBehavior;
+                autofillReadonly?: boolean | null;
+                autofillWhen: Array<{
+                  __typename?: 'EnableWhen';
+                  question?: string | null;
+                  localConstant?: string | null;
+                  operator: EnableOperator;
+                  answerCode?: string | null;
+                  answerCodes?: Array<string> | null;
+                  answerNumber?: number | null;
+                  answerBoolean?: boolean | null;
+                  answerGroupCode?: string | null;
+                  compareQuestion?: string | null;
+                }>;
+              }> | null;
+            }> | null;
+            mapping?: {
+              __typename?: 'FieldMapping';
+              recordType?: RelatedRecordType | null;
+              fieldName?: string | null;
+              customFieldKey?: string | null;
+            } | null;
+            bounds?: Array<{
+              __typename?: 'ValueBound';
+              id: string;
+              severity: ValidationSeverity;
+              type: BoundType;
+              question?: string | null;
+              valueNumber?: number | null;
+              valueDate?: string | null;
+              valueLocalConstant?: string | null;
+              offset?: number | null;
+            }> | null;
+            pickListOptions?: Array<{
+              __typename?: 'PickListOption';
+              code: string;
+              label?: string | null;
+              secondaryLabel?: string | null;
+              groupLabel?: string | null;
+              groupCode?: string | null;
+              initialSelected?: boolean | null;
+            }> | null;
+            initial?: Array<{
+              __typename?: 'InitialValue';
+              valueCode?: string | null;
+              valueBoolean?: boolean | null;
+              valueNumber?: number | null;
+              valueLocalConstant?: string | null;
+              initialBehavior: InitialBehavior;
+            }> | null;
+            enableWhen?: Array<{
+              __typename?: 'EnableWhen';
+              question?: string | null;
+              localConstant?: string | null;
+              operator: EnableOperator;
+              answerCode?: string | null;
+              answerCodes?: Array<string> | null;
+              answerNumber?: number | null;
+              answerBoolean?: boolean | null;
+              answerGroupCode?: string | null;
+              compareQuestion?: string | null;
+            }> | null;
+            autofillValues?: Array<{
+              __typename?: 'AutofillValue';
+              valueCode?: string | null;
+              valueQuestion?: string | null;
+              valueBoolean?: boolean | null;
+              valueNumber?: number | null;
+              sumQuestions?: Array<string> | null;
+              autofillBehavior: EnableBehavior;
+              autofillReadonly?: boolean | null;
+              autofillWhen: Array<{
+                __typename?: 'EnableWhen';
+                question?: string | null;
+                localConstant?: string | null;
+                operator: EnableOperator;
+                answerCode?: string | null;
+                answerCodes?: Array<string> | null;
+                answerNumber?: number | null;
+                answerBoolean?: boolean | null;
+                answerGroupCode?: string | null;
+                compareQuestion?: string | null;
+              }>;
+            }> | null;
+          }> | null;
+          mapping?: {
+            __typename?: 'FieldMapping';
+            recordType?: RelatedRecordType | null;
+            fieldName?: string | null;
+            customFieldKey?: string | null;
+          } | null;
+          bounds?: Array<{
+            __typename?: 'ValueBound';
+            id: string;
+            severity: ValidationSeverity;
+            type: BoundType;
+            question?: string | null;
+            valueNumber?: number | null;
+            valueDate?: string | null;
+            valueLocalConstant?: string | null;
+            offset?: number | null;
+          }> | null;
+          pickListOptions?: Array<{
+            __typename?: 'PickListOption';
+            code: string;
+            label?: string | null;
+            secondaryLabel?: string | null;
+            groupLabel?: string | null;
+            groupCode?: string | null;
+            initialSelected?: boolean | null;
+          }> | null;
+          initial?: Array<{
+            __typename?: 'InitialValue';
+            valueCode?: string | null;
+            valueBoolean?: boolean | null;
+            valueNumber?: number | null;
+            valueLocalConstant?: string | null;
+            initialBehavior: InitialBehavior;
+          }> | null;
+          enableWhen?: Array<{
+            __typename?: 'EnableWhen';
+            question?: string | null;
+            localConstant?: string | null;
+            operator: EnableOperator;
+            answerCode?: string | null;
+            answerCodes?: Array<string> | null;
+            answerNumber?: number | null;
+            answerBoolean?: boolean | null;
+            answerGroupCode?: string | null;
+            compareQuestion?: string | null;
+          }> | null;
+          autofillValues?: Array<{
+            __typename?: 'AutofillValue';
+            valueCode?: string | null;
+            valueQuestion?: string | null;
+            valueBoolean?: boolean | null;
+            valueNumber?: number | null;
+            sumQuestions?: Array<string> | null;
+            autofillBehavior: EnableBehavior;
+            autofillReadonly?: boolean | null;
+            autofillWhen: Array<{
+              __typename?: 'EnableWhen';
+              question?: string | null;
+              localConstant?: string | null;
+              operator: EnableOperator;
+              answerCode?: string | null;
+              answerCodes?: Array<string> | null;
+              answerNumber?: number | null;
+              answerBoolean?: boolean | null;
+              answerGroupCode?: string | null;
+              compareQuestion?: string | null;
+            }>;
+          }> | null;
+        }>;
+      };
+    };
+  }>;
 };
 
 export type MergeAuditEventFieldsFragment = {
@@ -31603,6 +32089,64 @@ export type GetClientFilesLazyQueryHookResult = ReturnType<
 export type GetClientFilesQueryResult = Apollo.QueryResult<
   GetClientFilesQuery,
   GetClientFilesQueryVariables
+>;
+export const ClientDetailFormsDocument = gql`
+  query ClientDetailForms {
+    clientDetailForms {
+      ...OccurrencePointFormFields
+    }
+  }
+  ${OccurrencePointFormFieldsFragmentDoc}
+`;
+
+/**
+ * __useClientDetailFormsQuery__
+ *
+ * To run a query within a React component, call `useClientDetailFormsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useClientDetailFormsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useClientDetailFormsQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useClientDetailFormsQuery(
+  baseOptions?: Apollo.QueryHookOptions<
+    ClientDetailFormsQuery,
+    ClientDetailFormsQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    ClientDetailFormsQuery,
+    ClientDetailFormsQueryVariables
+  >(ClientDetailFormsDocument, options);
+}
+export function useClientDetailFormsLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    ClientDetailFormsQuery,
+    ClientDetailFormsQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    ClientDetailFormsQuery,
+    ClientDetailFormsQueryVariables
+  >(ClientDetailFormsDocument, options);
+}
+export type ClientDetailFormsQueryHookResult = ReturnType<
+  typeof useClientDetailFormsQuery
+>;
+export type ClientDetailFormsLazyQueryHookResult = ReturnType<
+  typeof useClientDetailFormsLazyQuery
+>;
+export type ClientDetailFormsQueryResult = Apollo.QueryResult<
+  ClientDetailFormsQuery,
+  ClientDetailFormsQueryVariables
 >;
 export const GetMergeCandidatesDocument = gql`
   query GetMergeCandidates($limit: Int, $offset: Int) {


### PR DESCRIPTION
## Description

Add a "Custom Fields" section to the client dashboard. It gets populated if there are any active forms with role `CLIENT_DETAIL`. This can be used to collect or display arbitrary data on the client dashboard.

The card is basically the same as the `EnrollmentDetails` card on the Enrollment Dashboard, so I did some refactoring to allow them to share code.

Editing these fields requires `can_edit_clients` perm for the client. Viewing these fields requires `can_view_clients` perm for the client.

<img width="902" alt="Screenshot 2024-01-10 at 3 55 00 PM" src="https://github.com/greenriver/hmis-frontend/assets/5333982/325f42b0-dafe-454d-9879-8f6758d406d6">


### How to test

see instructions on backend pr

[//]: # 'remove if not applicable'
Depends on hmis-warehouse PR: https://github.com/greenriver/hmis-warehouse/pull/3898

## Type of change
- [x] New feature (adds functionality)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
