### PR TITLE
Wrap page title with actions on mobile

### DIFF
--- a/src/components/layout/PageTitle.tsx
+++ b/src/components/layout/PageTitle.tsx
@@ -1,5 +1,6 @@
 import { Stack, Typography } from '@mui/material';
 import { ReactNode } from 'react';
+import { useIsMobile } from '@/hooks/useIsMobile';
 
 const PageTitle = ({
   title,
@@ -8,17 +9,19 @@ const PageTitle = ({
   title: ReactNode;
   actions?: ReactNode;
 }) => {
+  const isTiny = useIsMobile('sm');
+
   return (
     <Stack
-      gap={3}
-      direction='row'
+      gap={isTiny ? 1 : 3}
+      direction={isTiny ? 'column' : 'row'}
       justifyContent={'space-between'}
+      width={isTiny ? 'fit-content' : '100%'}
       sx={{
-        mb: 3,
-        pr: 1,
-        alignItems: 'center',
-        // fixed height so its the same whether there are actions or not
-        height: '40px',
+        mb: isTiny ? 1 : 3,
+        alignItems: isTiny ? 'left' : 'center',
+        // fixed height (if not mobile), so height is the same whether there are actions or not
+        height: isTiny ? '' : '40px',
       }}
     >
       {typeof title === 'string' ? (

--- a/src/components/layout/dashboard/DashboardContentContainer.tsx
+++ b/src/components/layout/dashboard/DashboardContentContainer.tsx
@@ -116,8 +116,8 @@ const DashboardContentContainer: React.FC<Props> = ({
           )}
           <Box
             sx={{
-              py: { xs: 1, sm: 2 },
-              px: { xs: 2, sm: 3, lg: 4 },
+              py: { xs: 2 },
+              px: { xs: 0, sm: 1, lg: 4 },
               maxWidth: `${maxPageWidth}px`,
             }}
           >


### PR DESCRIPTION
## Description

This PR wraps the PageTitle action buttons around onto the next line on small screens. It also removes padding on the whole page for mobile. This is a big change that affects every screen! 😮
https://www.pivotaltracker.com/n/projects/2591838/stories/187166502

## Type of change
[//]: # 'remove options that are not relevant'
- [ ] Bug fix
- [x] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
