### PR TITLE
Clarify toggle on Form Preview page

### DIFF
--- a/src/modules/admin/components/forms/FormPreview.tsx
+++ b/src/modules/admin/components/forms/FormPreview.tsx
@@ -1,5 +1,3 @@
-import AccountBoxIcon from '@mui/icons-material/AccountBox';
-import ListIcon from '@mui/icons-material/List';
 import { Grid } from '@mui/material';
 import React, { useMemo, useRef, useState } from 'react';
 import CommonToggle, { ToggleItem } from '@/components/elements/CommonToggle';
@@ -24,17 +22,15 @@ import {
 } from '@/modules/form/util/formUtil';
 import { useGetFormDefinitionFieldsForEditorQuery } from '@/types/gqlTypes';
 
-type PreviewMode = 'preview' | 'readOnly';
+type PreviewMode = 'input' | 'readOnly';
 const toggleItems: ToggleItem<PreviewMode>[] = [
   {
-    value: 'preview',
-    label: 'Preview Form',
-    Icon: ListIcon,
+    value: 'input',
+    label: 'Input View',
   },
   {
     value: 'readOnly',
     label: 'Read Only View',
-    Icon: AccountBoxIcon,
   },
 ];
 
@@ -64,7 +60,7 @@ const FormPreview = () => {
   }, [formDefinition?.definition, localConstants]);
   const [formValues, setFormValues] = useState<object>(initialValues);
 
-  const [toggleValue, setToggleValue] = useState<PreviewMode>('preview');
+  const [toggleValue, setToggleValue] = useState<PreviewMode>('input');
 
   const itemMap = useMemo(
     () => formDefinition && getItemMap(formDefinition.definition),


### PR DESCRIPTION
## Description

This is a follow-up to GH issue: https://github.com/open-path/Green-River/issues/5981

It implements Bobby's suggestions on the designs here: https://www.figma.com/board/axGI9vwmuBRC4uZ11ZJ3RP?node-id=42-1926#797959838

- Remove icons from the toggle component because they aren't part of a consistent iconography
- Rename "Preview Form" to "Input View" in the toggle, because it's confusing for one of the toggle values to be the same as the page title itself.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
