### PR TITLE
Vertically center the Add Organization button

### DIFF
--- a/src/components/pages/AllProjects.tsx
+++ b/src/components/pages/AllProjects.tsx
@@ -152,7 +152,14 @@ const AllProjects = () => {
                 clearAdornment
               />
               <RootPermissionsFilter permissions={['canEditOrganization']}>
-                <Box sx={{ width: 'fit-content', pt: isMobile ? 0 : 3.5 }}>
+                <Box
+                  sx={{
+                    width: 'fit-content',
+                    pt: isMobile ? 0 : 3.5,
+                    display: 'flex',
+                    alignItems: 'center',
+                  }}
+                >
                   <ButtonLink
                     data-testid='addOrganizationButton'
                     to={generateSafePath(Routes.CREATE_ORGANIZATION)}


### PR DESCRIPTION
## Description

Include a summary of the changes and a link to the related issue. List any dependencies that are required for this change.

PT issue: https://www.pivotaltracker.com/story/show/186494330

This PR is a visual fix to vertically center the Add Organizations button, so it doesn't look bad next to the taller search box.

Before:
<img width="797" alt="Screenshot 2024-04-09 at 5 55 09 PM" src="https://github.com/greenriver/hmis-frontend/assets/16002775/7e712862-c334-47d3-a85f-929f73ffc912">

After:
<img width="797" alt="Screenshot 2024-04-09 at 5 55 02 PM" src="https://github.com/greenriver/hmis-frontend/assets/16002775/377b8cd4-d3f0-4806-98df-9a55dd9c170b">

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
