### PR TITLE
Enable rich text for labels on readonly form view

### DIFF
--- a/src/modules/form/components/viewable/DynamicViewField.tsx
+++ b/src/modules/form/components/viewable/DynamicViewField.tsx
@@ -13,6 +13,7 @@ import Image from './item/Image';
 
 import TextContent from './item/TextContent';
 
+import CommonHtmlContent from '@/components/elements/CommonHtmlContent';
 import { minutesToHoursAndMinutes } from '@/components/elements/input/MinutesDurationInput';
 import { FALSE_OPT, TRUE_OPT } from '@/components/elements/input/YesNoRadio';
 import LabelWithContent from '@/components/elements/LabelWithContent';
@@ -38,9 +39,13 @@ const getLabel = (item: FormItem, horizontal?: boolean) => {
 
   return (
     <Stack direction='row' spacing={1}>
-      <Typography variant='body2' fontWeight={horizontal ? undefined : 600}>
+      <CommonHtmlContent
+        variant='body2'
+        fontWeight={horizontal ? undefined : 600}
+        component='p'
+      >
         {label}
-      </Typography>
+      </CommonHtmlContent>
     </Stack>
   );
 };


### PR DESCRIPTION
## Description

This PR fixes the bug mentioned in this PT ticket comment where readonly labels are displaying raw html: https://www.pivotaltracker.com/story/show/187136045/comments/240492975

<img width="734" alt="Screenshot 2024-03-07 at 10 37 04 AM" src="https://github.com/greenriver/hmis-frontend/assets/16002775/367a34bc-11b0-499f-aa48-242e14483e51">

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
