### PR TITLE
Add form preview page and adjust permissions

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -37209,6 +37209,22 @@
             "deprecationReason": null
           },
           {
+            "name": "canManageForms",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "canManageIncomingReferrals",
             "description": null,
             "args": [],

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -20288,22 +20288,6 @@
             "deprecationReason": null
           },
           {
-            "name": "status",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "ENUM",
-                "name": "FormStatus",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "system",
             "description": null,
             "args": [],
@@ -22358,35 +22342,6 @@
         "inputFields": null,
         "interfaces": [],
         "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "ENUM",
-        "name": "FormStatus",
-        "description": null,
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": [
-          {
-            "name": "draft",
-            "description": "3 - Draft",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "published",
-            "description": "2 - Published",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "retired",
-            "description": "1 - Retired",
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
         "possibleTypes": null
       },
       {

--- a/src/api/operations/access.fragments.graphql
+++ b/src/api/operations/access.fragments.graphql
@@ -33,6 +33,7 @@ fragment RootPermissions on QueryAccess {
   canTransferEnrollments
   canSplitHouseholds
   canConfigureDataCollection
+  canManageForms
   canViewClientAlerts
   canManageExternalFormSubmissions
 }

--- a/src/components/layout/dashboard/contextHeader/useDashboardBreadcrumbs.tsx
+++ b/src/components/layout/dashboard/contextHeader/useDashboardBreadcrumbs.tsx
@@ -254,6 +254,10 @@ export const useAdminBreadcrumbConfig = (): CrumbConfig => {
         parent: AdminDashboardRoutes.VIEW_FORM,
         title: 'Edit Form',
       },
+      [AdminDashboardRoutes.PREVIEW_FORM]: {
+        parent: AdminDashboardRoutes.VIEW_FORM,
+        title: 'Preview Form',
+      },
       [AdminDashboardRoutes.USER_CLIENT_ACCESS_HISTORY]: {
         parent: AdminDashboardRoutes.USERS,
         title: 'Audit User',

--- a/src/modules/admin/components/forms/FormDefinitionDetailPage.tsx
+++ b/src/modules/admin/components/forms/FormDefinitionDetailPage.tsx
@@ -12,6 +12,7 @@ import { EditIcon } from '@/components/elements/SemanticIcons';
 import useSafeParams from '@/hooks/useSafeParams';
 import { useStaticFormDialog } from '@/modules/form/hooks/useStaticFormDialog';
 import HmisEnum from '@/modules/hmis/components/HmisEnum';
+import { RootPermissionsFilter } from '@/modules/permissions/PermissionsFilters';
 import { AdminDashboardRoutes } from '@/routes/routes';
 import { HmisEnums } from '@/types/gqlEnums';
 import {
@@ -94,16 +95,28 @@ const FormDefinitionDetailPage = () => {
           </Grid>
           <Grid item xs={12} md={4}>
             <CommonCard title='Form Actions'>
-              <Stack direction='row' gap={2}>
+              <Stack gap={1}>
+                <RootPermissionsFilter permissions={'canManageForms'}>
+                  <ButtonLink
+                    to={generatePath(AdminDashboardRoutes.EDIT_FORM, {
+                      formId,
+                    })}
+                    startIcon={<DashboardCustomizeIcon />}
+                    variant='contained'
+                    fullWidth
+                  >
+                    Edit Form
+                  </ButtonLink>
+                </RootPermissionsFilter>
                 <ButtonLink
-                  to={generatePath(AdminDashboardRoutes.EDIT_FORM, { formId })}
-                  startIcon={<DashboardCustomizeIcon />}
-                  variant='contained'
+                  to={generatePath(AdminDashboardRoutes.PREVIEW_FORM, {
+                    formId,
+                  })}
+                  variant='outlined'
                   fullWidth
                 >
-                  Edit Form
+                  Preview Form
                 </ButtonLink>
-                {/* TODO add: preview */}
               </Stack>
             </CommonCard>
           </Grid>

--- a/src/modules/admin/components/forms/FormDefinitionsPage.tsx
+++ b/src/modules/admin/components/forms/FormDefinitionsPage.tsx
@@ -5,6 +5,7 @@ import FormDefinitionTable from './FormDefinitionTable';
 import PageTitle from '@/components/layout/PageTitle';
 import useDebouncedState from '@/hooks/useDebouncedState';
 import { useStaticFormDialog } from '@/modules/form/hooks/useStaticFormDialog';
+import { RootPermissionsFilter } from '@/modules/permissions/PermissionsFilters';
 import CommonSearchInput from '@/modules/search/components/CommonSearchInput';
 import { AdminDashboardRoutes } from '@/routes/routes';
 import {
@@ -44,13 +45,15 @@ const FormDefinitionsPage = () => {
       <PageTitle
         title='Forms'
         actions={
-          <Button
-            startIcon={<AddIcon />}
-            variant='outlined'
-            onClick={() => openCreateDialog()}
-          >
-            New Form
-          </Button>
+          <RootPermissionsFilter permissions={'canManageForms'}>
+            <Button
+              startIcon={<AddIcon />}
+              variant='outlined'
+              onClick={() => openCreateDialog()}
+            >
+              New Form
+            </Button>
+          </RootPermissionsFilter>
         }
       />
       <Grid container gap={2}>

--- a/src/modules/admin/components/forms/FormPreview.tsx
+++ b/src/modules/admin/components/forms/FormPreview.tsx
@@ -104,7 +104,7 @@ const FormPreview = () => {
         />
       ))
     );
-  }, [formDefinition, formValues, localConstants, toggleValue]);
+  }, [formDefinition, formValues, initialValues, localConstants, toggleValue]);
 
   if (loading && !formDefinition) return <Loading />;
   if (error) throw error;

--- a/src/modules/admin/components/forms/FormPreview.tsx
+++ b/src/modules/admin/components/forms/FormPreview.tsx
@@ -20,9 +20,23 @@ import {
   AlwaysPresentLocalConstants,
   getInitialValues,
   getItemMap,
-  getLeftNavItems,
+  getFormStepperItems,
 } from '@/modules/form/util/formUtil';
 import { useGetFormDefinitionFieldsForEditorQuery } from '@/types/gqlTypes';
+
+type PreviewMode = 'preview' | 'readOnly';
+const toggleItems: ToggleItem<PreviewMode>[] = [
+  {
+    value: 'preview',
+    label: 'Preview Form',
+    Icon: ListIcon,
+  },
+  {
+    value: 'readOnly',
+    label: 'Read Only View',
+    Icon: AccountBoxIcon,
+  },
+];
 
 const FormPreview = () => {
   const { formId } = useSafeParams() as { formId: string };
@@ -50,50 +64,47 @@ const FormPreview = () => {
   }, [formDefinition?.definition, localConstants]);
   const [formValues, setFormValues] = useState<object>(initialValues);
 
-  type PreviewMode = 'preview' | 'readOnly';
-  const toggleItems: ToggleItem<PreviewMode>[] = [
-    {
-      value: 'preview',
-      label: 'Preview Form',
-      Icon: ListIcon,
-    },
-    {
-      value: 'readOnly',
-      label: 'Read Only View',
-      Icon: AccountBoxIcon,
-    },
-  ];
   const [toggleValue, setToggleValue] = useState<PreviewMode>('preview');
+
   const itemMap = useMemo(
     () => formDefinition && getItemMap(formDefinition.definition),
     [formDefinition]
   );
-  const leftNavItems = useMemo(
+
+  const formStepperItems = useMemo(
     () =>
-      getLeftNavItems(formDefinition, itemMap, initialValues, localConstants),
+      getFormStepperItems(
+        formDefinition,
+        itemMap,
+        initialValues,
+        localConstants
+      ),
     [itemMap, formDefinition, initialValues, localConstants]
   );
 
-  const form =
-    formDefinition &&
-    (toggleValue === 'readOnly' ? (
-      <DynamicView
-        definition={formDefinition.definition}
-        localConstants={localConstants}
-        values={formValues}
-      />
-    ) : (
-      <DynamicForm
-        definition={formDefinition.definition}
-        onSubmit={() => {}}
-        onSaveDraft={(values) => setFormValues(values)}
-        errors={{ errors: [], warnings: [] }}
-        localConstants={localConstants}
-        initialValues={formValues}
-        FormActionProps={{ config: [] }}
-        ref={formRef}
-      />
-    ));
+  const form = useMemo(() => {
+    return (
+      formDefinition &&
+      (toggleValue === 'readOnly' ? (
+        <DynamicView
+          definition={formDefinition.definition}
+          localConstants={localConstants}
+          values={formValues}
+        />
+      ) : (
+        <DynamicForm
+          definition={formDefinition.definition}
+          onSubmit={() => {}}
+          onSaveDraft={(values) => setFormValues(values)}
+          errors={{ errors: [], warnings: [] }}
+          localConstants={localConstants}
+          initialValues={initialValues}
+          FormActionProps={{ config: [] }}
+          ref={formRef}
+        />
+      ))
+    );
+  }, [formDefinition, formValues, localConstants, toggleValue]);
 
   if (loading && !formDefinition) return <Loading />;
   if (error) throw error;
@@ -113,9 +124,9 @@ const FormPreview = () => {
         sx={{ mb: 4 }}
       />
 
-      {leftNavItems ? (
+      {formStepperItems ? (
         <Grid container spacing={2} sx={{ pb: 20, mt: 0 }}>
-          <FormNavigation items={leftNavItems}>{form}</FormNavigation>
+          <FormNavigation items={formStepperItems}>{form}</FormNavigation>
         </Grid>
       ) : (
         form

--- a/src/modules/admin/components/forms/FormPreview.tsx
+++ b/src/modules/admin/components/forms/FormPreview.tsx
@@ -1,0 +1,127 @@
+import AccountBoxIcon from '@mui/icons-material/AccountBox';
+import ListIcon from '@mui/icons-material/List';
+import { Grid } from '@mui/material';
+import React, { useMemo, useRef, useState } from 'react';
+import CommonToggle, { ToggleItem } from '@/components/elements/CommonToggle';
+import Loading from '@/components/elements/Loading';
+import {
+  CONTEXT_HEADER_HEIGHT,
+  STICKY_BAR_HEIGHT,
+} from '@/components/layout/layoutConstants';
+import PageTitle from '@/components/layout/PageTitle';
+import useSafeParams from '@/hooks/useSafeParams';
+import { useScrollToHash } from '@/hooks/useScrollToHash';
+import DynamicForm, {
+  DynamicFormRef,
+} from '@/modules/form/components/DynamicForm';
+import FormNavigation from '@/modules/form/components/FormNavigation';
+import DynamicView from '@/modules/form/components/viewable/DynamicView';
+import {
+  AlwaysPresentLocalConstants,
+  getInitialValues,
+  getItemMap,
+  getLeftNavItems,
+} from '@/modules/form/util/formUtil';
+import { useGetFormDefinitionForEditorQuery } from '@/types/gqlTypes';
+
+const FormPreview = () => {
+  const { formId } = useSafeParams() as { formId: string };
+  const {
+    data: { formDefinition } = {},
+    loading,
+    error,
+  } = useGetFormDefinitionForEditorQuery({
+    variables: { id: formId },
+  });
+
+  const formRef = useRef<DynamicFormRef>(null);
+
+  // This form preview is not client- or enrollment-specific, so just use the always-present local constants
+  const localConstants = AlwaysPresentLocalConstants;
+
+  useScrollToHash(loading, STICKY_BAR_HEIGHT + CONTEXT_HEADER_HEIGHT);
+
+  const initialValues = useMemo(() => {
+    return formDefinition?.definition
+      ? {
+          ...getInitialValues(formDefinition?.definition, localConstants),
+        }
+      : {};
+  }, [formDefinition?.definition, localConstants]);
+  const [formValues, setFormValues] = useState<object>(initialValues);
+
+  type PreviewMode = 'preview' | 'readOnly';
+  const toggleItems: ToggleItem<PreviewMode>[] = [
+    {
+      value: 'preview',
+      label: 'Preview Form',
+      Icon: ListIcon,
+    },
+    {
+      value: 'readOnly',
+      label: 'Read Only View',
+      Icon: AccountBoxIcon,
+    },
+  ];
+  const [toggleValue, setToggleValue] = useState<PreviewMode>('preview');
+  const itemMap = useMemo(
+    () => formDefinition && getItemMap(formDefinition.definition),
+    [formDefinition]
+  );
+  const leftNavItems = useMemo(
+    () =>
+      getLeftNavItems(formDefinition, itemMap, initialValues, localConstants),
+    [itemMap, formDefinition, initialValues, localConstants]
+  );
+
+  const form =
+    formDefinition &&
+    (toggleValue === 'readOnly' ? (
+      <DynamicView
+        definition={formDefinition.definition}
+        localConstants={localConstants}
+        values={formValues}
+      />
+    ) : (
+      <DynamicForm
+        definition={formDefinition.definition}
+        onSubmit={() => {}}
+        onSaveDraft={(values) => setFormValues(values)}
+        errors={{ errors: [], warnings: [] }}
+        localConstants={localConstants}
+        initialValues={formValues}
+        FormActionProps={{ config: [] }}
+        ref={formRef}
+      />
+    ));
+
+  if (loading && !formDefinition) return <Loading />;
+  if (error) throw error;
+
+  return (
+    <>
+      <PageTitle title={`Preview Form: ${formDefinition?.title}`} />
+      <CommonToggle
+        value={toggleValue}
+        onChange={(value) => {
+          setToggleValue(value);
+          formRef.current?.SaveIfDirty();
+        }}
+        items={toggleItems}
+        size='small'
+        variant='gray'
+        sx={{ mb: 4 }}
+      />
+
+      {leftNavItems ? (
+        <Grid container spacing={2} sx={{ pb: 20, mt: 0 }}>
+          <FormNavigation items={leftNavItems}>{form}</FormNavigation>
+        </Grid>
+      ) : (
+        form
+      )}
+    </>
+  );
+};
+
+export default FormPreview;

--- a/src/modules/form/components/EditRecord.tsx
+++ b/src/modules/form/components/EditRecord.tsx
@@ -4,10 +4,7 @@ import { ReactNode, Ref, useMemo } from 'react';
 import { useDynamicFormHandlersForRecord } from '../hooks/useDynamicFormHandlersForRecord';
 import useFormDefinition from '../hooks/useFormDefinition';
 import { LocalConstants, SubmitFormAllowedTypes } from '../types';
-import {
-  AlwaysPresentLocalConstants,
-  shouldEnableItem,
-} from '../util/formUtil';
+import { AlwaysPresentLocalConstants, getLeftNavItems } from '../util/formUtil';
 
 import FormNavigation, { FormNavigationProps } from './FormNavigation';
 
@@ -22,7 +19,7 @@ import DynamicForm, {
   DynamicFormProps,
   DynamicFormRef,
 } from '@/modules/form/components/DynamicForm';
-import { FormInput, ItemType, RecordFormRole } from '@/types/gqlTypes';
+import { FormInput, RecordFormRole } from '@/types/gqlTypes';
 
 export interface Props<RecordType>
   extends Omit<
@@ -89,33 +86,23 @@ const EditRecord = <RecordType extends SubmitFormAllowedTypes>({
   useScrollToHash(definitionLoading, top);
 
   // Top-level items for the left nav (of >=3 groups)
-  const leftNavItems = useMemo(() => {
-    if (!formDefinition || !itemMap) return false;
-
-    let topLevelItems = formDefinition.definition.item.filter(
-      (i) => i.type === ItemType.Group && !i.hidden
-    );
-
-    if (topLevelItems.length < minGroupsForLeftNav) return false;
-
-    // Remove disabled groups
-    topLevelItems = topLevelItems.filter((item) =>
-      shouldEnableItem({
-        item,
-        values: initialValues,
+  const leftNavItems = useMemo(
+    () =>
+      getLeftNavItems(
+        formDefinition,
         itemMap,
-        localConstants: localConstants || {},
-      })
-    );
-    if (topLevelItems.length < 3) return false;
-    return topLevelItems;
-  }, [
-    itemMap,
-    formDefinition,
-    initialValues,
-    minGroupsForLeftNav,
-    localConstants,
-  ]);
+        initialValues,
+        localConstants,
+        minGroupsForLeftNav
+      ),
+    [
+      itemMap,
+      formDefinition,
+      initialValues,
+      minGroupsForLeftNav,
+      localConstants,
+    ]
+  );
 
   if (definitionLoading) return <Loading />;
   if (!formDefinition) return <NotFound text='Form definition not found.' />;

--- a/src/modules/form/components/EditRecord.tsx
+++ b/src/modules/form/components/EditRecord.tsx
@@ -4,7 +4,10 @@ import { ReactNode, Ref, useMemo } from 'react';
 import { useDynamicFormHandlersForRecord } from '../hooks/useDynamicFormHandlersForRecord';
 import useFormDefinition from '../hooks/useFormDefinition';
 import { LocalConstants, SubmitFormAllowedTypes } from '../types';
-import { AlwaysPresentLocalConstants, getLeftNavItems } from '../util/formUtil';
+import {
+  AlwaysPresentLocalConstants,
+  getFormStepperItems,
+} from '../util/formUtil';
 
 import FormNavigation, { FormNavigationProps } from './FormNavigation';
 
@@ -88,7 +91,7 @@ const EditRecord = <RecordType extends SubmitFormAllowedTypes>({
   // Top-level items for the left nav (of >=3 groups)
   const leftNavItems = useMemo(
     () =>
-      getLeftNavItems(
+      getFormStepperItems(
         formDefinition,
         itemMap,
         initialValues,

--- a/src/modules/form/util/formUtil.ts
+++ b/src/modules/form/util/formUtil.ts
@@ -1476,6 +1476,36 @@ export const parseOccurrencePointFormDefinition = (
 
   return { displayTitle, isEditable, readOnlyDefinition };
 };
+
+export const getLeftNavItems = (
+  formDefinition: FormDefinitionFieldsFragment | undefined | null,
+  itemMap: ItemMap | undefined | null,
+  initialValues: Record<string, any>,
+  localConstants: LocalConstants,
+  minGroupsForLeftNav: number = 3
+) => {
+  if (!formDefinition || !itemMap) return false;
+
+  let leftNavItems = formDefinition.definition.item.filter(
+    (i) => i.type === ItemType.Group && !i.hidden
+  );
+
+  if (leftNavItems.length < minGroupsForLeftNav) return false;
+
+  // Remove disabled groups
+  leftNavItems = leftNavItems.filter((item) =>
+    shouldEnableItem({
+      item,
+      values: initialValues,
+      itemMap,
+      localConstants: localConstants || {},
+    })
+  );
+  if (leftNavItems.length < 3) return false;
+
+  return leftNavItems;
+};
+
 export const MAX_INPUT_AND_LABEL_WIDTH = 500;
 export const FIXED_WIDTH_MEDIUM = 350;
 export const FIXED_WIDTH_SMALL = 200;

--- a/src/modules/form/util/formUtil.ts
+++ b/src/modules/form/util/formUtil.ts
@@ -1477,23 +1477,21 @@ export const parseOccurrencePointFormDefinition = (
   return { displayTitle, isEditable, readOnlyDefinition };
 };
 
-export const getLeftNavItems = (
+export const getFormStepperItems = (
   formDefinition: FormDefinitionFieldsFragment | undefined | null,
   itemMap: ItemMap | undefined | null,
   initialValues: Record<string, any>,
   localConstants: LocalConstants,
-  minGroupsForLeftNav: number = 3
+  minGroupsToDisplay: number = 3
 ) => {
   if (!formDefinition || !itemMap) return false;
 
-  let leftNavItems = formDefinition.definition.item.filter(
+  let items = formDefinition.definition.item.filter(
     (i) => i.type === ItemType.Group && !i.hidden
   );
 
-  if (leftNavItems.length < minGroupsForLeftNav) return false;
-
   // Remove disabled groups
-  leftNavItems = leftNavItems.filter((item) =>
+  items = items.filter((item) =>
     shouldEnableItem({
       item,
       values: initialValues,
@@ -1501,9 +1499,9 @@ export const getLeftNavItems = (
       localConstants: localConstants || {},
     })
   );
-  if (leftNavItems.length < 3) return false;
+  if (items.length < minGroupsToDisplay) return false;
 
-  return leftNavItems;
+  return items;
 };
 
 export const MAX_INPUT_AND_LABEL_WIDTH = 500;

--- a/src/routes/protected.tsx
+++ b/src/routes/protected.tsx
@@ -42,6 +42,7 @@ import AdminReferralDenials from '@/modules/admin/components/denials/AdminReferr
 import AdminReferralPosting from '@/modules/admin/components/denials/AdminReferralPosting';
 import FormDefinitionDetailPage from '@/modules/admin/components/forms/FormDefinitionDetailPage';
 import FormDefinitionsPage from '@/modules/admin/components/forms/FormDefinitionsPage';
+import FormPreview from '@/modules/admin/components/forms/FormPreview';
 import FormEditorPage from '@/modules/admin/components/forms/UpdateFormDefinitionPage';
 import ProjectConfigPage from '@/modules/admin/components/projectConfig/ProjectConfigPage';
 import ConfigureServicesPage from '@/modules/admin/components/services/ConfigureServicesPage';
@@ -752,8 +753,16 @@ export const protectedRoutes: RouteNode[] = [
           {
             path: AdminDashboardRoutes.EDIT_FORM,
             element: (
-              <RootPermissionsFilter permissions='canConfigureDataCollection'>
+              <RootPermissionsFilter permissions='canManageForms'>
                 <FormEditorPage />
+              </RootPermissionsFilter>
+            ),
+          },
+          {
+            path: AdminDashboardRoutes.PREVIEW_FORM,
+            element: (
+              <RootPermissionsFilter permissions='canConfigureDataCollection'>
+                <FormPreview />
               </RootPermissionsFilter>
             ),
           },

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -26,6 +26,7 @@ const adminDashboardRoutes = {
   FORMS: 'forms',
   VIEW_FORM: 'forms/:formId',
   EDIT_FORM: 'forms/:formId/edit',
+  PREVIEW_FORM: 'forms/:formId/preview',
   PROJECT_CONFIG: 'project-configs',
 };
 

--- a/src/types/gqlEnums.ts
+++ b/src/types/gqlEnums.ts
@@ -567,11 +567,6 @@ export const HmisEnums = {
     FORM_TITLE: 'Form Title',
     FORM_TYPE: 'Form Type',
   },
-  FormStatus: {
-    draft: '3 - Draft',
-    published: '2 - Published',
-    retired: '1 - Retired',
-  },
   FunderSortOption: { START_DATE: 'START_DATE' },
   FundingSource: {
     HHS_PATH_STREET_OUTREACH_SUPPORTIVE_SERVICES_ONLY:

--- a/src/types/gqlObjects.ts
+++ b/src/types/gqlObjects.ts
@@ -4967,6 +4967,14 @@ export const HmisObjectSchemas: GqlSchema[] = [
         },
       },
       {
+        name: 'canManageForms',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'Boolean', ofType: null },
+        },
+      },
+      {
         name: 'canManageIncomingReferrals',
         type: {
           kind: 'NON_NULL',

--- a/src/types/gqlObjects.ts
+++ b/src/types/gqlObjects.ts
@@ -3251,14 +3251,6 @@ export const HmisObjectSchemas: GqlSchema[] = [
         },
       },
       {
-        name: 'status',
-        type: {
-          kind: 'NON_NULL',
-          name: null,
-          ofType: { kind: 'ENUM', name: 'FormStatus', ofType: null },
-        },
-      },
-      {
         name: 'system',
         type: {
           kind: 'NON_NULL',

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -5824,6 +5824,7 @@ export type QueryAccess = {
   canManageClientAlerts: Scalars['Boolean']['output'];
   canManageDeniedReferrals: Scalars['Boolean']['output'];
   canManageExternalFormSubmissions: Scalars['Boolean']['output'];
+  canManageForms: Scalars['Boolean']['output'];
   canManageIncomingReferrals: Scalars['Boolean']['output'];
   canManageInventory: Scalars['Boolean']['output'];
   canManageOutgoingReferrals: Scalars['Boolean']['output'];
@@ -7718,6 +7719,7 @@ export type RootPermissionsFragment = {
   canTransferEnrollments: boolean;
   canSplitHouseholds: boolean;
   canConfigureDataCollection: boolean;
+  canManageForms: boolean;
   canViewClientAlerts: boolean;
   canManageExternalFormSubmissions: boolean;
 };
@@ -7831,6 +7833,7 @@ export type GetRootPermissionsQuery = {
     canTransferEnrollments: boolean;
     canSplitHouseholds: boolean;
     canConfigureDataCollection: boolean;
+    canManageForms: boolean;
     canViewClientAlerts: boolean;
     canManageExternalFormSubmissions: boolean;
   };
@@ -31191,6 +31194,7 @@ export const RootPermissionsFragmentDoc = gql`
     canTransferEnrollments
     canSplitHouseholds
     canConfigureDataCollection
+    canManageForms
     canViewClientAlerts
     canManageExternalFormSubmissions
   }

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -2867,7 +2867,6 @@ export type FormDefinition = {
   identifier: Scalars['String']['output'];
   rawDefinition: Scalars['JsonObject']['output'];
   role: FormRole;
-  status: FormStatus;
   system: Scalars['Boolean']['output'];
   title: Scalars['String']['output'];
 };
@@ -3151,15 +3150,6 @@ export type FormRulesPaginated = {
   offset: Scalars['Int']['output'];
   pagesCount: Scalars['Int']['output'];
 };
-
-export enum FormStatus {
-  /** 3 - Draft */
-  Draft = 'draft',
-  /** 2 - Published */
-  Published = 'published',
-  /** 1 - Retired */
-  Retired = 'retired',
-}
 
 export type Funder = {
   __typename?: 'Funder';


### PR DESCRIPTION
## Description
GH issue: https://github.com/open-path/Green-River/issues/5981
Depends on hmis-warehouse PR: https://github.com/greenriver/hmis-warehouse/pull/4325

This PR adds a new Preview page linked from the form details page. It is visible to everyone who has `canConfigureDataCollection` permissions. Meanwhile, the new permission `canManageForms` now restricts who can see and access the routes related to actually editing forms.

We should also wait to merge this until after the recent form versioning PRs are merged ([backend](https://github.com/greenriver/hmis-warehouse/pull/4310), [frontend](https://github.com/greenriver/hmis-frontend/pull/758)). ~I _think_ the url params for the new Preview route should be updated at that point to use the identifier rather than ID.~ Edit: Decided against this. The url params have been updated to use both `identifier` and `formId`, see comment here https://github.com/greenriver/hmis-frontend/pull/758#discussion_r1592688961

## Type of change
[//]: # 'remove options that are not relevant'
- [ ] Bug fix
- [x] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
