### PR TITLE
Patch date display for midnight-datetimes

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -39039,7 +39039,7 @@
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
-                "name": "ISO8601DateTime",
+                "name": "ISO8601Date",
                 "ofType": null
               }
             },

--- a/src/modules/hmis/hmisUtil.test.ts
+++ b/src/modules/hmis/hmisUtil.test.ts
@@ -44,6 +44,9 @@ describe('Date fns', () => {
     it('parse and format gql date for display', () => {
       expect(parseAndFormatDate('2021-12-01')).toBe('12/01/2021');
       expect(parseAndFormatDate('2021-01-31')).toBe('01/31/2021');
+      expect(parseAndFormatDate('2024-05-24T00:00:00+00:00')).toBe(
+        '05/24/2024'
+      );
       expect(parseAndFormatDateTime('2023-02-02T15:50:10.000Z').length).toEqual(
         '02/02/2023 10:50 AM'.length // avoid dealing with timezones right now
       );

--- a/src/modules/hmis/hmisUtil.ts
+++ b/src/modules/hmis/hmisUtil.ts
@@ -181,6 +181,9 @@ export const parseAndFormatDate = (
   dateString: string | null | undefined
 ): string | null => {
   if (!dateString) return null;
+  // Trim string to date only
+  if (dateString.length > 10) dateString = dateString.slice(0, 10);
+
   const parsed = parseHmisDateString(dateString);
   if (!parsed) return dateString;
   return formatDateForDisplay(parsed) || dateString;

--- a/src/modules/hmis/hmisUtil.ts
+++ b/src/modules/hmis/hmisUtil.ts
@@ -181,8 +181,8 @@ export const parseAndFormatDate = (
   dateString: string | null | undefined
 ): string | null => {
   if (!dateString) return null;
-  // Trim string to date only
-  if (dateString.length > 10) dateString = dateString.slice(0, 10);
+  // remove time from ISO8601 date-time string
+  dateString = dateString.slice(0, 10);
 
   const parsed = parseHmisDateString(dateString);
   if (!parsed) return dateString;

--- a/src/types/gqlObjects.ts
+++ b/src/types/gqlObjects.ts
@@ -5287,7 +5287,7 @@ export const HmisObjectSchemas: GqlSchema[] = [
         type: {
           kind: 'NON_NULL',
           name: null,
-          ofType: { kind: 'SCALAR', name: 'ISO8601DateTime', ofType: null },
+          ofType: { kind: 'SCALAR', name: 'ISO8601Date', ofType: null },
         },
       },
       {

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -6140,7 +6140,7 @@ export type ReferralPosting = {
   postingIdentifier?: Maybe<Scalars['ID']['output']>;
   /** Project that household is being referred to */
   project?: Maybe<Project>;
-  referralDate: Scalars['ISO8601DateTime']['output'];
+  referralDate: Scalars['ISO8601Date']['output'];
   referralIdentifier?: Maybe<Scalars['ID']['output']>;
   /** Note associated with the Referral that came from an External API */
   referralNotes?: Maybe<Scalars['String']['output']>;


### PR DESCRIPTION
## Description

Before: `parseAndFormatDate('2024-05-24T00:00:00+00:00') ==  '05/23/2024'`
After:    `parseAndFormatDate('2024-05-24T00:00:00+00:00') ==  '05/24/2024'`

I think this is what we want, because when you call `parseAndFormatDate` on a datetime string you are explicitly requesting the date to be formatted without the time. I think midnight of 5/24 is 5/24.

Also has schema changes from https://github.com/greenriver/hmis-warehouse/pull/4400

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
