### PR TITLE
Truncate service details column

### DIFF
--- a/src/modules/enrollment/components/dashboardPages/EnrollmentServicesPage.tsx
+++ b/src/modules/enrollment/components/dashboardPages/EnrollmentServicesPage.tsx
@@ -45,8 +45,19 @@ export const SERVICE_COLUMNS: {
     render: (service) => (
       <Stack>
         {serviceDetails(service).map((s, i) => (
-          // eslint-disable-next-line react/no-array-index-key
-          <Typography key={i} variant='body2'>
+          <Typography
+            // eslint-disable-next-line react/no-array-index-key
+            key={i}
+            variant='body2'
+            sx={{
+              whiteSpace: 'pre-wrap',
+              display: '-webkit-box',
+              WebkitBoxOrient: 'vertical',
+              WebkitLineClamp: '1',
+              overflow: 'hidden',
+              maxWidth: '300px',
+            }}
+          >
             {s}
           </Typography>
         ))}


### PR DESCRIPTION
## Description

This PR truncates the Service Details column both on the Enrollment Services page and on the Client Services page.

In case of multiple custom data elements that should be displayed in the Service Details column, it still stacks them and just truncates them individually, as shown:

<img width="894" alt="Screenshot 2024-05-16 at 11 18 38 AM" src="https://github.com/greenriver/hmis-frontend/assets/16002775/df9e123f-e07e-475b-8fe1-6dcca146437a">

## Type of change
[//]: # 'remove options that are not relevant'
- [ ] Bug fix
- [x] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
