### PR TITLE
Suppress some console noise

### DIFF
--- a/src/components/elements/input/GenericSelect.tsx
+++ b/src/components/elements/input/GenericSelect.tsx
@@ -34,6 +34,7 @@ const GenericSelect = <
   ...rest
 }: GenericSelectProps<T, Multiple, Creatable>) => {
   const { placeholder, ...inputProps } = textInputProps || {};
+  const { ariaLabel, ...restOfProps } = rest;
   // Show a loading indicator if we have a value but the picklist is still loading
   const startAdornment =
     rest.loading && hasMeaningfulValue(value) ? (
@@ -65,12 +66,13 @@ const GenericSelect = <
             ...inputProps.inputProps,
           }}
           disabled={rest.disabled}
+          aria-label={ariaLabel}
           // Only render placeholder if no values are selected
           placeholder={hasMeaningfulValue(value) ? undefined : placeholder}
           label={label}
         />
       )}
-      {...rest}
+      {...restOfProps}
     />
   );
 };

--- a/src/components/elements/input/GenericSelect.tsx
+++ b/src/components/elements/input/GenericSelect.tsx
@@ -20,6 +20,7 @@ export interface GenericSelectProps<
   > {
   label?: ReactNode;
   textInputProps?: TextInputProps;
+  ariaLabel?: string;
 }
 
 const GenericSelect = <
@@ -31,10 +32,10 @@ const GenericSelect = <
   label,
   textInputProps,
   options,
+  ariaLabel,
   ...rest
 }: GenericSelectProps<T, Multiple, Creatable>) => {
   const { placeholder, ...inputProps } = textInputProps || {};
-  const { ariaLabel, ...restOfProps } = rest;
   // Show a loading indicator if we have a value but the picklist is still loading
   const startAdornment =
     rest.loading && hasMeaningfulValue(value) ? (
@@ -72,7 +73,7 @@ const GenericSelect = <
           label={label}
         />
       )}
-      {...restOfProps}
+      {...rest}
     />
   );
 };

--- a/src/components/elements/input/GenericSelect.tsx
+++ b/src/components/elements/input/GenericSelect.tsx
@@ -65,9 +65,9 @@ const GenericSelect = <
             ...params.inputProps,
             value: rest.loading ? '' : params.inputProps.value,
             ...inputProps.inputProps,
+            'aria-label': ariaLabel,
           }}
           disabled={rest.disabled}
-          aria-label={ariaLabel}
           // Only render placeholder if no values are selected
           placeholder={hasMeaningfulValue(value) ? undefined : placeholder}
           label={label}

