### PR TITLE
Use new `referredTo` to display destination project, standardize incoming/outgoing referral tables

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -37090,7 +37090,7 @@
             "args": [
               {
                 "name": "projectId",
-                "description": "Optional Project to apply rule filtering (e.g. show/hide questions based on Project applicability)",
+                "description": "Optional Project to select the relevant form, and to apply rule filtering\n(e.g. show/hide questions based on Project applicability)",
                 "type": {
                   "kind": "SCALAR",
                   "name": "ID",
@@ -39020,7 +39020,7 @@
           },
           {
             "name": "project",
-            "description": "Project that household is being referred to",
+            "description": "Project that household is being referred to, if user can access it",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -39122,6 +39122,18 @@
                 "name": "String",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "referredTo",
+            "description": "Name of the Project that household is being referred to",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/src/api/operations/referralPosting.fragments.graphql
+++ b/src/api/operations/referralPosting.fragments.graphql
@@ -5,7 +5,9 @@ fragment ReferralPostingFields on ReferralPosting {
   hohName
   hohMciId
   householdSize
+  referredFrom
   referredBy
+  referredTo
   status
   assignedDate
   statusUpdatedAt
@@ -36,6 +38,7 @@ fragment ReferralPostingDetailFields on ReferralPosting {
   referralResult
   referredBy
   referredFrom
+  referredTo
   resourceCoordinatorNotes
   score
   status

--- a/src/modules/projects/components/ProjectReferrals.tsx
+++ b/src/modules/projects/components/ProjectReferrals.tsx
@@ -67,7 +67,16 @@ const ProjectReferrals = () => {
                 <ProjectReferralRequestsTable project={project} />
               </TitleCard>
             )}
-            <TitleCard title='Active Referrals' headerVariant='border'>
+            <TitleCard
+              title={
+                // If user is seeing both Outgoing+Incoming, call this "Incoming" to make the difference more obvious.
+                // If user only sees incoming referrals (AC providers), leave it as "Active Referrals".
+                project.access.canManageOutgoingReferrals
+                  ? 'Incoming Referrals'
+                  : 'Active Referrals'
+              }
+              headerVariant='border'
+            >
               <ProjectReferralPostingsTable
                 projectId={project.id}
                 externalReferrals={externalReferrals}

--- a/src/modules/projects/components/tables/ProjectOutgoingReferralPostingsTable.tsx
+++ b/src/modules/projects/components/tables/ProjectOutgoingReferralPostingsTable.tsx
@@ -26,10 +26,32 @@ const columns: ColumnDef<OutgoingReferral>[] = [
     render: (row: OutgoingReferral) => parseAndFormatDate(row.referralDate),
   },
   {
+    header: 'HoH',
+    render: ({ hohName, hohEnrollment }: OutgoingReferral) => {
+      if (!hohEnrollment) return hohName;
+
+      // If we have a hohEnrollment, link to it.
+      // NOTE: its possible that "hohName" and the actual person on "hohEnrollment" don't actually match up,
+      // if the Hoh was changed over time. Thats probably OK, the user can at least get to the right household.
+      const enrollmentPath = generateSafePath(
+        EnrollmentDashboardRoutes.ENROLLMENT_OVERVIEW,
+        {
+          clientId: hohEnrollment.client.id,
+          enrollmentId: hohEnrollment.id,
+        }
+      );
+      return (
+        <RouterLink to={enrollmentPath} openInNew>
+          {hohName}
+        </RouterLink>
+      );
+    },
+  },
+  {
     header: 'Project Referred To',
     linkTreatment: true,
-    render: ({ id, project }: OutgoingReferral) => {
-      if (!project) return null;
+    render: ({ id, referredTo, project }: OutgoingReferral) => {
+      if (!project) return referredTo; // user does not have access to the full project object, so just show the project name
 
       const projectPath = generateSafePath(
         ProjectDashboardRoutes.REFERRAL_POSTING,
@@ -60,28 +82,6 @@ const columns: ColumnDef<OutgoingReferral>[] = [
     render: ({ status }: OutgoingReferral) => (
       <ReferralPostingStatusDisplay status={status} />
     ),
-  },
-  {
-    header: 'HoH',
-    render: ({ hohName, hohEnrollment }: OutgoingReferral) => {
-      if (!hohEnrollment) return hohName;
-
-      // If we have a hohEnrollment, link to it.
-      // NOTE: its possible that "hohName" and the actual person on "hohEnrollment" don't actually match up,
-      // if the Hoh was changed over time. Thats probably OK, the user can at least get to the right household.
-      const enrollmentPath = generateSafePath(
-        EnrollmentDashboardRoutes.ENROLLMENT_OVERVIEW,
-        {
-          clientId: hohEnrollment.client.id,
-          enrollmentId: hohEnrollment.id,
-        }
-      );
-      return (
-        <RouterLink to={enrollmentPath} openInNew>
-          {hohName}
-        </RouterLink>
-      );
-    },
   },
   {
     header: 'Household Size',

--- a/src/modules/projects/components/tables/ProjectReferralPostingsTable.tsx
+++ b/src/modules/projects/components/tables/ProjectReferralPostingsTable.tsx
@@ -16,39 +16,6 @@ import {
 } from '@/types/gqlTypes';
 import { generateSafePath } from '@/utils/pathEncoding';
 
-const defaultColumns: ColumnDef<ReferralPostingFieldsFragment>[] = [
-  {
-    header: 'Referral Date',
-    render: (row: ReferralPostingFieldsFragment) =>
-      parseAndFormatDate(row.referralDate),
-  },
-  {
-    header: 'HoH',
-    render: ({ hohName }: ReferralPostingFieldsFragment) =>
-      hohName || 'Unnamed Client',
-    linkTreatment: true,
-  },
-  {
-    header: 'Household Size',
-    render: 'householdSize',
-  },
-  {
-    header: 'Referred By',
-    render: 'referredBy',
-  },
-  {
-    header: 'Status',
-    render: (row: ReferralPostingFieldsFragment) => (
-      <ReferralPostingStatusDisplay status={row.status} />
-    ),
-  },
-  {
-    header: 'Assigned Date',
-    render: (row: ReferralPostingFieldsFragment) =>
-      parseAndFormatDateTime(row.assignedDate),
-  },
-];
-
 interface Props {
   projectId: string;
   externalReferrals?: boolean;
@@ -69,18 +36,51 @@ const ProjectReferralPostingsTable: React.FC<Props> = ({
   );
 
   const columns = useMemo(() => {
-    if (externalReferrals) {
-      // external referrals have an ID from the sending system
-      return [
-        {
-          header: 'Referral ID',
-          render: (row) => row.referralIdentifier || 'N/A',
-        },
-        ...defaultColumns,
-      ];
-    }
-
-    return defaultColumns;
+    const cols: ColumnDef<ReferralPostingFieldsFragment>[] = [
+      {
+        header: 'Referral ID',
+        render: (row) => row.referralIdentifier || 'N/A',
+        hide: !externalReferrals,
+      },
+      {
+        header: 'Referral Date',
+        render: (row: ReferralPostingFieldsFragment) =>
+          parseAndFormatDate(row.referralDate),
+      },
+      {
+        header: 'HoH',
+        render: ({ hohName }: ReferralPostingFieldsFragment) =>
+          hohName || 'Unnamed Client',
+        linkTreatment: true,
+      },
+      {
+        header: 'Referred By',
+        render: 'referredBy',
+        hide: !externalReferrals,
+      },
+      {
+        header: 'Referred From',
+        render: 'referredFrom',
+        hide: externalReferrals,
+      },
+      {
+        header: 'Status',
+        render: (row: ReferralPostingFieldsFragment) => (
+          <ReferralPostingStatusDisplay status={row.status} />
+        ),
+      },
+      {
+        header: 'Assigned Date',
+        render: (row: ReferralPostingFieldsFragment) =>
+          parseAndFormatDateTime(row.assignedDate),
+        hide: !externalReferrals,
+      },
+      {
+        header: 'Household Size',
+        render: 'householdSize',
+      },
+    ];
+    return cols;
   }, [externalReferrals]);
 
   return (

--- a/src/types/gqlObjects.ts
+++ b/src/types/gqlObjects.ts
@@ -5319,6 +5319,10 @@ export const HmisObjectSchemas: GqlSchema[] = [
         },
       },
       {
+        name: 'referredTo',
+        type: { kind: 'SCALAR', name: 'String', ofType: null },
+      },
+      {
         name: 'resourceCoordinatorNotes',
         type: { kind: 'SCALAR', name: 'String', ofType: null },
       },

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -6138,7 +6138,7 @@ export type ReferralPosting = {
   needsWheelchairAccessibleUnit?: Maybe<Scalars['Boolean']['output']>;
   organization?: Maybe<Organization>;
   postingIdentifier?: Maybe<Scalars['ID']['output']>;
-  /** Project that household is being referred to */
+  /** Project that household is being referred to, if user can access it */
   project?: Maybe<Project>;
   referralDate: Scalars['ISO8601Date']['output'];
   referralIdentifier?: Maybe<Scalars['ID']['output']>;
@@ -6149,6 +6149,8 @@ export type ReferralPosting = {
   referredBy: Scalars['String']['output'];
   /** Name of project or external source that the referral originated from */
   referredFrom: Scalars['String']['output'];
+  /** Name of the Project that household is being referred to */
+  referredTo?: Maybe<Scalars['String']['output']>;
   /**
    * Note associated with the Referral Posting that either came from the External
    * API, or was entered when creating a referral within HMIS
@@ -28857,7 +28859,9 @@ export type GetProjectReferralPostingsQuery = {
         hohName: string;
         hohMciId?: string | null;
         householdSize: number;
+        referredFrom: string;
         referredBy: string;
+        referredTo?: string | null;
         status: ReferralPostingStatus;
         assignedDate: string;
         statusUpdatedAt?: string | null;
@@ -28902,7 +28906,9 @@ export type GetProjectOutgoingReferralPostingsQuery = {
         hohName: string;
         hohMciId?: string | null;
         householdSize: number;
+        referredFrom: string;
         referredBy: string;
+        referredTo?: string | null;
         status: ReferralPostingStatus;
         assignedDate: string;
         statusUpdatedAt?: string | null;
@@ -29446,6 +29452,7 @@ export type GetReferralPostingQuery = {
     referralResult?: ReferralResult | null;
     referredBy: string;
     referredFrom: string;
+    referredTo?: string | null;
     resourceCoordinatorNotes?: string | null;
     score?: number | null;
     status: ReferralPostingStatus;
@@ -29614,6 +29621,7 @@ export type UpdateReferralPostingMutation = {
       referralResult?: ReferralResult | null;
       referredBy: string;
       referredFrom: string;
+      referredTo?: string | null;
       resourceCoordinatorNotes?: string | null;
       score?: number | null;
       status: ReferralPostingStatus;
@@ -29792,7 +29800,9 @@ export type GetDeniedPendingReferralPostingsQuery = {
       hohName: string;
       hohMciId?: string | null;
       householdSize: number;
+      referredFrom: string;
       referredBy: string;
+      referredTo?: string | null;
       status: ReferralPostingStatus;
       assignedDate: string;
       statusUpdatedAt?: string | null;
@@ -29820,7 +29830,9 @@ export type ReferralPostingFieldsFragment = {
   hohName: string;
   hohMciId?: string | null;
   householdSize: number;
+  referredFrom: string;
   referredBy: string;
+  referredTo?: string | null;
   status: ReferralPostingStatus;
   assignedDate: string;
   statusUpdatedAt?: string | null;
@@ -29854,6 +29866,7 @@ export type ReferralPostingDetailFieldsFragment = {
   referralResult?: ReferralResult | null;
   referredBy: string;
   referredFrom: string;
+  referredTo?: string | null;
   resourceCoordinatorNotes?: string | null;
   score?: number | null;
   status: ReferralPostingStatus;
@@ -33083,7 +33096,9 @@ export const ReferralPostingFieldsFragmentDoc = gql`
     hohName
     hohMciId
     householdSize
+    referredFrom
     referredBy
+    referredTo
     status
     assignedDate
     statusUpdatedAt
@@ -33115,6 +33130,7 @@ export const ReferralPostingDetailFieldsFragmentDoc = gql`
     referralResult
     referredBy
     referredFrom
+    referredTo
     resourceCoordinatorNotes
     score
     status


### PR DESCRIPTION
## Description

* Use referredTo so providers can see destination name even if they can't access project
* Standardize columns

Depends on hmis-warehouse PR: https://github.com/greenriver/hmis-warehouse/pull/4408

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
