### PR TITLE
Fix readonly item inconsistency

### DIFF
--- a/src/modules/form/components/DynamicForm.stories.tsx
+++ b/src/modules/form/components/DynamicForm.stories.tsx
@@ -7,7 +7,8 @@ import { Default as ViewStory } from './viewable/DynamicView.stories';
 
 import { emptyErrorState } from '@/modules/errors/util';
 import formData from '@/test/__mocks__/mockFormDefinition.json';
-import { FormDefinitionJson } from '@/types/gqlTypes';
+import { generateMockValuesForDefinition } from '@/test/utils/testUtils';
+import { FormDefinitionJson, ItemType } from '@/types/gqlTypes';
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 const formDefinition: FormDefinitionJson = JSON.parse(JSON.stringify(formData));
 
@@ -67,6 +68,32 @@ WithValuesAsReadOnly.args = {
   ),
   initialValues: ViewStory.args?.values,
   errors: emptyErrorState,
+};
+
+// Render a mini form that doesn't have a top-level group
+const miniForm = {
+  item: [
+    {
+      type: ItemType.String,
+      required: true,
+      linkId: 'name',
+      text: 'Staff name',
+    },
+    {
+      type: ItemType.Integer,
+      required: false,
+      readOnly: true,
+      linkId: 'age',
+      text: "Client's age (read-only)",
+    },
+  ],
+} as FormDefinitionJson;
+export const MiniForm = Template.bind({});
+MiniForm.args = {
+  definition: miniForm,
+  initialValues: generateMockValuesForDefinition(miniForm),
+  errors: emptyErrorState,
+  hideSubmit: true,
 };
 
 // Render the DynamicForm with all fields having extra long labels

--- a/src/modules/form/components/DynamicFormFields.tsx
+++ b/src/modules/form/components/DynamicFormFields.tsx
@@ -1,3 +1,4 @@
+import { Grid } from '@mui/material';
 import { pick } from 'lodash-es';
 import React, { ReactNode, useCallback } from 'react';
 
@@ -125,18 +126,23 @@ const DynamicFormFields: React.FC<Props> = ({
       );
     }
 
+    // Render question item as an input field or a read-only field.
+    // Note: DynamicField automatically wraps components in an InputContainer, which is a Grid item.
+    // DynamicViewField does not, so we wrap it in a grid  item here for consistency
     const itemComponent = item.readOnly ? (
-      <DynamicViewField
-        item={item}
-        value={values[item.linkId]}
-        disabled={isDisabled}
-        nestingLevel={nestingLevel}
-        horizontal={horizontal}
-        pickListArgs={pickListArgs}
-        // Needed because there are some enable/disabled and autofill dependencies that depend on PickListOption.labels that are fetched (PriorLivingSituation is an example)
-        adjustValue={itemChanged}
-        {...props}
-      />
+      <Grid item key={item.linkId}>
+        <DynamicViewField
+          item={item}
+          value={values[item.linkId]}
+          disabled={isDisabled}
+          nestingLevel={nestingLevel}
+          horizontal={horizontal}
+          pickListArgs={pickListArgs}
+          // Needed because there are some enable/disabled and autofill dependencies that depend on PickListOption.labels that are fetched (PriorLivingSituation is an example)
+          adjustValue={itemChanged}
+          {...props}
+        />
+      </Grid>
     ) : (
       <DynamicField
         key={item.linkId}


### PR DESCRIPTION
## Description

Fix inconsistency in how read-only items are rendered within an editable form.




## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
