### PR TITLE
Prevent error on empty item.initial list

### DIFF
--- a/src/modules/form/util/formUtil.ts
+++ b/src/modules/form/util/formUtil.ts
@@ -777,7 +777,7 @@ export const getInitialValues = (
       if (Array.isArray(item.item)) {
         recursiveFillInValues(item.item, values);
       }
-      if (!item.initial || item.initial.length === 0) {
+      if (!item.initial) {
         // Make sure all linked fields are present in values to begin
         if (item.mapping && behavior !== InitialBehavior.Overwrite)
           values[item.linkId] = null;

--- a/src/modules/form/util/formUtil.ts
+++ b/src/modules/form/util/formUtil.ts
@@ -777,7 +777,7 @@ export const getInitialValues = (
       if (Array.isArray(item.item)) {
         recursiveFillInValues(item.item, values);
       }
-      if (!item.initial) {
+      if (!item.initial || item.initial.length === 0) {
         // Make sure all linked fields are present in values to begin
         if (item.mapping && behavior !== InitialBehavior.Overwrite)
           values[item.linkId] = null;

--- a/src/modules/formBuilder/components/FormBuilder.tsx
+++ b/src/modules/formBuilder/components/FormBuilder.tsx
@@ -207,7 +207,7 @@ const FormBuilder: React.FC<FormBuilderProps> = ({
               repeats: false,
               prefill: false,
               disabledDisplay: DisabledDisplay.Hidden,
-              enableBehavior: EnableBehavior.Any,
+              enableBehavior: EnableBehavior.All,
             };
 
             setSelectedItem(newItem);


### PR DESCRIPTION
## Description

https://greenriver.slack.com/archives/C061SAW3LFJ/p1718196001472859

The bug appears when `item.initial` list is present but empty.

I didn't find any forms in QA where this was actually the case, barring the one I created copied from a [local definition](https://qa-hmis.openpath.host/admin/forms/martha_test) that somehow got into this state. But, I think it's cleaner for our code to handle this case given that I think it's legal per the [json schema](https://github.com/greenriver/hmis-warehouse/blob/6702d55a7a29cba68b29bbf0342cadd83de7754a/drivers/hmis_external_apis/public/schemas/form_definition.json#L251).

I also updated the initial `enableBehavior` on newly added form items from the Palette to be `Any` instead of `All` - that initial `Any` was causing the newly added items to not appear in the preview, since none of the zero conditions were true 😭 . (The reason to include it at all here is just to make typescript happy, but perhaps it should instead be made optional and removed here?)

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
