### PR TITLE
Fix issue with param generation form editor

### DIFF
--- a/src/modules/admin/components/formRules/FormRuleTable.tsx
+++ b/src/modules/admin/components/formRules/FormRuleTable.tsx
@@ -168,6 +168,7 @@ const FormRuleTable: React.FC<Props> = ({ queryVariables }) => {
         filterInputType='FormRuleFilterOptions'
         paginationItemName='rule'
         filters={(filters) => omit(filters, 'definition', 'formType')}
+        noSort
         // tableProps={{ sx: { tableLayout: 'fixed' } }}
       />
       {renderFormDialog({

--- a/src/modules/admin/components/forms/FormDefinitionsPage.tsx
+++ b/src/modules/admin/components/forms/FormDefinitionsPage.tsx
@@ -1,7 +1,7 @@
 import AddIcon from '@mui/icons-material/Add';
 import { Button, Paper } from '@mui/material';
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { generatePath, useNavigate } from 'react-router-dom';
 import FormDefinitionTable, { Row } from './FormDefinitionTable';
 import PageTitle from '@/components/layout/PageTitle';
 import { useStaticFormDialog } from '@/modules/form/hooks/useStaticFormDialog';
@@ -17,7 +17,6 @@ import {
   UpdateFormDefinitionMutation,
 } from '@/types/gqlTypes';
 import { evictQuery } from '@/utils/cacheUtil';
-import { generateSafePath } from '@/utils/pathEncoding';
 
 const FormDefinitionsPage = () => {
   const [selected, setSelected] = useState<Row>();
@@ -55,9 +54,7 @@ const FormDefinitionsPage = () => {
       const id = data?.createFormDefinition?.formDefinition?.id;
       evictQuery('formDefinitions');
       if (id)
-        navigate(
-          generateSafePath(AdminDashboardRoutes.VIEW_FORM, { formId: id })
-        );
+        navigate(generatePath(AdminDashboardRoutes.VIEW_FORM, { formId: id }));
     },
     onClose: () => setSelected(undefined),
   });

--- a/src/modules/admin/components/forms/ViewFormDefinitionPage.tsx
+++ b/src/modules/admin/components/forms/ViewFormDefinitionPage.tsx
@@ -2,13 +2,14 @@ import AddIcon from '@mui/icons-material/Add';
 import DeleteIcon from '@mui/icons-material/Delete';
 import EditIcon from '@mui/icons-material/Edit';
 import { Button, Stack } from '@mui/material';
-// eslint-disable-next-line no-restricted-imports
-import { useNavigate, useParams } from 'react-router-dom';
+
+import { generatePath, useNavigate } from 'react-router-dom';
 import FormRuleTable from '../formRules/FormRuleTable';
 import ButtonLink from '@/components/elements/ButtonLink';
 import Loading from '@/components/elements/Loading';
 import TitleCard from '@/components/elements/TitleCard';
 import PageTitle from '@/components/layout/PageTitle';
+import useSafeParams from '@/hooks/useSafeParams';
 import DeleteMutationButton from '@/modules/dataFetching/components/DeleteMutationButton';
 import { useStaticFormDialog } from '@/modules/form/hooks/useStaticFormDialog';
 import { AdminDashboardRoutes } from '@/routes/routes';
@@ -24,10 +25,9 @@ import {
   useGetFormDefinitionForEditorQuery,
 } from '@/types/gqlTypes';
 import { evictQuery } from '@/utils/cacheUtil';
-import { generateSafePath } from '@/utils/pathEncoding';
 
 const ViewFormDefinitionPage = () => {
-  const { formId } = useParams() as { formId: string };
+  const { formId } = useSafeParams() as { formId: string };
   const navigate = useNavigate();
 
   const { data: { formDefinition } = {}, error } =
@@ -59,7 +59,7 @@ const ViewFormDefinitionPage = () => {
         actions={
           <Stack direction='row' gap={2}>
             <ButtonLink
-              to={generateSafePath(AdminDashboardRoutes.EDIT_FORM, { formId })}
+              to={generatePath(AdminDashboardRoutes.EDIT_FORM, { formId })}
               startIcon={<EditIcon />}
               variant='outlined'
             >
@@ -78,7 +78,7 @@ const ViewFormDefinitionPage = () => {
               }}
               onSuccess={() => {
                 evictQuery('formDefinitions');
-                navigate(generateSafePath(AdminDashboardRoutes.FORMS));
+                navigate(generatePath(AdminDashboardRoutes.FORMS));
               }}
             >
               Delete Definition


### PR DESCRIPTION
## Description

Minor bug fix for encoded urls. Form IDs do not need to be hidden

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix

## Checklist before requesting review
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (eslint)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
