### PR TITLE
Make Assessment tables have a consistent column order

### DIFF
--- a/src/components/clientDashboard/enrollments/ClientAssessments.tsx
+++ b/src/components/clientDashboard/enrollments/ClientAssessments.tsx
@@ -28,11 +28,11 @@ const columns: ColumnDef<AssessmentType>[] = [
   {
     header: 'Assessment Type',
     render: (assessment) => formRoleDisplay(assessment),
+    linkTreatment: true,
   },
   {
     header: 'Assessment Date',
     render: (a) => <AssessmentDateWithStatusIndicator assessment={a} />,
-    linkTreatment: true,
     ariaLabel: (row) => assessmentDescription(row),
   },
   {

--- a/src/components/clientDashboard/enrollments/ClientAssessments.tsx
+++ b/src/components/clientDashboard/enrollments/ClientAssessments.tsx
@@ -26,14 +26,14 @@ type AssessmentType = NonNullable<
 
 const columns: ColumnDef<AssessmentType>[] = [
   {
+    header: 'Assessment Type',
+    render: (assessment) => formRoleDisplay(assessment),
+  },
+  {
     header: 'Assessment Date',
     render: (a) => <AssessmentDateWithStatusIndicator assessment={a} />,
     linkTreatment: true,
     ariaLabel: (row) => assessmentDescription(row),
-  },
-  {
-    header: 'Assessment Type',
-    render: (assessment) => formRoleDisplay(assessment),
   },
   {
     header: 'Project Name',

--- a/src/modules/enrollment/components/EnrollmentAssessmentsTable.tsx
+++ b/src/modules/enrollment/components/EnrollmentAssessmentsTable.tsx
@@ -16,11 +16,11 @@ const columns: ColumnDef<AssessmentFieldsFragment>[] = [
   {
     header: 'Assessment Type',
     render: (assessment) => formRoleDisplay(assessment),
+    linkTreatment: true,
   },
   {
     header: 'Assessment Date',
     render: (a) => <AssessmentDateWithStatusIndicator assessment={a} />,
-    linkTreatment: true,
   },
   {
     header: 'Last Updated',

--- a/src/modules/enrollment/components/EnrollmentAssessmentsTable.tsx
+++ b/src/modules/enrollment/components/EnrollmentAssessmentsTable.tsx
@@ -14,13 +14,13 @@ import {
 
 const columns: ColumnDef<AssessmentFieldsFragment>[] = [
   {
+    header: 'Assessment Type',
+    render: (assessment) => formRoleDisplay(assessment),
+  },
+  {
     header: 'Assessment Date',
     render: (a) => <AssessmentDateWithStatusIndicator assessment={a} />,
     linkTreatment: true,
-  },
-  {
-    header: 'Assessment Type',
-    render: (assessment) => formRoleDisplay(assessment),
   },
   {
     header: 'Last Updated',

--- a/src/modules/enrollment/components/HouseholdAssessmentsTable.tsx
+++ b/src/modules/enrollment/components/HouseholdAssessmentsTable.tsx
@@ -27,11 +27,11 @@ const columns: ColumnDef<HhmAssessmentType>[] = [
   {
     header: 'Assessment Type',
     render: (assessment) => formRoleDisplay(assessment),
+    linkTreatment: true,
   },
   {
     header: 'Assessment Date',
     render: (a) => <AssessmentDateWithStatusIndicator assessment={a} />,
-    linkTreatment: true,
   },
   {
     header: 'Last Updated',


### PR DESCRIPTION
## Description

PT ticket: https://www.pivotaltracker.com/story/show/187296485
This is a follow-up to this PR: https://github.com/greenriver/hmis-frontend/pull/709/files
based on this Figma comment conversation: https://www.figma.com/file/F9EHR2IZYuMAlOJ9aOG2IL?type=design&node-id=2712-37748&mode=design#740858548

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
