### PR TITLE
Design tweaks to disability table

### DIFF
--- a/src/modules/form/components/group/DisabilityTable.tsx
+++ b/src/modules/form/components/group/DisabilityTable.tsx
@@ -152,9 +152,9 @@ const DisabilityTable = ({
     label?: ReactNode
   ) {
     return renderChildItem(cellItem, {
-      noLabel: !!label,
+      noLabel: !label,
       inputProps: {
-        label: label,
+        label,
         placeholder: idx === 0 ? 'Select Status' : 'Select Disabling Condition',
         // Reads as "Physical Disability Status" or "Physical Disability Disabling Condition"
         ariaLabelledBy:
@@ -213,7 +213,7 @@ const DisabilityTable = ({
                 }}
               >
                 <TableCell
-                  sx={isMobile ? {} : { width: '250px', py: 3 }}
+                  sx={isMobile ? {} : { width: '25%', py: 3 }}
                   id={disabilityTypeLabelId}
                 >
                   {!isMobile && (
@@ -245,12 +245,14 @@ const DisabilityTable = ({
                       key={cellItem.linkId}
                       sx={{
                         pr: 2,
+                        width: '33%',
                       }}
                     >
                       {getDisabilityDropdowns(
                         cellItem,
                         idx,
                         disabilityTypeLabelId
+                        // dont pass a label because it is labelled-by the header cells
                       )}
                     </TableCell>
                   ))}


### PR DESCRIPTION
## Description

* Have each column take up 30%
* Hide/show labels on mobile and desktop correctly

## Type of change
- [x] Bug fix
<img width="672" alt="Screenshot 2024-03-27 at 9 44 15 AM" src="https://github.com/greenriver/hmis-frontend/assets/5333982/a1647228-6fa6-4772-a238-d4e2fabfe2d1">
<img width="1146" alt="Screenshot 2024-03-27 at 9 44 09 AM" src="https://github.com/greenriver/hmis-frontend/assets/5333982/ad4073df-721d-428c-a200-4651e337bd25">

<img width="609" alt="Screenshot 2024-03-27 at 9 45 01 AM" src="https://github.com/greenriver/hmis-frontend/assets/5333982/efee54f0-836f-4167-ac69-78fe0ac1b67e">
<img width="984" alt="Screenshot 2024-03-27 at 9 44 57 AM" src="https://github.com/greenriver/hmis-frontend/assets/5333982/2d966980-3ae2-4ebc-ab35-5bd4817121f5">




## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (eslint)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
