### PR TITLE
Add phone input field that accepts only one number

### DIFF
--- a/src/modules/form/components/DynamicField.tsx
+++ b/src/modules/form/components/DynamicField.tsx
@@ -31,6 +31,7 @@ import DatePicker from '@/components/elements/input/DatePicker';
 import LabeledCheckbox from '@/components/elements/input/LabeledCheckbox';
 import NoYesMissingCheckbox from '@/components/elements/input/NoYesMissingCheckbox';
 import NumberInput from '@/components/elements/input/NumberInput';
+import PhoneInput from '@/components/elements/input/PhoneInput';
 import RadioGroupInput from '@/components/elements/input/RadioGroupInput';
 import SsnInput from '@/components/elements/input/SsnInput';
 import TextInput from '@/components/elements/input/TextInput';
@@ -38,7 +39,6 @@ import YesNoRadio from '@/components/elements/input/YesNoRadio';
 import Uploader from '@/components/elements/upload/UploaderBase';
 import MciClearance from '@/modules/external/mci/components/MciClearance';
 import SimpleAddressInput from '@/modules/form/components/client/addresses/SimpleAddressInput';
-import PhoneInput from '@/modules/form/components/client/phones/PhoneInputGroup';
 import { INVALID_ENUM, parseHmisDateString } from '@/modules/hmis/hmisUtil';
 import { Component, FormItem, InputSize, ItemType } from '@/types/gqlTypes';
 
@@ -238,7 +238,12 @@ const DynamicField: React.FC<DynamicFieldProps> = ({
           <PhoneInput
             id={linkId}
             value={value || ''}
-            onChange={onChangeValue}
+            onChange={onChangeEvent}
+            sx={{
+              width,
+              maxWidth: MAX_INPUT_AND_LABEL_WIDTH,
+              '.MuiInputBase-root': { maxWidth: MAX_INPUT_WIDTH },
+            }}
             {...commonInputProps}
           />
         );

--- a/src/modules/form/components/DynamicField.tsx
+++ b/src/modules/form/components/DynamicField.tsx
@@ -38,6 +38,7 @@ import YesNoRadio from '@/components/elements/input/YesNoRadio';
 import Uploader from '@/components/elements/upload/UploaderBase';
 import MciClearance from '@/modules/external/mci/components/MciClearance';
 import SimpleAddressInput from '@/modules/form/components/client/addresses/SimpleAddressInput';
+import PhoneInput from '@/modules/form/components/client/phones/PhoneInputGroup';
 import { INVALID_ENUM, parseHmisDateString } from '@/modules/hmis/hmisUtil';
 import { Component, FormItem, InputSize, ItemType } from '@/types/gqlTypes';
 
@@ -231,6 +232,17 @@ const DynamicField: React.FC<DynamicFieldProps> = ({
             />
           </InputContainer>
         );
+
+      if (item.component === Component.Phone) {
+        return (
+          <PhoneInput
+            id={linkId}
+            value={value || ''}
+            onChange={onChangeValue}
+            {...commonInputProps}
+          />
+        );
+      }
 
       const multiline = item.type === ItemType.Text;
       return (

--- a/src/modules/form/components/client/emails/EmailInput.tsx
+++ b/src/modules/form/components/client/emails/EmailInput.tsx
@@ -1,16 +1,16 @@
 import { Grid, Stack } from '@mui/material';
 
 import { getRequiredLabel } from '../../RequiredLabel';
-import { PhoneInputType } from '../types';
+import { EmailInputType } from '../types';
 
 import TextInput from '@/components/elements/input/TextInput';
 
-const PhoneInput = ({
+const EmailInput = ({
   value,
   onChange,
 }: {
-  value: PhoneInputType;
-  onChange: (value: PhoneInputType) => void;
+  value: EmailInputType;
+  onChange: (value: EmailInputType) => void;
 }) => {
   return (
     <Stack direction={'column'} rowGap={0}>
@@ -36,4 +36,4 @@ const PhoneInput = ({
   );
 };
 
-export default PhoneInput;
+export default EmailInput;

--- a/src/modules/form/components/client/phones/MultiPhoneInput.tsx
+++ b/src/modules/form/components/client/phones/MultiPhoneInput.tsx
@@ -7,7 +7,7 @@ import { PhoneInputType } from '../types';
 import { useRenderLastUpdated } from '../useRenderLastUpdated';
 import { createInitialValue } from '../util';
 
-import PhoneInput from './PhoneInputGroup';
+import PhoneInputGroup from './PhoneInputGroup';
 
 import { ClientContactPointFieldsFragmentDoc } from '@/types/gqlTypes';
 import { PartialPick } from '@/utils/typeUtil';
@@ -35,7 +35,7 @@ const MultiPhoneInput = ({ id, value, onChange, label }: Props) => {
       valueKey={(addrValue) => addrValue._key || addrValue.id || ''}
       renderChild={(addrValue, idx) => {
         return (
-          <PhoneInput
+          <PhoneInputGroup
             value={addrValue}
             onChange={(val) => {
               const copied = [...value];


### PR DESCRIPTION
## Description

The normal phone input component (currently in use on the default New Client form) enables adding multiple phone numbers, each with their own type (home, cell, etc.) and note.

For emergency contacts, I think we don't want to be able to add multiple phone numbers, but we do want a phone-validating input component, so it's useful to reuse this Phone component.

**Open Question**
Is it desirable to be able to input the phone type and any notes (see screenshot below)? This is built-in behavior with the Phone component, but we can also disable it.
<img width="1113" alt="Screenshot 2024-02-06 at 4 10 24 PM" src="https://github.com/greenriver/hmis-frontend/assets/16002775/49c58d8f-04c6-4245-aa5f-455dacf59d9a">

[//]: # 'remove if not applicable'
Depends on hmis-warehouse PR: https://github.com/greenriver/hmis-warehouse/pull/3987

## Type of change
[//]: # 'remove options that are not relevant'
- [ ] Bug fix
- [x] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
