### PR TITLE
silence build emitting excessive warnings

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -92,6 +92,15 @@ export default defineConfig(({ command, mode }) => {
             }
           },
         },
+        onwarn(warning, defaultHandler) {
+          if (warning.code === 'SOURCEMAP_ERROR') {
+            return;
+          }
+          if (warning.code === 'MODULE_LEVEL_DIRECTIVE') {
+            return;
+          }
+          defaultHandler(warning);
+        },
       },
       sourcemap: true,
       minify: mode === 'development' ? false : 'esbuild',


### PR DESCRIPTION
## Description

Running `yarn build` results in excessive warnings:
* "Module level directives cause errors when bundled, "use client" ([seems like a bug in the vite react plugin](https://github.com/vitejs/vite-plugin-react/pull/144), fixed in v4)
* "Error when using sourcemap for reporting an error: Can't resolve original location of error." [see issue](https://github.com/vitejs/vite/issues/15012)

These warnings don't seem to be actionable(?) and mask other warning or error messages that might occur. Suggest ignoring these messages.

## Type of change
[//]: # 'remove options that are not relevant'

- [x] Code clean-up / housekeeping

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
