### PR TITLE
Enable rich text labels in dynamic forms

### DIFF
--- a/src/components/elements/CommonHtmlContent.tsx
+++ b/src/components/elements/CommonHtmlContent.tsx
@@ -4,7 +4,7 @@ import { useMemo } from 'react';
 
 interface Props extends TypographyProps {
   children: string;
-  component: React.ElementType;
+  component?: React.ElementType;
 }
 const CommonHtmlContent: React.FC<Props> = ({
   children,

--- a/src/components/elements/CommonHtmlContent.tsx
+++ b/src/components/elements/CommonHtmlContent.tsx
@@ -1,14 +1,20 @@
 import { Typography, TypographyProps } from '@mui/material';
+import DOMPurify from 'dompurify';
+import { useMemo } from 'react';
 
 interface Props extends TypographyProps {
   children: string;
 }
 const CommonHtmlContent: React.FC<Props> = ({ children, ref, ...props }) => {
+  const purifiedHtml = useMemo(() => {
+    return DOMPurify.sanitize(children);
+  }, [children]);
+
   return children ? (
     <Typography
-      {...props}
       component='div'
-      dangerouslySetInnerHTML={{ __html: children }}
+      {...props}
+      dangerouslySetInnerHTML={{ __html: purifiedHtml }}
     />
   ) : null;
 };

--- a/src/components/elements/CommonHtmlContent.tsx
+++ b/src/components/elements/CommonHtmlContent.tsx
@@ -4,15 +4,21 @@ import { useMemo } from 'react';
 
 interface Props extends TypographyProps {
   children: string;
+  component: React.ElementType;
 }
-const CommonHtmlContent: React.FC<Props> = ({ children, ref, ...props }) => {
+const CommonHtmlContent: React.FC<Props> = ({
+  children,
+  ref,
+  component,
+  ...props
+}) => {
   const purifiedHtml = useMemo(() => {
     return DOMPurify.sanitize(children);
   }, [children]);
 
   return children ? (
     <Typography
-      component='div'
+      component={component || 'div'}
       {...props}
       dangerouslySetInnerHTML={{ __html: purifiedHtml }}
     />

--- a/src/modules/form/components/DynamicDisplay.tsx
+++ b/src/modules/form/components/DynamicDisplay.tsx
@@ -1,8 +1,8 @@
-import { Alert, AlertColor, Typography } from '@mui/material';
-import DOMPurify from 'dompurify';
+import { Alert, AlertColor } from '@mui/material';
 import { isNil } from 'lodash-es';
 import { useMemo } from 'react';
 
+import CommonHtmlContent from '@/components/elements/CommonHtmlContent';
 import { evaluateTemplate } from '@/modules/form/util/expressions/template';
 import { Component, FormItem } from '@/types/gqlTypes';
 
@@ -30,12 +30,7 @@ const DynamicDisplay: React.FC<Props> = ({
     let displayValue = item.text;
     if (viewOnly && !isNil(item.readonlyText)) displayValue = item.readonlyText;
     if (isNil(displayValue)) return undefined;
-
-    return {
-      __html: DOMPurify.sanitize(
-        evaluateTemplate(displayValue, new Map([['value', value]]))
-      ),
-    };
+    return evaluateTemplate(displayValue, new Map([['value', value]]));
   }, [item, viewOnly, value]);
 
   if (!html) return null;
@@ -51,17 +46,18 @@ const DynamicDisplay: React.FC<Props> = ({
           severity={SeverityMap[item.component as keyof typeof SeverityMap]}
           sx={{ mt: 2 }}
         >
-          <div dangerouslySetInnerHTML={html} />
+          <CommonHtmlContent>{html}</CommonHtmlContent>
         </Alert>
       );
     default:
       return (
-        <Typography
-          data-testid={`display-${item.linkId}`}
+        <CommonHtmlContent
           variant='body2'
+          data-testid={`display-${item.linkId}`}
           sx={{ maxWidth }}
-          dangerouslySetInnerHTML={html}
-        />
+        >
+          {html}
+        </CommonHtmlContent>
       );
   }
 };

--- a/src/modules/form/components/RequiredLabel.tsx
+++ b/src/modules/form/components/RequiredLabel.tsx
@@ -1,4 +1,5 @@
 import { Stack, Typography, TypographyProps } from '@mui/material';
+import CommonHtmlContent from '@/components/elements/CommonHtmlContent';
 
 const RequiredLabel = ({
   text,
@@ -13,9 +14,9 @@ const RequiredLabel = ({
 }) => {
   return (
     <Stack direction='row' spacing={1} component='span'>
-      <Typography variant='body2' {...TypographyProps} component='span'>
+      <CommonHtmlContent variant='body2' {...TypographyProps} component='span'>
         {text}
-      </Typography>
+      </CommonHtmlContent>
       {required && (
         <Typography
           variant='body2'

--- a/src/test/__mocks__/mockFormDefinition.json
+++ b/src/test/__mocks__/mockFormDefinition.json
@@ -17,7 +17,7 @@
           "type": "STRING",
           "required": false,
           "linkId": "string-2",
-          "text": "String with bounds",
+          "text": "String with <b>bounds</b> <span style='color:#1976D2'>and a rich text label</span>",
           "helperText": "You can't type more than 8 characters",
           "bounds": [
             {


### PR DESCRIPTION
## Description

This enables rich text in Dynamic Form field labels.
PT issue: [186869594](https://www.pivotaltracker.com/story/show/186869594)

Design work around this is still ongoing. My understanding of the issue is that form field labels are semi-bold by default right now; but, removing the semi-boldness default (which seems sensible/perhaps necessary as a default for a rich-text field) has wider impacts for the text hierarchy on the page. In this PR, the semi-boldness is not modified, but rich text is just enabled on top of it. In the Storybook mock, you can see how it will look to add bold on top of semi-bold:
<img width="537" alt="Screenshot 2024-02-29 at 9 34 37 AM" src="https://github.com/greenriver/hmis-frontend/assets/16002775/3871fdee-247f-48f8-accb-0e381cb660c5">

## Type of change
[//]: # 'remove options that are not relevant'
- [ ] Bug fix
- [x] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
