### PR TITLE
Show auto-exited in Enrollment Status

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -14665,6 +14665,22 @@
             "deprecationReason": null
           },
           {
+            "name": "autoExited",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "ceAssessments",
             "description": null,
             "args": [

--- a/src/api/operations/customCaseNoteQueries.graphql
+++ b/src/api/operations/customCaseNoteQueries.graphql
@@ -49,6 +49,7 @@ query GetClientCaseNotes(
           projectType
           entryDate
           exitDate
+          autoExited
           inProgress
         }
       }

--- a/src/api/operations/customCaseNoteQueries.graphql
+++ b/src/api/operations/customCaseNoteQueries.graphql
@@ -43,14 +43,7 @@ query GetClientCaseNotes(
       nodes {
         ...CustomCaseNoteFields
         enrollment {
-          id
-          lockVersion
-          projectName
-          projectType
-          entryDate
-          exitDate
-          autoExited
-          inProgress
+          ...ClientEnrollmentFields
         }
       }
     }

--- a/src/api/operations/enrollment.fragments.graphql
+++ b/src/api/operations/enrollment.fragments.graphql
@@ -4,6 +4,7 @@ fragment ProjectEnrollmentFields on Enrollment {
   lockVersion
   entryDate
   exitDate
+  autoExited
   inProgress
   relationshipToHoH
   enrollmentCoc
@@ -26,6 +27,7 @@ fragment ClientEnrollmentFields on Enrollment {
   lockVersion
   entryDate
   exitDate
+  autoExited
   moveInDate
   lastBedNightDate
   projectName
@@ -46,6 +48,7 @@ fragment EnrollmentFields on Enrollment {
   entryDate
   exitDate
   exitDestination
+  autoExited
   project {
     ...ProjectNameAndType
   }

--- a/src/api/operations/household.fragments.graphql
+++ b/src/api/operations/household.fragments.graphql
@@ -31,6 +31,7 @@ fragment HouseholdClientFields on HouseholdClient {
     entryDate
     exitDate
     inProgress
+    autoExited
     currentUnit {
       id
       name
@@ -61,5 +62,6 @@ fragment ProjectEnrollmentsHouseholdClientFields on HouseholdClient {
     entryDate
     exitDate
     inProgress
+    autoExited
   }
 }

--- a/src/modules/hmis/components/EnrollmentStatus.tsx
+++ b/src/modules/hmis/components/EnrollmentStatus.tsx
@@ -8,6 +8,7 @@ import {
   ClientEnrollmentFieldsFragment,
   EnrollmentFieldsFragment,
   HouseholdClientFieldsFragment,
+  ProjectEnrollmentFieldsFragment,
 } from '@/types/gqlTypes';
 type Colors =
   | 'disabled'
@@ -26,7 +27,8 @@ const EnrollmentStatus = ({
   enrollment:
     | EnrollmentFieldsFragment
     | HouseholdClientFieldsFragment['enrollment']
-    | ClientEnrollmentFieldsFragment;
+    | ClientEnrollmentFieldsFragment
+    | ProjectEnrollmentFieldsFragment;
   hideIcon?: boolean;
   withActiveRange?: boolean;
   activeColor?: Colors;
@@ -41,6 +43,8 @@ const EnrollmentStatus = ({
     Icon = ErrorOutlineIcon;
     text = 'Incomplete';
     textColor = 'error';
+  } else if (enrollment.autoExited) {
+    text = 'Auto-Exited';
   } else if (!enrollment.exitDate) {
     Icon = HistoryIcon;
     text = 'Open';

--- a/src/types/gqlObjects.ts
+++ b/src/types/gqlObjects.ts
@@ -2033,6 +2033,14 @@ export const HmisObjectSchemas: GqlSchema[] = [
         type: { kind: 'ENUM', name: 'AnnualPercentAMI', ofType: null },
       },
       {
+        name: 'autoExited',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'Boolean', ofType: null },
+        },
+      },
+      {
         name: 'childWelfareMonths',
         type: { kind: 'SCALAR', name: 'Int', ofType: null },
       },

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -2208,6 +2208,7 @@ export type Enrollment = {
   assessmentEligibilities: Array<AssessmentEligibility>;
   assessments: AssessmentsPaginated;
   auditHistory: EnrollmentAuditEventsPaginated;
+  autoExited: Scalars['Boolean']['output'];
   ceAssessments: CeAssessmentsPaginated;
   childWelfareMonths?: Maybe<Scalars['Int']['output']>;
   childWelfareYears?: Maybe<RhyNumberofYears>;
@@ -10078,6 +10079,7 @@ export type GetClientAssessmentsQuery = {
           lockVersion: number;
           entryDate: string;
           exitDate?: string | null;
+          autoExited: boolean;
           moveInDate?: string | null;
           lastBedNightDate?: string | null;
           projectName: string;
@@ -13426,6 +13428,7 @@ export type GetClientEnrollmentsQuery = {
         lockVersion: number;
         entryDate: string;
         exitDate?: string | null;
+        autoExited: boolean;
         moveInDate?: string | null;
         lastBedNightDate?: string | null;
         projectName: string;
@@ -13481,6 +13484,7 @@ export type GetClientServicesQuery = {
           lockVersion: number;
           entryDate: string;
           exitDate?: string | null;
+          autoExited: boolean;
           moveInDate?: string | null;
           lastBedNightDate?: string | null;
           projectName: string;
@@ -13835,6 +13839,7 @@ export type GetClientHouseholdMemberCandidatesQuery = {
               entryDate: string;
               exitDate?: string | null;
               inProgress: boolean;
+              autoExited: boolean;
               currentUnit?: {
                 __typename?: 'Unit';
                 id: string;
@@ -13928,6 +13933,7 @@ export type GetClientFilesQuery = {
           lockVersion: number;
           entryDate: string;
           exitDate?: string | null;
+          autoExited: boolean;
           moveInDate?: string | null;
           lastBedNightDate?: string | null;
           projectName: string;
@@ -16012,6 +16018,7 @@ export type ProjectEnrollmentFieldsFragment = {
   lockVersion: number;
   entryDate: string;
   exitDate?: string | null;
+  autoExited: boolean;
   inProgress: boolean;
   relationshipToHoH: RelationshipToHoH;
   enrollmentCoc?: string | null;
@@ -16046,6 +16053,7 @@ export type ClientEnrollmentFieldsFragment = {
   lockVersion: number;
   entryDate: string;
   exitDate?: string | null;
+  autoExited: boolean;
   moveInDate?: string | null;
   lastBedNightDate?: string | null;
   projectName: string;
@@ -16067,6 +16075,7 @@ export type EnrollmentFieldsFragment = {
   entryDate: string;
   exitDate?: string | null;
   exitDestination?: Destination | null;
+  autoExited: boolean;
   inProgress: boolean;
   relationshipToHoH: RelationshipToHoH;
   enrollmentCoc?: string | null;
@@ -16108,6 +16117,7 @@ export type AllEnrollmentDetailsFragment = {
   entryDate: string;
   exitDate?: string | null;
   exitDestination?: Destination | null;
+  autoExited: boolean;
   inProgress: boolean;
   relationshipToHoH: RelationshipToHoH;
   enrollmentCoc?: string | null;
@@ -16925,6 +16935,7 @@ export type SubmittedEnrollmentResultFieldsFragment = {
   entryDate: string;
   exitDate?: string | null;
   exitDestination?: Destination | null;
+  autoExited: boolean;
   inProgress: boolean;
   relationshipToHoH: RelationshipToHoH;
   enrollmentCoc?: string | null;
@@ -17075,6 +17086,7 @@ export type GetEnrollmentQuery = {
     entryDate: string;
     exitDate?: string | null;
     exitDestination?: Destination | null;
+    autoExited: boolean;
     inProgress: boolean;
     relationshipToHoH: RelationshipToHoH;
     enrollmentCoc?: string | null;
@@ -17182,6 +17194,7 @@ export type GetEnrollmentDetailsQuery = {
     entryDate: string;
     exitDate?: string | null;
     exitDestination?: Destination | null;
+    autoExited: boolean;
     inProgress: boolean;
     relationshipToHoH: RelationshipToHoH;
     enrollmentCoc?: string | null;
@@ -17903,6 +17916,7 @@ export type GetEnrollmentWithHouseholdQuery = {
     entryDate: string;
     exitDate?: string | null;
     exitDestination?: Destination | null;
+    autoExited: boolean;
     inProgress: boolean;
     relationshipToHoH: RelationshipToHoH;
     enrollmentCoc?: string | null;
@@ -17985,6 +17999,7 @@ export type GetEnrollmentWithHouseholdQuery = {
           entryDate: string;
           exitDate?: string | null;
           inProgress: boolean;
+          autoExited: boolean;
           currentUnit?: {
             __typename?: 'Unit';
             id: string;
@@ -25609,6 +25624,7 @@ export type SubmitFormMutation = {
           entryDate: string;
           exitDate?: string | null;
           exitDestination?: Destination | null;
+          autoExited: boolean;
           inProgress: boolean;
           relationshipToHoH: RelationshipToHoH;
           enrollmentCoc?: string | null;
@@ -26279,6 +26295,7 @@ export type HouseholdFieldsFragment = {
       entryDate: string;
       exitDate?: string | null;
       inProgress: boolean;
+      autoExited: boolean;
       currentUnit?: { __typename?: 'Unit'; id: string; name: string } | null;
     };
   }>;
@@ -26356,6 +26373,7 @@ export type HouseholdClientFieldsFragment = {
     entryDate: string;
     exitDate?: string | null;
     inProgress: boolean;
+    autoExited: boolean;
     currentUnit?: { __typename?: 'Unit'; id: string; name: string } | null;
   };
 };
@@ -26395,6 +26413,7 @@ export type ProjectEnrollmentsHouseholdFieldsFragment = {
       entryDate: string;
       exitDate?: string | null;
       inProgress: boolean;
+      autoExited: boolean;
     };
   }>;
 };
@@ -26429,6 +26448,7 @@ export type ProjectEnrollmentsHouseholdClientFieldsFragment = {
     entryDate: string;
     exitDate?: string | null;
     inProgress: boolean;
+    autoExited: boolean;
   };
 };
 
@@ -26515,6 +26535,7 @@ export type GetHouseholdQuery = {
         entryDate: string;
         exitDate?: string | null;
         inProgress: boolean;
+        autoExited: boolean;
         currentUnit?: { __typename?: 'Unit'; id: string; name: string } | null;
       };
     }>;
@@ -27853,6 +27874,7 @@ export type ProjectEnrollmentQueryEnrollmentFieldsFragment = {
   lockVersion: number;
   entryDate: string;
   exitDate?: string | null;
+  autoExited: boolean;
   inProgress: boolean;
   relationshipToHoH: RelationshipToHoH;
   enrollmentCoc?: string | null;
@@ -28097,6 +28119,7 @@ export type GetProjectEnrollmentsQuery = {
         lockVersion: number;
         entryDate: string;
         exitDate?: string | null;
+        autoExited: boolean;
         inProgress: boolean;
         relationshipToHoH: RelationshipToHoH;
         enrollmentCoc?: string | null;
@@ -28186,6 +28209,7 @@ export type GetProjectHouseholdsQuery = {
             entryDate: string;
             exitDate?: string | null;
             inProgress: boolean;
+            autoExited: boolean;
           };
         }>;
       }>;
@@ -28285,6 +28309,7 @@ export type GetProjectAssessmentsQuery = {
           entryDate: string;
           exitDate?: string | null;
           exitDestination?: Destination | null;
+          autoExited: boolean;
           inProgress: boolean;
           relationshipToHoH: RelationshipToHoH;
           enrollmentCoc?: string | null;
@@ -32124,6 +32149,7 @@ export const ClientEnrollmentFieldsFragmentDoc = gql`
     lockVersion
     entryDate
     exitDate
+    autoExited
     moveInDate
     lastBedNightDate
     projectName
@@ -32160,6 +32186,7 @@ export const EnrollmentFieldsFragmentDoc = gql`
     entryDate
     exitDate
     exitDestination
+    autoExited
     project {
       ...ProjectNameAndType
     }
@@ -32560,6 +32587,7 @@ export const HouseholdClientFieldsFragmentDoc = gql`
       entryDate
       exitDate
       inProgress
+      autoExited
       currentUnit {
         id
         name
@@ -32598,6 +32626,7 @@ export const ProjectEnrollmentsHouseholdClientFieldsFragmentDoc = gql`
       entryDate
       exitDate
       inProgress
+      autoExited
     }
   }
   ${ClientNameFragmentDoc}
@@ -32817,6 +32846,7 @@ export const ProjectEnrollmentFieldsFragmentDoc = gql`
     lockVersion
     entryDate
     exitDate
+    autoExited
     inProgress
     relationshipToHoH
     enrollmentCoc

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -15880,12 +15880,21 @@ export type GetClientCaseNotesQuery = {
           __typename?: 'Enrollment';
           id: string;
           lockVersion: number;
-          projectName: string;
-          projectType?: ProjectType | null;
           entryDate: string;
           exitDate?: string | null;
           autoExited: boolean;
+          moveInDate?: string | null;
+          lastBedNightDate?: string | null;
+          projectName: string;
+          organizationName: string;
+          projectType?: ProjectType | null;
           inProgress: boolean;
+          relationshipToHoH: RelationshipToHoH;
+          access: {
+            __typename?: 'EnrollmentAccess';
+            id: string;
+            canViewEnrollmentDetails: boolean;
+          };
         };
         user?: {
           __typename: 'ApplicationUser';
@@ -36984,20 +36993,14 @@ export const GetClientCaseNotesDocument = gql`
         nodes {
           ...CustomCaseNoteFields
           enrollment {
-            id
-            lockVersion
-            projectName
-            projectType
-            entryDate
-            exitDate
-            autoExited
-            inProgress
+            ...ClientEnrollmentFields
           }
         }
       }
     }
   }
   ${CustomCaseNoteFieldsFragmentDoc}
+  ${ClientEnrollmentFieldsFragmentDoc}
 `;
 
 /**

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -15884,6 +15884,7 @@ export type GetClientCaseNotesQuery = {
           projectType?: ProjectType | null;
           entryDate: string;
           exitDate?: string | null;
+          autoExited: boolean;
           inProgress: boolean;
         };
         user?: {
@@ -36989,6 +36990,7 @@ export const GetClientCaseNotesDocument = gql`
             projectType
             entryDate
             exitDate
+            autoExited
             inProgress
           }
         }


### PR DESCRIPTION
## Description

GH issue: https://github.com/open-path/Green-River/issues/5741
Depends on hmis-warehouse PR: https://github.com/greenriver/hmis-warehouse/pull/4293

This PR updates the Enrollment Status component to say "Auto-Exited" when the enrollment was auto-exited. The component is used in a lot of places, so here are the usages I've QAd:
- [x] `HouseholdMemberTable.tsx` - `EnrollmentStatus` is used in `HOUSEHOLD_MEMBER_COLUMNS`
    - [x] `HouseholdMemberTable` rendered by `EnrollmentOverview`: 
       <img width="613" alt="Screenshot 2024-04-29 at 8 26 59 AM" src="https://github.com/greenriver/hmis-frontend/assets/16002775/1c29f4ef-699d-4d74-9188-ad51954fee56">
    - [x] `HouseholdMemberTable` is also used in a couple other places, but without the status column.
- [x] `ProjectClientEnrollmentsTable.tsx` - `EnrollmentStatus` is used in `ENROLLMENT_STATUS_COL`
    - [x] Usage in `ProjectClientEnrollmentsTable`:
       <img width="756" alt="Screenshot 2024-04-29 at 8 36 29 AM" src="https://github.com/greenriver/hmis-frontend/assets/16002775/b7607303-9a90-4429-85e1-f681f3f20c4a">
    - [x] `ENROLLMENT_STATUS_COL` is also used in `ClientEnrollmentCard`, which only shows *recent* enrollments ([within 30 days](https://github.com/greenriver/hmis-frontend/blob/c37b83c10d89e6bf897e65d8241ad8c0a3eb1c44/src/modules/hmis/hmisUtil.ts#L332-L341)). Since we require auto-exits to configure a length of absence >= 30 days, I think this usage should never occur in practice? But I did QA it anyway by manually maneuvering the code, and it looks good:
      <img width="572" alt="Screenshot 2024-04-29 at 8 56 38 AM" src="https://github.com/greenriver/hmis-frontend/assets/16002775/359aa7c5-cb03-4fee-a201-9ebf25d73b80">
- [x] `ProjectHouseholdsTable.tsx`
      <img width="959" alt="Screenshot 2024-04-29 at 8 39 27 AM" src="https://github.com/greenriver/hmis-frontend/assets/16002775/ab52a221-feca-47d9-b4b3-b4ef3b6b66e5">
- [x] `EnrollmentDetails.tsx` - `EnrollmentStatus` component is only used directly here if the enrollment is incomplete.

## Type of change
[//]: # 'remove options that are not relevant'
- [ ] Bug fix
- [x] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
