### PR TITLE
Only show hud assessments (not custom) in autofill dialog

### DIFF
--- a/src/modules/form/components/RecordPickerDialog.tsx
+++ b/src/modules/form/components/RecordPickerDialog.tsx
@@ -16,7 +16,7 @@ import CommonDialog from '@/components/elements/CommonDialog';
 import RelativeDate from '@/components/elements/RelativeDate';
 import { ColumnDef } from '@/components/elements/table/types';
 import HmisField from '@/modules/hmis/components/HmisField';
-import { FormItem, FormRole } from '@/types/gqlTypes';
+import { AssessmentRole, FormItem, FormRole } from '@/types/gqlTypes';
 
 interface Props extends Omit<DialogProps, 'children'> {
   clientId: string;
@@ -72,6 +72,14 @@ const RecordPickerDialog = ({
   // Need to set height on the dialog in order for the scrolling to work
   const height = `${Math.min(Math.max(columns.length * 60 + 250, 550), 850)}px`;
 
+  const hudRoles = [
+    AssessmentRole.Intake,
+    AssessmentRole.Update,
+    AssessmentRole.Exit,
+    AssessmentRole.Annual,
+    AssessmentRole.PostExit,
+  ];
+
   return (
     <CommonDialog
       open={open}
@@ -104,7 +112,7 @@ const RecordPickerDialog = ({
       >
         {description}
         <AssessmentsForPopulationTable
-          queryVariables={{ id: clientId }}
+          queryVariables={{ id: clientId, roles: hudRoles }}
           defaultPageSize={5}
           columns={columns}
           nonTablePagination


### PR DESCRIPTION
## Description

It doesn't make sense to show custom assessments in the autofill dialog for HUD assessments, so this PR filters the graphql query so that only hud assessment types are returned.
PT issue: https://www.pivotaltracker.com/story/show/187105010

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
