### PR TITLE
Allow scrolling on record picker dialog

### DIFF
--- a/src/modules/assessments/components/AssessmentForm.tsx
+++ b/src/modules/assessments/components/AssessmentForm.tsx
@@ -380,12 +380,10 @@ const AssessmentForm: React.FC<Props> = ({
           onSelected={onSelectAutofillRecord}
           onCancel={() => setDialogOpen(false)}
           description={
-            // <Alert severity='info' icon={false} sx={{ mb: 2 }}>
-            <Typography variant='body2' sx={{ mb: 2 }}>
+            <Typography variant='body2' sx={{ my: 2 }}>
               Select a previous assessment to populate the current assessment.
               Any changes you have made will be overwritten.
             </Typography>
-            // </Alert>
           }
         />
       )}

--- a/src/modules/assessments/components/AssessmentFormSideBar.tsx
+++ b/src/modules/assessments/components/AssessmentFormSideBar.tsx
@@ -90,7 +90,7 @@ const AssessmentFormSideBar: React.FC<Props> = ({
         p: 2,
         position: 'sticky',
         top: top + 16,
-        maxHeight: `calc(100vh - ${top}px)`,
+        maxHeight: `calc(100vh - ${top + 16 * 2}px)`,
         overflowY: 'auto',
       }}
     >

