### PR TITLE
Assessment caching fix

### DIFF
--- a/src/components/pages/EnrollmentDashboard.tsx
+++ b/src/components/pages/EnrollmentDashboard.tsx
@@ -71,9 +71,10 @@ const EnrollmentDashboard: React.FC = () => {
             overrideBreadcrumbTitles,
             enrollment,
             enabledFeatures,
+            enrollmentLoading: loading,
           }
         : undefined,
-    [client, enrollment, enabledFeatures]
+    [client, enrollment, enabledFeatures, loading]
   );
 
   const breadCrumbConfig = useEnrollmentBreadcrumbConfig(outletContext);
@@ -82,7 +83,7 @@ const EnrollmentDashboard: React.FC = () => {
     breadcrumbOverrides
   );
 
-  if (loading || !navItems) return <Loading />;
+  if (loading && !enrollment) return <Loading />;
   if (!enrollment || !client || !outletContext) return <NotFound />;
   if (enrollment && enrollment.client.id !== params.clientId) {
     return <NotFound />;
@@ -130,6 +131,7 @@ const EnrollmentDashboard: React.FC = () => {
 export type EnrollmentDashboardContext = {
   client: ClientNameDobVetFragment;
   enrollment?: DashboardEnrollment;
+  enrollmentLoading?: boolean; // this would indicate a re-loading, not the initial load
   overrideBreadcrumbTitles: (crumbs: any) => void;
   enabledFeatures: DataCollectionFeatureRole[];
 };

--- a/src/modules/assessments/components/ExitAssessmentPage.tsx
+++ b/src/modules/assessments/components/ExitAssessmentPage.tsx
@@ -11,17 +11,20 @@ import { AssessmentRole } from '@/types/gqlTypes';
 import { generateSafePath } from '@/utils/pathEncoding';
 
 const ExitAssessmentPage = () => {
-  const { enrollment, client } = useEnrollmentDashboardContext();
+  const { enrollment, enrollmentLoading, client } =
+    useEnrollmentDashboardContext();
   const navigate = useNavigate();
 
-  const { formDefinition, loading } = useAssessmentFormDefinition({
-    role: AssessmentRole.Exit,
-    projectId: enrollment?.project.id || '',
-    // apply form rules based on the exit date. if this enrollment exited a year ago and the project was funded by PATH at that time, we want to see PATH questions.
-    assessmentDate: enrollment?.exitDate,
-  });
+  const { formDefinition, loading: definitionLoading } =
+    useAssessmentFormDefinition({
+      role: AssessmentRole.Exit,
+      projectId: enrollment?.project.id || '',
+      // apply form rules based on the exit date. if this enrollment exited a year ago and the project was funded by PATH at that time, we want to see PATH questions.
+      assessmentDate: enrollment?.exitDate,
+    });
 
   useEffect(() => {
+    if (enrollmentLoading) return; // if enrollment is reloading, dont do anything yet
     if (!enrollment || !formDefinition) return;
     if (enrollment.householdSize > 1) return; // render in-place
 
@@ -46,11 +49,11 @@ const ExitAssessmentPage = () => {
         { replace: true }
       );
     }
-  }, [client, enrollment, formDefinition, navigate]);
+  }, [client, enrollment, enrollmentLoading, formDefinition, navigate]);
 
-  if (!enrollment) return <NotFound />;
-  if (!formDefinition && loading) return <Loading />;
+  if (!formDefinition && definitionLoading) return <Loading />;
   if (!formDefinition) return <MissingDefinitionAlert />;
+  if (!enrollment) return <NotFound />;
 
   // Househould has multiple members
   if (enrollment.householdSize > 1) {
@@ -63,7 +66,7 @@ const ExitAssessmentPage = () => {
     );
   }
 
-  return <NotFound />;
+  return null;
 };
 
 export default ExitAssessmentPage;

