### PR TITLE
Stack household assessment buttons

### DIFF
--- a/src/components/elements/TitleCard.tsx
+++ b/src/components/elements/TitleCard.tsx
@@ -20,7 +20,7 @@ interface Props extends PaperProps {
   headerSx?: SxProps;
   padded?: boolean;
   stackOnMobile?: boolean;
-  mobileBreakpoint?: 'xs' | 'sm' | 'md';
+  mobileBreakpoint?: 'xs' | 'sm' | 'md'; // breakpoint at which the actions will stack below the title
 }
 const TitleCard: React.FC<Props> = ({
   title,

--- a/src/components/elements/TitleCard.tsx
+++ b/src/components/elements/TitleCard.tsx
@@ -20,6 +20,7 @@ interface Props extends PaperProps {
   headerSx?: SxProps;
   padded?: boolean;
   stackOnMobile?: boolean;
+  mobileBreakpoint?: 'xs' | 'sm' | 'md';
 }
 const TitleCard: React.FC<Props> = ({
   title,
@@ -30,16 +31,18 @@ const TitleCard: React.FC<Props> = ({
   headerSx,
   padded = false,
   stackOnMobile = true,
+  mobileBreakpoint = 'xs',
   ...props
 }) => {
-  const isTiny = useIsMobile('sm');
+  const isMobile = useIsMobile(mobileBreakpoint);
 
   return (
     <Paper data-testid={props['data-testid']} {...props}>
       <Stack
         justifyContent={'space-between'}
-        alignItems={isTiny && stackOnMobile ? 'left' : 'center'}
-        direction={isTiny && stackOnMobile ? 'column' : 'row'}
+        alignItems={isMobile && stackOnMobile ? 'left' : 'center'}
+        direction={isMobile && stackOnMobile ? 'column' : 'row'}
+        spacing={{ sm: 1, md: 2, lg: 4 }}
         sx={{
           px: 2,
           py: actions ? 2 : 1,
@@ -51,12 +54,18 @@ const TitleCard: React.FC<Props> = ({
               }
             : {}),
           ...headerSx,
+          '& MuiButton-root': {
+            width: 'fit-content',
+          },
         }}
       >
-        <Typography variant={headerTypographyVariant} sx={{ py: 1 }}>
+        <Typography
+          variant={headerTypographyVariant}
+          sx={{ py: 1, flexGrow: 1 }}
+        >
           {title}
         </Typography>
-        <Box sx={{ width: 'fit-content' }}>{actions}</Box>
+        {actions}
       </Stack>
 
       {padded ? <Box sx={{ px: 2, pb: 2 }}>{children}</Box> : children}

--- a/src/components/elements/TitleCard.tsx
+++ b/src/components/elements/TitleCard.tsx
@@ -42,7 +42,7 @@ const TitleCard: React.FC<Props> = ({
         justifyContent={'space-between'}
         alignItems={isMobile && stackOnMobile ? 'left' : 'center'}
         direction={isMobile && stackOnMobile ? 'column' : 'row'}
-        spacing={{ sm: 1, md: 2, lg: 4 }}
+        spacing={{ xs: 1, md: 2, lg: 4 }}
         sx={{
           px: 2,
           py: actions ? 2 : 1,

--- a/src/modules/enrollment/components/HouseholdAssessmentsTable.tsx
+++ b/src/modules/enrollment/components/HouseholdAssessmentsTable.tsx
@@ -25,13 +25,13 @@ const columns: ColumnDef<HhmAssessmentType>[] = [
     render: (a) => clientBriefName(a.enrollment.client),
   },
   {
+    header: 'Assessment Type',
+    render: (assessment) => formRoleDisplay(assessment),
+  },
+  {
     header: 'Assessment Date',
     render: (a) => <AssessmentDateWithStatusIndicator assessment={a} />,
     linkTreatment: true,
-  },
-  {
-    header: 'Assessment Type',
-    render: (assessment) => formRoleDisplay(assessment),
   },
   {
     header: 'Last Updated',

--- a/src/modules/enrollment/components/dashboardPages/EnrollmentAssessmentsPage.tsx
+++ b/src/modules/enrollment/components/dashboardPages/EnrollmentAssessmentsPage.tsx
@@ -1,6 +1,5 @@
 import PersonIcon from '@mui/icons-material/Person';
-import { Stack } from '@mui/material';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import EnrollmentAssessmentActionButtons from '../EnrollmentAssessmentActionButtons';
 import EnrollmentAssessmentsTable from '../EnrollmentAssessmentsTable';
 import HouseholdAssessmentsTable from '../HouseholdAssessmentsTable';
@@ -19,6 +18,45 @@ const AssessmentsTable = () => {
   const enrollmentId = enrollment?.id;
   const clientId = enrollment?.client.id;
 
+  const actions = useMemo(() => {
+    if (!enrollment) return [];
+
+    const actions = [];
+    if (enrollment.householdSize > 1) {
+      actions.push(
+        <CommonToggle
+          value={mode}
+          onChange={setMode}
+          variant='gray'
+          size='small'
+          aria-label='view assessments for'
+          items={[
+            {
+              value: 'current_client',
+              label: 'Client',
+              Icon: PersonIcon,
+            },
+            {
+              value: 'household',
+              label: 'Household',
+              Icon: HouseholdIcon,
+            },
+          ]}
+          key='household-client-toggle'
+        />
+      );
+    }
+    if (enrollment.access.canEditEnrollments) {
+      actions.push(
+        <EnrollmentAssessmentActionButtons
+          enrollment={enrollment}
+          key='enrollment-assessment-action'
+        />
+      );
+    }
+    return actions;
+  }, [enrollment, mode]);
+
   if (!enrollment || !enrollmentId || !clientId) return <NotFound />;
 
   return (
@@ -28,36 +66,10 @@ const AssessmentsTable = () => {
           ? `${clientBriefName(enrollment.client)} Assessments`
           : 'Household Assessments'
       }
-      actions={
-        <Stack direction='row' gap={4}>
-          {enrollment.householdSize > 1 && (
-            <CommonToggle
-              value={mode}
-              onChange={setMode}
-              variant='gray'
-              size='small'
-              aria-label='view assessments for'
-              items={[
-                {
-                  value: 'current_client',
-                  label: 'Client',
-                  Icon: PersonIcon,
-                },
-                {
-                  value: 'household',
-                  label: 'Household',
-                  Icon: HouseholdIcon,
-                },
-              ]}
-            />
-          )}
-          {enrollment.access.canEditEnrollments && (
-            <EnrollmentAssessmentActionButtons enrollment={enrollment} />
-          )}
-        </Stack>
-      }
+      actions={actions}
       headerVariant='border'
       data-testid='enrollmentAssessmentsCard'
+      mobileBreakpoint='md'
     >
       {mode === 'current_client' && (
         <EnrollmentAssessmentsTable


### PR DESCRIPTION
## Description

Include a summary of the changes and a link to the related issue. List any dependencies that are required for this change.

PT ticket: https://www.pivotaltracker.com/story/show/187296485
This PR makes the following changes:
- Update the TitleCard component so that it more gracefully accepts an Iterable for the `actions` prop. It also adds customizability for the mobile breakpoint. (Most TitleCards should wrap buttons to the next line on size `xs` only, but if there are a lot of buttons we want to be able to tell it to wrap sooner)
- Swap the order of Assessment Type and Assessment Date in the table. Awaiting confirmation on whether it's OK to make this change everywhere, or it should be mobile-only (https://www.figma.com/file/F9EHR2IZYuMAlOJ9aOG2IL?type=design&node-id=2712-37748&mode=design#740858548)
- Modify the EnrollmentAssessmentsPage component to pass an iterable list of TitleCard actions, instead of wrapping them in a Stack. This enables wrapping them as part of the TitleCard's stack's breakpoint logic instead of building separate logic

Before:
<img width="319" alt="Screenshot 2024-03-26 at 12 07 52 PM" src="https://github.com/greenriver/hmis-frontend/assets/16002775/328999b8-3a54-4fe0-932e-ae4bddf357d6">
After:
<img width="319" alt="Screenshot 2024-03-26 at 12 07 37 PM" src="https://github.com/greenriver/hmis-frontend/assets/16002775/539416f2-c662-4a46-86ba-6f3e0192b036">

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
