### PR TITLE
Restrict referral project pick list to open projects

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -30229,6 +30229,12 @@
             "deprecationReason": null
           },
           {
+            "name": "OPEN_PROJECTS",
+            "description": "Open Projects that the user can see",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "ORGANIZATION",
             "description": "All Organizations that the User can see",
             "isDeprecated": false,

--- a/src/modules/projects/components/ProjectOutgoingReferralForm.tsx
+++ b/src/modules/projects/components/ProjectOutgoingReferralForm.tsx
@@ -108,7 +108,7 @@ const ProjectOutgoingReferralForm: React.FC<Props> = ({
             required: true,
             linkId: 'project',
             text: 'Project',
-            pickListReference: PickListType.Project,
+            pickListReference: PickListType.OpenProjects,
           }}
           itemChanged={({ value }) =>
             setFormState((old) => ({

--- a/src/types/gqlEnums.ts
+++ b/src/types/gqlEnums.ts
@@ -934,6 +934,7 @@ export const HmisEnums = {
     EXTERNAL_FORM_TYPES_FOR_PROJECT: 'External form types for the project.',
     GEOCODE: 'GEOCODE',
     OPEN_HOH_ENROLLMENTS_FOR_PROJECT: 'Open HoH enrollments at the project.',
+    OPEN_PROJECTS: 'Open Projects that the user can see',
     ORGANIZATION: 'All Organizations that the User can see',
     POSSIBLE_UNIT_TYPES_FOR_PROJECT:
       'Unit types that are eligible to be added to project',

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -4478,6 +4478,8 @@ export enum PickListType {
   Geocode = 'GEOCODE',
   /** Open HoH enrollments at the project. */
   OpenHohEnrollmentsForProject = 'OPEN_HOH_ENROLLMENTS_FOR_PROJECT',
+  /** Open Projects that the user can see */
+  OpenProjects = 'OPEN_PROJECTS',
   /** All Organizations that the User can see */
   Organization = 'ORGANIZATION',
   /** Unit types that are eligible to be added to project */


### PR DESCRIPTION
## Description

This PR updates the outgoing referrals workflow to pick from a pick list of only Open projects.

GH issue: https://github.com/open-path/Green-River/issues/5938
Depends on hmis-warehouse PR: https://github.com/greenriver/hmis-warehouse/pull/4301

## Type of change
[//]: # 'remove options that are not relevant'
- [ ] Bug fix
- [x] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
