### PR TITLE
Hide some external referral elements behind flag

### DIFF
--- a/src/modules/admin/components/denials/AdminReferralDenials.tsx
+++ b/src/modules/admin/components/denials/AdminReferralDenials.tsx
@@ -1,9 +1,11 @@
 import { Paper } from '@mui/material';
 
+import { useMemo } from 'react';
 import { ColumnDef } from '@/components/elements/table/types';
 import PageTitle from '@/components/layout/PageTitle';
 import GenericTableWithData from '@/modules/dataFetching/components/GenericTableWithData';
 import { parseAndFormatDate } from '@/modules/hmis/hmisUtil';
+import { useHmisAppSettings } from '@/modules/hmisAppSettings/useHmisAppSettings';
 import { AdminDashboardRoutes } from '@/routes/routes';
 import {
   GetDeniedPendingReferralPostingsDocument,
@@ -19,42 +21,50 @@ const rowLinkTo = (row: ReferralPostingFieldsFragment): string => {
   });
 };
 
-const columns: ColumnDef<ReferralPostingFieldsFragment>[] = [
-  {
-    header: 'Referral ID',
-    linkTreatment: true,
-    render: (row: ReferralPostingFieldsFragment) =>
-      row.referralIdentifier || 'N/A',
-  },
-  {
-    header: 'Referral Date',
-    render: (row: ReferralPostingFieldsFragment) =>
-      parseAndFormatDate(row.referralDate),
-  },
-  {
-    header: 'Project',
-    render: (row: ReferralPostingFieldsFragment) => row.project?.projectName,
-  },
-  {
-    header: 'Organization',
-    render: (row: ReferralPostingFieldsFragment) =>
-      row.organization?.organizationName,
-  },
-  {
-    header: 'HoH Name',
-    render: (row: ReferralPostingFieldsFragment) => row.hohName,
-  },
-  {
-    header: 'HoH MCI ID',
-    render: (row: ReferralPostingFieldsFragment) => row.hohMciId,
-  },
-  {
-    header: 'Denied By',
-    render: (row: ReferralPostingFieldsFragment) => row.statusUpdatedBy,
-  },
-];
-
 const AdminReferralDenials = () => {
+  const { globalFeatureFlags: { externalReferrals } = {} } =
+    useHmisAppSettings();
+
+  const columns: ColumnDef<ReferralPostingFieldsFragment>[] = useMemo(
+    () => [
+      {
+        header: 'Referral ID',
+        linkTreatment: true,
+        render: (row: ReferralPostingFieldsFragment) =>
+          row.referralIdentifier || 'N/A',
+        hide: !externalReferrals, // only show for external referral which have ID from another system
+      },
+      {
+        header: 'Referral Date',
+        render: (row: ReferralPostingFieldsFragment) =>
+          parseAndFormatDate(row.referralDate),
+      },
+      {
+        header: 'Project',
+        render: (row: ReferralPostingFieldsFragment) =>
+          row.project?.projectName,
+      },
+      {
+        header: 'Organization',
+        render: (row: ReferralPostingFieldsFragment) =>
+          row.organization?.organizationName,
+      },
+      {
+        header: 'HoH Name',
+        render: (row: ReferralPostingFieldsFragment) => row.hohName,
+      },
+      {
+        header: 'HoH MCI ID',
+        render: (row: ReferralPostingFieldsFragment) => row.hohMciId,
+        hide: !externalReferrals,
+      },
+      {
+        header: 'Denied By',
+        render: (row: ReferralPostingFieldsFragment) => row.statusUpdatedBy,
+      },
+    ],
+    [externalReferrals]
+  );
   return (
     <>
       <PageTitle title='Denials' />

--- a/src/modules/admin/components/denials/AdminReferralPosting.tsx
+++ b/src/modules/admin/components/denials/AdminReferralPosting.tsx
@@ -10,6 +10,7 @@ import PageTitle from '@/components/layout/PageTitle';
 import NotFound from '@/components/pages/NotFound';
 import useSafeParams from '@/hooks/useSafeParams';
 import ApolloErrorAlert from '@/modules/errors/components/ApolloErrorAlert';
+import { useHmisAppSettings } from '@/modules/hmisAppSettings/useHmisAppSettings';
 import ReferralHouseholdMembersTable from '@/modules/referrals/components/ProjectReferralHouseholdMembersTable';
 import {
   ReferralPostingStatus,
@@ -18,6 +19,9 @@ import {
 
 const AdminReferralPosting: React.FC = () => {
   const { referralPostingId } = useSafeParams<{ referralPostingId: string }>();
+  const { globalFeatureFlags: { externalReferrals } = {} } =
+    useHmisAppSettings();
+
   const { data, loading, error } = useGetReferralPostingQuery({
     variables: { id: referralPostingId as any as string },
     fetchPolicy: 'network-only',
@@ -39,7 +43,10 @@ const AdminReferralPosting: React.FC = () => {
       <PageTitle title='Manage Denied Referral' />
       <Grid spacing={4} container>
         <Grid item lg={4} sm={12}>
-          <AdminReferralPostingDetails referralPosting={referralPosting} />
+          <AdminReferralPostingDetails
+            referralPosting={referralPosting}
+            externalReferrals={externalReferrals}
+          />
         </Grid>
         <Grid item lg={8} sm={12}>
           <Stack spacing={4}>

--- a/src/modules/admin/components/denials/AdminReferralPostingDetails.tsx
+++ b/src/modules/admin/components/denials/AdminReferralPostingDetails.tsx
@@ -24,8 +24,12 @@ import { generateSafePath } from '@/utils/pathEncoding';
 
 interface Props {
   referralPosting: ReferralPostingDetailFieldsFragment;
+  externalReferrals?: boolean;
 }
-const AdminReferralPostingDetails: React.FC<Props> = ({ referralPosting }) => {
+const AdminReferralPostingDetails: React.FC<Props> = ({
+  referralPosting,
+  externalReferrals,
+}) => {
   const verb = useMemo<string>(() => {
     switch (referralPosting.status) {
       case ReferralPostingStatus.DeniedPendingStatus:
@@ -53,7 +57,7 @@ const AdminReferralPostingDetails: React.FC<Props> = ({ referralPosting }) => {
           sx={{ mt: 0.5 }}
         />,
       ],
-      ['Referral ID', referralPosting.referralIdentifier || 'N/A'],
+      ['Referral ID', referralPosting.referralIdentifier],
       ['Referral Date', parseAndFormatDate(referralPosting.referralDate)],
       ['Referred From', referralPosting.referredFrom],
       ['Organization Name', referralPosting.organization?.organizationName],
@@ -110,7 +114,7 @@ const AdminReferralPostingDetails: React.FC<Props> = ({ referralPosting }) => {
         </Stack>
       </TitleCard>
       <Stack gap={2}>
-        {referralPosting.referralIdentifier && (
+        {referralPosting.referralIdentifier && externalReferrals && (
           <ConsumerSummaryReportButton
             referralIdentifier={referralPosting.referralIdentifier}
           />

--- a/src/modules/enrollment/components/EnrollmentQuickActions.tsx
+++ b/src/modules/enrollment/components/EnrollmentQuickActions.tsx
@@ -5,6 +5,7 @@ import ButtonLink from '@/components/elements/ButtonLink';
 import TitleCard from '@/components/elements/TitleCard';
 import { useClientFormDialog } from '@/modules/client/hooks/useClientFormDialog';
 import { DashboardEnrollment } from '@/modules/hmis/types';
+import { useHmisAppSettings } from '@/modules/hmisAppSettings/useHmisAppSettings';
 import { useServiceDialog } from '@/modules/services/hooks/useServiceDialog';
 import { EnrollmentDashboardRoutes } from '@/routes/routes';
 import { DataCollectionFeatureRole } from '@/types/gqlTypes';
@@ -17,6 +18,7 @@ const EnrollmentQuickActions = ({
   enrollment: DashboardEnrollment;
   enabledFeatures: DataCollectionFeatureRole[];
 }) => {
+  const { globalFeatureFlags } = useHmisAppSettings();
   const { renderServiceDialog, openServiceDialog } = useServiceDialog({
     enrollment,
   });
@@ -33,7 +35,8 @@ const EnrollmentQuickActions = ({
   const canEditClient = enrollment.client.access.canEditClient;
 
   const canViewEsgFundingReport =
-    enrollment.project.access.canManageIncomingReferrals;
+    enrollment.project.access.canManageIncomingReferrals &&
+    globalFeatureFlags?.externalReferrals;
 
   if (
     ![canRecordService, canEditClient, canViewEsgFundingReport].some((b) => !!b)

--- a/src/modules/projects/components/ProjectReferralPosting.tsx
+++ b/src/modules/projects/components/ProjectReferralPosting.tsx
@@ -12,6 +12,7 @@ import PageTitle from '@/components/layout/PageTitle';
 import NotFound from '@/components/pages/NotFound';
 import useSafeParams from '@/hooks/useSafeParams';
 import ApolloErrorAlert from '@/modules/errors/components/ApolloErrorAlert';
+import { useHmisAppSettings } from '@/modules/hmisAppSettings/useHmisAppSettings';
 import ProjectReferralPostingDetails from '@/modules/projects/components/ReferralPostingDetails';
 import ReferralHouseholdMembersTable from '@/modules/referrals/components/ProjectReferralHouseholdMembersTable';
 import { ProjectDashboardRoutes } from '@/routes/routes';
@@ -22,6 +23,8 @@ import {
 import { generateSafePath } from '@/utils/pathEncoding';
 
 const ProjectReferralPosting: React.FC = () => {
+  const { globalFeatureFlags: { externalReferrals } = {} } =
+    useHmisAppSettings();
   const { referralPostingId } = useSafeParams<{ referralPostingId: string }>();
   const { data, loading, error } = useGetReferralPostingQuery({
     variables: { id: referralPostingId as any as string },
@@ -52,20 +55,28 @@ const ProjectReferralPosting: React.FC = () => {
       <Grid spacing={4} container>
         <Grid item lg={4} sm={12}>
           <TitleCard title='Referral Details' sx={{ mb: 2 }} padded>
-            <ProjectReferralPostingDetails referralPosting={referralPosting} />
+            <ProjectReferralPostingDetails
+              referralPosting={referralPosting}
+              externalReferrals={externalReferrals}
+            />
           </TitleCard>
           <Stack gap={2}>
-            <ButtonLink
-              fullWidth
-              variant='outlined'
-              color='secondary'
-              to={generateSafePath(ProjectDashboardRoutes.ESG_FUNDING_REPORT, {
-                projectId: referralPosting.project?.id,
-                referralPostingId,
-              })}
-            >
-              ESG Funding Report
-            </ButtonLink>
+            {externalReferrals && (
+              <ButtonLink
+                fullWidth
+                variant='outlined'
+                color='secondary'
+                to={generateSafePath(
+                  ProjectDashboardRoutes.ESG_FUNDING_REPORT,
+                  {
+                    projectId: referralPosting.project?.id,
+                    referralPostingId,
+                  }
+                )}
+              >
+                ESG Funding Report
+              </ButtonLink>
+            )}
             {referralPosting.referralIdentifier && (
               <Button
                 fullWidth

--- a/src/modules/projects/components/ProjectReferrals.tsx
+++ b/src/modules/projects/components/ProjectReferrals.tsx
@@ -9,42 +9,19 @@ import ProjectReferralRequestsTable from './tables/ProjectReferralRequestsTable'
 import ButtonLink from '@/components/elements/ButtonLink';
 import TitleCard from '@/components/elements/TitleCard';
 import PageTitle from '@/components/layout/PageTitle';
+import { useHmisAppSettings } from '@/modules/hmisAppSettings/useHmisAppSettings';
 import { ProjectDashboardRoutes } from '@/routes/routes';
 import { generateSafePath } from '@/utils/pathEncoding';
 
 const ProjectReferrals = () => {
+  const { globalFeatureFlags: { externalReferrals } = {} } =
+    useHmisAppSettings();
   const { project } = useProjectDashboardContext();
 
   return (
     <>
       <PageTitle title='Referrals' />
       <Stack spacing={4}>
-        {project.access.canManageIncomingReferrals && (
-          <>
-            <TitleCard
-              title='Referral Requests'
-              headerVariant='border'
-              actions={
-                <ButtonLink
-                  to={generateSafePath(
-                    ProjectDashboardRoutes.NEW_REFERRAL_REQUEST,
-                    {
-                      projectId: project.id,
-                    }
-                  )}
-                  Icon={AddIcon}
-                >
-                  New Referral Request
-                </ButtonLink>
-              }
-            >
-              <ProjectReferralRequestsTable project={project} />
-            </TitleCard>
-            <TitleCard title='Active Referrals' headerVariant='border'>
-              <ProjectReferralPostingsTable projectId={project.id} />
-            </TitleCard>
-          </>
-        )}
         {project.access.canManageOutgoingReferrals && (
           <TitleCard
             title='Outgoing Referrals'
@@ -65,6 +42,38 @@ const ProjectReferrals = () => {
           >
             <ProjectOutgoingReferralPostingsTable projectId={project.id} />
           </TitleCard>
+        )}
+        {project.access.canManageIncomingReferrals && (
+          <>
+            {/* Referral Requests are only used for external integration */}
+            {externalReferrals && (
+              <TitleCard
+                title='Referral Requests'
+                headerVariant='border'
+                actions={
+                  <ButtonLink
+                    to={generateSafePath(
+                      ProjectDashboardRoutes.NEW_REFERRAL_REQUEST,
+                      {
+                        projectId: project.id,
+                      }
+                    )}
+                    Icon={AddIcon}
+                  >
+                    New Referral Request
+                  </ButtonLink>
+                }
+              >
+                <ProjectReferralRequestsTable project={project} />
+              </TitleCard>
+            )}
+            <TitleCard title='Active Referrals' headerVariant='border'>
+              <ProjectReferralPostingsTable
+                projectId={project.id}
+                externalReferrals={externalReferrals}
+              />
+            </TitleCard>
+          </>
         )}
       </Stack>
     </>

--- a/src/modules/projects/components/ReferralPostingDetails.tsx
+++ b/src/modules/projects/components/ReferralPostingDetails.tsx
@@ -1,6 +1,6 @@
 import { Box, Grid, Stack, Typography } from '@mui/material';
 import { isNil } from 'lodash-es';
-import { ReactNode } from 'react';
+import { ReactNode, useMemo } from 'react';
 
 import { CommonUnstyledList } from '@/components/CommonUnstyledList';
 import NotCollectedText from '@/components/elements/NotCollectedText';
@@ -18,11 +18,13 @@ import { generateSafePath } from '@/utils/pathEncoding';
 
 interface Props {
   referralPosting: ReferralPostingDetailFieldsFragment;
+  externalReferrals?: boolean;
 }
 const ProjectReferralPostingDetails: React.FC<Props> = ({
   referralPosting,
+  externalReferrals,
 }) => {
-  const col1: Array<[string, ReactNode]> = [
+  const standardDetails: Array<[string, ReactNode]> = [
     [
       'Referral Status',
       <ReferralPostingStatusDisplay
@@ -49,59 +51,71 @@ const ProjectReferralPostingDetails: React.FC<Props> = ({
     ['Referred By', referralPosting.referredBy],
     ['Assigned At', parseAndFormatDateTime(referralPosting.assignedDate)],
   ];
-  const col2: Array<[string, ReactNode]> = [
-    ['Referral ID', referralPosting.referralIdentifier],
-    ['Unit Type', referralPosting?.unitType?.description],
-    ['Score', referralPosting.score],
-    [
-      'Chronically Homeless',
-      <YesNoDisplay
-        booleanValue={referralPosting.chronic}
-        fallback={<NotCollectedText variant='body2' />}
-      />,
-    ],
-    [
-      'HUD Chronically Homeless' as string,
-      !isNil(referralPosting.hudChronic) ? (
-        <YesNoDisplay booleanValue={referralPosting.hudChronic} />
-      ) : (
-        (undefined as ReactNode)
-      ),
-    ] as const,
-    [
-      'Needs Wheelchair Accessible Unit',
-      <YesNoDisplay
-        booleanValue={referralPosting.needsWheelchairAccessibleUnit}
-        fallback={<NotCollectedText variant='body2' />}
-      />,
-    ],
-  ].filter((ary): ary is [string, ReactNode] => !!ary[1]);
+
+  const externalDetails: Array<[string, ReactNode]> = useMemo(() => {
+    if (!externalReferrals) return [];
+
+    return [
+      ['Referral ID', referralPosting.referralIdentifier],
+      ['Unit Type', referralPosting?.unitType?.description],
+      ['Score', referralPosting.score],
+      [
+        'Chronically Homeless',
+        <YesNoDisplay
+          booleanValue={referralPosting.chronic}
+          fallback={<NotCollectedText variant='body2' />}
+        />,
+      ],
+      [
+        'HUD Chronically Homeless' as string,
+        !isNil(referralPosting.hudChronic) ? (
+          <YesNoDisplay booleanValue={referralPosting.hudChronic} />
+        ) : (
+          (undefined as ReactNode)
+        ),
+      ] as const,
+      [
+        'Needs Wheelchair Accessible Unit',
+        <YesNoDisplay
+          booleanValue={referralPosting.needsWheelchairAccessibleUnit}
+          fallback={<NotCollectedText variant='body2' />}
+        />,
+      ],
+    ].filter((ary): ary is [string, ReactNode] => !!ary[1]);
+  }, [externalReferrals, referralPosting]);
+
   return (
     <Grid container columnSpacing={6} rowSpacing={2}>
-      {[col1, col2].map((list) => (
-        <Grid item key={list[0][0]}>
-          <Stack spacing={2} component={CommonUnstyledList} sx={{ columns: 2 }}>
-            {list
-              .filter((labelValue) => hasMeaningfulValue(labelValue[1]))
-              .map(([label, value]) => (
-                <Typography component='li' key={label} variant='body2'>
-                  <Box
-                    sx={({ typography }) => ({
-                      fontWeight: typography.fontWeightBold,
-                    })}
-                  >
-                    {label}
-                  </Box>
-                  {hasMeaningfulValue(value) ? (
-                    value
-                  ) : (
-                    <NotCollectedText variant='body2' />
-                  )}
-                </Typography>
-              ))}
-          </Stack>
-        </Grid>
-      ))}
+      {[standardDetails, externalDetails]
+        .filter((list) => list.length > 0)
+        .map((list) => (
+          <Grid item key={list[0][0]}>
+            <Stack
+              spacing={2}
+              component={CommonUnstyledList}
+              sx={{ columns: 2 }}
+            >
+              {list
+                .filter((labelValue) => hasMeaningfulValue(labelValue[1]))
+                .map(([label, value]) => (
+                  <Typography component='li' key={label} variant='body2'>
+                    <Box
+                      sx={({ typography }) => ({
+                        fontWeight: typography.fontWeightBold,
+                      })}
+                    >
+                      {label}
+                    </Box>
+                    {hasMeaningfulValue(value) ? (
+                      value
+                    ) : (
+                      <NotCollectedText variant='body2' />
+                    )}
+                  </Typography>
+                ))}
+            </Stack>
+          </Grid>
+        ))}
     </Grid>
   );
 };

--- a/src/modules/projects/components/tables/ProjectReferralPostingsTable.tsx
+++ b/src/modules/projects/components/tables/ProjectReferralPostingsTable.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import { ColumnDef } from '@/components/elements/table/types';
 import GenericTableWithData from '@/modules/dataFetching/components/GenericTableWithData';
@@ -16,11 +16,7 @@ import {
 } from '@/types/gqlTypes';
 import { generateSafePath } from '@/utils/pathEncoding';
 
-const columns: ColumnDef<ReferralPostingFieldsFragment>[] = [
-  {
-    header: 'Referral ID',
-    render: (row) => row.referralIdentifier || 'N/A',
-  },
+const defaultColumns: ColumnDef<ReferralPostingFieldsFragment>[] = [
   {
     header: 'Referral Date',
     render: (row: ReferralPostingFieldsFragment) =>
@@ -55,9 +51,13 @@ const columns: ColumnDef<ReferralPostingFieldsFragment>[] = [
 
 interface Props {
   projectId: string;
+  externalReferrals?: boolean;
 }
 
-const ProjectReferralPostingsTable: React.FC<Props> = ({ projectId }) => {
+const ProjectReferralPostingsTable: React.FC<Props> = ({
+  projectId,
+  externalReferrals,
+}) => {
   const rowLinkTo = useCallback(
     (row: ReferralPostingFieldsFragment): string => {
       return generateSafePath(ProjectDashboardRoutes.REFERRAL_POSTING, {
@@ -67,6 +67,21 @@ const ProjectReferralPostingsTable: React.FC<Props> = ({ projectId }) => {
     },
     [projectId]
   );
+
+  const columns = useMemo(() => {
+    if (externalReferrals) {
+      // external referrals have an ID from the sending system
+      return [
+        {
+          header: 'Referral ID',
+          render: (row) => row.referralIdentifier || 'N/A',
+        },
+        ...defaultColumns,
+      ];
+    }
+
+    return defaultColumns;
+  }, [externalReferrals]);
 
   return (
     <GenericTableWithData<

--- a/src/modules/projects/hooks/useProjectDashboardNavItems.tsx
+++ b/src/modules/projects/hooks/useProjectDashboardNavItems.tsx
@@ -1,7 +1,6 @@
 import { useMemo } from 'react';
 
 import { NavItem } from '@/components/layout/dashboard/sideNav/types';
-import { useHmisAppSettings } from '@/modules/hmisAppSettings/useHmisAppSettings';
 import { ProjectDashboardRoutes } from '@/routes/routes';
 import {
   DataCollectionFeatureRole,
@@ -13,8 +12,6 @@ import {
 export const useProjectDashboardNavItems = (
   project?: ProjectAllFieldsFragment
 ) => {
-  const { globalFeatureFlags } = useHmisAppSettings();
-
   const navItems: NavItem<ProjectAccessFieldsFragment>[] = useMemo(() => {
     if (!project) return [];
     const dataCollectionRoles = project.dataCollectionFeatures.map(
@@ -87,7 +84,6 @@ export const useProjectDashboardNavItems = (
               'canManageOutgoingReferrals',
             ],
             permissionMode: 'any',
-            hide: !globalFeatureFlags?.externalReferrals,
           },
         ],
       },
@@ -130,7 +126,7 @@ export const useProjectDashboardNavItems = (
         ],
       },
     ];
-  }, [globalFeatureFlags, project]);
+  }, [project]);
 
   return navItems;
 };

--- a/src/modules/referrals/components/ProjectReferralHouseholdMembersTable.tsx
+++ b/src/modules/referrals/components/ProjectReferralHouseholdMembersTable.tsx
@@ -1,6 +1,6 @@
 import { Stack } from '@mui/material';
 import { filter } from 'lodash-es';
-
+import { useMemo } from 'react';
 import ExternalIdDisplay from '@/components/elements/ExternalIdDisplay';
 import GenericTable from '@/components/elements/table/GenericTable';
 import { ColumnDef } from '@/components/elements/table/types';
@@ -17,68 +17,79 @@ import {
 
 type Row = ReferralPostingDetailFieldsFragment['householdMembers'][number];
 
-const columns: ColumnDef<Row>[] = [
-  {
-    header: '',
-    key: 'indicator',
-    width: '1%',
-    render: (row: Row) => (
-      <HohIndicator relationshipToHoh={row.relationshipToHoH} />
-    ),
-  },
-  {
-    header: 'Name',
-    render: ({ client }: Row) => <ClientName client={client} linkToProfile />,
-  },
-  {
-    header: 'MCI ID',
-    render: ({ client }: Row) => (
-      <Stack gap={0.8}>
-        {filter(client.externalIds, { type: ExternalIdentifierType.MciId }).map(
-          (val) => (
-            <ExternalIdDisplay key={val.id} value={val} />
-          )
-        )}
-      </Stack>
-    ),
-  },
-  {
-    header: 'Relationship to HoH',
-    render: (row: Row) => (
-      <HmisEnum
-        value={row.relationshipToHoH}
-        enumMap={HmisEnums.RelationshipToHoH}
-      />
-    ),
-  },
-  {
-    header: 'DOB / Age',
-    render: ({ client }: Row) => <ClientDobAge client={client} alwaysShow />,
-  },
-  {
-    header: 'Open Enrollments',
-    render: (row: Row) => {
-      return (
-        <EnrollmentSummaryCount
-          enrollmentSummary={row.openEnrollmentSummary}
-          clientId={row.client.id}
-        />
-      );
-    },
-  },
-  // {
-  //   header: 'Gender',
-  //   render: ({ client }: Row) => (
-  //     <MultiHmisEnum values={client.gender} enumMap={HmisEnums.Gender} />
-  //   ),
-  // },
-];
-
 interface Props {
   rows: ReferralPostingDetailFieldsFragment['householdMembers'];
 }
 
 const ReferralHouseholdMembersTable: React.FC<Props> = ({ rows }) => {
+  const hasAnyMci = useMemo(
+    () =>
+      rows.some((row) =>
+        row.client.externalIds.some(
+          (id) => id.type === ExternalIdentifierType.MciId
+        )
+      ),
+    [rows]
+  );
+
+  const columns: ColumnDef<Row>[] = useMemo(
+    () => [
+      {
+        header: '',
+        key: 'indicator',
+        width: '1%',
+        render: (row: Row) => (
+          <HohIndicator relationshipToHoh={row.relationshipToHoH} />
+        ),
+      },
+      {
+        header: 'Name',
+        render: ({ client }: Row) => (
+          <ClientName client={client} linkToProfile />
+        ),
+      },
+      {
+        header: 'MCI ID',
+        hide: !hasAnyMci,
+        render: ({ client }: Row) => (
+          <Stack gap={0.8}>
+            {filter(client.externalIds, {
+              type: ExternalIdentifierType.MciId,
+            }).map((val) => (
+              <ExternalIdDisplay key={val.id} value={val} />
+            ))}
+          </Stack>
+        ),
+      },
+      {
+        header: 'Relationship to HoH',
+        render: (row: Row) => (
+          <HmisEnum
+            value={row.relationshipToHoH}
+            enumMap={HmisEnums.RelationshipToHoH}
+          />
+        ),
+      },
+      {
+        header: 'DOB / Age',
+        render: ({ client }: Row) => (
+          <ClientDobAge client={client} alwaysShow />
+        ),
+      },
+      {
+        header: 'Open Enrollments',
+        render: (row: Row) => {
+          return (
+            <EnrollmentSummaryCount
+              enrollmentSummary={row.openEnrollmentSummary}
+              clientId={row.client.id}
+            />
+          );
+        },
+      },
+    ],
+    [hasAnyMci]
+  );
   return <GenericTable<Row> rows={rows} columns={columns} />;
 };
 


### PR DESCRIPTION
## Description

Use existing `globalFeatureFlags.externalReferrals` to toggle visibility of external AC-specific parts of the referral interfaces.

https://github.com/open-path/Green-River/issues/6036

Testing:
* modify app_settings_controller to return true or false for the flag
* enable referral permissions

## Type of change
- [x] New feature (adds functionality)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
