### PR TITLE
Add bounds to form definition story

### DIFF
--- a/src/test/__mocks__/mockFormDefinition.json
+++ b/src/test/__mocks__/mockFormDefinition.json
@@ -14,6 +14,20 @@
           "helperText": "This is helper text"
         },
         {
+          "type": "STRING",
+          "required": false,
+          "linkId": "string-2",
+          "text": "String with bounds",
+          "helperText": "You can't type more than 8 characters",
+          "bounds": [
+            {
+              "id": "max-chars-string",
+              "type": "MAX",
+              "valueNumber": 8
+            }
+          ]
+        },
+        {
           "type": "INTEGER",
           "required": false,
           "linkId": "int-1",
@@ -125,6 +139,20 @@
           "linkId": "text-1",
           "text": "Text Field",
           "helperText": "This is helper text"
+        },
+        {
+          "type": "TEXT",
+          "required": false,
+          "linkId": "text-2",
+          "text": "Text with bounds",
+          "helperText": "You can't type more than 5000 characters",
+          "bounds": [
+            {
+              "id": "max-chars-text",
+              "type": "MAX",
+              "valueNumber": 5000
+            }
+          ]
         },
         {
           "type": "CHOICE",


### PR DESCRIPTION
## Description

This arose out of trying to debug a problem with character bounds. PT issue: https://www.pivotaltracker.com/story/show/187116631

The issue turns out to be because of an Apollo caching problem, so, it's not reproduced here, but I'll put up the PR anyway so we can add it and make our stories slightly more useful.

I also considered just adding bounds on the existing string and text inputs here, rather than making separate ones. Let me know if you'd like me to implement this change. 

## Type of change
[//]: # 'remove options that are not relevant'
- [ ] Bug fix
- [ ] New feature (adds functionality)
- [x] Code clean-up / housekeeping (adds storybook detail)
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
