### PR TITLE
Hint about active filters

### DIFF
--- a/src/components/elements/tableFilters/filters/FilterMenu.tsx
+++ b/src/components/elements/tableFilters/filters/FilterMenu.tsx
@@ -1,8 +1,8 @@
 import FilterListIcon from '@mui/icons-material/FilterList';
 import { Stack } from '@mui/material';
 import { isDate, isValid } from 'date-fns';
-import { isEmpty, isNil } from 'lodash-es';
-import { useCallback } from 'react';
+import { isEmpty, isNil, startCase } from 'lodash-es';
+import { useCallback, useMemo } from 'react';
 
 import TableFilterItem from './FilterItem';
 import TableControlPopover from './TableControlPopover';
@@ -22,11 +22,23 @@ const TableFilterMenu = <T,>(props: TableFilterMenuProps<T>): JSX.Element => {
     defaultValue as typeof props.filterValues
   );
 
-  // Count # of filters that have values applied
-  const filterCount = Object.entries(props.filterValues)
-    // Skip filters that aren't visible to the user
-    .filter(([k]) => props.filters.hasOwnProperty(k))
-    .filter(([, v]) => (Array.isArray(v) ? !isEmpty(v) : !isNil(v))).length;
+  const { filterCount, filterHint } = useMemo(() => {
+    const filters = Object.entries(props.filterValues)
+      // Skip filters that aren't visible to the user
+      .filter(([k]) => props.filters.hasOwnProperty(k))
+      // Count # of filters that have values applied
+      .filter(([, v]) => (Array.isArray(v) ? !isEmpty(v) : !isNil(v)))
+      // Convert to human-readable strings
+      .map(([k]) => startCase(k));
+
+    const filterCount = filters.length;
+    const filterHint = filters
+      .slice(0, 2) // only hint about the first 2
+      .join(', ')
+      .concat(filterCount > 2 ? `, ${filterCount - 2} more` : ''); // if > 2, show # of remaining filters
+
+    return { filterCount, filterHint };
+  }, [props.filterValues, props.filters]);
 
   const cleanedValues = useCallback((values: Partial<T>) => {
     const cleaned: typeof values = {};
@@ -47,6 +59,7 @@ const TableFilterMenu = <T,>(props: TableFilterMenuProps<T>): JSX.Element => {
       icon={<FilterListIcon />}
       header='Filter By'
       applyLabel='Apply Filters'
+      filterHint={filterHint}
       filterCount={filterCount}
       onCancel={cancel}
       onApply={() => props.setFilterValues(cleanedValues(state))}

--- a/src/components/elements/tableFilters/filters/TableControlPopover.tsx
+++ b/src/components/elements/tableFilters/filters/TableControlPopover.tsx
@@ -8,9 +8,11 @@ import {
 import { ReactNode } from 'react';
 
 import TableFilterButton from './FilterButton';
+import { useIsMobile } from '@/hooks/useIsMobile';
 
 export interface TableControlPopoverProps {
   filterCount?: number;
+  filterHint?: ReactNode;
   children: ReactNode;
   onCancel: VoidFunction;
   onReset: VoidFunction;
@@ -24,6 +26,7 @@ export interface TableControlPopoverProps {
 const TableControlPopover = (props: TableControlPopoverProps): JSX.Element => {
   const {
     filterCount = 0,
+    filterHint,
     children,
     onCancel,
     onReset,
@@ -38,6 +41,8 @@ const TableControlPopover = (props: TableControlPopoverProps): JSX.Element => {
     popupId: 'filterMenu',
   });
 
+  const isTiny = useIsMobile('sm');
+
   return (
     <>
       <TableFilterButton
@@ -46,7 +51,8 @@ const TableControlPopover = (props: TableControlPopoverProps): JSX.Element => {
         {...bindTrigger(popupState)}
       >
         {label}
-        {filterCount > 0 && <> ({filterCount})</>}
+        {!isTiny && filterHint && <> ({filterHint})</>}
+        {filterCount > 0 && (isTiny || !filterHint) && <> ({filterCount})</>}
       </TableFilterButton>
       <Popover
         {...bindPopover(popupState)}


### PR DESCRIPTION
## Description

[PT issue](https://www.pivotaltracker.com/story/show/187296454)

Instead of just displaying the (#) of filters in parentheses, if there is space (we aren't on mobile), display the names of the first 2 filters.

To discuss, maybe with design tomorrow: Let's go over how this looks on various screen sizes, and decide whether to change the cutoff for just shifting to (#) or perhaps reducing the # of displayed filters from 2 to 1 before doing so?

## Type of change
[//]: # 'remove options that are not relevant'
- [ ] Bug fix
- [x] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
