### PR TITLE
Link enrollment from assessment view

### DIFF
--- a/src/components/elements/RouterLink.tsx
+++ b/src/components/elements/RouterLink.tsx
@@ -24,7 +24,12 @@ const RouterLink = forwardRef<RouterLinkProps, any>(
       target={openInNew ? '_blank' : undefined}
     >
       {openInNew || Icon ? (
-        <Stack direction={'row'} gap={0.75} alignItems='center'>
+        <Stack
+          direction={'row'}
+          gap={0.75}
+          alignItems='center'
+          sx={{ display: 'inline-flex', textDecoration: 'inherit' }}
+        >
           {children}
           {openInNew ? (
             <OpenInNewIcon fontSize='inherit' />

--- a/src/modules/assessments/components/AssessmentTitle.tsx
+++ b/src/modules/assessments/components/AssessmentTitle.tsx
@@ -3,7 +3,10 @@ import { Stack } from '@mui/system';
 import { ReactNode, useState } from 'react';
 import { useRelatedAnnualAssessments } from '../hooks/useRelatedAnnualAssessments';
 import RouterLink from '@/components/elements/RouterLink';
-import { parseAndFormatDate } from '@/modules/hmis/hmisUtil';
+import {
+  parseAndFormatDate,
+  parseAndFormatDateRange,
+} from '@/modules/hmis/hmisUtil';
 import { Routes } from '@/routes/routes';
 import { AssessmentRole } from '@/types/gqlTypes';
 import { generateSafePath } from '@/utils/pathEncoding';
@@ -95,10 +98,8 @@ const AssessmentTitle = ({
             clientId,
           })}
           openInNew
-          sx={{ display: 'inline-flex' }}
         >
-          {projectName} ({parseAndFormatDate(entryDate)} -{' '}
-          {exitDate ? parseAndFormatDate(exitDate) : 'Active'})
+          {projectName} ({parseAndFormatDateRange(entryDate, exitDate)})
         </RouterLink>
       </Typography>
       {subtitle}

--- a/src/modules/assessments/components/AssessmentTitle.tsx
+++ b/src/modules/assessments/components/AssessmentTitle.tsx
@@ -4,15 +4,20 @@ import { ReactNode, useState } from 'react';
 import { useRelatedAnnualAssessments } from '../hooks/useRelatedAnnualAssessments';
 import RouterLink from '@/components/elements/RouterLink';
 import { parseAndFormatDate } from '@/modules/hmis/hmisUtil';
+import { Routes } from '@/routes/routes';
 import { AssessmentRole } from '@/types/gqlTypes';
+import { generateSafePath } from '@/utils/pathEncoding';
 
 export interface AssessmentTitleProps {
   projectName: string;
   assessmentTitle?: ReactNode;
   assessmentRole: AssessmentRole;
   clientName: ReactNode;
+  clientId: string;
   assessmentId?: string;
   enrollmentId: string;
+  entryDate: string;
+  exitDate?: string | null;
   householdId: string;
   embeddedInWorkflow?: boolean;
   householdSize: number;
@@ -22,8 +27,11 @@ const AssessmentTitle = ({
   projectName,
   assessmentTitle,
   clientName,
+  clientId,
   householdId,
   enrollmentId,
+  entryDate,
+  exitDate,
   assessmentId,
   embeddedInWorkflow,
   assessmentRole,
@@ -81,7 +89,17 @@ const AssessmentTitle = ({
           {assessmentTitle}
           {': '}
         </b>
-        {projectName}
+        <RouterLink
+          to={generateSafePath(Routes.ENROLLMENT_DASHBOARD, {
+            enrollmentId,
+            clientId,
+          })}
+          openInNew
+          sx={{ display: 'inline-flex' }}
+        >
+          {projectName} ({parseAndFormatDate(entryDate)} -{' '}
+          {exitDate ? parseAndFormatDate(exitDate) : 'Active'})
+        </RouterLink>
       </Typography>
       {subtitle}
     </Stack>

--- a/src/modules/assessments/components/IndividualAssessment.tsx
+++ b/src/modules/assessments/components/IndividualAssessment.tsx
@@ -150,8 +150,11 @@ const IndividualAssessment = ({
     <AssessmentTitle
       assessmentTitle={title}
       clientName={clientBriefName(client)}
+      clientId={client.id}
       projectName={enrollment.project.projectName}
       enrollmentId={enrollment.id}
+      entryDate={enrollment.entryDate}
+      exitDate={enrollment.exitDate}
       householdId={enrollment.householdId}
       assessmentRole={formRole as unknown as AssessmentRole}
       embeddedInWorkflow={embeddedInWorkflow}


### PR DESCRIPTION
## Description

GH issue: https://github.com/open-path/Green-River/issues/5939
This PR adds a link in the Assessment view to get to the relevant Enrollment. A few new props are added to the AssessmentTitle component so that it can display info about the enrollment in the link text.
<img width="468" alt="Screenshot 2024-04-29 at 2 50 50 PM" src="https://github.com/greenriver/hmis-frontend/assets/16002775/b38be29f-a59c-4240-8119-4de3091c7e33">

## Type of change
[//]: # 'remove options that are not relevant'
- [ ] Bug fix
- [x] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
