### PR TITLE
Fix bug that caused filter disappearance

### DIFF
--- a/src/modules/admin/components/users/ClientAccessSummaryTable.tsx
+++ b/src/modules/admin/components/users/ClientAccessSummaryTable.tsx
@@ -60,6 +60,7 @@ const ClientAccessSummaryTable: React.FC<Props> = ({
       noData='No access history'
       filterInputType='ClientAccessSummaryFilterOptions'
       paginationItemName='accessed client'
+      recordType='ClientAccessSummary'
       filters={(filters) => omit(filters, 'searchTerm')}
       showFilters
     />

--- a/src/modules/admin/components/users/EnrollmentAccessSummaryTable.tsx
+++ b/src/modules/admin/components/users/EnrollmentAccessSummaryTable.tsx
@@ -65,6 +65,7 @@ const EnrollmentAccessSummaryTable: React.FC<Props> = ({
       noData='No access history'
       filterInputType='EnrollmentAccessSummaryFilterOptions'
       paginationItemName='accessed enrollment'
+      recordType='EnrollmentAccessSummary'
       filters={(filters) => omit(filters, 'searchTerm')}
       showFilters
     />

--- a/src/modules/admin/components/users/UserAuditHistory.tsx
+++ b/src/modules/admin/components/users/UserAuditHistory.tsx
@@ -84,11 +84,12 @@ const UserAuditHistory = () => {
           fetchPolicy='cache-and-network'
           noData='No audit history'
           pagePath='user.auditHistory'
-          paginationItemName='user audit event'
+          paginationItemName='event'
           queryDocument={GetUserAuditEventsDocument}
           queryVariables={{ id: userId }}
           rowSx={() => ({ whiteSpace: 'nowrap' })}
           tableProps={{ sx: { tableLayout: 'fixed' } }}
+          recordType='ApplicationUserAuditEvent'
           filterInputType='UserAuditEventFilterOptions'
           showFilters
         />


### PR DESCRIPTION
## Description

Mary Ann pointed out when testing the User Audit feature in QA that it lacked filter capabilities. I also noticed that after my changes, the filter capability disappeared from the client and enrollment access summary tables! 🐞 

It turned out to be because all three of these tables require a `recordType` prop in order to render filtering, so this PR addresses that problem. The Client and Enrollment access tabs are restored to their former filter functionality. The User Audit (edit history) filter function looks like this: 

<img width="338" alt="Screenshot 2024-02-12 at 10 01 13 AM" src="https://github.com/greenriver/hmis-frontend/assets/16002775/5762e32f-f4cf-4f6e-bd4d-4b5617979a83">

Question: is adding an "on or after date" part of the filtering requirements? Any other filter requirements to meet?

PT issue: https://www.pivotaltracker.com/n/projects/2591838/stories/186570782/comments/240192255

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
