### PR TITLE
UI tweaks: dashboard card headings, loading states, and horizontal inputs

### DIFF
--- a/src/components/clientDashboard/enrollments/EnrollmentReminders.tsx
+++ b/src/components/clientDashboard/enrollments/EnrollmentReminders.tsx
@@ -290,7 +290,6 @@ const EnrollmentReminders: React.FC<Props> = ({ enrollmentId }) => {
           ? 'Household Tasks'
           : `Household Tasks (${displayReminders.length})`
       }
-      headerTypographyVariant='h5'
     >
       {loading && !data ? (
         <Loading />

--- a/src/components/clientDashboard/enrollments/EnrollmentReminders.tsx
+++ b/src/components/clientDashboard/enrollments/EnrollmentReminders.tsx
@@ -290,6 +290,7 @@ const EnrollmentReminders: React.FC<Props> = ({ enrollmentId }) => {
           ? 'Household Tasks'
           : `Household Tasks (${displayReminders.length})`
       }
+      headerVariant='border'
     >
       {loading && !data ? (
         <Loading />

--- a/src/components/pages/AllProjects.tsx
+++ b/src/components/pages/AllProjects.tsx
@@ -129,6 +129,7 @@ const AllProjects = () => {
               fullWidth
               size='medium'
               searchAdornment
+              clearAdornment
             />
           </Grid>
         )}

--- a/src/modules/client/components/ClientCustomDataElementsCard.tsx
+++ b/src/modules/client/components/ClientCustomDataElementsCard.tsx
@@ -43,11 +43,7 @@ const ClientCustomDataElementsCard: React.FC<Props> = ({ client }) => {
   if (rows.length === 0) return null;
 
   return (
-    <TitleCard
-      title='Custom Fields'
-      headerVariant='border'
-      headerTypographyVariant='body1'
-    >
+    <TitleCard title='Custom Fields' headerVariant='border'>
       <CommonDetailGridContainer>
         {rows.map(({ id, label, value }) => (
           <CommonDetailGridItem label={label} key={id}>

--- a/src/modules/client/components/ClientEnrollmentCard.tsx
+++ b/src/modules/client/components/ClientEnrollmentCard.tsx
@@ -98,11 +98,7 @@ interface Props {
 
 const ClientEnrollmentCard: React.FC<Props> = ({ client }) => {
   return (
-    <TitleCard
-      title='Recent Enrollments'
-      headerVariant='border'
-      headerTypographyVariant='body1'
-    >
+    <TitleCard title='Recent Enrollments' headerVariant='border'>
       <RecentEnrollments clientId={client.id} />
     </TitleCard>
   );

--- a/src/modules/client/components/clientAlerts/ClientAlertCard.tsx
+++ b/src/modules/client/components/clientAlerts/ClientAlertCard.tsx
@@ -1,5 +1,6 @@
 import { Box, Stack, Typography } from '@mui/material';
-import { ReactNode } from 'react';
+import { ReactNode, useMemo } from 'react';
+import Loading from '@/components/elements/Loading';
 import TitleCard from '@/components/elements/TitleCard';
 import { ClientAlertType } from '@/modules/client/components/clientAlerts/ClientAlert';
 import ClientAlertStack from '@/modules/client/components/clientAlerts/ClientAlertStack';
@@ -13,22 +14,25 @@ interface ClientAlertCardProps {
   alertContext: AlertContext;
   clientAlerts: ClientAlertType[];
   children?: ReactNode;
+  loading?: boolean;
 }
 const ClientAlertCard: React.FC<ClientAlertCardProps> = ({
   alertContext = AlertContext.Client,
   clientAlerts,
   children,
+  loading = false,
 }) => {
-  const title = `${alertContext} Alerts (${clientAlerts.length})`;
+  const title = useMemo(() => {
+    const cardTitle = `${alertContext} Alerts`;
+    if (loading) return cardTitle;
+    return `${cardTitle} (${clientAlerts.length})`;
+  }, [alertContext, clientAlerts.length, loading]);
 
   return (
-    <TitleCard
-      title={title}
-      headerVariant='border'
-      headerTypographyVariant='body1'
-    >
+    <TitleCard title={title} headerVariant='border'>
       <Box sx={{ m: 2 }}>
-        {clientAlerts.length === 0 && (
+        {loading && <Loading />}
+        {!loading && clientAlerts.length === 0 && (
           <Stack
             direction='row'
             justifyContent='space-between'
@@ -40,7 +44,7 @@ const ClientAlertCard: React.FC<ClientAlertCardProps> = ({
               borderRadius: 1,
             }}
           >
-            <Typography variant={'body2'}>
+            <Typography variant='body2'>
               {alertContext} has no alerts at this time
             </Typography>
             {children}

--- a/src/modules/client/components/clientAlerts/ClientAlertWrappers.tsx
+++ b/src/modules/client/components/clientAlerts/ClientAlertWrappers.tsx
@@ -1,4 +1,3 @@
-import Loading from '@/components/elements/Loading';
 import ClientAlertCard, {
   AlertContext,
 } from '@/modules/client/components/clientAlerts/ClientAlertCard';
@@ -39,13 +38,12 @@ export const ClientAlertHouseholdWrapper: React.FC<
   });
 
   if (!showClientAlertCard) return;
-  if (loading && (!clientAlerts || clientAlerts.length === 0))
-    return <Loading />;
 
   return (
     <ClientAlertCard
       alertContext={AlertContext.Household}
       clientAlerts={clientAlerts}
+      loading={loading}
     />
   );
 };

--- a/src/modules/client/hooks/useClientAlerts.tsx
+++ b/src/modules/client/hooks/useClientAlerts.tsx
@@ -79,7 +79,7 @@ export default function useClientAlerts(params: ClientAlertParams) {
 
   return {
     clientAlerts,
-    loading,
+    loading: loading && !household,
     showClientAlertCard: canViewAlertsForAnyHouseholdMembers,
   };
 }

--- a/src/modules/form/components/DynamicGroup.tsx
+++ b/src/modules/form/components/DynamicGroup.tsx
@@ -22,7 +22,10 @@ export const InfoGroup = ({
       backgroundColor: (theme) => lighten(theme.palette.grey[100], 0.2),
       borderRadius: 1,
       width: 'fit-content',
-      p: 1,
+      px: 0.5,
+      // use box shadow to "extend" background color beyond div. doing this so we dont mess with the height
+      boxShadow: (theme) =>
+        `0 2px 0 6px ${lighten(theme.palette.grey[100], 0.2)}`,
     }}
   >
     {children}

--- a/src/modules/form/components/group/HorizontalGroup.tsx
+++ b/src/modules/form/components/group/HorizontalGroup.tsx
@@ -9,10 +9,17 @@ const HorizontalGroup = ({
   const manyChildren = (item.item || []).length > 2;
   const columnGap = manyChildren ? 2 : 4;
   const rowGap = manyChildren ? 1 : 2;
+
   return (
     <Grid item xs>
       {item.text && <Typography sx={{ mb: 2 }}>{item.text}</Typography>}
-      <Grid container direction='row' columnGap={columnGap} rowGap={rowGap}>
+      <Grid
+        container
+        direction='row'
+        columnGap={columnGap}
+        rowGap={rowGap}
+        alignItems='end'
+      >
         {renderChildItem &&
           item.item?.map((childItem) => renderChildItem(childItem))}
       </Grid>


### PR DESCRIPTION
## Description


Some miscellaneous design updates for release-103:

* Standardize card titles on Client and Enrollment dash to all use `cardTitle` variant, with no bold
* Enable "clear" button on project search
* Change alignment on horizontal group so we don't get bumpy inputs like this:
<img width="296" alt="Screenshot 2024-02-13 at 3 59 10 PM" src="https://github.com/greenriver/hmis-frontend/assets/5333982/873d5979-005c-48c1-afee-5a7cfc0e8e70">

* Standardize loading states on the Enrollment Dashboard so that the `Loading` spinner appears _inside_ the cards for both Household Alerts and Household Tasks (previously Household Alert spinner appeared without a card)

## Type of change
- [x] Bug fix
- [x] Code clean-up / housekeeping

## Checklist before requesting review
- [ ] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (eslint)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
