### PR TITLE
Fix QA issues for Form Builder layout

### DIFF
--- a/src/components/layout/dashboard/contextHeader/useDashboardBreadcrumbs.tsx
+++ b/src/components/layout/dashboard/contextHeader/useDashboardBreadcrumbs.tsx
@@ -250,6 +250,10 @@ export const useAdminBreadcrumbConfig = (): CrumbConfig => {
         parent: AdminDashboardRoutes.FORMS,
         title: 'View Form Details',
       },
+      [AdminDashboardRoutes.JSON_EDIT_FORM]: {
+        parent: AdminDashboardRoutes.VIEW_FORM,
+        title: 'Edit Form JSON',
+      },
       [AdminDashboardRoutes.EDIT_FORM]: {
         parent: AdminDashboardRoutes.VIEW_FORM,
         title: 'Edit Form',

--- a/src/modules/formBuilder/components/formTree/FormTree.tsx
+++ b/src/modules/formBuilder/components/formTree/FormTree.tsx
@@ -1,9 +1,8 @@
 import { RichTreeView } from '@mui/x-tree-view/RichTreeView';
 import React, { useMemo } from 'react';
 import Loading from '@/components/elements/Loading';
-import FormTreeItem, {
-  TreeItemContext,
-} from '@/modules/formBuilder/components/formTree/FormTreeItem';
+import { FormTreeContext } from '@/modules/formBuilder/components/formTree/FormTreeContext';
+import FormTreeItem from '@/modules/formBuilder/components/formTree/FormTreeItem';
 import { getItemsForTree } from '@/modules/formBuilder/components/formTree/formTreeUtil';
 import { FormDefinitionJson, FormItem } from '@/types/gqlTypes';
 
@@ -27,7 +26,7 @@ const FormTree: React.FC<FormTreeProps> = ({ definition, setSelectedItem }) => {
   if (!definition) return <Loading />;
 
   return (
-    <TreeItemContext.Provider value={context}>
+    <FormTreeContext.Provider value={context}>
       <RichTreeView
         aria-label='form tree view'
         items={definitionForTree}
@@ -35,7 +34,7 @@ const FormTree: React.FC<FormTreeProps> = ({ definition, setSelectedItem }) => {
         getItemLabel={(item) => item.text || item.helperText || item.linkId}
         slots={{ item: FormTreeItem }}
       />
-    </TreeItemContext.Provider>
+    </FormTreeContext.Provider>
   );
 };
 

--- a/src/modules/formBuilder/components/formTree/FormTreeContext.tsx
+++ b/src/modules/formBuilder/components/formTree/FormTreeContext.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { FormItem } from '@/types/gqlTypes';
+
+export const FormTreeContext = React.createContext<{
+  onEditButtonClicked: (item: FormItem) => void;
+}>({ onEditButtonClicked: () => {} });

--- a/src/modules/formBuilder/components/formTree/FormTreeItem.tsx
+++ b/src/modules/formBuilder/components/formTree/FormTreeItem.tsx
@@ -14,17 +14,14 @@ import React, { useMemo } from 'react';
 import { EditIcon } from '@/components/elements/SemanticIcons';
 import theme from '@/config/theme';
 import { FORM_ITEM_PALETTE } from '@/modules/formBuilder/components/FormBuilderPalette';
+import { FormTreeContext } from '@/modules/formBuilder/components/formTree/FormTreeContext';
 import FormTreeLabel from '@/modules/formBuilder/components/formTree/FormTreeLabel';
 import { FormItemPaletteType } from '@/modules/formBuilder/components/formTree/types';
-import { FormItem, ItemType } from '@/types/gqlTypes';
+import { ItemType } from '@/types/gqlTypes';
 
 export const getItemDisplayAttrs = (type: ItemType): FormItemPaletteType => {
   return FORM_ITEM_PALETTE[type];
 };
-
-export const TreeItemContext = React.createContext<{
-  onEditButtonClicked: (item: FormItem) => void;
-}>({ onEditButtonClicked: () => {} });
 
 interface FormTreeItemProps
   extends Omit<UseTreeItem2Parameters, 'rootRef'>,
@@ -36,7 +33,7 @@ const FormTreeItem = React.forwardRef(function FormTreeItem(
 ) {
   const { id, itemId, label, disabled, children, ...other } = props;
 
-  const { onEditButtonClicked } = React.useContext(TreeItemContext);
+  const { onEditButtonClicked } = React.useContext(FormTreeContext);
 
   const {
     getRootProps,


### PR DESCRIPTION
## Description

This PR fixes the breadcrumbs for the JSON form editor - I overlooked them when I migrated the route from EDIT_FORM to JSON_EDIT_FORM.

It also moves the form context to its own file as suggested in a [comment](https://github.com/greenriver/hmis-frontend/pull/772#discussion_r1603264656) on the previous PR.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
