### PR TITLE
Enable enrollment deletion if no intake exists

### DIFF
--- a/src/modules/enrollment/components/dashboardPages/EnrollmentOverview.tsx
+++ b/src/modules/enrollment/components/dashboardPages/EnrollmentOverview.tsx
@@ -87,8 +87,8 @@ const EnrollmentOverview = () => {
               enrollment={enrollment}
               enabledFeatures={enabledFeatures}
             />
-            {enrollment.inProgress &&
-              enrollment.access.canDeleteEnrollments && (
+            {enrollment.access.canDeleteEnrollments &&
+              (enrollment.inProgress || !enrollment.intakeAssessment) && (
                 <DeleteMutationButton<
                   DeleteEnrollmentMutation,
                   DeleteEnrollmentMutationVariables


### PR DESCRIPTION
## Description

This one should be merged first: https://github.com/greenriver/hmis-warehouse/pull/3926

Enables deleting enrollments if the intake assessment does not exist: something that should never happen now, but could happen due to bad data, or in the future if we support projects that don't do intake assessments.

https://www.pivotaltracker.com/n/projects/2591838/stories/186726767/

[//]: # 'remove if not applicable'
Depends on hmis-warehouse PR:

## Type of change
[//]: # 'remove options that are not relevant'
- [ ] Bug fix
- [x] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [?] I have updated the documentation (or not applicable)
- [?] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue

@gigxz I have the same question here -- let me know if there are any unit tests or any documentation I should change!
