### PR TITLE
Use h1 for page titles

### DIFF
--- a/src/components/layout/PageTitle.tsx
+++ b/src/components/layout/PageTitle.tsx
@@ -25,7 +25,9 @@ const PageTitle = ({
       }}
     >
       {typeof title === 'string' ? (
-        <Typography variant='h3'>{title}</Typography>
+        <Typography variant='h3' component='h1'>
+          {title}
+        </Typography>
       ) : (
         title
       )}

--- a/src/modules/admin/components/services/ServiceTypeDetailPage.tsx
+++ b/src/modules/admin/components/services/ServiceTypeDetailPage.tsx
@@ -44,7 +44,7 @@ const ServiceTypeDetailPage = () => {
       <PageTitle
         title={
           <Stack direction='row' gap={1} key={data.serviceType.name}>
-            <Typography variant='h3'>
+            <Typography variant='h3' component='h1'>
               Manage Service: <b>{data.serviceType.name}</b>
             </Typography>
             <IconButton


### PR DESCRIPTION
## Description

This should catch the majority of page titles throughout the application. Top level title should use `h1`.

## Type of change
- [x] Code clean-up / housekeeping

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
