### PR TITLE
Enable editing additional form attributes

### DIFF
--- a/src/modules/formBuilder/components/FormBuilder.tsx
+++ b/src/modules/formBuilder/components/FormBuilder.tsx
@@ -80,7 +80,12 @@ const FormBuilder: React.FC<FormBuilderProps> = ({
       if (blockedActionFunction) blockedActionFunction();
       setBlockedActionFunction(undefined);
     });
-  }, [workingDefinition, blockedActionFunction, setBlockedActionFunction]);
+  }, [
+    workingDefinition,
+    blockedActionFunction,
+    setBlockedActionFunction,
+    onSave,
+  ]);
 
   if (!workingDefinition || !setWorkingDefinition) return <Loading />;
 

--- a/src/modules/formBuilder/components/FormEditorItemProperties.tsx
+++ b/src/modules/formBuilder/components/FormEditorItemProperties.tsx
@@ -12,7 +12,7 @@ import {
   localResolvePickList,
   MAX_INPUT_AND_LABEL_WIDTH,
 } from '@/modules/form/util/formUtil';
-import { getComponents } from '@/modules/formBuilder/components/formBuilderUtil';
+import { validComponentsForType } from '@/modules/formBuilder/components/formBuilderUtil';
 import {
   AssessmentRole,
   Component,
@@ -52,9 +52,9 @@ const FormEditorItemProperties: React.FC<FormEditorItemPropertiesProps> = ({
   );
   const [initialLinkId] = useState<string>(item.linkId);
 
-  const components = useMemo(
+  const componentOverridePicklist = useMemo(
     () =>
-      getComponents(item.type).map((component) => {
+      validComponentsForType(item.type).map((component) => {
         return {
           code: component,
           label: startCase(component.toLowerCase()),
@@ -74,11 +74,11 @@ const FormEditorItemProperties: React.FC<FormEditorItemPropertiesProps> = ({
         }}
         sx={{ maxWidth: MAX_INPUT_AND_LABEL_WIDTH }}
       >
-        {components.length > 0 && (
+        {componentOverridePicklist.length > 0 && (
           <FormSelect
-            label='Component'
+            label='Component Override'
             value={item.component ? { code: item.component } : null}
-            options={components}
+            options={componentOverridePicklist}
             onChange={(_e, value) => {
               onChangeProperty(
                 'component',
@@ -232,7 +232,7 @@ const FormEditorItemProperties: React.FC<FormEditorItemPropertiesProps> = ({
           (item.type === ItemType.Object &&
             item.component === Component.Address)) && (
           <LabeledCheckbox
-            label='Repeats'
+            label='Allow multiple responses'
             checked={item.repeats}
             onChange={(e) =>
               onChangeProperty(

--- a/src/modules/formBuilder/components/FormEditorItemProperties.tsx
+++ b/src/modules/formBuilder/components/FormEditorItemProperties.tsx
@@ -1,5 +1,6 @@
 import { LoadingButton } from '@mui/lab';
 import { Button, Stack, Typography } from '@mui/material';
+import { startCase } from 'lodash-es';
 import { useMemo, useState } from 'react';
 import LabeledCheckbox from '@/components/elements/input/LabeledCheckbox';
 import TextInput from '@/components/elements/input/TextInput';
@@ -11,8 +12,10 @@ import {
   localResolvePickList,
   MAX_INPUT_AND_LABEL_WIDTH,
 } from '@/modules/form/util/formUtil';
+import { getComponents } from '@/modules/formBuilder/components/formBuilderUtil';
 import {
   AssessmentRole,
+  Component,
   FormDefinitionFieldsForEditorFragment,
   FormItem,
   ItemType,
@@ -49,6 +52,17 @@ const FormEditorItemProperties: React.FC<FormEditorItemPropertiesProps> = ({
   );
   const [initialLinkId] = useState<string>(item.linkId);
 
+  const components = useMemo(
+    () =>
+      getComponents(item.type).map((component) => {
+        return {
+          code: component,
+          label: startCase(component.toLowerCase()),
+        };
+      }),
+    [item.type]
+  );
+
   return (
     <>
       <Typography>Properties</Typography>
@@ -60,6 +74,19 @@ const FormEditorItemProperties: React.FC<FormEditorItemPropertiesProps> = ({
         }}
         sx={{ maxWidth: MAX_INPUT_AND_LABEL_WIDTH }}
       >
+        {components.length > 0 && (
+          <FormSelect
+            label='Component'
+            value={item.component ? { code: item.component } : null}
+            options={components}
+            onChange={(_e, value) => {
+              onChangeProperty(
+                'component',
+                isPickListOption(value) ? value.code : null
+              );
+            }}
+          />
+        )}
         <TextInput
           label='Link ID'
           value={item.linkId}
@@ -201,22 +228,50 @@ const FormEditorItemProperties: React.FC<FormEditorItemPropertiesProps> = ({
             }}
           />
         )}
-        {[ItemType.Choice, ItemType.OpenChoice].includes(item.type) && (
-          <FormSelect
-            label='Pick list reference'
-            value={
-              pickListTypesPickList.find(
-                (o) => o.code === item.pickListReference
-              ) || undefined
-            }
-            options={pickListTypesPickList}
-            onChange={(_e, value) => {
+        {([ItemType.Choice, ItemType.OpenChoice].includes(item.type) ||
+          (item.type === ItemType.Object &&
+            item.component === Component.Address)) && (
+          <LabeledCheckbox
+            label='Repeats'
+            checked={item.repeats}
+            onChange={(e) =>
               onChangeProperty(
-                'pickListReference',
-                isPickListOption(value) ? value.code : undefined
-              );
-            }}
+                'repeats',
+                (e.target as HTMLInputElement).checked
+              )
+            }
           />
+        )}
+        {[ItemType.Choice, ItemType.OpenChoice].includes(item.type) && (
+          <>
+            <TextInput
+              label='Allowed Responses'
+              value={item.pickListOptions?.map((o) => o.code).join(',')}
+              onChange={(e) => {
+                onChangeProperty(
+                  'pickListOptions',
+                  e.target.value.split(',').map((o) => {
+                    return { code: o };
+                  })
+                );
+              }}
+            />
+            <FormSelect
+              label='Reference list for allowed responses'
+              value={
+                pickListTypesPickList.find(
+                  (o) => o.code === item.pickListReference
+                ) || undefined
+              }
+              options={pickListTypesPickList}
+              onChange={(_e, value) => {
+                onChangeProperty(
+                  'pickListReference',
+                  isPickListOption(value) ? value.code : undefined
+                );
+              }}
+            />
+          </>
         )}
         {errorState?.errors && errorState.errors.length > 0 && (
           <Stack gap={1} sx={{ mt: 4 }}>

--- a/src/modules/formBuilder/components/formBuilderUtil.ts
+++ b/src/modules/formBuilder/components/formBuilderUtil.ts
@@ -1,0 +1,45 @@
+import { ItemType, Component } from '@/types/gqlTypes';
+
+export const getComponents = (type: ItemType) => {
+  switch (type) {
+    case ItemType.Object:
+      return [
+        Component.Address,
+        Component.Phone,
+        Component.Email,
+        Component.Name,
+      ];
+    case ItemType.Display:
+      return [
+        Component.AlertInfo,
+        Component.AlertWarning,
+        Component.AlertSuccess,
+        Component.AlertError,
+      ];
+    case ItemType.Boolean:
+      return [Component.Checkbox];
+    case ItemType.Choice:
+    case ItemType.OpenChoice:
+      return [
+        Component.Dropdown,
+        Component.RadioButtons,
+        Component.RadioButtonsVertical,
+      ];
+    case ItemType.Group:
+      return [
+        Component.HorizontalGroup,
+        Component.InfoGroup,
+        Component.InputGroup,
+        Component.SignatureGroup,
+        Component.Signature,
+        Component.Table,
+      ];
+    case ItemType.Integer:
+      return [Component.MinutesDuration];
+    case ItemType.String:
+    case ItemType.Text:
+      return [Component.Phone, Component.Ssn];
+    default:
+      return [];
+  }
+};

--- a/src/modules/formBuilder/components/formBuilderUtil.ts
+++ b/src/modules/formBuilder/components/formBuilderUtil.ts
@@ -1,6 +1,11 @@
 import { ItemType, Component } from '@/types/gqlTypes';
 
-export const getComponents = (type: ItemType) => {
+export const validComponentsForType = (type: ItemType) => {
+  /**
+   * You can select a component override for some item types, but each item type
+   * also has a default component that it displays (Except for Object?).
+   * These are specified in code in the DynamicField/DynamicViewField.
+   */
   switch (type) {
     case ItemType.Object:
       return [
@@ -19,7 +24,6 @@ export const getComponents = (type: ItemType) => {
     case ItemType.Boolean:
       return [Component.Checkbox];
     case ItemType.Choice:
-    case ItemType.OpenChoice:
       return [
         Component.Dropdown,
         Component.RadioButtons,


### PR DESCRIPTION
## Description

GH issue: https://github.com/open-path/Green-River/issues/6087

This PR adds a few new attributes to the Item Editor drawer, notably the Component dropdown.

Note - There aren't design mocks yet for the multi-pick list option creation, so I've implemented it as a comma-separated text box for now. I think this is v1-only and should be improved upon by the time we actually ship this to any customers.

## Type of change
[//]: # 'remove options that are not relevant'
- [ ] Bug fix
- [x] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
