### PR TITLE
Fix bug with LabeledCheckbox and RHF

### DIFF
--- a/src/components/elements/input/LabeledCheckbox.tsx
+++ b/src/components/elements/input/LabeledCheckbox.tsx
@@ -6,7 +6,13 @@ import {
   FormGroup,
   FormHelperText,
 } from '@mui/material';
-import { KeyboardEventHandler, Ref, SyntheticEvent, useCallback } from 'react';
+import {
+  KeyboardEventHandler,
+  Ref,
+  SyntheticEvent,
+  useCallback,
+  useMemo,
+} from 'react';
 
 import { horizontalInputSx } from './TextInput';
 
@@ -61,6 +67,17 @@ const LabeledCheckbox = ({
     [onChange]
   );
 
+  // Determine the checked state based on the value OR checked prop
+  const checked = useMemo(() => {
+    if (props.checked !== undefined) {
+      return props.checked;
+    }
+    if (props.value !== undefined) {
+      return !!props.value;
+    }
+    return;
+  }, [props.checked, props.value]);
+
   return (
     <FormControl>
       <FormGroup sx={horizontal ? horizontalInputSx : undefined}>
@@ -85,6 +102,7 @@ const LabeledCheckbox = ({
           }}
           onChange={onChange}
           {...props}
+          checked={checked}
         />
       </FormGroup>
       {helperText && <FormHelperText>{helperText}</FormHelperText>}


### PR DESCRIPTION
## Description

React-hook-form controller passes `value` to the checkbox, so update LabeledCheckbox to consider itself checked if a value is passed. This should not affect dynamic form usages, which [already passed checked](https://github.com/greenriver/hmis-frontend/blob/b8ed4197791dcf831a168d0ba93cd39ecf18b987/src/modules/form/components/DynamicField.tsx#L187).


Repro bug:
* Open a form item in the form builder that has "warn if empty: true". The UI will show that the checkbox is not checked, even though its true.

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
