### PR TITLE
Form detail page update

### DIFF
--- a/src/modules/admin/components/formRules/FormRuleCard.tsx
+++ b/src/modules/admin/components/formRules/FormRuleCard.tsx
@@ -40,6 +40,7 @@ const FormRuleCard: React.FC<Props> = ({ formTitle, formId, formRole }) => {
       <TitleCard
         title='Form Rules'
         headerVariant='border'
+        headerTypographyVariant='h5'
         actions={
           <Stack direction='row' gap={1}>
             <Button

--- a/src/modules/admin/components/forms/FormDefinitionDetailPage.tsx
+++ b/src/modules/admin/components/forms/FormDefinitionDetailPage.tsx
@@ -86,7 +86,7 @@ const FormDefinitionDetailPage = () => {
                     value={formDefinition.role}
                   />
                 </CommonLabeledTextBlock>
-                <CommonLabeledTextBlock title='Form identifier'>
+                <CommonLabeledTextBlock title='Form Identifier'>
                   {formDefinition.identifier}
                 </CommonLabeledTextBlock>
               </Stack>

--- a/src/modules/admin/components/forms/FormDefinitionDetailPage.tsx
+++ b/src/modules/admin/components/forms/FormDefinitionDetailPage.tsx
@@ -1,13 +1,14 @@
 import DashboardCustomizeIcon from '@mui/icons-material/DashboardCustomize';
-import { IconButton, Paper, Stack, Typography } from '@mui/material';
+import { Grid, IconButton, Stack, Typography } from '@mui/material';
 
 import { generatePath } from 'react-router-dom';
 import FormRuleCard from '../formRules/FormRuleCard';
 import ButtonLink from '@/components/elements/ButtonLink';
+import ButtonTooltipContainer from '@/components/elements/ButtonTooltipContainer';
+import { CommonCard } from '@/components/elements/CommonCard';
 import { CommonLabeledTextBlock } from '@/components/elements/CommonLabeledTextBlock';
 import Loading from '@/components/elements/Loading';
 import { EditIcon } from '@/components/elements/SemanticIcons';
-import PageTitle from '@/components/layout/PageTitle';
 import useSafeParams from '@/hooks/useSafeParams';
 import { useStaticFormDialog } from '@/modules/form/hooks/useStaticFormDialog';
 import HmisEnum from '@/modules/hmis/components/HmisEnum';
@@ -38,6 +39,7 @@ const FormDefinitionDetailPage = () => {
     >({
       formRole: StaticFormRole.FormDefinition,
       initialValues: formDefinition || {},
+      localConstants: { definitionId: formId },
       mutationDocument: UpdateFormDefinitionDocument,
       getErrors: (data) => data.updateFormDefinition?.errors || [],
       getVariables: (values) => ({
@@ -51,65 +53,62 @@ const FormDefinitionDetailPage = () => {
 
   return (
     <>
-      <PageTitle
-        title={
-          <Stack direction='row' gap={1}>
-            <Typography variant='h3'>
-              Manage Form: <b>{formDefinition.title}</b>
-            </Typography>
+      <Stack gap={0.5}>
+        <Typography
+          variant='caption'
+          color='links'
+          sx={{ textTransform: 'uppercase', fontWeight: 800 }}
+        >
+          Selected Form
+        </Typography>
+        <Stack direction='row' gap={1} sx={{ pb: 2 }}>
+          <Typography variant='h3'>{formDefinition.title}</Typography>
+          <ButtonTooltipContainer title='Edit Title'>
             <IconButton
               aria-label='edit title'
               onClick={openEditDialog}
               size='small'
+              sx={{ color: (theme) => theme.palette.links }}
             >
               <EditIcon fontSize='inherit' />
             </IconButton>
-          </Stack>
-        }
-        actions={
-          <Stack direction='row' gap={2}>
-            <ButtonLink
-              to={generatePath(AdminDashboardRoutes.EDIT_FORM, { formId })}
-              startIcon={<DashboardCustomizeIcon />}
-              variant='contained'
-            >
-              Edit Form
-            </ButtonLink>
-            {/* Form deletion is not allowed, disabling */}
-            {/* <DeleteMutationButton<
-              DeleteFormDefinitionMutation,
-              DeleteFormDefinitionMutationVariables
-            >
-              queryDocument={DeleteFormDefinitionDocument}
-              variables={{ id: formId }}
-              idPath={'deleteFormDefinition.formDefinition.id'}
-              recordName='Form Definition'
-              ButtonProps={{
-                startIcon: <DeleteIcon />,
-              }}
-              onSuccess={() => {
-                evictQuery('formDefinitions');
-                navigate(generatePath(AdminDashboardRoutes.FORMS));
-              }}
-            >
-              Delete
-            </DeleteMutationButton> */}
-          </Stack>
-        }
-      />
+          </ButtonTooltipContainer>
+        </Stack>
+      </Stack>
 
       <Stack gap={2}>
-        <Paper sx={{ p: 2 }}>
-          <Stack gap={1}>
-            <CommonLabeledTextBlock title='Form Type'>
-              <HmisEnum
-                enumMap={HmisEnums.FormRole}
-                value={formDefinition.role}
-              />
-            </CommonLabeledTextBlock>
-            {/* maybe add more details here, such as recent edit history and project usage */}
-          </Stack>
-        </Paper>
+        <Grid container spacing={2}>
+          <Grid item xs={12} md={8}>
+            <CommonCard title='Form Details'>
+              <Stack gap={1}>
+                <CommonLabeledTextBlock title='Form Type'>
+                  <HmisEnum
+                    enumMap={HmisEnums.FormRole}
+                    value={formDefinition.role}
+                  />
+                </CommonLabeledTextBlock>
+                <CommonLabeledTextBlock title='Form identifier'>
+                  {formDefinition.identifier}
+                </CommonLabeledTextBlock>
+              </Stack>
+            </CommonCard>
+          </Grid>
+          <Grid item xs={12} md={4}>
+            <CommonCard title='Form Actions'>
+              <Stack direction='row' gap={2}>
+                <ButtonLink
+                  to={generatePath(AdminDashboardRoutes.EDIT_FORM, { formId })}
+                  startIcon={<DashboardCustomizeIcon />}
+                  variant='contained'
+                  fullWidth
+                >
+                  Edit Form
+                </ButtonLink>
+                {/* TODO add: preview */}
+              </Stack>
+            </CommonCard>
+          </Grid>
+        </Grid>
         <FormRuleCard
           formId={formId}
           formTitle={formDefinition.title}

--- a/src/modules/admin/components/forms/FormDefinitionDetailPage.tsx
+++ b/src/modules/admin/components/forms/FormDefinitionDetailPage.tsx
@@ -53,7 +53,7 @@ const FormDefinitionDetailPage = () => {
 
   return (
     <>
-      <Stack gap={0.5}>
+      <Stack gap={0.5} sx={{ my: 2 }}>
         <Typography
           variant='caption'
           color='links'
@@ -61,7 +61,7 @@ const FormDefinitionDetailPage = () => {
         >
           Selected Form
         </Typography>
-        <Stack direction='row' gap={1} sx={{ pb: 2 }}>
+        <Stack direction='row' gap={1}>
           <Typography variant='h3'>{formDefinition.title}</Typography>
           <ButtonTooltipContainer title='Edit Title'>
             <IconButton
@@ -75,7 +75,6 @@ const FormDefinitionDetailPage = () => {
           </ButtonTooltipContainer>
         </Stack>
       </Stack>
-
       <Stack gap={2}>
         <Grid container spacing={2}>
           <Grid item xs={12} md={8}>


### PR DESCRIPTION
## Description

* Minor style updates to form detail page
* Add `localConstant` to make it so form identifier field doesn't show up when editing (https://github.com/greenriver/hmis-warehouse/pull/4290)

<img width="1118" alt="Screenshot 2024-04-26 at 12 29 05 PM" src="https://github.com/greenriver/hmis-frontend/assets/5333982/aeeda5b9-3ff4-4b69-b493-c1091aac1494">
<img width="653" alt="Screenshot 2024-04-26 at 12 26 18 PM" src="https://github.com/greenriver/hmis-frontend/assets/5333982/8fa5b21e-0a39-445c-b4a1-b6ced432d898">


## Type of change
- [x] New feature (adds functionality)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