--- a/src/modules/assessments/components/IndividualAssessmentFormController.tsx
+++ b/src/modules/assessments/components/IndividualAssessmentFormController.tsx
@@ -49,12 +49,9 @@ const IndividualAssessmentFormController: React.FC<Props> = ({
   const onCompletedMutation = useCallback(
     (status: AssessmentResponseStatus) => {
       if (!['saved', 'submitted'].includes(status)) return;
-      // We created a NEW assessment, clear assessment queries from cache before navigating so the table reloads
+      // If we created a NEW assessment, evict Enrollment from the cache.
       if (!assessment) {
-        cache.evict({
-          id: `Enrollment:${enrollment.id}`,
-          fieldName: 'assessments',
-        });
+        cache.evict({ id: `Enrollment:${enrollment.id}` });
       }
       navigateToEnrollment();
     },

--- a/src/modules/assessments/components/IntakeAssessmentPage.tsx
+++ b/src/modules/assessments/components/IntakeAssessmentPage.tsx
@@ -11,17 +11,20 @@ import { AssessmentRole } from '@/types/gqlTypes';
 import { generateSafePath } from '@/utils/pathEncoding';
 
 const IntakeAssessmentPage = () => {
-  const { enrollment, client } = useEnrollmentDashboardContext();
+  const { enrollment, enrollmentLoading, client } =
+    useEnrollmentDashboardContext();
   const navigate = useNavigate();
 
-  const { formDefinition, loading } = useAssessmentFormDefinition({
-    role: AssessmentRole.Intake,
-    projectId: enrollment?.project.id || '',
-    // apply form rules based on the entry date. if this enrollment is from a year ago and the project was funded by PATH at that time, we want to see PATH questions.
-    assessmentDate: enrollment?.entryDate,
-  });
+  const { formDefinition, loading: definitionLoading } =
+    useAssessmentFormDefinition({
+      role: AssessmentRole.Intake,
+      projectId: enrollment?.project.id || '',
+      // apply form rules based on the entry date. if this enrollment is from a year ago and the project was funded by PATH at that time, we want to see PATH questions.
+      assessmentDate: enrollment?.entryDate,
+    });
 
   useEffect(() => {
+    if (enrollmentLoading) return; // if enrollment is reloading, dont do anything yet
     if (!enrollment || !formDefinition) return;
     if (enrollment.householdSize > 1) return; // render in-place
 
@@ -46,11 +49,11 @@ const IntakeAssessmentPage = () => {
         { replace: true }
       );
     }
-  }, [client, enrollment, formDefinition, navigate]);
+  }, [client, enrollment, enrollmentLoading, formDefinition, navigate]);
 
-  if (!enrollment) return <NotFound />;
-  if (!formDefinition && loading) return <Loading />;
+  if (!formDefinition && definitionLoading) return <Loading />;
   if (!formDefinition) return <MissingDefinitionAlert />;
+  if (!enrollment) return <NotFound />;
 
   // Househould has multiple members
   if (enrollment.householdSize > 1) {
@@ -63,7 +66,7 @@ const IntakeAssessmentPage = () => {
     );
   }
 
-  return <NotFound />;
+  return null;
 };
 
 export default IntakeAssessmentPage;

--- a/src/modules/enrollment/components/EnrollmentAssessmentActionButtons.tsx
+++ b/src/modules/enrollment/components/EnrollmentAssessmentActionButtons.tsx
@@ -11,7 +11,10 @@ import CommonMenuButton, {
 import { DashboardEnrollment } from '@/modules/hmis/types';
 import { useHouseholdMembers } from '@/modules/household/hooks/useHouseholdMembers';
 import { EnrollmentDashboardRoutes } from '@/routes/routes';
-import { AssessmentEligibility, AssessmentRole } from '@/types/gqlTypes';
+import {
+  AssessmentRole,
+  GetEnrollmentAssessmentEligibilitiesQuery,
+} from '@/types/gqlTypes';
 import { generateSafePath } from '@/utils/pathEncoding';
 
 type FinishIntakeButtonProps = {
@@ -33,15 +36,17 @@ const FinishIntakeButton: React.FC<FinishIntakeButtonProps> = ({
   );
 };
 
+type AssessmentEligibilityType = NonNullable<
+  GetEnrollmentAssessmentEligibilitiesQuery['enrollment']
+>['assessmentEligibilities'][0];
+
 type Props = {
   enrollment: DashboardEnrollment;
-  assessmentEligibilities: AssessmentEligibility[];
 };
 
-const NewAssessmentMenu: React.FC<Props> = ({
-  enrollment,
-  assessmentEligibilities,
-}) => {
+const NewAssessmentMenu: React.FC<
+  Props & { assessmentEligibilities: AssessmentEligibilityType[] }
+> = ({ enrollment, assessmentEligibilities }) => {
   const enrollmentId = enrollment.id;
   const clientId = enrollment.client.id;
 

--- a/src/modules/enrollment/hooks/useAssessmentEligibilities.tsx
+++ b/src/modules/enrollment/hooks/useAssessmentEligibilities.tsx
@@ -1,0 +1,16 @@
+import { useGetEnrollmentAssessmentEligibilitiesQuery } from '@/types/gqlTypes';
+
+export function useAssessmentEligibilities(enrollmentId: string) {
+  const { data, error, loading } = useGetEnrollmentAssessmentEligibilitiesQuery(
+    {
+      fetchPolicy: 'cache-and-network',
+      variables: { enrollmentId },
+    }
+  );
+  if (error) throw error;
+
+  return {
+    assessmentEligibilities: data?.enrollment?.assessmentEligibilities,
+    loading,
+  };
+}

--- a/src/modules/enrollment/hooks/useDetailedEnrollment.tsx
+++ b/src/modules/enrollment/hooks/useDetailedEnrollment.tsx
@@ -14,8 +14,5 @@ export function useDetailedEnrollment(enrollmentId?: string) {
   const enrollment: AllEnrollmentDetailsFragment | undefined =
     data?.enrollment || undefined;
 
-  return {
-    enrollment,
-    loading: loading && !enrollment,
-  };
+  return { enrollment, loading };
 }


### PR DESCRIPTION
## Description

* fix issue where `enrollment.intakeAssessment` wasnt cleared from the cache so the intake page was navigating wrong
* fix issue where intake page was navigating wrong while enrollment was being refetched. add loading bool to context for this

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (eslint)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
