### PR TITLE
Add client fields as local constants on assessments

### DIFF
--- a/src/api/operations/client.fragments.graphql
+++ b/src/api/operations/client.fragments.graphql
@@ -80,6 +80,12 @@ fragment ClientNameDobVet on Client {
   veteranStatus
 }
 
+fragment ClientNameDobSsn on Client {
+  ...ClientName
+  ssn
+  dob
+}
+
 fragment ClientNameObjectFields on ClientName {
   id
   first

--- a/src/api/operations/client.fragments.graphql
+++ b/src/api/operations/client.fragments.graphql
@@ -80,12 +80,6 @@ fragment ClientNameDobVet on Client {
   veteranStatus
 }
 
-fragment ClientNameDobSsn on Client {
-  ...ClientName
-  ssn
-  dob
-}
-
 fragment ClientNameObjectFields on ClientName {
   id
   first

--- a/src/api/operations/enrollment.fragments.graphql
+++ b/src/api/operations/enrollment.fragments.graphql
@@ -87,6 +87,7 @@ fragment AllEnrollmentDetails on Enrollment {
   client {
     hudChronic
     ...ClientNameDobVet
+    ssn
     customDataElements {
       ...CustomDataElementFields
     }

--- a/src/modules/assessments/components/AssessmentForm.tsx
+++ b/src/modules/assessments/components/AssessmentForm.tsx
@@ -24,6 +24,7 @@ import { useScrollToHash } from '@/hooks/useScrollToHash';
 import AssessmentAutofillButton from '@/modules/assessments/components/AssessmentAutofillButton';
 import AssessmentFormSideBar from '@/modules/assessments/components/AssessmentFormSideBar';
 import { HouseholdAssessmentFormAction } from '@/modules/assessments/components/household/formState';
+import { ClientNameDobSsn } from '@/modules/assessments/components/IndividualAssessment';
 import { ErrorState, hasAnyValue } from '@/modules/errors/util';
 import DynamicForm, {
   DynamicFormProps,
@@ -42,7 +43,6 @@ import {
   initialValuesFromAssessment,
 } from '@/modules/form/util/formUtil';
 import {
-  ClientNameDobSsnFragment,
   EnrollmentFieldsFragment,
   FormDefinitionFieldsFragment,
   FormRole,
@@ -52,7 +52,7 @@ import {
 
 interface Props {
   enrollment: EnrollmentFieldsFragment;
-  client: ClientNameDobSsnFragment;
+  client: ClientNameDobSsn;
   formRole?: FormRole;
   definition: FormDefinitionFieldsFragment;
   assessment?: FullAssessmentFragment;

--- a/src/modules/assessments/components/AssessmentForm.tsx
+++ b/src/modules/assessments/components/AssessmentForm.tsx
@@ -42,6 +42,7 @@ import {
   initialValuesFromAssessment,
 } from '@/modules/form/util/formUtil';
 import {
+  ClientNameDobSsnFragment,
   EnrollmentFieldsFragment,
   FormDefinitionFieldsFragment,
   FormRole,
@@ -51,7 +52,7 @@ import {
 
 interface Props {
   enrollment: EnrollmentFieldsFragment;
-  clientId: string;
+  client: ClientNameDobSsnFragment;
   formRole?: FormRole;
   definition: FormDefinitionFieldsFragment;
   assessment?: FullAssessmentFragment;
@@ -75,7 +76,7 @@ interface Props {
 
 const AssessmentForm: React.FC<Props> = ({
   assessment,
-  clientId,
+  client,
   assessmentTitle,
   formRole,
   definition,
@@ -147,9 +148,14 @@ const AssessmentForm: React.FC<Props> = ({
       entryDate: enrollment.entryDate,
       exitDate: enrollment.exitDate,
       projectName: enrollment.project.projectName,
+      clientFirstName: client.firstName,
+      clientMiddleInitial: client.middleName ? client.middleName[0] : '',
+      clientLastName: client.lastName,
+      clientDob: client.dob,
+      clientSsn: client.ssn,
       ...AlwaysPresentLocalConstants,
     }),
-    [enrollment]
+    [enrollment, client]
   );
 
   // Set initial values for the assessment. This happens on initial load,
@@ -351,7 +357,7 @@ const AssessmentForm: React.FC<Props> = ({
             errors={errors}
             locked={locked}
             visible={visible}
-            clientId={clientId}
+            clientId={client.id}
             showSavePrompt
             alwaysShowSaveSlide={!!embeddedInWorkflow}
             FormActionProps={formActionsPropsWithLastUpdated}
@@ -368,7 +374,7 @@ const AssessmentForm: React.FC<Props> = ({
       {definition && (
         <RecordPickerDialog
           id='assessmentPickerDialog'
-          clientId={clientId}
+          clientId={client.id}
           open={dialogOpen}
           role={formRole}
           onSelected={onSelectAutofillRecord}

--- a/src/modules/assessments/components/IndividualAssessment.tsx
+++ b/src/modules/assessments/components/IndividualAssessment.tsx
@@ -33,7 +33,7 @@ import {
 
 export type ClientNameDobSsn = ClientNameFragment & {
   ssn?: string;
-  dob?: string;
+  dob?: string | null;
 };
 
 export interface IndividualAssessmentProps {

--- a/src/modules/assessments/components/IndividualAssessment.tsx
+++ b/src/modules/assessments/components/IndividualAssessment.tsx
@@ -25,11 +25,16 @@ import {
 import { clientBriefName } from '@/modules/hmis/hmisUtil';
 import {
   AssessmentRole,
-  ClientNameDobSsnFragment,
+  ClientNameFragment,
   FormDefinitionFieldsFragment,
   FormRole,
   FullAssessmentFragment,
 } from '@/types/gqlTypes';
+
+export type ClientNameDobSsn = ClientNameFragment & {
+  ssn?: string;
+  dob?: string;
+};
 
 export interface IndividualAssessmentProps {
   // FormDefiniton to use for rendering the assessment
@@ -42,7 +47,7 @@ export interface IndividualAssessmentProps {
   formRole?: FormRole;
   // Whether the assessment is embedded in a household workflow
   embeddedInWorkflow?: boolean;
-  client: ClientNameDobSsnFragment;
+  client: ClientNameDobSsn;
   // Assessment status to use for indicator
   assessmentStatus?: AssessmentStatus;
   // Whether the form is currently visible on the page. Used for household workflow when the assessment is on an inactive tab.

--- a/src/modules/assessments/components/IndividualAssessment.tsx
+++ b/src/modules/assessments/components/IndividualAssessment.tsx
@@ -25,7 +25,7 @@ import {
 import { clientBriefName } from '@/modules/hmis/hmisUtil';
 import {
   AssessmentRole,
-  ClientNameFragment,
+  ClientNameDobSsnFragment,
   FormDefinitionFieldsFragment,
   FormRole,
   FullAssessmentFragment,
@@ -42,7 +42,7 @@ export interface IndividualAssessmentProps {
   formRole?: FormRole;
   // Whether the assessment is embedded in a household workflow
   embeddedInWorkflow?: boolean;
-  client: ClientNameFragment;
+  client: ClientNameDobSsnFragment;
   // Assessment status to use for indicator
   assessmentStatus?: AssessmentStatus;
   // Whether the form is currently visible on the page. Used for household workflow when the assessment is on an inactive tab.
@@ -158,7 +158,7 @@ const IndividualAssessment = ({
   return (
     <AssessmentForm
       assessmentTitle={titleNode}
-      clientId={client.id}
+      client={client}
       navigationTitle={navigationTitle}
       key={assessment?.id}
       formRole={formRole}

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -12690,18 +12690,6 @@ export type ClientNameDobVetFragment = {
   nameSuffix?: string | null;
 };
 
-export type ClientNameDobSsnFragment = {
-  __typename?: 'Client';
-  ssn?: string | null;
-  dob?: string | null;
-  id: string;
-  lockVersion: number;
-  firstName?: string | null;
-  middleName?: string | null;
-  lastName?: string | null;
-  nameSuffix?: string | null;
-};
-
 export type ClientNameObjectFieldsFragment = {
   __typename?: 'ClientName';
   id: string;
@@ -30584,14 +30572,6 @@ export const ClientFieldsFragmentDoc = gql`
   ${ClientAddressFieldsFragmentDoc}
   ${ClientContactPointFieldsFragmentDoc}
   ${ClientAlertFieldsFragmentDoc}
-`;
-export const ClientNameDobSsnFragmentDoc = gql`
-  fragment ClientNameDobSsn on Client {
-    ...ClientName
-    ssn
-    dob
-  }
-  ${ClientNameFragmentDoc}
 `;
 export const ClientImageFieldsFragmentDoc = gql`
   fragment ClientImageFields on ClientImage {

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -12690,6 +12690,18 @@ export type ClientNameDobVetFragment = {
   nameSuffix?: string | null;
 };
 
+export type ClientNameDobSsnFragment = {
+  __typename?: 'Client';
+  ssn?: string | null;
+  dob?: string | null;
+  id: string;
+  lockVersion: number;
+  firstName?: string | null;
+  middleName?: string | null;
+  lastName?: string | null;
+  nameSuffix?: string | null;
+};
+
 export type ClientNameObjectFieldsFragment = {
   __typename?: 'ClientName';
   id: string;
@@ -15498,6 +15510,7 @@ export type AllEnrollmentDetailsFragment = {
   client: {
     __typename?: 'Client';
     hudChronic?: boolean | null;
+    ssn?: string | null;
     dob?: string | null;
     veteranStatus: NoYesReasonsForMissingData;
     id: string;
@@ -16574,6 +16587,7 @@ export type GetEnrollmentDetailsQuery = {
     client: {
       __typename?: 'Client';
       hudChronic?: boolean | null;
+      ssn?: string | null;
       dob?: string | null;
       veteranStatus: NoYesReasonsForMissingData;
       id: string;
@@ -30571,6 +30585,14 @@ export const ClientFieldsFragmentDoc = gql`
   ${ClientContactPointFieldsFragmentDoc}
   ${ClientAlertFieldsFragmentDoc}
 `;
+export const ClientNameDobSsnFragmentDoc = gql`
+  fragment ClientNameDobSsn on Client {
+    ...ClientName
+    ssn
+    dob
+  }
+  ${ClientNameFragmentDoc}
+`;
 export const ClientImageFieldsFragmentDoc = gql`
   fragment ClientImageFields on ClientImage {
     id
@@ -30980,6 +31002,7 @@ export const AllEnrollmentDetailsFragmentDoc = gql`
     client {
       hudChronic
       ...ClientNameDobVet
+      ssn
       customDataElements {
         ...CustomDataElementFields
       }


### PR DESCRIPTION
## Description

PT issue https://www.pivotaltracker.com/story/show/187136045
This change allows us to pull in info about the client -- DOB, name, and SSN -- to autofill in assessments.

I have a few questions:
- Is pulling SSN in here like this okay? The client is from the enrollment, so the most obvious way to do it (and what I've implemented here) is to add client's ssn on the enrollment fragment. But of course I can think of lots of reasons not to do that, and it's a huge change! Is there a better way?
- Also related to SSN, should it be auto-filled but hidden unless the user clicks, like on the client profile?
- And, should we do any checking of the `canViewFullSsn` or `canViewPartialSsn` before passing the ssn around?
- Just to make sure, it looks like the UHA form has space for a lot of household members, but this change is only putting the info for the head of household into local constants. Is this okay?

## Type of change
[//]: # 'remove options that are not relevant'
- [ ] Bug fix
- [x] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
