### PR TITLE
Enable bounds that specify tomorrow as local constant

### DIFF
--- a/src/modules/client/components/clientAlerts/CreateClientAlertDialog.tsx
+++ b/src/modules/client/components/clientAlerts/CreateClientAlertDialog.tsx
@@ -5,6 +5,7 @@ import {
   DialogProps,
   DialogTitle,
 } from '@mui/material';
+import { startOfTomorrow } from 'date-fns';
 import CommonDialog from '@/components/elements/CommonDialog';
 import StaticForm from '@/modules/form/components/StaticForm';
 import { clientBriefName } from '@/modules/hmis/hmisUtil';
@@ -69,6 +70,7 @@ export const CreateClientAlertDialog: React.FC<ClientAlertDialogProps> = ({
                 discardButtonText: 'Cancel',
               },
             }}
+            localConstants={{ tomorrow: startOfTomorrow() }}
           />
         </Box>
       </DialogContent>


### PR DESCRIPTION
## Description

This fixes a bug where creating an alert whose expiry date is equal to today causes the alert to immediately disappear since it's already expired. The desired behavior instead is that users shouldn't be able to create alerts that expire today. Alerts should expire tomorrow or later.
PT issue: [#187135490](https://www.pivotaltracker.com/story/show/187135490)

I just added it to the `CreateClientAlertDialog`'s local constants, but we could also consider adding it to the `AlwaysPresentLocalConstants` [here](https://github.com/greenriver/hmis-frontend/blob/eeaaa6ffae1d60f04e2452922cd17ae14544d4da/src/modules/form/util/formUtil.ts#L1399).

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
