### PR TITLE
Disallow changing linkid on persisted item, add constraints

### DIFF
--- a/src/modules/formBuilder/components/itemEditor/FormItemEditor.tsx
+++ b/src/modules/formBuilder/components/itemEditor/FormItemEditor.tsx
@@ -1,5 +1,6 @@
 import { Divider, Drawer, Typography } from '@mui/material';
-import React from 'react';
+import { startCase } from 'lodash-es';
+import React, { useMemo } from 'react';
 import { DeepPartial, useForm } from 'react-hook-form';
 import { ErrorState } from '@/modules/errors/util';
 import FormEditorItemProperties from '@/modules/formBuilder/components/itemEditor/FormEditorItemProperties';
@@ -39,6 +40,9 @@ const FormItemEditor: React.FC<FormItemEditorProps> = ({
     // errors: errorState?.errors,
   });
 
+  // If typename is not present, then this is a new item that hasn't been saved yet.
+  const isNewItem = useMemo(() => !item.__typename, [item]);
+
   return (
     <Drawer
       open={!!item}
@@ -59,7 +63,9 @@ const FormItemEditor: React.FC<FormItemEditorProps> = ({
       }}
     >
       <Typography variant='cardTitle' sx={{ p: 2 }}>
-        Edit Form Item: {item.linkId}
+        {isNewItem
+          ? `Add New ${startCase(item.type.toLowerCase())} Item`
+          : `Edit Form Item: ${item.linkId}`}
       </Typography>
       <Divider />
       {/** maybe just inline this component?  it gets basically the same props */}
@@ -71,6 +77,7 @@ const FormItemEditor: React.FC<FormItemEditorProps> = ({
         errorState={errorState}
         onDiscard={onDiscard}
         handlers={handlers}
+        isNewItem={isNewItem}
       />
     </Drawer>
   );


### PR DESCRIPTION
## Description

* Disallow changing LinkID on item once it has been persisted
* Add regex constraints to LinkID when adding new item
* Present as "Question ID" to end user

https://github.com/open-path/Green-River/issues/6167

## Type of change
- [x] New feature (adds functionality)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
