### PR TITLE
Fix padding for page containers on mobile

### DIFF
--- a/src/components/layout/PageContainer.tsx
+++ b/src/components/layout/PageContainer.tsx
@@ -11,7 +11,7 @@ const PageContainer = ({
   title: ReactNode;
   actions?: ReactNode;
 }) => (
-  <Container maxWidth='lg' sx={{ pt: 4, pb: 6 }}>
+  <Container maxWidth='lg' sx={{ px: { xs: 1, sm: 3, lg: 4 }, pt: 4, pb: 6 }}>
     <Stack
       spacing={2}
       direction='row'

--- a/src/components/layout/dashboard/DashboardContentContainer.tsx
+++ b/src/components/layout/dashboard/DashboardContentContainer.tsx
@@ -116,8 +116,8 @@ const DashboardContentContainer: React.FC<Props> = ({
           )}
           <Box
             sx={{
-              py: { xs: 2 },
-              px: { xs: 0, sm: 1, lg: 4 },
+              py: 2,
+              px: { xs: 1, sm: 3, lg: 4 },
               maxWidth: `${maxPageWidth}px`,
             }}
           >

--- a/src/components/layout/dashboard/DashboardContentContainer.tsx
+++ b/src/components/layout/dashboard/DashboardContentContainer.tsx
@@ -116,7 +116,8 @@ const DashboardContentContainer: React.FC<Props> = ({
           )}
           <Box
             sx={{
-              py: 2,
+              pt: 2,
+              pb: 8,
               px: { xs: 1, sm: 3, lg: 4 },
               maxWidth: `${maxPageWidth}px`,
             }}

--- a/src/components/pages/ClientDashboard.tsx
+++ b/src/components/pages/ClientDashboard.tsx
@@ -81,7 +81,7 @@ const ClientDashboard: React.FC = () => {
       navLabel='Client'
       {...dashboardState}
     >
-      <Container maxWidth='xl' sx={{ pb: 6 }}>
+      <Container maxWidth='xl' disableGutters sx={{ pb: 6 }}>
         <Outlet context={outletContext} />
       </Container>
     </DashboardContentContainer>

--- a/src/components/pages/ClientDashboard.tsx
+++ b/src/components/pages/ClientDashboard.tsx
@@ -81,7 +81,7 @@ const ClientDashboard: React.FC = () => {
       navLabel='Client'
       {...dashboardState}
     >
-      <Container maxWidth='xl' disableGutters sx={{ pb: 6 }}>
+      <Container maxWidth='xl' disableGutters>
         <Outlet context={outletContext} />
       </Container>
     </DashboardContentContainer>

--- a/src/components/pages/EnrollmentDashboard.tsx
+++ b/src/components/pages/EnrollmentDashboard.tsx
@@ -116,14 +116,9 @@ const EnrollmentDashboard: React.FC = () => {
       {...dashboardState}
       focusMode={focusMode}
     >
-      {focusMode ? (
-        // focused views like household intake/exit shouldn't have a container
+      <Container maxWidth='xl' disableGutters>
         <Outlet context={outletContext} />
-      ) : (
-        <Container maxWidth='xl' disableGutters sx={{ pb: 6 }}>
-          <Outlet context={outletContext} />
-        </Container>
-      )}
+      </Container>
     </DashboardContentContainer>
   );
 };

--- a/src/components/pages/EnrollmentDashboard.tsx
+++ b/src/components/pages/EnrollmentDashboard.tsx
@@ -120,7 +120,7 @@ const EnrollmentDashboard: React.FC = () => {
         // focused views like household intake/exit shouldn't have a container
         <Outlet context={outletContext} />
       ) : (
-        <Container maxWidth='xl' sx={{ pb: 6 }}>
+        <Container maxWidth='xl' disableGutters sx={{ pb: 6 }}>
           <Outlet context={outletContext} />
         </Container>
       )}

--- a/src/modules/admin/components/AdminDashboard.tsx
+++ b/src/modules/admin/components/AdminDashboard.tsx
@@ -127,7 +127,7 @@ const AdminDashboard: React.FC = () => {
       }
       {...dashboardState}
     >
-      <Container maxWidth='xl' sx={{ pb: 6 }}>
+      <Container maxWidth='xl' disableGutters sx={{ pb: 6 }}>
         <Outlet />
       </Container>
     </DashboardContentContainer>

--- a/src/modules/admin/components/AdminDashboard.tsx
+++ b/src/modules/admin/components/AdminDashboard.tsx
@@ -127,7 +127,7 @@ const AdminDashboard: React.FC = () => {
       }
       {...dashboardState}
     >
-      <Container maxWidth='xl' disableGutters sx={{ pb: 6 }}>
+      <Container maxWidth='xl' disableGutters>
         <Outlet />
       </Container>
     </DashboardContentContainer>

--- a/src/modules/assessments/components/IndividualAssessment.tsx
+++ b/src/modules/assessments/components/IndividualAssessment.tsx
@@ -181,7 +181,7 @@ const IndividualAssessment = ({
 };
 
 const WrappedAssessment = (props: IndividualAssessmentProps) => (
-  <Box sx={{ mt: 3 }}>
+  <Box sx={{ mt: { xs: 0, lg: 2 } }}>
     <SentryErrorBoundary>
       <IndividualAssessment {...props} />
     </SentryErrorBoundary>

--- a/src/modules/assessments/components/household/HouseholdAssessments.tsx
+++ b/src/modules/assessments/components/household/HouseholdAssessments.tsx
@@ -269,8 +269,8 @@ const HouseholdAssessments: React.FC<Props> = ({
           top: STICKY_BAR_HEIGHT + CONTEXT_HEADER_HEIGHT,
           backgroundColor: 'white',
           px: { sm: 3, lg: 5 },
-          ml: { xs: -2, sm: -3, lg: -4 },
-          mt: { xs: -1, sm: -2 },
+          ml: { xs: -1, sm: -3, lg: -4 },
+          mt: { xs: -2, sm: -2 },
           // Has same scrollbar gutter issue
           width: '100vw',
         }}

--- a/src/modules/projects/components/ProjectDashboard.tsx
+++ b/src/modules/projects/components/ProjectDashboard.tsx
@@ -105,7 +105,7 @@ const ProjectDashboard: React.FC = () => {
       contextHeader={<ContextHeaderContent breadcrumbs={breadcrumbs} />}
       {...dashboardState}
     >
-      <Container maxWidth='xl' disableGutters sx={{ pb: 6 }}>
+      <Container maxWidth='xl' disableGutters>
         <Outlet context={outletContext} />
       </Container>
     </DashboardContentContainer>

--- a/src/modules/projects/components/ProjectDashboard.tsx
+++ b/src/modules/projects/components/ProjectDashboard.tsx
@@ -105,7 +105,7 @@ const ProjectDashboard: React.FC = () => {
       contextHeader={<ContextHeaderContent breadcrumbs={breadcrumbs} />}
       {...dashboardState}
     >
-      <Container maxWidth='xl' sx={{ pb: 6 }}>
+      <Container maxWidth='xl' disableGutters sx={{ pb: 6 }}>
         <Outlet context={outletContext} />
       </Container>
     </DashboardContentContainer>


### PR DESCRIPTION
## Description

This is a follow-up PR from this comment: https://github.com/greenriver/hmis-frontend/pull/684#discussion_r1513612926
Related to this ticket: https://www.pivotaltracker.com/story/show/187166502

I looked around at a few options for places where we could solve this padding problem for dashboards, and I think it's probably best to add this common padding to `DashboardContentContainer`, which is used in common by the Client, Admin, Enrollment, and Project dashboards.

Then, I added the same change to PageContainer.tsx, which seems to be used in a few other places -- I just noticed it because of toggling back and forth between the All Projects tab and the Projects dashboard while testing.

Let me know what you think! There may be other places in the app that want similar updates too?

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
