### PR TITLE
Add CLS tab to Projects dash

### DIFF
--- a/src/api/operations/currentLivingSituation.fragments.graphql
+++ b/src/api/operations/currentLivingSituation.fragments.graphql
@@ -18,3 +18,14 @@ fragment CurrentLivingSituationFields on CurrentLivingSituation {
     ...CustomDataElementFields
   }
 }
+
+fragment ProjectCurrentLivingSituationFields on CurrentLivingSituation {
+  client {
+    id
+    ...ClientName
+  }
+  enrollment {
+    id
+  }
+  ...CurrentLivingSituationFields
+}

--- a/src/api/operations/currentLivingSituation.fragments.graphql
+++ b/src/api/operations/currentLivingSituation.fragments.graphql
@@ -26,6 +26,7 @@ fragment ProjectCurrentLivingSituationFields on CurrentLivingSituation {
   }
   enrollment {
     id
+    ...EnrollmentRangeFields
   }
   ...CurrentLivingSituationFields
 }

--- a/src/api/operations/currentLivingSituation.queries.graphql
+++ b/src/api/operations/currentLivingSituation.queries.graphql
@@ -23,8 +23,7 @@ query GetProjectCurrentLivingSituations(
 ) {
   project(id: $id) {
     id
-    currentLivingSit
-    uations(limit: $limit, offset: $offset) {
+    currentLivingSituations(limit: $limit, offset: $offset) {
       offset
       limit
       nodesCount

--- a/src/api/operations/currentLivingSituation.queries.graphql
+++ b/src/api/operations/currentLivingSituation.queries.graphql
@@ -15,3 +15,22 @@ query GetEnrollmentCurrentLivingSituations(
     }
   }
 }
+
+query GetProjectCurrentLivingSituations(
+  $id: ID!
+  $limit: Int = 10
+  $offset: Int = 0
+) {
+  project(id: $id) {
+    id
+    currentLivingSit
+    uations(limit: $limit, offset: $offset) {
+      offset
+      limit
+      nodesCount
+      nodes {
+        ...ProjectCurrentLivingSituationFields
+      }
+    }
+  }
+}

--- a/src/api/operations/enrollment.fragments.graphql
+++ b/src/api/operations/enrollment.fragments.graphql
@@ -252,3 +252,9 @@ fragment EnrollmentSummaryFields on EnrollmentSummary {
   projectType
   canViewEnrollment
 }
+
+fragment EnrollmentRangeFields on Enrollment {
+  entryDate
+  exitDate
+  inProgress
+}

--- a/src/api/operations/household.fragments.graphql
+++ b/src/api/operations/household.fragments.graphql
@@ -28,9 +28,7 @@ fragment HouseholdClientFields on HouseholdClient {
   enrollment {
     id
     lockVersion
-    entryDate
-    exitDate
-    inProgress
+    ...EnrollmentRangeFields
     autoExited
     currentUnit {
       id

--- a/src/api/operations/project.queries.graphql
+++ b/src/api/operations/project.queries.graphql
@@ -112,8 +112,7 @@ query GetProjectServices(
         ...ServiceBasicFields
         enrollment {
           id
-          entryDate
-          exitDate
+          ...EnrollmentRangeFields
           client {
             ...ClientNameDobVet
           }

--- a/src/modules/enrollment/components/dashboardPages/EnrollmentCurrentLivingSituationsPage.tsx
+++ b/src/modules/enrollment/components/dashboardPages/EnrollmentCurrentLivingSituationsPage.tsx
@@ -1,7 +1,6 @@
 import AddIcon from '@mui/icons-material/Add';
 import { Button } from '@mui/material';
 import { useCallback, useMemo } from 'react';
-import { ColumnDef } from '@/components/elements/table/types';
 import TitleCard from '@/components/elements/TitleCard';
 import { useEnrollmentDashboardContext } from '@/components/pages/EnrollmentDashboard';
 import NotFound from '@/components/pages/NotFound';
@@ -23,28 +22,29 @@ import {
   RecordFormRole,
 } from '@/types/gqlTypes';
 
-const baseColumns: ColumnDef<CurrentLivingSituationFieldsFragment>[] = [
-  {
+export const baseColumns = {
+  informationDate: {
     header: 'Information Date',
     width: '180px',
-    render: (e) => parseAndFormatDate(e.informationDate),
+    render: (e: CurrentLivingSituationFieldsFragment) =>
+      parseAndFormatDate(e.informationDate),
     linkTreatment: true,
   },
-  {
+  livingSituation: {
     header: 'Living Situation',
     width: '400px',
-    render: (e) => (
+    render: (e: CurrentLivingSituationFieldsFragment) => (
       <HmisEnum
         value={e.currentLivingSituation}
         enumMap={HmisEnums.CurrentLivingSituationOptions}
       />
     ),
   },
-  {
+  locationDetails: {
     header: 'Location Details',
-    render: (e) => e.locationDetails,
+    render: (e: CurrentLivingSituationFieldsFragment) => e.locationDetails,
   },
-];
+};
 
 const EnrollmentCurrentLivingSituationsPage = () => {
   const { enrollment } = useEnrollmentDashboardContext();
@@ -85,7 +85,12 @@ const EnrollmentCurrentLivingSituationsPage = () => {
   const getColumnDefs = useCallback(
     (rows: CurrentLivingSituationFieldsFragment[]) => {
       const customColumns = getCustomDataElementColumns(rows);
-      return [...baseColumns, ...customColumns];
+      return [
+        baseColumns.informationDate,
+        baseColumns.livingSituation,
+        baseColumns.locationDetails,
+        ...customColumns,
+      ];
     },
     []
   );

--- a/src/modules/hmis/components/EnrollmentDateRangeWithStatus.tsx
+++ b/src/modules/hmis/components/EnrollmentDateRangeWithStatus.tsx
@@ -3,7 +3,7 @@ import { ReactNode } from 'react';
 
 import { formatDateForDisplay, parseHmisDateString } from '../hmisUtil';
 
-import { HouseholdClientFieldsFragment } from '@/types/gqlTypes';
+import { EnrollmentRangeFieldsFragment } from '@/types/gqlTypes';
 
 const ACTIVE_TEXT = 'Ongoing';
 
@@ -11,7 +11,7 @@ const EnrollmentDateRangeWithStatus = ({
   enrollment,
   treatIncompleteAsActive = false,
 }: {
-  enrollment: HouseholdClientFieldsFragment['enrollment'];
+  enrollment: EnrollmentRangeFieldsFragment;
   // if the status is called out separately, use this prop to render
   // incomplete as if it were active
   treatIncompleteAsActive?: boolean;

--- a/src/modules/projects/components/ProjectCurrentLivingSituations.tsx
+++ b/src/modules/projects/components/ProjectCurrentLivingSituations.tsx
@@ -6,6 +6,7 @@ import useSafeParams from '@/hooks/useSafeParams';
 import ClientName from '@/modules/client/components/ClientName';
 import GenericTableWithData from '@/modules/dataFetching/components/GenericTableWithData';
 import { baseColumns } from '@/modules/enrollment/components/dashboardPages/EnrollmentCurrentLivingSituationsPage';
+import EnrollmentDateRangeWithStatus from '@/modules/hmis/components/EnrollmentDateRangeWithStatus';
 import { EnrollmentDashboardRoutes } from '@/routes/routes';
 import {
   GetProjectCurrentLivingSituationsDocument,
@@ -38,14 +39,17 @@ const ProjectCurrentLivingSituations = () => {
       },
       { ...baseColumns.informationDate, linkTreatment: false },
       baseColumns.livingSituation,
-      baseColumns.locationDetails,
+      {
+        header: 'Enrollment Period',
+        render: (cls: ProjectCurrentLivingSituationFieldsFragment) => (
+          <EnrollmentDateRangeWithStatus enrollment={cls.enrollment} />
+        ),
+      },
     ];
   }, []);
 
   const rowLinkTo = useCallback(
     (cls: ProjectCurrentLivingSituationFieldsFragment) => {
-      if (!cls) return;
-
       return generateSafePath(
         EnrollmentDashboardRoutes.CURRENT_LIVING_SITUATIONS,
         {

--- a/src/modules/projects/components/ProjectCurrentLivingSituations.tsx
+++ b/src/modules/projects/components/ProjectCurrentLivingSituations.tsx
@@ -1,0 +1,81 @@
+import { Paper } from '@mui/material';
+
+import { useCallback, useMemo } from 'react';
+import PageTitle from '@/components/layout/PageTitle';
+import useSafeParams from '@/hooks/useSafeParams';
+import ClientName from '@/modules/client/components/ClientName';
+import GenericTableWithData from '@/modules/dataFetching/components/GenericTableWithData';
+import { baseColumns } from '@/modules/enrollment/components/dashboardPages/EnrollmentCurrentLivingSituationsPage';
+import { EnrollmentDashboardRoutes } from '@/routes/routes';
+import {
+  GetProjectCurrentLivingSituationsDocument,
+  GetProjectCurrentLivingSituationsQuery,
+  GetProjectCurrentLivingSituationsQueryVariables,
+  ProjectCurrentLivingSituationFieldsFragment,
+} from '@/types/gqlTypes';
+import { generateSafePath } from '@/utils/pathEncoding';
+
+const ProjectCurrentLivingSituations = () => {
+  const { projectId } = useSafeParams() as {
+    projectId: string;
+  };
+
+  const columns = useMemo(() => {
+    return [
+      {
+        header: 'First Name',
+        linkTreatment: true,
+        render: (cls: ProjectCurrentLivingSituationFieldsFragment) => (
+          <ClientName client={cls.client} nameParts='first_only' />
+        ),
+      },
+      {
+        header: 'Last Name',
+        linkTreatment: true,
+        render: (cls: ProjectCurrentLivingSituationFieldsFragment) => (
+          <ClientName client={cls.client} nameParts='last_only' />
+        ),
+      },
+      { ...baseColumns.informationDate, linkTreatment: false },
+      baseColumns.livingSituation,
+      baseColumns.locationDetails,
+    ];
+  }, []);
+
+  const rowLinkTo = useCallback(
+    (cls: ProjectCurrentLivingSituationFieldsFragment) => {
+      if (!cls) return;
+
+      return generateSafePath(
+        EnrollmentDashboardRoutes.CURRENT_LIVING_SITUATIONS,
+        {
+          clientId: cls.client.id,
+          enrollmentId: cls.enrollment.id,
+        }
+      );
+    },
+    []
+  );
+
+  return (
+    <>
+      <PageTitle title='Current Living Situations' />
+      <Paper>
+        <GenericTableWithData<
+          GetProjectCurrentLivingSituationsQuery,
+          GetProjectCurrentLivingSituationsQueryVariables,
+          ProjectCurrentLivingSituationFieldsFragment
+        >
+          queryVariables={{ id: projectId }}
+          queryDocument={GetProjectCurrentLivingSituationsDocument}
+          columns={columns}
+          pagePath='project.currentLivingSituations'
+          noData='No current living situations'
+          recordType='CurrentLivingSituation'
+          rowLinkTo={rowLinkTo}
+        />
+      </Paper>
+    </>
+  );
+};
+export default ProjectCurrentLivingSituations;

--- a/src/modules/projects/components/tables/ProjectServicesTable.tsx
+++ b/src/modules/projects/components/tables/ProjectServicesTable.tsx
@@ -1,17 +1,19 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import { ColumnDef } from '@/components/elements/table/types';
 import ClientName from '@/modules/client/components/ClientName';
 import GenericTableWithData from '@/modules/dataFetching/components/GenericTableWithData';
 import { SERVICE_BASIC_COLUMNS } from '@/modules/enrollment/components/dashboardPages/EnrollmentServicesPage';
+import EnrollmentDateRangeWithStatus from '@/modules/hmis/components/EnrollmentDateRangeWithStatus';
 import { useFilters } from '@/modules/hmis/filterUtil';
-import { parseAndFormatDateRange } from '@/modules/hmis/hmisUtil';
+import { EnrollmentDashboardRoutes } from '@/routes/routes';
 import {
   GetProjectServicesDocument,
   GetProjectServicesQuery,
   GetProjectServicesQueryVariables,
   ServicesForProjectFilterOptions,
 } from '@/types/gqlTypes';
+import { generateSafePath } from '@/utils/pathEncoding';
 
 export type ServiceFields = NonNullable<
   GetProjectServicesQuery['project']
@@ -53,11 +55,9 @@ const ProjectServicesTable = ({
       SERVICE_BASIC_COLUMNS.serviceType,
       {
         header: 'Enrollment Period',
-        render: (s: ServiceFields) =>
-          parseAndFormatDateRange(
-            s.enrollment.entryDate,
-            s.enrollment.exitDate
-          ),
+        render: (s: ServiceFields) => (
+          <EnrollmentDateRangeWithStatus enrollment={s.enrollment} />
+        ),
       },
     ];
   }, [columns]);
@@ -65,6 +65,13 @@ const ProjectServicesTable = ({
   const filters = useFilters({
     type: 'ServicesForProjectFilterOptions',
   });
+
+  const rowLinkTo = useCallback((s: ServiceFields) => {
+    return generateSafePath(EnrollmentDashboardRoutes.SERVICES, {
+      clientId: s.enrollment.client.id,
+      enrollmentId: s.enrollment.id,
+    });
+  }, []);
 
   return (
     <GenericTableWithData<
@@ -82,6 +89,7 @@ const ProjectServicesTable = ({
       pagePath='project.services'
       recordType='Service'
       filters={filters}
+      rowLinkTo={rowLinkTo}
     />
   );
 };

--- a/src/modules/projects/hooks/useProjectDashboardNavItems.tsx
+++ b/src/modules/projects/hooks/useProjectDashboardNavItems.tsx
@@ -49,7 +49,15 @@ export const useProjectDashboardNavItems = (
               DataCollectionFeatureRole.Service
             ),
           },
-
+          {
+            id: 'current-living-situations',
+            title: 'Current Living Situations',
+            path: ProjectDashboardRoutes.PROJECT_CURRENT_LIVING_SITUATIONS,
+            permissions: ['canViewEnrollmentDetails'],
+            hide: !dataCollectionRoles.includes(
+              DataCollectionFeatureRole.CurrentLivingSituation
+            ),
+          },
           {
             id: 'externalForms',
             title: 'External Forms',

--- a/src/routes/protected.tsx
+++ b/src/routes/protected.tsx
@@ -86,6 +86,7 @@ import NewOutgoingReferral from '@/modules/projects/components/NewOutgoingReferr
 import NewReferralRequest from '@/modules/projects/components/NewReferralRequest';
 import ProjectAssessments from '@/modules/projects/components/ProjectAssessments';
 import ProjectCoc from '@/modules/projects/components/ProjectCoc';
+import ProjectCurrentLivingSituations from '@/modules/projects/components/ProjectCurrentLivingSituations';
 import ProjectDashboard from '@/modules/projects/components/ProjectDashboard';
 import ProjectEnrollments from '@/modules/projects/components/ProjectEnrollments';
 import ProjectEsgFundingReport from '@/modules/projects/components/ProjectEsgFundingReport';
@@ -163,6 +164,10 @@ export const protectedRoutes: RouteNode[] = [
           {
             path: ProjectDashboardRoutes.PROJECT_SERVICES,
             element: <ProjectServices />,
+          },
+          {
+            path: ProjectDashboardRoutes.PROJECT_CURRENT_LIVING_SITUATIONS,
+            element: <ProjectCurrentLivingSituations />,
           },
           {
             path: ProjectDashboardRoutes.BULK_BED_NIGHTS,

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -76,6 +76,7 @@ const projectDashboardRoutes = {
   PROJECT_ENROLLMENTS: 'enrollments',
   PROJECT_ASSESSMENTS: 'assessments',
   PROJECT_SERVICES: 'services',
+  PROJECT_CURRENT_LIVING_SITUATIONS: 'current-living-situations',
   BULK_BED_NIGHTS: 'bed-nights',
   BULK_ASSIGN_SERVICE: 'bulk-service',
   BULK_BED_NIGHTS_NEW_HOUSEHOLD: 'bed-nights/new-household',

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -15670,6 +15670,85 @@ export type CurrentLivingSituationFieldsFragment = {
   }>;
 };
 
+export type ProjectCurrentLivingSituationFieldsFragment = {
+  __typename?: 'CurrentLivingSituation';
+  id: string;
+  clsSubsidyType?: RentalSubsidyType | null;
+  currentLivingSituation: CurrentLivingSituationOptions;
+  informationDate?: string | null;
+  leaseOwn60Day?: NoYesReasonsForMissingData | null;
+  leaveSituation14Days?: NoYesReasonsForMissingData | null;
+  locationDetails?: string | null;
+  movedTwoOrMore?: NoYesReasonsForMissingData | null;
+  resourcesToObtain?: NoYesReasonsForMissingData | null;
+  subsequentResidence?: NoYesReasonsForMissingData | null;
+  dateUpdated?: string | null;
+  dateCreated?: string | null;
+  client: {
+    __typename?: 'Client';
+    id: string;
+    lockVersion: number;
+    firstName?: string | null;
+    middleName?: string | null;
+    lastName?: string | null;
+    nameSuffix?: string | null;
+  };
+  enrollment: { __typename?: 'Enrollment'; id: string };
+  user?: {
+    __typename: 'ApplicationUser';
+    id: string;
+    name: string;
+    email: string;
+  } | null;
+  customDataElements: Array<{
+    __typename?: 'CustomDataElement';
+    id: string;
+    key: string;
+    label: string;
+    fieldType: CustomDataElementType;
+    repeats: boolean;
+    displayHooks: Array<DisplayHook>;
+    value?: {
+      __typename?: 'CustomDataElementValue';
+      id: string;
+      valueBoolean?: boolean | null;
+      valueDate?: string | null;
+      valueFloat?: number | null;
+      valueInteger?: number | null;
+      valueJson?: any | null;
+      valueString?: string | null;
+      valueText?: string | null;
+      dateCreated?: string | null;
+      dateUpdated?: string | null;
+      user?: {
+        __typename: 'ApplicationUser';
+        id: string;
+        name: string;
+        email: string;
+      } | null;
+    } | null;
+    values?: Array<{
+      __typename?: 'CustomDataElementValue';
+      id: string;
+      valueBoolean?: boolean | null;
+      valueDate?: string | null;
+      valueFloat?: number | null;
+      valueInteger?: number | null;
+      valueJson?: any | null;
+      valueString?: string | null;
+      valueText?: string | null;
+      dateCreated?: string | null;
+      dateUpdated?: string | null;
+      user?: {
+        __typename: 'ApplicationUser';
+        id: string;
+        name: string;
+        email: string;
+      } | null;
+    }> | null;
+  }>;
+};
+
 export type GetEnrollmentCurrentLivingSituationsQueryVariables = Exact<{
   id: Scalars['ID']['input'];
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -15700,6 +15779,104 @@ export type GetEnrollmentCurrentLivingSituationsQuery = {
         subsequentResidence?: NoYesReasonsForMissingData | null;
         dateUpdated?: string | null;
         dateCreated?: string | null;
+        user?: {
+          __typename: 'ApplicationUser';
+          id: string;
+          name: string;
+          email: string;
+        } | null;
+        customDataElements: Array<{
+          __typename?: 'CustomDataElement';
+          id: string;
+          key: string;
+          label: string;
+          fieldType: CustomDataElementType;
+          repeats: boolean;
+          displayHooks: Array<DisplayHook>;
+          value?: {
+            __typename?: 'CustomDataElementValue';
+            id: string;
+            valueBoolean?: boolean | null;
+            valueDate?: string | null;
+            valueFloat?: number | null;
+            valueInteger?: number | null;
+            valueJson?: any | null;
+            valueString?: string | null;
+            valueText?: string | null;
+            dateCreated?: string | null;
+            dateUpdated?: string | null;
+            user?: {
+              __typename: 'ApplicationUser';
+              id: string;
+              name: string;
+              email: string;
+            } | null;
+          } | null;
+          values?: Array<{
+            __typename?: 'CustomDataElementValue';
+            id: string;
+            valueBoolean?: boolean | null;
+            valueDate?: string | null;
+            valueFloat?: number | null;
+            valueInteger?: number | null;
+            valueJson?: any | null;
+            valueString?: string | null;
+            valueText?: string | null;
+            dateCreated?: string | null;
+            dateUpdated?: string | null;
+            user?: {
+              __typename: 'ApplicationUser';
+              id: string;
+              name: string;
+              email: string;
+            } | null;
+          }> | null;
+        }>;
+      }>;
+    };
+  } | null;
+};
+
+export type GetProjectCurrentLivingSituationsQueryVariables = Exact<{
+  id: Scalars['ID']['input'];
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+}>;
+
+export type GetProjectCurrentLivingSituationsQuery = {
+  __typename?: 'Query';
+  project?: {
+    __typename?: 'Project';
+    id: string;
+    currentLivingSituations: {
+      __typename?: 'CurrentLivingSituationsPaginated';
+      offset: number;
+      limit: number;
+      nodesCount: number;
+      nodes: Array<{
+        __typename?: 'CurrentLivingSituation';
+        id: string;
+        clsSubsidyType?: RentalSubsidyType | null;
+        currentLivingSituation: CurrentLivingSituationOptions;
+        informationDate?: string | null;
+        leaseOwn60Day?: NoYesReasonsForMissingData | null;
+        leaveSituation14Days?: NoYesReasonsForMissingData | null;
+        locationDetails?: string | null;
+        movedTwoOrMore?: NoYesReasonsForMissingData | null;
+        resourcesToObtain?: NoYesReasonsForMissingData | null;
+        subsequentResidence?: NoYesReasonsForMissingData | null;
+        dateUpdated?: string | null;
+        dateCreated?: string | null;
+        client: {
+          __typename?: 'Client';
+          id: string;
+          lockVersion: number;
+          firstName?: string | null;
+          middleName?: string | null;
+          lastName?: string | null;
+          nameSuffix?: string | null;
+        };
+        enrollment: { __typename?: 'Enrollment'; id: string };
         user?: {
           __typename: 'ApplicationUser';
           id: string;
@@ -32275,6 +32452,20 @@ export const CurrentLivingSituationFieldsFragmentDoc = gql`
   ${UserFieldsFragmentDoc}
   ${CustomDataElementFieldsFragmentDoc}
 `;
+export const ProjectCurrentLivingSituationFieldsFragmentDoc = gql`
+  fragment ProjectCurrentLivingSituationFields on CurrentLivingSituation {
+    client {
+      id
+      ...ClientName
+    }
+    enrollment {
+      id
+    }
+    ...CurrentLivingSituationFields
+  }
+  ${ClientNameFragmentDoc}
+  ${CurrentLivingSituationFieldsFragmentDoc}
+`;
 export const CustomCaseNoteFieldsFragmentDoc = gql`
   fragment CustomCaseNoteFields on CustomCaseNote {
     id
@@ -37007,6 +37198,79 @@ export type GetEnrollmentCurrentLivingSituationsQueryResult =
     GetEnrollmentCurrentLivingSituationsQuery,
     GetEnrollmentCurrentLivingSituationsQueryVariables
   >;
+export const GetProjectCurrentLivingSituationsDocument = gql`
+  query GetProjectCurrentLivingSituations(
+    $id: ID!
+    $limit: Int = 10
+    $offset: Int = 0
+  ) {
+    project(id: $id) {
+      id
+      currentLivingSituations(limit: $limit, offset: $offset) {
+        offset
+        limit
+        nodesCount
+        nodes {
+          ...ProjectCurrentLivingSituationFields
+        }
+      }
+    }
+  }
+  ${ProjectCurrentLivingSituationFieldsFragmentDoc}
+`;
+
+/**
+ * __useGetProjectCurrentLivingSituationsQuery__
+ *
+ * To run a query within a React component, call `useGetProjectCurrentLivingSituationsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetProjectCurrentLivingSituationsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetProjectCurrentLivingSituationsQuery({
+ *   variables: {
+ *      id: // value for 'id'
+ *      limit: // value for 'limit'
+ *      offset: // value for 'offset'
+ *   },
+ * });
+ */
+export function useGetProjectCurrentLivingSituationsQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    GetProjectCurrentLivingSituationsQuery,
+    GetProjectCurrentLivingSituationsQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    GetProjectCurrentLivingSituationsQuery,
+    GetProjectCurrentLivingSituationsQueryVariables
+  >(GetProjectCurrentLivingSituationsDocument, options);
+}
+export function useGetProjectCurrentLivingSituationsLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GetProjectCurrentLivingSituationsQuery,
+    GetProjectCurrentLivingSituationsQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    GetProjectCurrentLivingSituationsQuery,
+    GetProjectCurrentLivingSituationsQueryVariables
+  >(GetProjectCurrentLivingSituationsDocument, options);
+}
+export type GetProjectCurrentLivingSituationsQueryHookResult = ReturnType<
+  typeof useGetProjectCurrentLivingSituationsQuery
+>;
+export type GetProjectCurrentLivingSituationsLazyQueryHookResult = ReturnType<
+  typeof useGetProjectCurrentLivingSituationsLazyQuery
+>;
+export type GetProjectCurrentLivingSituationsQueryResult = Apollo.QueryResult<
+  GetProjectCurrentLivingSituationsQuery,
+  GetProjectCurrentLivingSituationsQueryVariables
+>;
 export const GetEnrollmentCustomCaseNotesDocument = gql`
   query GetEnrollmentCustomCaseNotes(
     $id: ID!

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -13908,10 +13908,10 @@ export type GetClientHouseholdMemberCandidatesQuery = {
               __typename?: 'Enrollment';
               id: string;
               lockVersion: number;
+              autoExited: boolean;
               entryDate: string;
               exitDate?: string | null;
               inProgress: boolean;
-              autoExited: boolean;
               currentUnit?: {
                 __typename?: 'Unit';
                 id: string;
@@ -15693,7 +15693,13 @@ export type ProjectCurrentLivingSituationFieldsFragment = {
     lastName?: string | null;
     nameSuffix?: string | null;
   };
-  enrollment: { __typename?: 'Enrollment'; id: string };
+  enrollment: {
+    __typename?: 'Enrollment';
+    id: string;
+    entryDate: string;
+    exitDate?: string | null;
+    inProgress: boolean;
+  };
   user?: {
     __typename: 'ApplicationUser';
     id: string;
@@ -15876,7 +15882,13 @@ export type GetProjectCurrentLivingSituationsQuery = {
           lastName?: string | null;
           nameSuffix?: string | null;
         };
-        enrollment: { __typename?: 'Enrollment'; id: string };
+        enrollment: {
+          __typename?: 'Enrollment';
+          id: string;
+          entryDate: string;
+          exitDate?: string | null;
+          inProgress: boolean;
+        };
         user?: {
           __typename: 'ApplicationUser';
           id: string;
@@ -17342,6 +17354,13 @@ export type EnrollmentSummaryFieldsFragment = {
   canViewEnrollment: boolean;
 };
 
+export type EnrollmentRangeFieldsFragment = {
+  __typename?: 'Enrollment';
+  entryDate: string;
+  exitDate?: string | null;
+  inProgress: boolean;
+};
+
 export type GetEnrollmentQueryVariables = Exact<{
   id: Scalars['ID']['input'];
 }>;
@@ -18271,10 +18290,10 @@ export type GetEnrollmentWithHouseholdQuery = {
           __typename?: 'Enrollment';
           id: string;
           lockVersion: number;
+          autoExited: boolean;
           entryDate: string;
           exitDate?: string | null;
           inProgress: boolean;
-          autoExited: boolean;
           currentUnit?: {
             __typename?: 'Unit';
             id: string;
@@ -26599,10 +26618,10 @@ export type HouseholdFieldsFragment = {
       __typename?: 'Enrollment';
       id: string;
       lockVersion: number;
+      autoExited: boolean;
       entryDate: string;
       exitDate?: string | null;
       inProgress: boolean;
-      autoExited: boolean;
       currentUnit?: { __typename?: 'Unit'; id: string; name: string } | null;
     };
   }>;
@@ -26677,10 +26696,10 @@ export type HouseholdClientFieldsFragment = {
     __typename?: 'Enrollment';
     id: string;
     lockVersion: number;
+    autoExited: boolean;
     entryDate: string;
     exitDate?: string | null;
     inProgress: boolean;
-    autoExited: boolean;
     currentUnit?: { __typename?: 'Unit'; id: string; name: string } | null;
   };
 };
@@ -26839,10 +26858,10 @@ export type GetHouseholdQuery = {
         __typename?: 'Enrollment';
         id: string;
         lockVersion: number;
+        autoExited: boolean;
         entryDate: string;
         exitDate?: string | null;
         inProgress: boolean;
-        autoExited: boolean;
         currentUnit?: { __typename?: 'Unit'; id: string; name: string } | null;
       };
     }>;
@@ -28551,6 +28570,7 @@ export type GetProjectServicesQuery = {
           id: string;
           entryDate: string;
           exitDate?: string | null;
+          inProgress: boolean;
           client: {
             __typename?: 'Client';
             dob?: string | null;
@@ -32428,6 +32448,13 @@ export const ServiceTypeConfigFieldsFragmentDoc = gql`
   }
   ${ServiceTypeFieldsFragmentDoc}
 `;
+export const EnrollmentRangeFieldsFragmentDoc = gql`
+  fragment EnrollmentRangeFields on Enrollment {
+    entryDate
+    exitDate
+    inProgress
+  }
+`;
 export const CurrentLivingSituationFieldsFragmentDoc = gql`
   fragment CurrentLivingSituationFields on CurrentLivingSituation {
     id
@@ -32460,10 +32487,12 @@ export const ProjectCurrentLivingSituationFieldsFragmentDoc = gql`
     }
     enrollment {
       id
+      ...EnrollmentRangeFields
     }
     ...CurrentLivingSituationFields
   }
   ${ClientNameFragmentDoc}
+  ${EnrollmentRangeFieldsFragmentDoc}
   ${CurrentLivingSituationFieldsFragmentDoc}
 `;
 export const CustomCaseNoteFieldsFragmentDoc = gql`
@@ -32930,9 +32959,7 @@ export const HouseholdClientFieldsFragmentDoc = gql`
     enrollment {
       id
       lockVersion
-      entryDate
-      exitDate
-      inProgress
+      ...EnrollmentRangeFields
       autoExited
       currentUnit {
         id
@@ -32945,6 +32972,7 @@ export const HouseholdClientFieldsFragmentDoc = gql`
   ${ClientAccessFieldsFragmentDoc}
   ${ClientIdentifierFieldsFragmentDoc}
   ${ClientAlertFieldsFragmentDoc}
+  ${EnrollmentRangeFieldsFragmentDoc}
 `;
 export const HouseholdFieldsFragmentDoc = gql`
   fragment HouseholdFields on Household {
@@ -40547,8 +40575,7 @@ export const GetProjectServicesDocument = gql`
           ...ServiceBasicFields
           enrollment {
             id
-            entryDate
-            exitDate
+            ...EnrollmentRangeFields
             client {
               ...ClientNameDobVet
             }
@@ -40558,6 +40585,7 @@ export const GetProjectServicesDocument = gql`
     }
   }
   ${ServiceBasicFieldsFragmentDoc}
+  ${EnrollmentRangeFieldsFragmentDoc}
   ${ClientNameDobVetFragmentDoc}
 `;
 


### PR DESCRIPTION
## Description

GH issue: https://github.com/open-path/Green-River/issues/6075
Depends on hmis-warehouse PR: https://github.com/greenriver/hmis-warehouse/pull/4430

This PR adds the Current Living Situation tab to the Projects dashboard.

Pending confirmation on custom columns such as Notes, see: https://github.com/open-path/Green-River/issues/6075#issuecomment-2146017018

## Type of change
[//]: # 'remove options that are not relevant'
- [ ] Bug fix
- [x] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
