### PR TITLE
Add back white bg for alerts

### DIFF
--- a/src/config/theme.ts
+++ b/src/config/theme.ts
@@ -308,6 +308,10 @@ const createThemeOptions = (theme: Theme) => ({
       },
     },
     MuiAlert: {
+      styleOverrides: {
+        // override default transparent bg
+        outlined: { backgroundColor: '#fff' },
+      },
       variants: [
         {
           // styles that are shared across all withHeader alerts


### PR DESCRIPTION
## Description

Revert inadvertend change from https://github.com/greenriver/hmis-frontend/commit/aecb8bec13da783eb8ba8c400aea1c4bdee3cbcc#diff-6e272d18794b7b928057372a50cf6b1ff67d2261714613bd40657152538e26d2 that made outlined backgrounds be transparent instead of white



<img width="1206" alt="Screenshot 2024-02-05 at 11 34 39 AM" src="https://github.com/greenriver/hmis-frontend/assets/5333982/e8ac8987-3d14-48c6-8132-572cef7280c5">


## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