--- a/src/components/elements/input/LabeledCheckbox.tsx
+++ b/src/components/elements/input/LabeledCheckbox.tsx
@@ -25,6 +25,7 @@ const LabeledCheckbox = ({
   helperText,
   horizontal = false,
   warnIfEmptyTreatment: _ignored,
+  ariaLabel,
   ...props
 }: Props & DynamicInputCommonProps) => {
   const labelSx = horizontal
@@ -56,13 +57,17 @@ const LabeledCheckbox = ({
     [onChange]
   );
 
-  const { ariaLabel, ...restOfProps } = props;
-
   return (
     <FormControl>
       <FormGroup sx={horizontal ? horizontalInputSx : undefined}>
         <FormControlLabel
-          control={<Checkbox sx={checkboxSx} onKeyDown={onKeyDown} />}
+          control={
+            <Checkbox
+              sx={checkboxSx}
+              onKeyDown={onKeyDown}
+              aria-label={ariaLabel}
+            />
+          }
           labelPlacement={horizontal ? 'start' : 'end'}
           label={label}
           sx={{
@@ -73,8 +78,7 @@ const LabeledCheckbox = ({
             ...labelSx,
           }}
           onChange={onChange}
-          aria-label={ariaLabel}
-          {...restOfProps}
+          {...props}
         />
       </FormGroup>
       {helperText && <FormHelperText>{helperText}</FormHelperText>}

--- a/src/components/elements/input/LabeledCheckbox.tsx
+++ b/src/components/elements/input/LabeledCheckbox.tsx
@@ -56,6 +56,8 @@ const LabeledCheckbox = ({
     [onChange]
   );
 
+  const { ariaLabel, ...restOfProps } = props;
+
   return (
     <FormControl>
       <FormGroup sx={horizontal ? horizontalInputSx : undefined}>
@@ -71,7 +73,8 @@ const LabeledCheckbox = ({
             ...labelSx,
           }}
           onChange={onChange}
-          {...props}
+          aria-label={ariaLabel}
+          {...restOfProps}
         />
       </FormGroup>
       {helperText && <FormHelperText>{helperText}</FormHelperText>}

--- a/src/components/elements/input/RadioGroupInput.tsx
+++ b/src/components/elements/input/RadioGroupInput.tsx
@@ -84,6 +84,7 @@ const RadioGroupInput = ({
 
   const GroupComponent = checkbox ? FormGroup : RadioGroup;
   const ControlComponent = checkbox ? Checkbox : Radio;
+  const { ariaLabel, ...restOfProps } = props;
 
   return (
     <FormControl component='fieldset'>
@@ -118,7 +119,8 @@ const RadioGroupInput = ({
           }),
           ...sx,
         }}
-        {...props}
+        aria-label={ariaLabel}
+        {...restOfProps}
       >
         {options.map((option) => (
           <RadioGroupInputOption

--- a/src/components/elements/input/RadioGroupInput.tsx
+++ b/src/components/elements/input/RadioGroupInput.tsx
@@ -66,6 +66,7 @@ const RadioGroupInput = ({
   sx,
   clearable,
   helperText,
+  ariaLabel,
   checkbox = false,
   ...props
 }: RadioGroupInputProps) => {
@@ -84,7 +85,6 @@ const RadioGroupInput = ({
 
   const GroupComponent = checkbox ? FormGroup : RadioGroup;
   const ControlComponent = checkbox ? Checkbox : Radio;
-  const { ariaLabel, ...restOfProps } = props;
 
   return (
     <FormControl component='fieldset'>
@@ -120,7 +120,7 @@ const RadioGroupInput = ({
           ...sx,
         }}
         aria-label={ariaLabel}
-        {...restOfProps}
+        {...props}
       >
         {options.map((option) => (
           <RadioGroupInputOption

--- a/src/components/elements/input/SsnInput.tsx
+++ b/src/components/elements/input/SsnInput.tsx
@@ -26,6 +26,7 @@ const SsnInput = ({
   warnIfEmptyTreatment,
   ...props
 }: SsnInputProps) => {
+  const { ariaLabel, ...restOfProps } = props;
   const baseInputProps: TextFieldProps = {
     inputProps: {
       // FIXME: switch to string input, allow use to type "X" or "x"
@@ -34,7 +35,7 @@ const SsnInput = ({
       ...inputProps,
     },
     InputProps,
-    ...props,
+    ...restOfProps,
   };
 
   const values = useMemo(() => {

--- a/src/components/elements/input/SsnInput.tsx
+++ b/src/components/elements/input/SsnInput.tsx
@@ -24,9 +24,9 @@ const SsnInput = ({
   helperText,
   onlylast4 = false,
   warnIfEmptyTreatment,
+  ariaLabel,
   ...props
 }: SsnInputProps) => {
-  const { ariaLabel, ...restOfProps } = props;
   const baseInputProps: TextFieldProps = {
     inputProps: {
       // FIXME: switch to string input, allow use to type "X" or "x"
@@ -35,7 +35,7 @@ const SsnInput = ({
       ...inputProps,
     },
     InputProps,
-    ...restOfProps,
+    ...props,
   };
 
   const values = useMemo(() => {

--- a/src/components/elements/input/TextInput.tsx
+++ b/src/components/elements/input/TextInput.tsx
@@ -54,6 +54,7 @@ const TextInput = ({
   }
 
   const isTiny = useIsMobile('sm');
+  const { ariaLabel, ...restOfProps } = props;
 
   const textField = (
     <TextField
@@ -64,7 +65,8 @@ const TextInput = ({
         !props.multiline && e.key === 'Enter' && e.preventDefault()
       }
       autoComplete={formAutoCompleteOff}
-      {...props}
+      aria-label={ariaLabel}
+      {...restOfProps}
       sx={sx}
       inputProps={{
         'aria-label': hiddenLabel ? String(label) : undefined,

--- a/src/components/elements/input/TextInput.tsx
+++ b/src/components/elements/input/TextInput.tsx
@@ -42,6 +42,7 @@ const TextInput = ({
   sx,
   warnIfEmptyTreatment,
   ariaLabelledBy,
+  ariaLabel,
   id,
   ...props
 }: TextInputProps) => {
@@ -54,7 +55,6 @@ const TextInput = ({
   }
 
   const isTiny = useIsMobile('sm');
-  const { ariaLabel, ...restOfProps } = props;
 
   const textField = (
     <TextField
@@ -66,10 +66,14 @@ const TextInput = ({
       }
       autoComplete={formAutoCompleteOff}
       aria-label={ariaLabel}
-      {...restOfProps}
+      {...props}
       sx={sx}
       inputProps={{
-        'aria-label': hiddenLabel ? String(label) : undefined,
+        'aria-label': ariaLabel
+          ? ariaLabel
+          : hiddenLabel
+          ? String(label)
+          : undefined,
         'aria-labelledby': ariaLabelledBy,
         minLength: min,
         maxLength: max,

--- a/src/components/elements/input/TextInput.tsx
+++ b/src/components/elements/input/TextInput.tsx
@@ -65,15 +65,10 @@ const TextInput = ({
         !props.multiline && e.key === 'Enter' && e.preventDefault()
       }
       autoComplete={formAutoCompleteOff}
-      aria-label={ariaLabel}
       {...props}
       sx={sx}
       inputProps={{
-        'aria-label': ariaLabel
-          ? ariaLabel
-          : hiddenLabel
-          ? String(label)
-          : undefined,
+        'aria-label': hiddenLabel ? ariaLabel || String(label) : undefined,
         'aria-labelledby': ariaLabelledBy,
         minLength: min,
         maxLength: max,

--- a/src/modules/form/components/CreatableFormSelect.tsx
+++ b/src/modules/form/components/CreatableFormSelect.tsx
@@ -57,6 +57,7 @@ const CreatableFormSelect = <Multiple extends boolean | undefined>({
   helperText,
   warnIfEmptyTreatment,
   ariaLabelledBy,
+  ariaLabel,
   ...props
 }: GenericSelectProps<Option, Multiple, boolean> & DynamicInputCommonProps) => {
   const isGrouped = !!options[0]?.groupLabel;
@@ -124,6 +125,7 @@ const CreatableFormSelect = <Multiple extends boolean | undefined>({
         error,
         warnIfEmptyTreatment,
         ariaLabelledBy,
+        ariaLabel,
       }}
       onChange={
         onChange

--- a/src/modules/form/components/FormSelect.tsx
+++ b/src/modules/form/components/FormSelect.tsx
@@ -82,6 +82,7 @@ const FormSelect = <Multiple extends boolean | undefined>({
   warnIfEmptyTreatment,
   onChange,
   ariaLabelledBy,
+  ariaLabel,
   ...props
 }: GenericSelectProps<Option, Multiple, false> & DynamicInputCommonProps) => {
   const isGrouped = !!options[0]?.groupLabel;
@@ -132,8 +133,6 @@ const FormSelect = <Multiple extends boolean | undefined>({
     [multiple, onChange]
   );
 
-  const { ariaLabel, ...restOfProps } = props;
-
   return (
     <GenericSelect
       getOptionLabel={getOptionLabel}
@@ -145,11 +144,11 @@ const FormSelect = <Multiple extends boolean | undefined>({
       groupBy={isGrouped ? (option) => option.groupLabel || '' : undefined}
       isOptionEqualToValue={isOptionEqualToValue}
       value={value}
-      aria-label={ariaLabel}
-      {...restOfProps}
+      {...props}
       onChange={handleChange}
       textInputProps={{
         ...props.textInputProps,
+        ariaLabel,
         ariaLabelledBy,
         placeholder,
         error,

--- a/src/modules/form/components/FormSelect.tsx
+++ b/src/modules/form/components/FormSelect.tsx
@@ -132,6 +132,8 @@ const FormSelect = <Multiple extends boolean | undefined>({
     [multiple, onChange]
   );
 
+  const { ariaLabel, ...restOfProps } = props;
+
   return (
     <GenericSelect
       getOptionLabel={getOptionLabel}
@@ -143,7 +145,8 @@ const FormSelect = <Multiple extends boolean | undefined>({
       groupBy={isGrouped ? (option) => option.groupLabel || '' : undefined}
       isOptionEqualToValue={isOptionEqualToValue}
       value={value}
-      {...props}
+      aria-label={ariaLabel}
+      {...restOfProps}
       onChange={handleChange}
       textInputProps={{
         ...props.textInputProps,

--- a/src/modules/form/components/group/TableGroup.tsx
+++ b/src/modules/form/components/group/TableGroup.tsx
@@ -2,6 +2,7 @@ import {
   Grid,
   Stack,
   Table,
+  TableBody,
   TableCell,
   TableHead,
   TableRow,
@@ -128,23 +129,25 @@ const TableGroup = ({
             ))}
           </TableRow>
         </TableHead>
-        {item.item?.map((rowItem) => (
-          <TableRow key={rowItem.linkId}>
-            {rowItem.item?.map((cellItem, index) => (
-              <TableCell key={cellItem.linkId}>
-                {renderChildItem(
-                  // remove helper text, it is shown in table header
-                  { ...cellItem, helperText: null },
-                  // hide label for each input, since they are labeled by the header
-                  {
-                    noLabel: true,
-                    inputProps: { ariaLabelledBy: tableHeaderInfo[index].id },
-                  }
-                )}
-              </TableCell>
-            ))}
-          </TableRow>
-        ))}
+        <TableBody>
+          {item.item?.map((rowItem) => (
+            <TableRow key={rowItem.linkId}>
+              {rowItem.item?.map((cellItem, index) => (
+                <TableCell key={cellItem.linkId}>
+                  {renderChildItem(
+                    // remove helper text, it is shown in table header
+                    { ...cellItem, helperText: null },
+                    // hide label for each input, since they are labeled by the header
+                    {
+                      noLabel: true,
+                      inputProps: { ariaLabelledBy: tableHeaderInfo[index].id },
+                    }
+                  )}
+                </TableCell>
+              ))}
+            </TableRow>
+          ))}
+        </TableBody>
       </Table>
     </Grid>
   );


### PR DESCRIPTION
## Description

Lowest priority;
I was noticing some console noise on the Dynamic Form (both in storybook and when these components are used in their natural habitats), and since I actively use the console while developing, and had a bit of extra time last week, I thought it would be worth while to dig in a little and see if I could solve a few of them.

Let me know if you think it looks okay, or, I'm fine to drop this PR entirely if you think it's not worthwhile!

The changes in TableGroup suppress the error:
```
Warning: validateDOMNesting(...): <tr> cannot appear as a child of <table>. Add a <tbody>, <thead> or <tfoot> to your code to match the DOM tree generated by the browser.
```

The other changes related to aria labelling suppress the errors:
```
Warning: Invalid ARIA attribute `ariaLabel`. Did you mean `aria-label`?
```

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
