### PR TITLE
Fix linking to new exit assessment

### DIFF
--- a/src/modules/enrollment/components/EnrollmentAssessmentActionButtons.tsx
+++ b/src/modules/enrollment/components/EnrollmentAssessmentActionButtons.tsx
@@ -51,13 +51,29 @@ const NewAssessmentMenu: React.FC<
   const clientId = enrollment.client.id;
 
   const getPath = useCallback(
-    (formRole: AssessmentRole, formDefinitionId?: string) =>
-      generateSafePath(EnrollmentDashboardRoutes.NEW_ASSESSMENT, {
+    (formRole: AssessmentRole, formDefinitionId?: string) => {
+      // For intake and exit, navigate to the specific Intake/Exit page
+      // so that assessment can be rendered in Household view if applicable
+      if (formRole === AssessmentRole.Intake) {
+        return generateSafePath(EnrollmentDashboardRoutes.INTAKE, {
+          clientId,
+          enrollmentId,
+        });
+      }
+      if (formRole === AssessmentRole.Exit) {
+        return generateSafePath(EnrollmentDashboardRoutes.EXIT, {
+          clientId,
+          enrollmentId,
+        });
+      }
+
+      return generateSafePath(EnrollmentDashboardRoutes.NEW_ASSESSMENT, {
         clientId,
         enrollmentId,
         formRole,
         formDefinitionId,
-      }),
+      });
+    },
     [clientId, enrollmentId]
   );
 


### PR DESCRIPTION
## Description

Fix bug where "new exit assessment" button would always take you to the "individual" view, even for a household.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
