### PR TITLE
Fix minor issues with client image tile and uploader

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -5475,6 +5475,38 @@
             "deprecationReason": null
           },
           {
+            "name": "canViewClientName",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "canViewClientPhoto",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "canViewDob",
             "description": null,
             "args": [],
@@ -29615,6 +29647,29 @@
         "possibleTypes": null
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "OrganizationFilterOptions",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "searchTerm",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "ENUM",
         "name": "OrganizationSortOption",
         "description": "HUD Organization Sorting Options",
@@ -35990,6 +36045,18 @@
             "description": null,
             "args": [
               {
+                "name": "filters",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "OrganizationFilterOptions",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
                 "name": "limit",
                 "description": null,
                 "type": {
@@ -37171,6 +37238,54 @@
           },
           {
             "name": "canViewClientAlerts",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "canViewClientContactInfo",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "canViewClientName",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "canViewClientPhoto",
             "description": null,
             "args": [],
             "type": {

--- a/src/api/operations/access.fragments.graphql
+++ b/src/api/operations/access.fragments.graphql
@@ -13,6 +13,7 @@ fragment RootPermissions on QueryAccess {
   canViewFullSsn
   canDeleteProject
   canViewPartialSsn
+  canViewClientPhoto
   canEnrollClients
   canEditEnrollments
   canViewEnrollmentDetails

--- a/src/api/operations/client.fragments.graphql
+++ b/src/api/operations/client.fragments.graphql
@@ -123,6 +123,10 @@ fragment ClientImage on Client {
   image {
     ...ClientImageFields
   }
+  access {
+    canEditClient
+    canViewClientPhoto
+  }
 }
 
 fragment ClientIdentificationFields on Client {

--- a/src/components/elements/upload/UploaderBase.tsx
+++ b/src/components/elements/upload/UploaderBase.tsx
@@ -231,7 +231,11 @@ const Uploader: React.FC<UploaderProps> = ({
             setCurrentUpload(res);
             onUpload(res, file);
           })
-          .then(() => setLoading(false));
+          .then(() => setLoading(false))
+          .catch((error) => {
+            setLoading(false);
+            setError(error.message);
+          });
       }
     },
     [uploadFile, onUpload]

--- a/src/modules/client/components/ClientProfileCard.tsx
+++ b/src/modules/client/components/ClientProfileCard.tsx
@@ -360,6 +360,8 @@ const ClientProfileCard: React.FC<Props> = ({ client }) => {
     variables: { id: client.id },
   });
 
+  const [canViewClientPhoto] = useHasRootPermissions(['canViewClientPhoto']);
+
   const [canViewSsn] = useHasRootPermissions([
     'canViewFullSsn',
     'canViewPartialSsn',
@@ -381,20 +383,21 @@ const ClientProfileCard: React.FC<Props> = ({ client }) => {
             <Typography variant='h4'>{clientNameAllParts(client)}</Typography>
           </Grid>
           <Grid item xs={12} sx={{ display: 'flex', gap: 2 }}>
-            {imageLoading ? (
-              <Skeleton
-                variant='rectangular'
-                sx={{
-                  height: size,
-                  width: size,
-                }}
-              />
-            ) : (
-              <ClientCardImage
-                size={size}
-                client={clientImageData || undefined}
-              />
-            )}
+            {canViewClientPhoto &&
+              (imageLoading ? (
+                <Skeleton
+                  variant='rectangular'
+                  sx={{
+                    height: size,
+                    width: size,
+                  }}
+                />
+              ) : (
+                <ClientCardImage
+                  size={size}
+                  client={clientImageData || undefined}
+                />
+              ))}
             <Box
               sx={{
                 display: 'flex',

--- a/src/modules/client/components/ClientProfileCard.tsx
+++ b/src/modules/client/components/ClientProfileCard.tsx
@@ -269,6 +269,8 @@ const ClientCardImage = ({
 
   if (!client) return <ClientCardImageElement />;
 
+  if (!client.access.canViewClientPhoto) return;
+
   const overlaySx: SxProps = {
     opacity: 0,
     display: 'flex',
@@ -287,54 +289,58 @@ const ClientCardImage = ({
         onClose={handleClose}
         clientId={client.id}
       />
-      <Link
-        component='button'
-        underline='none'
-        onClick={handleOpen}
-        ref={linkRef}
-        sx={{
-          position: 'relative',
-          width: size,
-          height: size,
-          '&:focus-within > .overlay': {
-            opacity: 1,
-          },
-          '&:hover > .overlay': {
-            opacity: 1,
-          },
-        }}
-      >
-        <ClientCardImageElement size={size} client={client} />
-        {client.image?.base64 ? (
-          // Has photo
-          <Box
-            className='overlay'
-            sx={{
-              ...overlaySx,
-              backgroundColor: 'rgba(0,0,0, 0.5)',
-            }}
-          >
-            <Chip
-              label='Update Photo'
-              icon={<EditIcon />}
+      {client.access.canEditClient ? (
+        <Link
+          component='button'
+          underline='none'
+          onClick={handleOpen}
+          ref={linkRef}
+          sx={{
+            position: 'relative',
+            width: size,
+            height: size,
+            '&:focus-within > .overlay': {
+              opacity: 1,
+            },
+            '&:hover > .overlay': {
+              opacity: 1,
+            },
+          }}
+        >
+          <ClientCardImageElement size={size} client={client} />
+          {client.image?.base64 ? (
+            // Has photo
+            <Box
+              className='overlay'
               sx={{
-                backgroundColor: (theme) => theme.palette.grey[200],
+                ...overlaySx,
+                backgroundColor: 'rgba(0,0,0, 0.5)',
               }}
-            />
-          </Box>
-        ) : (
-          // No photo
-          <Box
-            className='overlay'
-            sx={{
-              ...overlaySx,
-              backgroundColor: (theme) => theme.palette.grey[100],
-            }}
-          >
-            <Chip label='Add Client Photo' icon={<PhotoCameraIcon />} />
-          </Box>
-        )}
-      </Link>
+            >
+              <Chip
+                label='Update Photo'
+                icon={<EditIcon />}
+                sx={{
+                  backgroundColor: (theme) => theme.palette.grey[200],
+                }}
+              />
+            </Box>
+          ) : (
+            // No photo
+            <Box
+              className='overlay'
+              sx={{
+                ...overlaySx,
+                backgroundColor: (theme) => theme.palette.grey[100],
+              }}
+            >
+              <Chip label='Add Client Photo' icon={<PhotoCameraIcon />} />
+            </Box>
+          )}
+        </Link>
+      ) : (
+        <ClientCardImageElement size={size} client={client} />
+      )}
     </>
   );
 };
@@ -359,6 +365,8 @@ const ClientProfileCard: React.FC<Props> = ({ client }) => {
     'canViewPartialSsn',
   ]);
 
+  const size = 175;
+
   return (
     <Box>
       <Card
@@ -377,14 +385,13 @@ const ClientProfileCard: React.FC<Props> = ({ client }) => {
               <Skeleton
                 variant='rectangular'
                 sx={{
-                  height: 150,
-                  width: 150,
-                  mr: 1,
+                  height: size,
+                  width: size,
                 }}
               />
             ) : (
               <ClientCardImage
-                size={175}
+                size={size}
                 client={clientImageData || undefined}
               />
             )}

--- a/src/types/gqlObjects.ts
+++ b/src/types/gqlObjects.ts
@@ -920,6 +920,22 @@ export const HmisObjectSchemas: GqlSchema[] = [
         },
       },
       {
+        name: 'canViewClientName',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'Boolean', ofType: null },
+        },
+      },
+      {
+        name: 'canViewClientPhoto',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'Boolean', ofType: null },
+        },
+      },
+      {
         name: 'canViewDob',
         type: {
           kind: 'NON_NULL',
@@ -5035,6 +5051,30 @@ export const HmisObjectSchemas: GqlSchema[] = [
         },
       },
       {
+        name: 'canViewClientContactInfo',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'Boolean', ofType: null },
+        },
+      },
+      {
+        name: 'canViewClientName',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'Boolean', ofType: null },
+        },
+      },
+      {
+        name: 'canViewClientPhoto',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'Boolean', ofType: null },
+        },
+      },
+      {
         name: 'canViewClients',
         type: {
           kind: 'NON_NULL',
@@ -7074,6 +7114,15 @@ export const HmisInputObjectSchemas: GqlInputObjectSchema[] = [
             },
           },
         },
+      },
+    ],
+  },
+  {
+    name: 'OrganizationFilterOptions',
+    args: [
+      {
+        name: 'searchTerm',
+        type: { kind: 'SCALAR', name: 'String', ofType: null },
       },
     ],
   },

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -7676,6 +7676,7 @@ export type RootPermissionsFragment = {
   canViewFullSsn: boolean;
   canDeleteProject: boolean;
   canViewPartialSsn: boolean;
+  canViewClientPhoto: boolean;
   canEnrollClients: boolean;
   canEditEnrollments: boolean;
   canViewEnrollmentDetails: boolean;
@@ -7788,6 +7789,7 @@ export type GetRootPermissionsQuery = {
     canViewFullSsn: boolean;
     canDeleteProject: boolean;
     canViewPartialSsn: boolean;
+    canViewClientPhoto: boolean;
     canEnrollClients: boolean;
     canEditEnrollments: boolean;
     canViewEnrollmentDetails: boolean;
@@ -31008,6 +31010,7 @@ export const RootPermissionsFragmentDoc = gql`
     canViewFullSsn
     canDeleteProject
     canViewPartialSsn
+    canViewClientPhoto
     canEnrollClients
     canEditEnrollments
     canViewEnrollmentDetails

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -730,6 +730,8 @@ export type ClientAccess = {
   canViewAnyFiles: Scalars['Boolean']['output'];
   canViewAnyNonconfidentialClientFiles: Scalars['Boolean']['output'];
   canViewClientAlerts: Scalars['Boolean']['output'];
+  canViewClientName: Scalars['Boolean']['output'];
+  canViewClientPhoto: Scalars['Boolean']['output'];
   canViewDob: Scalars['Boolean']['output'];
   canViewEnrollmentDetails: Scalars['Boolean']['output'];
   canViewFullSsn: Scalars['Boolean']['output'];
@@ -4363,6 +4365,10 @@ export type OrganizationAccess = {
   id: Scalars['ID']['output'];
 };
 
+export type OrganizationFilterOptions = {
+  searchTerm?: InputMaybe<Scalars['String']['input']>;
+};
+
 /** HUD Organization Sorting Options */
 export enum OrganizationSortOption {
   Name = 'NAME',
@@ -5691,6 +5697,7 @@ export type QueryOrganizationArgs = {
 };
 
 export type QueryOrganizationsArgs = {
+  filters?: InputMaybe<OrganizationFilterOptions>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   sortOrder?: InputMaybe<OrganizationSortOption>;
@@ -5806,6 +5813,9 @@ export type QueryAccess = {
   canViewAnyConfidentialClientFiles: Scalars['Boolean']['output'];
   canViewAnyNonconfidentialClientFiles: Scalars['Boolean']['output'];
   canViewClientAlerts: Scalars['Boolean']['output'];
+  canViewClientContactInfo: Scalars['Boolean']['output'];
+  canViewClientName: Scalars['Boolean']['output'];
+  canViewClientPhoto: Scalars['Boolean']['output'];
   canViewClients: Scalars['Boolean']['output'];
   canViewDob: Scalars['Boolean']['output'];
   canViewEnrollmentDetails: Scalars['Boolean']['output'];
@@ -12939,6 +12949,11 @@ export type ClientImageFragment = {
     contentType: string;
     base64: string;
   } | null;
+  access: {
+    __typename?: 'ClientAccess';
+    canEditClient: boolean;
+    canViewClientPhoto: boolean;
+  };
 };
 
 export type ClientIdentificationFieldsFragment = {
@@ -13347,6 +13362,11 @@ export type GetClientImageQuery = {
       contentType: string;
       base64: string;
     } | null;
+    access: {
+      __typename?: 'ClientAccess';
+      canEditClient: boolean;
+      canViewClientPhoto: boolean;
+    };
   } | null;
 };
 
@@ -13530,6 +13550,11 @@ export type UpdateClientImageMutation = {
         contentType: string;
         base64: string;
       } | null;
+      access: {
+        __typename?: 'ClientAccess';
+        canEditClient: boolean;
+        canViewClientPhoto: boolean;
+      };
     } | null;
     errors: Array<{
       __typename?: 'ValidationError';
@@ -13566,6 +13591,11 @@ export type DeleteClientImageMutation = {
         contentType: string;
         base64: string;
       } | null;
+      access: {
+        __typename?: 'ClientAccess';
+        canEditClient: boolean;
+        canViewClientPhoto: boolean;
+      };
     } | null;
     errors: Array<{
       __typename?: 'ValidationError';
@@ -31810,6 +31840,10 @@ export const ClientImageFragmentDoc = gql`
     id
     image {
       ...ClientImageFields
+    }
+    access {
+      canEditClient
+      canViewClientPhoto
     }
   }
   ${ClientImageFieldsFragmentDoc}


### PR DESCRIPTION
## Description

Include a summary of the changes and a link to the related issue. List any dependencies that are required for this change.

[//]: # 'remove if not applicable'
Depends on hmis-warehouse PR: https://github.com/greenriver/hmis-warehouse/pull/4222
PT issue: https://www.pivotaltracker.com/story/show/187354988

This PR makes the following minor UI fixes around client images:
- If you are not allowed to edit clients, the client image tile no longer appears as a button, preventing users clicking around from getting the 'access denied' error mentioned in the ticket.
- If you are not allowed to view client photos, you shouldn't see the image tile at all.
- If uploading the photo fails, the UI displays an error instead of hanging on the loading screen. (Hopefully this isn't user-facing, but since uploading fails locally without s3 set up, this is just to make developer experience a little more helpful)

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
