### PR TITLE
WIP - adjust Info Group width

### DIFF
--- a/src/modules/form/components/DynamicGroup.tsx
+++ b/src/modules/form/components/DynamicGroup.tsx
@@ -1,5 +1,4 @@
-import { Box, Grid, lighten } from '@mui/material';
-import { ReactNode } from 'react';
+import { Grid, lighten } from '@mui/material';
 
 import { GroupItemComponentProps } from '../types';
 
@@ -13,27 +12,6 @@ import SignatureGroupCard from './group/SignatureGroupCard';
 import TableGroup from './group/TableGroup';
 import Signature from '@/modules/form/components/group/Signature';
 import { Component } from '@/types/gqlTypes';
-
-export const InfoGroup = ({
-  children,
-}: {
-  children: ReactNode;
-  nestingLevel?: number;
-}) => (
-  <Box
-    sx={{
-      backgroundColor: (theme) => lighten(theme.palette.grey[100], 0.2),
-      borderRadius: 1,
-      width: 'fit-content',
-      px: 0.5,
-      // use box shadow to "extend" background color beyond div. doing this so we dont mess with the height
-      boxShadow: (theme) =>
-        `0 2px 0 6px ${lighten(theme.palette.grey[100], 0.2)}`,
-    }}
-  >
-    {children}
-  </Box>
-);
 
 interface Props extends GroupItemComponentProps {
   clientId?: string;
@@ -75,9 +53,18 @@ const DynamicGroup: React.FC<Props> = ({ debug, ...props }) => {
       return <Signature key={props.item.linkId} {...props} />;
     case Component.InfoGroup:
       return (
-        <InfoGroup nestingLevel={props.nestingLevel}>
-          <QuestionGroup key={props.item.linkId} {...props} />
-        </InfoGroup>
+        <QuestionGroup
+          key={props.item.linkId}
+          {...props}
+          sx={{
+            backgroundColor: (theme) => lighten(theme.palette.grey[100], 0.2),
+            borderRadius: 1,
+            px: 0.5,
+            // use box shadow to "extend" background color beyond div. doing this so we dont mess with the height
+            boxShadow: (theme) =>
+              `0 2px 0 6px ${lighten(theme.palette.grey[100], 0.2)}`,
+          }}
+        />
       );
     case Component.Table:
       return <TableGroup key={props.item.linkId} {...props} />;

--- a/src/modules/form/components/group/QuestionGroup.tsx
+++ b/src/modules/form/components/group/QuestionGroup.tsx
@@ -1,4 +1,4 @@
-import { Box, Grid, Typography } from '@mui/material';
+import { Box, Grid, SxProps, Theme, Typography } from '@mui/material';
 
 import { GroupItemComponentProps } from '../../types';
 
@@ -9,7 +9,8 @@ const QuestionGroup = ({
   nestingLevel,
   renderChildItem,
   viewOnly = false,
-}: GroupItemComponentProps) => {
+  sx,
+}: GroupItemComponentProps & { sx?: SxProps<Theme> }) => {
   const wrappedChildren = (
     <Grid container direction='column' sx={{ mt: 0 }} gap={3}>
       {renderChildItem &&
@@ -27,7 +28,7 @@ const QuestionGroup = ({
 
   if (nestingLevel >= 1) {
     return (
-      <Grid item xs>
+      <Grid item xs sx={sx}>
         <Box
           sx={
             isConditionalGroup
@@ -52,7 +53,7 @@ const QuestionGroup = ({
   }
 
   return (
-    <Grid item xs>
+    <Grid item xs sx={sx}>
       {label && <Typography sx={{ mb: 2 }}>{label}</Typography>}
       {wrappedChildren}
     </Grid>


### PR DESCRIPTION
## Description

Attempt to fix info group. Previously it relied on `width: 'fit-content',`, since Inputs used to have a minimum width. Thats not the case anymore, so it squishes together inputs.

This approach makes it full -width, which also doesn't look ideal. Needs some more hacking / design review. The "info group" was originally designed for the Data Quality fields. It is now in use in one other place, for describing the PLS breaks.

<img width="1235" alt="Screenshot 2024-03-27 at 10 04 39 AM" src="https://github.com/greenriver/hmis-frontend/assets/5333982/ca07483a-95b7-4c65-b241-c30483066655">
<img width="1156" alt="Screenshot 2024-03-27 at 10 04 29 AM" src="https://github.com/greenriver/hmis-frontend/assets/5333982/da79dc29-74b3-4982-bf27-2b5cb79a7f52">



## Type of change
- [ ] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (eslint)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
