### PR TITLE
Add Service Details column to Client Services table

### DIFF
--- a/src/modules/enrollment/components/dashboardPages/EnrollmentServicesPage.tsx
+++ b/src/modules/enrollment/components/dashboardPages/EnrollmentServicesPage.tsx
@@ -18,13 +18,15 @@ import {
   ServiceFieldsFragment,
 } from '@/types/gqlTypes';
 
-export const SERVICE_COLUMNS: ColumnDef<ServiceBasicFieldsFragment>[] = [
-  {
+export const SERVICE_BASIC_COLUMNS: {
+  [key: string]: ColumnDef<ServiceBasicFieldsFragment>;
+} = {
+  dateProvided: {
     header: 'Date Provided',
     linkTreatment: true,
-    render: (e) => parseAndFormatDate(e.dateProvided),
+    render: (s) => parseAndFormatDate(s.dateProvided),
   },
-  {
+  serviceType: {
     header: 'Service Type',
     render: (service) => {
       const { name, category } = service.serviceType;
@@ -32,7 +34,25 @@ export const SERVICE_COLUMNS: ColumnDef<ServiceBasicFieldsFragment>[] = [
       return `${category} - ${name}`;
     },
   },
-];
+};
+
+export const SERVICE_COLUMNS: {
+  [key: string]: ColumnDef<ServiceFieldsFragment>;
+} = {
+  serviceDetails: {
+    header: 'Service Details',
+    render: (service) => (
+      <Stack>
+        {serviceDetails(service).map((s, i) => (
+          // eslint-disable-next-line react/no-array-index-key
+          <Typography key={i} variant='body2'>
+            {s}
+          </Typography>
+        ))}
+      </Stack>
+    ),
+  },
+};
 
 const EnrollmentServicesPage = () => {
   const { enrollment } = useEnrollmentDashboardContext();
@@ -53,20 +73,9 @@ const EnrollmentServicesPage = () => {
   const canEditServices = enrollment.access.canEditEnrollments;
 
   const columns = [
-    ...SERVICE_COLUMNS,
-    {
-      header: 'Service Details',
-      render: (e: ServiceFieldsFragment) => (
-        <Stack>
-          {serviceDetails(e).map((s, i) => (
-            // eslint-disable-next-line react/no-array-index-key
-            <Typography key={i} variant='body2'>
-              {s}
-            </Typography>
-          ))}
-        </Stack>
-      ),
-    },
+    SERVICE_BASIC_COLUMNS.dateProvided,
+    SERVICE_BASIC_COLUMNS.serviceType,
+    SERVICE_COLUMNS.serviceDetails,
   ];
 
   return (

--- a/src/modules/projects/components/tables/ProjectServicesTable.tsx
+++ b/src/modules/projects/components/tables/ProjectServicesTable.tsx
@@ -3,7 +3,7 @@ import { useMemo } from 'react';
 import { ColumnDef } from '@/components/elements/table/types';
 import ClientName from '@/modules/client/components/ClientName';
 import GenericTableWithData from '@/modules/dataFetching/components/GenericTableWithData';
-import { SERVICE_COLUMNS } from '@/modules/enrollment/components/dashboardPages/EnrollmentServicesPage';
+import { SERVICE_BASIC_COLUMNS } from '@/modules/enrollment/components/dashboardPages/EnrollmentServicesPage';
 import { parseAndFormatDateRange } from '@/modules/hmis/hmisUtil';
 import {
   GetProjectServicesDocument,
@@ -48,10 +48,8 @@ const ProjectServicesTable = ({
           />
         ),
       },
-      ...SERVICE_COLUMNS.map((c) => {
-        if (c.header === 'Date Provided') return { ...c, linkTreatment: false };
-        return c;
-      }),
+      { ...SERVICE_BASIC_COLUMNS.dateProvided, linkTreatment: false },
+      SERVICE_BASIC_COLUMNS.serviceType,
       {
         header: 'Enrollment Period',
         render: (s: ServiceFields) =>

--- a/src/modules/services/components/ClientServices.tsx
+++ b/src/modules/services/components/ClientServices.tsx
@@ -6,7 +6,10 @@ import { ColumnDef } from '@/components/elements/table/types';
 import PageTitle from '@/components/layout/PageTitle';
 import useSafeParams from '@/hooks/useSafeParams';
 import GenericTableWithData from '@/modules/dataFetching/components/GenericTableWithData';
-import { SERVICE_COLUMNS } from '@/modules/enrollment/components/dashboardPages/EnrollmentServicesPage';
+import {
+  SERVICE_BASIC_COLUMNS,
+  SERVICE_COLUMNS,
+} from '@/modules/enrollment/components/dashboardPages/EnrollmentServicesPage';
 import EnrollmentDateRangeWithStatus from '@/modules/hmis/components/EnrollmentDateRangeWithStatus';
 import { EnrollmentDashboardRoutes } from '@/routes/routes';
 import {
@@ -31,7 +34,8 @@ const ClientServices: React.FC<{
     () =>
       (
         [
-          ...SERVICE_COLUMNS,
+          SERVICE_BASIC_COLUMNS.dateProvided,
+          SERVICE_BASIC_COLUMNS.serviceType,
           {
             key: 'project',
             header: 'Project Name',
@@ -55,9 +59,15 @@ const ClientServices: React.FC<{
           {
             key: 'en-period',
             header: 'Enrollment Period',
+            optional: true,
             render: (row) => (
               <EnrollmentDateRangeWithStatus enrollment={row.enrollment} />
             ),
+          },
+          {
+            ...SERVICE_COLUMNS.serviceDetails,
+            optional: true,
+            defaultHidden: true,
           },
         ] as ColumnDef<ServiceType>[]
       ).filter((col) => {
@@ -87,6 +97,7 @@ const ClientServices: React.FC<{
           recordType='Service'
           defaultSortOption={ServiceSortOption.DateProvided}
           noSort
+          showOptionalColumns
         />
       </Paper>
     </>


### PR DESCRIPTION
## Description

GH issue: https://github.com/open-path/Green-River/issues/5947

This PR adds the column Service Details, which is already shown on the Enrollment Services table, to the Client Services table as well. It should be an optional column that's hidden by default. The Enrollment Period column on that table is also made optional (but still shown by default) since the table is getting a bit tight for space.

<img width="817" alt="Screenshot 2024-04-24 at 6 07 06 PM" src="https://github.com/greenriver/hmis-frontend/assets/16002775/f01ea66c-e58f-439d-9395-9801745db773">

## Type of change
[//]: # 'remove options that are not relevant'
- [ ] Bug fix
- [x] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
