### PR TITLE
Fix width issue in input group element

### DIFF
--- a/src/modules/form/components/group/InputGroup.tsx
+++ b/src/modules/form/components/group/InputGroup.tsx
@@ -49,7 +49,6 @@ const InputGroup = ({
             pl: 1,
             pb: 0.5,
             pr: 0.5,
-            maxWidth: FIXED_WIDTH_X_LARGE,
             ...(viewOnly
               ? {
                   '.MuiFormLabel-root .MuiTypography-root': {
@@ -132,7 +131,7 @@ const InputGroup = ({
   let label = item.text;
   if (viewOnly && !isNil(item.readonlyText)) label = item.readonlyText;
   return (
-    <Box id={item.linkId} sx={{ mb: 2, maxWidth: '100%' }}>
+    <Box id={item.linkId} sx={{ mb: 2, maxWidth: FIXED_WIDTH_X_LARGE }}>
       {label && (
         <Typography
           id={groupLabelId}


### PR DESCRIPTION
## Description

Fix misaligned "summary" item in input groups.

Before:
<img width="1195" alt="Screenshot 2024-05-08 at 4 12 17 PM" src="https://github.com/greenriver/hmis-frontend/assets/5333982/0496d122-8ec2-4f64-b6c3-a4321d267980">
<img width="1207" alt="Screenshot 2024-05-08 at 4 12 08 PM" src="https://github.com/greenriver/hmis-frontend/assets/5333982/f67334ef-148b-4ae9-9b6a-5dbf7f35e8dc">

After:
<img width="1182" alt="Screenshot 2024-05-08 at 4 17 01 PM" src="https://github.com/greenriver/hmis-frontend/assets/5333982/337188fb-a7d0-4b3a-82b4-7abdb1c2489a">

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
