### PR TITLE
Bring generated files up to date

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -14696,6 +14696,22 @@
             "deprecationReason": null
           },
           {
+            "name": "autoExited",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "ceAssessments",
             "description": null,
             "args": [

--- a/src/types/gqlObjects.ts
+++ b/src/types/gqlObjects.ts
@@ -2033,6 +2033,14 @@ export const HmisObjectSchemas: GqlSchema[] = [
         type: { kind: 'ENUM', name: 'AnnualPercentAMI', ofType: null },
       },
       {
+        name: 'autoExited',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'Boolean', ofType: null },
+        },
+      },
+      {
         name: 'childWelfareMonths',
         type: { kind: 'SCALAR', name: 'Int', ofType: null },
       },

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -2212,6 +2212,7 @@ export type Enrollment = {
   assessmentEligibilities: Array<AssessmentEligibility>;
   assessments: AssessmentsPaginated;
   auditHistory: EnrollmentAuditEventsPaginated;
+  autoExited: Scalars['Boolean']['output'];
   ceAssessments: CeAssessmentsPaginated;
   childWelfareMonths?: Maybe<Scalars['Int']['output']>;
   childWelfareYears?: Maybe<RhyNumberofYears>;


### PR DESCRIPTION
## Description

This PR is a follow-up to https://github.com/greenriver/hmis-frontend/pull/752, fixing a few spots where `autoExited` should've been added to the schema but got left behind. Sorry about this!

https://github.com/open-path/Green-River/issues/5741

## Type of change
[//]: # 'remove options that are not relevant'
- [ ] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (eslint)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
