### PR TITLE
Return instead of erroring if related record doesn't exist

### DIFF
--- a/src/modules/form/components/RecordPickerDialog.tsx
+++ b/src/modules/form/components/RecordPickerDialog.tsx
@@ -55,6 +55,7 @@ const RecordPickerDialog = ({
             assessment,
             i.mapping
           );
+          if (!record || !recordType) return;
 
           return (
             <HmisField

--- a/src/modules/form/util/formUtil.ts
+++ b/src/modules/form/util/formUtil.ts
@@ -1425,6 +1425,7 @@ export const getFieldOnAssessment = (
   }
 
   const record = get(assessment, relatedRecordAttribute);
+  if (!record) return {};
 
   let value;
   if (mapping.fieldName) {


### PR DESCRIPTION
## Description

Include a summary of the changes and a link to the related issue. List any dependencies that are required for this change.

[PT issue](https://www.pivotaltracker.com/story/show/187150878)

A bug surfaced with form auto-filling where we throw an error if an assessment form definition calls for custom data elements on a related record, but the related record connected to that Assessment itself doesn't exist. This shouldn't be an error case, it should just return and not display anything.

I checked the other usage of `getFieldOnAssessment`; it's [here](https://github.com/greenriver/hmis-frontend/blob/66547dbc158a9a37fdb16fbc6768d76bc4b9ed84/src/modules/form/components/group/FormCard.tsx#L86) in FormCard.tsx, which already handles the case when the response is null, so no change should be needed there.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
