### PR TITLE
Add spacing between client alert and form errors

### DIFF
--- a/src/modules/form/hooks/useFormDialog.tsx
+++ b/src/modules/form/hooks/useFormDialog.tsx
@@ -152,9 +152,14 @@ export function useFormDialog<T extends SubmitFormAllowedTypes>({
             {definitionLoading ? (
               <Loading />
             ) : formDefinition ? (
-              <Grid container spacing={2} sx={{ mb: 2, mt: 0 }}>
+              <Grid
+                container
+                direction='column'
+                spacing={2}
+                sx={{ mb: 2, mt: 0 }}
+              >
+                <Grid item>{props.preFormComponent}</Grid>
                 <Grid item xs>
-                  {props.preFormComponent}
                   <DynamicForm
                     ref={formRef}
                     definition={formDefinition.definition}

--- a/src/modules/form/hooks/useFormDialog.tsx
+++ b/src/modules/form/hooks/useFormDialog.tsx
@@ -158,7 +158,9 @@ export function useFormDialog<T extends SubmitFormAllowedTypes>({
                 spacing={2}
                 sx={{ mb: 2, mt: 0 }}
               >
-                <Grid item>{props.preFormComponent}</Grid>
+                {props.preFormComponent && (
+                  <Grid item>{props.preFormComponent}</Grid>
+                )}
                 <Grid item xs>
                   <DynamicForm
                     ref={formRef}


### PR DESCRIPTION
## Description

This fixes a bug where there was no spacing between the client alert and the form errors in the enrollment dialog.
PT issue: [187117705](https://www.pivotaltracker.com/n/projects/2591838/stories/187117705)

After this change:
<img width="669" alt="Screenshot 2024-02-29 at 11 58 39 AM" src="https://github.com/greenriver/hmis-frontend/assets/16002775/bc1db1e7-7931-4e22-8d2a-1c2c2a057380">

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