--- a/src/modules/assessments/components/IndividualAssessment.tsx
+++ b/src/modules/assessments/components/IndividualAssessment.tsx
@@ -189,7 +189,7 @@ const IndividualAssessment = ({
 };
 
 const WrappedAssessment = (props: IndividualAssessmentProps) => (
-  <Box sx={{ mt: { xs: 0, lg: 2 } }}>
+  <Box sx={{ mt: 0 }}>
     <SentryErrorBoundary>
       <IndividualAssessment {...props} />
     </SentryErrorBoundary>

--- a/src/modules/form/components/RecordPickerDialog.tsx
+++ b/src/modules/form/components/RecordPickerDialog.tsx
@@ -70,11 +70,6 @@ const RecordPickerDialog = ({
     return [...assessmentColumns, ...dataColumns];
   }, [item]);
 
-  // Need to set height on the dialog in order for the scrolling to work
-  // Columns are really rows here because this is a vertical table.
-  // The height should be between 550 and 850, with the # of columns determining where it falls within that.
-  const height = `${Math.min(Math.max(columns.length * 60 + 250, 550), 850)}px`;
-
   const hudRoles = [
     AssessmentRole.Intake,
     AssessmentRole.Update,
@@ -91,7 +86,7 @@ const RecordPickerDialog = ({
       fullWidth
       onClose={onCancel}
       sx={{
-        '.MuiDialog-paper': { overflow: 'hidden', height },
+        '.MuiDialog-paper': { overflow: 'hidden' },
       }}
       {...other}
     >
@@ -107,9 +102,8 @@ const RecordPickerDialog = ({
 
       <DialogContent
         sx={{
-          pb: 6,
-          my: 2,
-          height: '100%', // need for scrolling
+          pb: 2,
+          my: 0,
         }}
       >
         {description}

--- a/src/modules/form/components/RecordPickerDialog.tsx
+++ b/src/modules/form/components/RecordPickerDialog.tsx
@@ -1,4 +1,4 @@
-import { Box, Stack } from '@mui/material';
+import { Stack } from '@mui/material';
 import Button from '@mui/material/Button';
 import { DialogProps } from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
@@ -70,9 +70,6 @@ const RecordPickerDialog = ({
     return [...assessmentColumns, ...dataColumns];
   }, [item]);
 
-  // Need to set height on the dialog in order for the scrolling to work
-  const height = `${Math.min(Math.max(columns.length * 60 + 250, 550), 850)}px`;
-
   const hudRoles = [
     AssessmentRole.Intake,
     AssessmentRole.Update,
@@ -105,52 +102,49 @@ const RecordPickerDialog = ({
 
       <DialogContent
         sx={{
-          py: 0,
+          pb: 2,
           my: 0,
-          height,
         }}
       >
         {description}
-        <Box sx={{ height: `calc(${height} - 190px)` }}>
-          <AssessmentsForPopulationTable
-            queryVariables={{ id: clientId, roles: hudRoles }}
-            defaultPageSize={5}
-            columns={columns}
-            nonTablePagination
-            vertical
-            fullHeight
-            tableProps={{
-              size: 'small',
-              stickyHeader: true,
-              width: 'fit-content',
-            }}
-            renderVerticalHeaderCell={(record) => {
-              return (
-                <Stack spacing={2} sx={{ py: 1 }}>
-                  <RelativeDate
-                    dateString={record.assessmentDate}
-                    dateUpdated={record.dateUpdated || undefined}
-                    variant='body2'
-                    textAlign={'center'}
-                    fontWeight={600}
-                    withTooltip
-                    prefix='Assessment Date: '
-                  />
-                  <Button
-                    onClick={() => onSelected(record)}
-                    variant='outlined'
-                    size='small'
-                    sx={{ backgroundColor: 'white' }}
-                    fullWidth
-                    aria-label={`Select record from ${record.assessmentDate}`}
-                  >
-                    Select
-                  </Button>
-                </Stack>
-              );
-            }}
-          />
-        </Box>
+        <AssessmentsForPopulationTable
+          queryVariables={{ id: clientId, roles: hudRoles }}
+          defaultPageSize={5}
+          columns={columns}
+          nonTablePagination
+          vertical
+          fullHeight
+          tableProps={{
+            size: 'small',
+            stickyHeader: true,
+            width: 'fit-content',
+          }}
+          renderVerticalHeaderCell={(record) => {
+            return (
+              <Stack spacing={2} sx={{ py: 1 }}>
+                <RelativeDate
+                  dateString={record.assessmentDate}
+                  dateUpdated={record.dateUpdated || undefined}
+                  variant='body2'
+                  textAlign={'center'}
+                  fontWeight={600}
+                  withTooltip
+                  prefix='Assessment Date: '
+                />
+                <Button
+                  onClick={() => onSelected(record)}
+                  variant='outlined'
+                  size='small'
+                  sx={{ backgroundColor: 'white' }}
+                  fullWidth
+                  aria-label={`Select record from ${record.assessmentDate}`}
+                >
+                  Select
+                </Button>
+              </Stack>
+            );
+          }}
+        />
       </DialogContent>
       <DialogActions sx={{ justifyContent: 'center' }}>
         <Button onClick={onCancel} variant='gray'>

--- a/src/modules/form/components/RecordPickerDialog.tsx
+++ b/src/modules/form/components/RecordPickerDialog.tsx
@@ -1,4 +1,4 @@
-import { Stack } from '@mui/material';
+import { Box, Stack } from '@mui/material';
 import Button from '@mui/material/Button';
 import { DialogProps } from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
@@ -70,6 +70,9 @@ const RecordPickerDialog = ({
     return [...assessmentColumns, ...dataColumns];
   }, [item]);
 
+  // Need to set height on the dialog in order for the scrolling to work
+  const height = `${Math.min(Math.max(columns.length * 60 + 250, 550), 850)}px`;
+
   const hudRoles = [
     AssessmentRole.Intake,
     AssessmentRole.Update,
@@ -102,49 +105,52 @@ const RecordPickerDialog = ({
 
       <DialogContent
         sx={{
-          pb: 2,
+          py: 0,
           my: 0,
+          height,
         }}
       >
         {description}
-        <AssessmentsForPopulationTable
-          queryVariables={{ id: clientId, roles: hudRoles }}
-          defaultPageSize={5}
-          columns={columns}
-          nonTablePagination
-          vertical
-          fullHeight
-          tableProps={{
-            size: 'small',
-            stickyHeader: true,
-            width: 'fit-content',
-          }}
-          renderVerticalHeaderCell={(record) => {
-            return (
-              <Stack spacing={2} sx={{ py: 1 }}>
-                <RelativeDate
-                  dateString={record.assessmentDate}
-                  dateUpdated={record.dateUpdated || undefined}
-                  variant='body2'
-                  textAlign={'center'}
-                  fontWeight={600}
-                  withTooltip
-                  prefix='Assessment Date: '
-                />
-                <Button
-                  onClick={() => onSelected(record)}
-                  variant='outlined'
-                  size='small'
-                  sx={{ backgroundColor: 'white' }}
-                  fullWidth
-                  aria-label={`Select record from ${record.assessmentDate}`}
-                >
-                  Select
-                </Button>
-              </Stack>
-            );
-          }}
-        />
+        <Box sx={{ height: `calc(${height} - 190px)` }}>
+          <AssessmentsForPopulationTable
+            queryVariables={{ id: clientId, roles: hudRoles }}
+            defaultPageSize={5}
+            columns={columns}
+            nonTablePagination
+            vertical
+            fullHeight
+            tableProps={{
+              size: 'small',
+              stickyHeader: true,
+              width: 'fit-content',
+            }}
+            renderVerticalHeaderCell={(record) => {
+              return (
+                <Stack spacing={2} sx={{ py: 1 }}>
+                  <RelativeDate
+                    dateString={record.assessmentDate}
+                    dateUpdated={record.dateUpdated || undefined}
+                    variant='body2'
+                    textAlign={'center'}
+                    fontWeight={600}
+                    withTooltip
+                    prefix='Assessment Date: '
+                  />
+                  <Button
+                    onClick={() => onSelected(record)}
+                    variant='outlined'
+                    size='small'
+                    sx={{ backgroundColor: 'white' }}
+                    fullWidth
+                    aria-label={`Select record from ${record.assessmentDate}`}
+                  >
+                    Select
+                  </Button>
+                </Stack>
+              );
+            }}
+          />
+        </Box>
       </DialogContent>
       <DialogActions sx={{ justifyContent: 'center' }}>
         <Button onClick={onCancel} variant='gray'>

--- a/src/modules/form/components/RecordPickerDialog.tsx
+++ b/src/modules/form/components/RecordPickerDialog.tsx
@@ -71,6 +71,8 @@ const RecordPickerDialog = ({
   }, [item]);
 
   // Need to set height on the dialog in order for the scrolling to work
+  // Columns are really rows here because this is a vertical table.
+  // The height should be between 550 and 850, with the # of columns determining where it falls within that.
   const height = `${Math.min(Math.max(columns.length * 60 + 250, 550), 850)}px`;
 
   const hudRoles = [
@@ -107,7 +109,6 @@ const RecordPickerDialog = ({
         sx={{
           pb: 6,
           my: 2,
-          overflow: 'hidden',
           height: '100%', // need for scrolling
         }}
       >


### PR DESCRIPTION
## Description

GH issue: https://github.com/open-path/Green-River/issues/6062

Removing `overflow: hidden` in RecordPickerDialog fixes the usability bug and enables scrolling. However, I think it's still not the originally desired appearance. The record picker table is being told to take up 100% height, but I think that this needs to be a calculated value (100% minus some overhead) in order to not cause the table to always scroll even when its own content is short enough that it shouldn't cause scrolling.

I spent quite a bit of time fiddling with the height CSS, including trying to implement something using flex box; and also trying to change how the `fullHeight` prop is implemented in `GenericTable`. In the end I decided I had spent too much time on it to continue blocking the usability issue. I'd be glad to pair on this though.

The other two changes fix a more minor scrolling issue with the assessment form sidebar. The left hand assessment nav bar should be sticky, but previosuly it would move around a bit when you first scrolled down the page, and the bottom (including the autofill button) would be truncated a bit -- just a visual annoyance, not enough to impact functionality. These problems should both be fixed now.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
