### PR TITLE
186854441-fix-session-expiry

### DIFF
--- a/src/modules/auth/api/sessions.ts
+++ b/src/modules/auth/api/sessions.ts
@@ -6,6 +6,7 @@ import * as storage from '@/modules/auth/api/storage';
 
 import apolloClient from '@/providers/apolloClient';
 import { getCsrfToken } from '@/utils/csrf';
+import { HttpError } from '@/utils/HttpError';
 
 export interface HmisUser {
   id: string;
@@ -88,7 +89,9 @@ export async function fetchCurrentUser(): Promise<HmisUser | undefined> {
     storage.clearUser();
     return undefined;
   } else {
-    return Promise.reject(response.status);
+    return Promise.reject(
+      new HttpError('Failed to fetch currentUser', response.status)
+    );
   }
 }
 
@@ -213,3 +216,6 @@ export async function stopImpersonating() {
     return user;
   }
 }
+
+// if we auto-reload due to an error, only do it once
+export const RELOAD_ONCE_SESSION_KEY = 'reload-once';

--- a/src/modules/auth/components/SessionStatusManager.tsx
+++ b/src/modules/auth/components/SessionStatusManager.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useState } from 'react';
 
 import ConfirmationDialog from '@/components/elements/ConfirmationDialog';
 import {
+  RELOAD_ONCE_SESSION_KEY,
   resetLocalSession,
   sendSessionKeepalive,
 } from '@/modules/auth/api/sessions';
@@ -16,6 +17,7 @@ const SessionStatusManager: React.FC<HmisSessionProps> = ({
   const [loading, setLoading] = useState(false);
 
   const handleResetSession = useCallback(() => {
+    sessionStorage.removeItem(RELOAD_ONCE_SESSION_KEY);
     setLoading(true);
     resetLocalSession();
     reloadWindow();
@@ -31,6 +33,7 @@ const SessionStatusManager: React.FC<HmisSessionProps> = ({
 
   // current session has ended, user clicks continue
   const handleReload = useCallback(() => {
+    sessionStorage.removeItem(RELOAD_ONCE_SESSION_KEY);
     setLoading(true);
     reloadWindow();
   }, [setLoading]);

--- a/src/modules/hmisAppSettings/api.tsx
+++ b/src/modules/hmisAppSettings/api.tsx
@@ -1,4 +1,5 @@
 import { HmisAppSettings } from './types';
+import { HttpError } from '@/utils/HttpError';
 
 export const fetchHmisAppSettings = async (): Promise<HmisAppSettings> => {
   const response = await fetch(`/hmis/app_settings`, {
@@ -14,8 +15,11 @@ export const fetchHmisAppSettings = async (): Promise<HmisAppSettings> => {
   if (response.ok) {
     return json;
   } else {
-    throw new Error(`Failed to fetch app settings: ${JSON.stringify(json)}`, {
-      cause: json,
-    });
+    const error = new HttpError(
+      `Failed to fetch app settings`,
+      response.status
+    );
+    error.cause = json;
+    throw error;
   }
 };

--- a/src/utils/HttpError.ts
+++ b/src/utils/HttpError.ts
@@ -1,0 +1,9 @@
+export class HttpError extends Error {
+  status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.status = status;
+    this.name = 'HttpError';
+  }
+}


### PR DESCRIPTION
## Description

If requests to fetch user/settings fail due to authorization error, try to reload the page. Reload only happens once to protect from infinite reloads if something unexpected happens.

Also returns more appropriate HttpError for api failures 

[Server error after session expiration
](https://www.pivotaltracker.com/story/show/186854441)

[//]: # 'remove if not applicable'
[Depends on hmis-warehouse PR:
](https://github.com/greenriver/hmis-warehouse/pull/3919)

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
