### PR TITLE
Propose gutter fix for small assessments

### DIFF
--- a/src/components/pages/EnrollmentDashboard.tsx
+++ b/src/components/pages/EnrollmentDashboard.tsx
@@ -116,14 +116,9 @@ const EnrollmentDashboard: React.FC = () => {
       {...dashboardState}
       focusMode={focusMode}
     >
-      {focusMode ? (
-        // focused views like household intake/exit shouldn't have a container
+      <Container maxWidth='xl' sx={{ pb: 6 }}>
         <Outlet context={outletContext} />
-      ) : (
-        <Container maxWidth='xl' sx={{ pb: 6 }}>
-          <Outlet context={outletContext} />
-        </Container>
-      )}
+      </Container>
     </DashboardContentContainer>
   );
 };

--- a/src/modules/assessments/components/IndividualAssessment.tsx
+++ b/src/modules/assessments/components/IndividualAssessment.tsx
@@ -181,7 +181,7 @@ const IndividualAssessment = ({
 };
 
 const WrappedAssessment = (props: IndividualAssessmentProps) => (
-  <Box sx={{ mt: 3 }}>
+  <Box sx={{ mt: { xs: 0, lg: 2 } }}>
     <SentryErrorBoundary>
       <IndividualAssessment {...props} />
     </SentryErrorBoundary>

--- a/src/modules/assessments/components/household/HouseholdAssessments.tsx
+++ b/src/modules/assessments/components/household/HouseholdAssessments.tsx
@@ -269,8 +269,9 @@ const HouseholdAssessments: React.FC<Props> = ({
           top: STICKY_BAR_HEIGHT + CONTEXT_HEADER_HEIGHT,
           backgroundColor: 'white',
           px: { sm: 3, lg: 5 },
-          ml: { xs: -2, sm: -3, lg: -4 },
-          mt: { xs: -1, sm: -2 },
+          // negative left-margin to offset the Container gutter
+          ml: { xs: -2, sm: -4, lg: -8 },
+          mt: { xs: -2, sm: -2 },
           // Has same scrollbar gutter issue
           width: '100vw',
         }}


### PR DESCRIPTION
## Description

fix gutter issue for assessments on small screens

to test `FOCUS_MODE_ROUTES`:
* look at a single-member assessment
* look at the intake or exit for a multi-household enrollment (tabs along the top) 


## Type of change
- [x] Code clean-up / housekeeping

## Checklist before requesting review
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (eslint)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
