### PR TITLE
Make buttons look better and more usable on mobile

### DIFF
--- a/src/components/elements/CommonToggle.tsx
+++ b/src/components/elements/CommonToggle.tsx
@@ -38,13 +38,15 @@ const primaryToggleSx: SxProps<Theme> = {
   '& .MuiToggleButtonGroup-grouped': {
     margin: 0.5,
     border: 0,
-    px: 2,
+    px: { xs: 1, sm: 2 },
+    py: { xs: 1, sm: '11px' }, // 11px is default coming from MUI
     '&.Mui-selected, &.Mui-selected:hover': {
       backgroundColor: (theme) => theme.palette.primary.main,
       color: (theme) => theme.palette.primary.contrastText,
     },
     '&:not(:first-of-type)': {
       borderRadius: 1,
+      ml: '-1px', // Default coming from MUI, but clobbered by setting margin on the group above
     },
     '&:first-of-type': {
       borderRadius: 1,

--- a/src/components/elements/TitleCard.tsx
+++ b/src/components/elements/TitleCard.tsx
@@ -8,6 +8,7 @@ import {
   TypographyVariant,
 } from '@mui/material';
 import { ReactNode } from 'react';
+import { useIsMobile } from '@/hooks/useIsMobile';
 
 interface Props extends PaperProps {
   title: string;
@@ -18,6 +19,7 @@ interface Props extends PaperProps {
   'data-testid'?: string;
   headerSx?: SxProps;
   padded?: boolean;
+  stackOnMobile?: boolean;
 }
 const TitleCard: React.FC<Props> = ({
   title,
@@ -27,34 +29,39 @@ const TitleCard: React.FC<Props> = ({
   headerVariant,
   headerSx,
   padded = false,
+  stackOnMobile = true,
   ...props
-}) => (
-  <Paper data-testid={props['data-testid']} {...props}>
-    <Stack
-      justifyContent={'space-between'}
-      alignItems='center'
-      direction='row'
-      sx={{
-        px: 2,
-        py: actions ? 2 : 1,
-        ...(headerVariant === 'border'
-          ? {
-              borderBottomColor: 'borders.light',
-              borderBottomWidth: 1,
-              borderBottomStyle: 'solid',
-            }
-          : {}),
-        ...headerSx,
-      }}
-    >
-      <Typography variant={headerTypographyVariant} sx={{ py: 1 }}>
-        {title}
-      </Typography>
-      {actions}
-    </Stack>
+}) => {
+  const isTiny = useIsMobile('sm');
 
-    {padded ? <Box sx={{ px: 2, pb: 2 }}>{children}</Box> : children}
-  </Paper>
-);
+  return (
+    <Paper data-testid={props['data-testid']} {...props}>
+      <Stack
+        justifyContent={'space-between'}
+        alignItems={isTiny && stackOnMobile ? 'left' : 'center'}
+        direction={isTiny && stackOnMobile ? 'column' : 'row'}
+        sx={{
+          px: 2,
+          py: actions ? 2 : 1,
+          ...(headerVariant === 'border'
+            ? {
+                borderBottomColor: 'borders.light',
+                borderBottomWidth: 1,
+                borderBottomStyle: 'solid',
+              }
+            : {}),
+          ...headerSx,
+        }}
+      >
+        <Typography variant={headerTypographyVariant} sx={{ py: 1 }}>
+          {title}
+        </Typography>
+        <Box sx={{ width: 'fit-content' }}>{actions}</Box>
+      </Stack>
+
+      {padded ? <Box sx={{ px: 2, pb: 2 }}>{children}</Box> : children}
+    </Paper>
+  );
+};
 
 export default TitleCard;

--- a/src/components/layout/PageContainer.tsx
+++ b/src/components/layout/PageContainer.tsx
@@ -1,6 +1,7 @@
 import { Typography } from '@mui/material';
-import { Container, Stack } from '@mui/system';
+import { Box, Container, Stack } from '@mui/system';
 import { ReactNode } from 'react';
+import { useIsMobile } from '@/hooks/useIsMobile';
 
 const PageContainer = ({
   children,
@@ -10,20 +11,23 @@ const PageContainer = ({
   children: ReactNode;
   title: ReactNode;
   actions?: ReactNode;
-}) => (
-  <Container maxWidth='lg' sx={{ px: { xs: 1, sm: 3, lg: 4 }, pt: 4, pb: 6 }}>
-    <Stack
-      spacing={2}
-      direction='row'
-      justifyContent='space-between'
-      sx={{ mb: 4 }}
-      alignItems='center'
-    >
-      <Typography variant='h3'>{title}</Typography>
-      {actions}
-    </Stack>
+}) => {
+  const isTiny = useIsMobile('sm');
+  return (
+    <Container maxWidth='lg' sx={{ px: { xs: 1, sm: 3, lg: 4 }, pt: 4, pb: 6 }}>
+      <Stack
+        spacing={2}
+        direction={isTiny ? 'column' : 'row'}
+        justifyContent='space-between'
+        sx={{ mb: { xs: actions ? 2 : 0, sm: 4 } }}
+        alignItems={isTiny ? 'left' : 'center'}
+      >
+        <Typography variant='h3'>{title}</Typography>
+        <Box sx={{ width: 'fit-content' }}>{actions}</Box>
+      </Stack>
 
-    {children}
-  </Container>
-);
+      {children}
+    </Container>
+  );
+};
 export default PageContainer;

--- a/src/components/pages/Organization.tsx
+++ b/src/components/pages/Organization.tsx
@@ -63,6 +63,7 @@ const Organization = () => {
         <TitleCard
           data-testid='projectsCard'
           title='Projects'
+          stackOnMobile={false}
           actions={
             canCreateProject && (
               <ButtonLink

--- a/src/modules/assessments/components/IndividualAssessmentFormController.tsx
+++ b/src/modules/assessments/components/IndividualAssessmentFormController.tsx
@@ -70,6 +70,7 @@ const IndividualAssessmentFormController: React.FC<Props> = ({
   const FormActionProps = useMemo(() => {
     return {
       onDiscard: navigateToEnrollment,
+      stackOnMobile: true,
       config: [
         {
           id: 'submit',

--- a/src/modules/assessments/components/alerts/AssessmentAlert.tsx
+++ b/src/modules/assessments/components/alerts/AssessmentAlert.tsx
@@ -3,6 +3,7 @@ import NotStartedIcon from '@mui/icons-material/PendingOutlined';
 import InProgressIcon from '@mui/icons-material/Timelapse';
 import { Alert, AlertColor, AlertTitle, Button, Stack } from '@mui/material';
 import React from 'react';
+import { useIsMobile } from '@/hooks/useIsMobile';
 import { FullAssessmentFragment } from '@/types/gqlTypes';
 
 interface Props {
@@ -17,6 +18,8 @@ const AssessmentAlert: React.FC<Props> = ({
   allowUnlock,
   onUnlock,
 }) => {
+  const isTiny = useIsMobile('sm');
+
   let text;
   let Icon;
   let severity: AlertColor | undefined;
@@ -39,7 +42,7 @@ const AssessmentAlert: React.FC<Props> = ({
         data-testid='unlockAssessmentButton'
         onClick={onUnlock}
         color='inherit'
-        sx={{ fontWeight: 600 }}
+        sx={{ fontWeight: 600, width: isTiny ? '100%' : 'fit-content' }}
       >
         Unlock Assessment
       </Button>
@@ -52,13 +55,18 @@ const AssessmentAlert: React.FC<Props> = ({
     color: 'text.primary',
     '.MuiAlert-icon': { alignItems: 'center', color: 'text.secondary' },
   };
+
+  // If an Icon is provided for the Alert, but there's also an Icon on the
+  // Button, then on mobile screens it looks better if we omit the Alert icon
+  const omitIcon = isTiny && action?.props.startIcon;
+
   if (!text) return null;
 
   return (
     <Alert
       severity={severity}
       variant='outlined'
-      icon={Icon ? <Icon /> : false}
+      icon={Icon && !omitIcon ? <Icon /> : false}
       sx={{
         my: 2,
         '.MuiAlert-message': { width: '100%' },
@@ -67,7 +75,7 @@ const AssessmentAlert: React.FC<Props> = ({
       }}
     >
       <Stack
-        direction='row'
+        direction={isTiny ? 'column' : 'row'}
         justifyContent={'space-between'}
         display='flex'
         alignItems={'flex-end'}

--- a/src/modules/enrollment/components/EnrollmentQuickActions.tsx
+++ b/src/modules/enrollment/components/EnrollmentQuickActions.tsx
@@ -43,7 +43,7 @@ const EnrollmentQuickActions = ({
 
   return (
     <TitleCard title='Quick Actions'>
-      <Stack spacing={2} sx={{ px: 2, pb: 2 }}>
+      <Stack spacing={2} sx={{ px: 2, pb: 2, textAlign: 'center' }}>
         {/* Record a Service */}
         {canRecordService && (
           <Button onClick={openServiceDialog} variant='outlined'>

--- a/src/modules/form/components/FormActions.tsx
+++ b/src/modules/form/components/FormActions.tsx
@@ -14,6 +14,7 @@ import { FormActionTypes } from '../types';
 import ButtonLink from '@/components/elements/ButtonLink';
 import ButtonTooltipContainer from '@/components/elements/ButtonTooltipContainer';
 import LoadingButton from '@/components/elements/LoadingButton';
+import { useIsMobile } from '@/hooks/useIsMobile';
 import AssessmentLastUpdated from '@/modules/hmis/components/AssessmentLastUpdated';
 
 type ButtonConfig = {
@@ -39,6 +40,7 @@ export interface FormActionProps {
   lastSaved?: string;
   lastSubmitted?: string;
   noDiscard?: boolean;
+  stackOnMobile?: boolean;
 }
 
 const FormActions = ({
@@ -53,8 +55,10 @@ const FormActions = ({
   lastSaved,
   lastSubmitted,
   noDiscard = false,
+  stackOnMobile = false,
 }: FormActionProps) => {
   const navigate = useNavigate();
+  const isTiny = useIsMobile('sm');
 
   const [leftConfig, centerConfig, rightConfig] = useMemo(() => {
     if (config) {
@@ -168,7 +172,17 @@ const FormActions = ({
     );
   };
 
-  return (
+  return isTiny && stackOnMobile ? (
+    <Stack direction='column' spacing={2}>
+      {leftConfig.map((c) => renderButton(c))}
+      {centerConfig.map((c) => renderButton(c))}
+      <AssessmentLastUpdated
+        lastSaved={lastSaved}
+        lastSubmitted={lastSubmitted}
+      />
+      {rightConfig.map((c) => renderButton(c))}
+    </Stack>
+  ) : (
     <Stack direction='row' spacing={2} justifyContent={'space-between'}>
       {leftConfig.length > 0 && (
         <Stack direction='row' spacing={2}>

--- a/src/modules/household/components/elements/HouseholdActionButtons.tsx
+++ b/src/modules/household/components/elements/HouseholdActionButtons.tsx
@@ -6,6 +6,7 @@ import { useMemo } from 'react';
 
 import ButtonLink from '@/components/elements/ButtonLink';
 import ButtonTooltipContainer from '@/components/elements/ButtonTooltipContainer';
+import { useIsMobile } from '@/hooks/useIsMobile';
 import { EnrollmentDashboardRoutes } from '@/routes/routes';
 import { HouseholdClientFieldsFragment } from '@/types/gqlTypes';
 import { generateSafePath } from '@/utils/pathEncoding';
@@ -56,8 +57,14 @@ const HouseholdActionButtons = ({
     return [true, message, 'error'];
   }, [householdMembers]);
 
+  const isTiny = useIsMobile('sm');
+
   return (
-    <Stack direction='row' gap={3} sx={{ mt: 4, mb: 4 }}>
+    <Stack
+      direction={isTiny ? 'column' : 'row'}
+      gap={{ xs: 1, sm: 2, md: 3 }}
+      sx={{ mt: 4, mb: 4 }}
+    >
       <ButtonLink
         Icon={PeopleIcon}
         to={generateSafePath(EnrollmentDashboardRoutes.EDIT_HOUSEHOLD, {
@@ -65,6 +72,7 @@ const HouseholdActionButtons = ({
           enrollmentId,
         })}
         color='secondary'
+        sx={{ width: { xs: '100%', sm: 'fit-content' }, textAlign: 'center' }}
       >
         Manage Household
       </ButtonLink>
@@ -78,6 +86,10 @@ const HouseholdActionButtons = ({
               clientId,
               enrollmentId,
             })}
+            sx={{
+              width: { xs: '100%', sm: 'fit-content' },
+              textAlign: 'center',
+            }}
           >
             {individual ? 'Intake Assessment' : 'Household Intakes'}
           </ButtonLink>
@@ -92,6 +104,10 @@ const HouseholdActionButtons = ({
               clientId,
               enrollmentId,
             })}
+            sx={{
+              width: { xs: '100%', sm: 'fit-content' },
+              textAlign: 'center',
+            }}
           >
             {individual ? 'Exit Assessment' : 'Household Exits'}
           </ButtonLink>


### PR DESCRIPTION
## Description

This PR addresses some button mobile usability and appearance issues. I'll add screenshots inline so that it's easier to review!

PT issue: https://www.pivotaltracker.com/story/show/187166572

Since we agreed that this change should to make buttons stack correctly in context, rather than applying a whole-app rule that button line height can't exceed 1rem, this PR is not a comprehensive fix to all buttons on the whole site. Instead I fixed the issues that were called out in figma, and a few others that glared at me as I was working on those. But let me know if a comprehensive audit is something that should be in scope for this ticket-- in that case, I think it would be good to collaborate with design to do an audit.

Something else to note is that the buttons on mobile Intake Assessments for multi-family households still look pretty terrible, but I figured that is a problem out of scope for the ticket, since it goes way beyond buttons; it is more of a screen real estate usability issue overall, and I think needs more design thought to get right. (I called this out in the figma doc for design grumps [here](https://www.figma.com/file/F9EHR2IZYuMAlOJ9aOG2IL/OP-%2F-HMIS-%2F-Phase-2-(2024)?type=design&node-id=2548-7099&mode=design&t=i7XgcbCHf8fCwmiP-0))

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
