### PR TITLE
Make small fixes to the Project Enrollments and Project Services pages

### DIFF
--- a/src/modules/bedNights/components/ProjectEnrollmentsTableForBedNights.tsx
+++ b/src/modules/bedNights/components/ProjectEnrollmentsTableForBedNights.tsx
@@ -132,7 +132,7 @@ const ProjectEnrollmentsTableForBedNights = ({
           ],
         }}
         noData={noResultsDisplay}
-        selectable={editable ? 'row' : undefined}
+        selectable={editable ? 'checkbox' : undefined}
         defaultPageSize={25}
         rowsPerPageOptions={[25, 50, 100, 150, 200]}
         EnhancedTableToolbarProps={{

--- a/src/modules/enrollment/components/dashboardPages/EnrollmentServicesPage.tsx
+++ b/src/modules/enrollment/components/dashboardPages/EnrollmentServicesPage.tsx
@@ -31,19 +31,6 @@ export const SERVICE_COLUMNS: ColumnDef<ServiceFieldsFragment>[] = [
       return `${category} - ${name}`;
     },
   },
-  {
-    header: 'Service Details',
-    render: (e) => (
-      <Stack>
-        {serviceDetails(e).map((s, i) => (
-          // eslint-disable-next-line react/no-array-index-key
-          <Typography key={i} variant='body2'>
-            {s}
-          </Typography>
-        ))}
-      </Stack>
-    ),
-  },
 ];
 
 const EnrollmentServicesPage = () => {
@@ -63,6 +50,24 @@ const EnrollmentServicesPage = () => {
   if (!enrollment || !enrollmentId || !clientId) return <NotFound />;
 
   const canEditServices = enrollment.access.canEditEnrollments;
+
+  const columns = [
+    ...SERVICE_COLUMNS,
+    {
+      header: 'Service Details',
+      render: (e: ServiceFieldsFragment) => (
+        <Stack>
+          {serviceDetails(e).map((s, i) => (
+            // eslint-disable-next-line react/no-array-index-key
+            <Typography key={i} variant='body2'>
+              {s}
+            </Typography>
+          ))}
+        </Stack>
+      ),
+    },
+  ];
+
   return (
     <>
       <TitleCard
@@ -95,7 +100,7 @@ const EnrollmentServicesPage = () => {
           }
           queryVariables={{ id: enrollmentId }}
           queryDocument={GetEnrollmentServicesDocument}
-          columns={SERVICE_COLUMNS}
+          columns={columns}
           pagePath='enrollment.services'
           noData='No services'
           recordType='Service'

--- a/src/modules/projects/components/tables/ProjectClientEnrollmentsTable.tsx
+++ b/src/modules/projects/components/tables/ProjectClientEnrollmentsTable.tsx
@@ -4,6 +4,7 @@ import { useCallback, useMemo } from 'react';
 
 import { ColumnDef } from '@/components/elements/table/types';
 import ClientName from '@/modules/client/components/ClientName';
+import { SsnDobShowContextProvider } from '@/modules/client/providers/ClientSsnDobVisibility';
 import GenericTableWithData from '@/modules/dataFetching/components/GenericTableWithData';
 import EnrollmentClientNameWithAge from '@/modules/hmis/components/EnrollmentClientNameWithAge';
 import EnrollmentDateRangeWithStatus from '@/modules/hmis/components/EnrollmentDateRangeWithStatus';
@@ -16,6 +17,7 @@ import {
   formatDateForGql,
   parseAndFormatDate,
 } from '@/modules/hmis/hmisUtil';
+import { CLIENT_COLUMNS } from '@/modules/search/components/ClientSearch';
 import { EnrollmentDashboardRoutes } from '@/routes/routes';
 import {
   ClientEnrollmentFieldsFragment,
@@ -179,52 +181,54 @@ const ProjectClientEnrollmentsTable = ({
   const defaultColumns: ColumnDef<ProjectEnrollmentQueryEnrollmentFieldsFragment>[] =
     useMemo(() => {
       return [
-        ENROLLMENT_COLUMNS.clientNameLinkedToEnrollmentWithAge,
+        ENROLLMENT_COLUMNS.clientNameLinkedToEnrollment,
+        CLIENT_COLUMNS.dobAge,
         ENROLLMENT_COLUMNS.enrollmentStatus,
         ENROLLMENT_COLUMNS.enrollmentPeriod,
-        ENROLLMENT_COLUMNS.householdId,
         ENROLLMENT_COLUMNS.lastClsDate,
       ];
     }, []);
 
   return (
-    <GenericTableWithData<
-      GetProjectEnrollmentsQuery,
-      GetProjectEnrollmentsQueryVariables,
-      EnrollmentFields,
-      EnrollmentsForProjectFilterOptions
-    >
-      queryVariables={{
-        id: projectId,
-        filters: {
-          searchTerm,
-          openOnDate: openOnDateString,
-        },
-      }}
-      queryDocument={GetProjectEnrollmentsDocument}
-      columns={columns || defaultColumns}
-      rowLinkTo={linkRowToEnrollment ? rowLinkTo : undefined}
-      noData={
-        openOnDate
-          ? `No enrollments open on ${formatDateForDisplay(openOnDate)}`
-          : 'No enrollments'
-      }
-      pagePath='project.enrollments'
-      recordType='Enrollment'
-      showFilters
-      filters={(f) => omit(f, 'searchTerm', 'bedNightOnDate')}
-      filterInputType='EnrollmentsForProjectFilterOptions'
-      defaultSortOption={EnrollmentSortOption.MostRecent}
-      showOptionalColumns
-      applyOptionalColumns={(cols) => {
-        const result: Partial<GetProjectEnrollmentsQueryVariables> = {};
+    <SsnDobShowContextProvider>
+      <GenericTableWithData<
+        GetProjectEnrollmentsQuery,
+        GetProjectEnrollmentsQueryVariables,
+        EnrollmentFields,
+        EnrollmentsForProjectFilterOptions
+      >
+        queryVariables={{
+          id: projectId,
+          filters: {
+            searchTerm,
+            openOnDate: openOnDateString,
+          },
+        }}
+        queryDocument={GetProjectEnrollmentsDocument}
+        columns={columns || defaultColumns}
+        rowLinkTo={linkRowToEnrollment ? rowLinkTo : undefined}
+        noData={
+          openOnDate
+            ? `No enrollments open on ${formatDateForDisplay(openOnDate)}`
+            : 'No enrollments'
+        }
+        pagePath='project.enrollments'
+        recordType='Enrollment'
+        showFilters
+        filters={(f) => omit(f, 'searchTerm', 'bedNightOnDate')}
+        filterInputType='EnrollmentsForProjectFilterOptions'
+        defaultSortOption={EnrollmentSortOption.MostRecent}
+        showOptionalColumns
+        applyOptionalColumns={(cols) => {
+          const result: Partial<GetProjectEnrollmentsQueryVariables> = {};
 
-        if (cols.includes(ENROLLMENT_COLUMNS.lastClsDate.key || ''))
-          result.includeCls = true;
+          if (cols.includes(ENROLLMENT_COLUMNS.lastClsDate.key || ''))
+            result.includeCls = true;
 
-        return result;
-      }}
-    />
+          return result;
+        }}
+      />
+    </SsnDobShowContextProvider>
   );
 };
 export default ProjectClientEnrollmentsTable;

--- a/src/modules/projects/components/tables/ProjectServicesTable.tsx
+++ b/src/modules/projects/components/tables/ProjectServicesTable.tsx
@@ -27,12 +27,24 @@ const ProjectServicesTable = ({
     if (columns) return columns;
     return [
       {
-        header: 'Client',
+        header: 'First Name',
         linkTreatment: true,
         render: (s: ServiceFields) => (
           <ClientName
             client={s.enrollment.client}
             linkToEnrollmentId={s.enrollment.id}
+            nameParts='first_only'
+          />
+        ),
+      },
+      {
+        header: 'Last Name',
+        linkTreatment: true,
+        render: (s: ServiceFields) => (
+          <ClientName
+            client={s.enrollment.client}
+            linkToEnrollmentId={s.enrollment.id}
+            nameParts='last_only'
           />
         ),
       },

--- a/src/modules/services/components/ClientServices.tsx
+++ b/src/modules/services/components/ClientServices.tsx
@@ -31,7 +31,7 @@ const ClientServices: React.FC<{
     () =>
       (
         [
-          ...SERVICE_COLUMNS.filter((col) => col.header !== 'Service Details'),
+          ...SERVICE_COLUMNS,
           {
             key: 'project',
             header: 'Project Name',


### PR DESCRIPTION
## Description

This PR covers the first 3 tasks from https://www.pivotaltracker.com/n/projects/2591838/stories/187019133:
- On the Bed Night workflow, make it so the rows are selectable only by clicking checkbox, not clicking row
- Add DOB column to Project->Enrollments-> Client table and remove household ID column
- Split out names to First/Last columns on Project->Services table and remove Service Details column

## Type of change
[//]: # 'remove options that are not relevant'
- [ ] Bug fix
- [x] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
