### PR TITLE
Form builder style updates and bug fixes on preview

### DIFF
--- a/src/components/elements/EditIconButton.tsx
+++ b/src/components/elements/EditIconButton.tsx
@@ -1,0 +1,24 @@
+import { IconButton, IconButtonProps } from '@mui/material';
+import ButtonTooltipContainer from './ButtonTooltipContainer';
+import { EditIcon } from './SemanticIcons';
+
+export interface EditIconButtonProps extends IconButtonProps {}
+
+const EditIconButton: React.FC<EditIconButtonProps> = ({ ...props }) => {
+  return (
+    <ButtonTooltipContainer title={props.title}>
+      <IconButton
+        size='small'
+        {...props}
+        sx={{
+          color: (theme) => theme.palette.links,
+          ...props.sx,
+        }}
+      >
+        <EditIcon fontSize='inherit' />
+      </IconButton>
+    </ButtonTooltipContainer>
+  );
+};
+
+export default EditIconButton;

--- a/src/components/layout/PageTitle.tsx
+++ b/src/components/layout/PageTitle.tsx
@@ -29,7 +29,7 @@ const PageTitle = ({
       }}
     >
       {typeof title === 'string' ? (
-        <Typography variant='h3' component='h1' sx={{ mt: 0 }}>
+        <Typography variant='h3' component='h1'>
           {overlineText ? (
             <Typography variant='overline' color='links' display='block'>
               {overlineText}

--- a/src/components/layout/PageTitle.tsx
+++ b/src/components/layout/PageTitle.tsx
@@ -14,7 +14,6 @@ const PageTitle = ({
   actions?: ReactNode; // element to float to the right (e.g. action button)
 }) => {
   const isTiny = useIsMobile('sm');
-  const hasOverlineText = !!overlineText;
 
   return (
     <Stack
@@ -25,8 +24,8 @@ const PageTitle = ({
       sx={{
         mb: isTiny ? 1 : 3,
         alignItems: isTiny ? 'left' : 'center',
-        // fixed height (if not mobile), so height is the same whether there are actions or not
-        height: isTiny ? '' : hasOverlineText ? '60px' : '40px',
+        // fixed min height (if not mobile), so height is the same whether there are actions or not
+        minHeight: isTiny ? '' : '40px',
       }}
     >
       {typeof title === 'string' ? (
@@ -40,7 +39,10 @@ const PageTitle = ({
           {endElement}
         </Typography>
       ) : (
-        title
+        <>
+          {title}
+          {endElement}
+        </>
       )}
       {actions}
     </Stack>

--- a/src/components/layout/PageTitle.tsx
+++ b/src/components/layout/PageTitle.tsx
@@ -6,12 +6,15 @@ const PageTitle = ({
   title,
   overlineText,
   actions,
+  endElement,
 }: {
   title: ReactNode;
   overlineText?: string;
-  actions?: ReactNode;
+  endElement?: ReactNode; // element to appear directly to the right of the title
+  actions?: ReactNode; // element to float to the right (e.g. action button)
 }) => {
   const isTiny = useIsMobile('sm');
+  const hasOverlineText = !!overlineText;
 
   return (
     <Stack
@@ -23,17 +26,18 @@ const PageTitle = ({
         mb: isTiny ? 1 : 3,
         alignItems: isTiny ? 'left' : 'center',
         // fixed height (if not mobile), so height is the same whether there are actions or not
-        height: isTiny ? '' : '40px',
+        height: isTiny ? '' : hasOverlineText ? '60px' : '40px',
       }}
     >
       {typeof title === 'string' ? (
-        <Typography variant='h3' component='h1'>
+        <Typography variant='h3' component='h1' sx={{ mt: 0 }}>
           {overlineText ? (
             <Typography variant='overline' color='links' display='block'>
               {overlineText}
             </Typography>
           ) : null}
           {title}
+          {endElement}
         </Typography>
       ) : (
         title

--- a/src/modules/admin/components/forms/FormDefinitionDetailPage.tsx
+++ b/src/modules/admin/components/forms/FormDefinitionDetailPage.tsx
@@ -79,11 +79,11 @@ const FormDefinitionDetailPage = () => {
 
   return (
     <>
+      <PageTitle
+        overlineText='Selected Form'
+        title={formIdentifier.displayVersion.title}
+      />
       <Stack gap={2}>
-        <PageTitle
-          overlineText='Selected Form'
-          title={formIdentifier.displayVersion.title}
-        />
         <Grid container spacing={2}>
           <Grid item xs={12} md={8}>
             <CommonCard title='Details'>

--- a/src/modules/admin/components/services/ServiceTypeDetailPage.tsx
+++ b/src/modules/admin/components/services/ServiceTypeDetailPage.tsx
@@ -1,8 +1,8 @@
-import { IconButton, Paper, Stack, Typography } from '@mui/material';
-import * as React from 'react';
+import { IconButton, Paper, Stack } from '@mui/material';
 import { useState } from 'react';
 import { generatePath, useNavigate } from 'react-router-dom';
 import { CommonUnstyledList } from '@/components/CommonUnstyledList';
+import ButtonTooltipContainer from '@/components/elements/ButtonTooltipContainer';
 import { CommonLabeledTextBlock } from '@/components/elements/CommonLabeledTextBlock';
 import Loading from '@/components/elements/Loading';
 import RouterLink from '@/components/elements/RouterLink';
@@ -42,19 +42,19 @@ const ServiceTypeDetailPage = () => {
   return (
     <>
       <PageTitle
-        title={
-          <Stack direction='row' gap={1} key={data.serviceType.name}>
-            <Typography variant='h3' component='h1'>
-              Manage Service: <b>{data.serviceType.name}</b>
-            </Typography>
+        overlineText='Manage Service'
+        title={data.serviceType.name}
+        endElement={
+          <ButtonTooltipContainer title='Edit Service Type'>
             <IconButton
-              aria-label='edit title'
+              aria-label='edit service type'
               onClick={() => setUpdateDialogOpen(true)}
               size='small'
+              sx={{ color: (theme) => theme.palette.links, ml: 1, mb: 0.5 }}
             >
               <EditIcon fontSize='inherit' />
             </IconButton>
-          </Stack>
+          </ButtonTooltipContainer>
         }
         actions={
           <DeleteMutationButton<

--- a/src/modules/admin/components/services/ServiceTypeDetailPage.tsx
+++ b/src/modules/admin/components/services/ServiceTypeDetailPage.tsx
@@ -1,12 +1,11 @@
-import { IconButton, Paper, Stack } from '@mui/material';
+import { Paper, Stack } from '@mui/material';
 import { useState } from 'react';
 import { generatePath, useNavigate } from 'react-router-dom';
 import { CommonUnstyledList } from '@/components/CommonUnstyledList';
-import ButtonTooltipContainer from '@/components/elements/ButtonTooltipContainer';
 import { CommonLabeledTextBlock } from '@/components/elements/CommonLabeledTextBlock';
+import EditIconButton from '@/components/elements/EditIconButton';
 import Loading from '@/components/elements/Loading';
 import RouterLink from '@/components/elements/RouterLink';
-import { EditIcon } from '@/components/elements/SemanticIcons';
 import PageTitle from '@/components/layout/PageTitle';
 import NotFound from '@/components/pages/NotFound';
 import useSafeParams from '@/hooks/useSafeParams';
@@ -45,16 +44,11 @@ const ServiceTypeDetailPage = () => {
         overlineText='Manage Service'
         title={data.serviceType.name}
         endElement={
-          <ButtonTooltipContainer title='Edit Service Type'>
-            <IconButton
-              aria-label='edit service type'
-              onClick={() => setUpdateDialogOpen(true)}
-              size='small'
-              sx={{ color: (theme) => theme.palette.links, ml: 1, mb: 0.5 }}
-            >
-              <EditIcon fontSize='inherit' />
-            </IconButton>
-          </ButtonTooltipContainer>
+          <EditIconButton
+            title='Edit Service Type'
+            onClick={() => setUpdateDialogOpen(true)}
+            sx={{ ml: 1, mb: 0.5 }}
+          />
         }
         actions={
           <DeleteMutationButton<

--- a/src/modules/form/components/viewable/DynamicViewField.tsx
+++ b/src/modules/form/components/viewable/DynamicViewField.tsx
@@ -14,18 +14,22 @@ import Image from './item/Image';
 import TextContent from './item/TextContent';
 
 import CommonHtmlContent from '@/components/elements/CommonHtmlContent';
+import { CommonLabeledTextBlock } from '@/components/elements/CommonLabeledTextBlock';
 import { minutesToHoursAndMinutes } from '@/components/elements/input/MinutesDurationInput';
 import { FALSE_OPT, TRUE_OPT } from '@/components/elements/input/YesNoRadio';
 import LabelWithContent from '@/components/elements/LabelWithContent';
 import NotCollectedText from '@/components/elements/NotCollectedText';
 import RecoverableError from '@/components/elements/RecoverableError';
 import ClientAddress from '@/modules/client/components/ClientAddress';
+import ClientContactPoint from '@/modules/client/components/ClientContactPoint';
+import ClientName from '@/modules/client/components/ClientName';
 import {
   formatDateForDisplay,
   formatTimeOfDay,
   parseAndFormatDate,
 } from '@/modules/hmis/hmisUtil';
 import {
+  ClientContactPointSystem,
   Component,
   DisabledDisplay,
   FormItem,
@@ -184,9 +188,49 @@ const DynamicViewField: React.FC<DynamicViewFieldProps> = ({
       return <File id={value} />;
     case ItemType.Object:
       switch (item.component) {
-        case Component.Address:
+        case Component.Address: // Used in Move-in Date Display
           return ensureArray(value).map((address) => (
-            <ClientAddress address={address} key={JSON.stringify(address)} />
+            <CommonLabeledTextBlock title={label} key={JSON.stringify(address)}>
+              <ClientAddress address={address} />
+            </CommonLabeledTextBlock>
+          ));
+        case Component.Name:
+          // Only used for Form Preview as read-only
+          return ensureArray(value).map((name) => (
+            <CommonLabeledTextBlock title={label} key={JSON.stringify(name)}>
+              <ClientName
+                client={{
+                  firstName: name.first,
+                  middleName: name.middle,
+                  lastName: name.last,
+                  nameSuffix: name.suffix,
+                }}
+              />
+            </CommonLabeledTextBlock>
+          ));
+        case Component.Email:
+          // Only used for Form Preview as read-only
+          return ensureArray(value).map((email) => (
+            <CommonLabeledTextBlock title={label} key={JSON.stringify(email)}>
+              <ClientContactPoint
+                contactPoint={{
+                  ...email,
+                  system: ClientContactPointSystem.Email,
+                }}
+              />
+            </CommonLabeledTextBlock>
+          ));
+        case Component.Phone:
+          // Only used for Form Preview as read-only
+          return ensureArray(value).map((phone) => (
+            <CommonLabeledTextBlock title={label} key={JSON.stringify(phone)}>
+              <ClientContactPoint
+                contactPoint={{
+                  ...phone,
+                  system: ClientContactPointSystem.Phone,
+                }}
+              />
+            </CommonLabeledTextBlock>
           ));
         default:
           return (

--- a/src/modules/form/util/formUtil.ts
+++ b/src/modules/form/util/formUtil.ts
@@ -1209,7 +1209,7 @@ export const createInitialValuesFromRecord = (
  * Create initial form values based on saved assessment values.
  *
  * @param itemMap Map of linkId -> Item
- * @param values  Vaved value state
+ * @param values  Saved value state
  *
  * @returns initial form state, ready to pass to DynamicForm as initialValues
  */

--- a/src/modules/form/util/formUtil.ts
+++ b/src/modules/form/util/formUtil.ts
@@ -795,7 +795,11 @@ export const getInitialValues = (
       } else if (!isNil(initial.valueNumber)) {
         values[item.linkId] = initial.valueNumber;
       } else if (initial.valueCode) {
-        values[item.linkId] = getOptionValue(initial.valueCode, item);
+        if ([ItemType.Choice, ItemType.OpenChoice].includes(item.type)) {
+          values[item.linkId] = getOptionValue(initial.valueCode, item);
+        } else {
+          values[item.linkId] = initial.valueCode; // set code directly for non-choice type (eg string)
+        }
       } else if (initial.valueLocalConstant) {
         const varName = initial.valueLocalConstant.replace(/^\$/, '');
         if (localConstants && varName in localConstants) {

--- a/src/modules/formBuilder/components/FormBuilderHeader.tsx
+++ b/src/modules/formBuilder/components/FormBuilderHeader.tsx
@@ -3,7 +3,8 @@ import { Stack } from '@mui/system';
 import React from 'react';
 import ButtonTooltipContainer from '@/components/elements/ButtonTooltipContainer';
 
-import { DeleteIcon, EditIcon } from '@/components/elements/SemanticIcons';
+import EditIconButton from '@/components/elements/EditIconButton';
+import { DeleteIcon } from '@/components/elements/SemanticIcons';
 import PageTitle from '@/components/layout/PageTitle';
 import { useStaticFormDialog } from '@/modules/form/hooks/useStaticFormDialog';
 import {
@@ -54,16 +55,11 @@ const FormBuilderHeader: React.FC<FormEditorHeaderProps> = ({
           title={formDefinition.title}
           overlineText='Editing Draft'
           endElement={
-            <ButtonTooltipContainer title='Edit Title'>
-              <IconButton
-                aria-label='edit title'
-                onClick={openEditDialog}
-                size='small'
-                sx={{ color: (theme) => theme.palette.links, ml: 1, mb: 0.5 }}
-              >
-                <EditIcon fontSize='small' />
-              </IconButton>
-            </ButtonTooltipContainer>
+            <EditIconButton
+              title='Edit Title'
+              onClick={openEditDialog}
+              sx={{ ml: 1, mb: 0.5 }}
+            />
           }
         />
 

--- a/src/modules/formBuilder/components/FormBuilderHeader.tsx
+++ b/src/modules/formBuilder/components/FormBuilderHeader.tsx
@@ -1,8 +1,10 @@
-import { Button, IconButton, Typography } from '@mui/material';
+import { Button, IconButton } from '@mui/material';
 import { Stack } from '@mui/system';
 import React from 'react';
 import ButtonTooltipContainer from '@/components/elements/ButtonTooltipContainer';
+
 import { DeleteIcon, EditIcon } from '@/components/elements/SemanticIcons';
+import PageTitle from '@/components/layout/PageTitle';
 import { useStaticFormDialog } from '@/modules/form/hooks/useStaticFormDialog';
 import {
   FormDefinitionFieldsForEditorFragment,
@@ -48,22 +50,22 @@ const FormBuilderHeader: React.FC<FormEditorHeaderProps> = ({
         justifyContent='space-between'
         alignItems='end'
       >
-        <Typography sx={{ mb: 2 }} variant='h2' component='h1'>
-          <Typography variant='overline' color='links' display='block'>
-            Editing Draft
-          </Typography>
-          {formDefinition.title}
-          <ButtonTooltipContainer title='Edit Title'>
-            <IconButton
-              aria-label='edit title'
-              onClick={openEditDialog}
-              size='small'
-              sx={{ color: (theme) => theme.palette.links, ml: 2, mb: 0.5 }}
-            >
-              <EditIcon fontSize='small' />
-            </IconButton>
-          </ButtonTooltipContainer>
-        </Typography>
+        <PageTitle
+          title={formDefinition.title}
+          overlineText='Editing Draft!'
+          endElement={
+            <ButtonTooltipContainer title='Edit Title'>
+              <IconButton
+                aria-label='edit title'
+                onClick={openEditDialog}
+                size='small'
+                sx={{ color: (theme) => theme.palette.links, ml: 1, mb: 0.5 }}
+              >
+                <EditIcon fontSize='small' />
+              </IconButton>
+            </ButtonTooltipContainer>
+          }
+        />
 
         <Stack direction='row' spacing={4} alignItems='center'>
           <Button

--- a/src/modules/formBuilder/components/FormBuilderHeader.tsx
+++ b/src/modules/formBuilder/components/FormBuilderHeader.tsx
@@ -52,7 +52,7 @@ const FormBuilderHeader: React.FC<FormEditorHeaderProps> = ({
       >
         <PageTitle
           title={formDefinition.title}
-          overlineText='Editing Draft!'
+          overlineText='Editing Draft'
           endElement={
             <ButtonTooltipContainer title='Edit Title'>
               <IconButton


### PR DESCRIPTION
## Description

* Fix issue where titles with `overlineText` were not tall enough (switch to minHeight)
* Fix bugs in form preview:
  * Error preview client form due to special object components (eg phone, email). Added display logic to DynamicViewField for them
  * Issues previewing pick list options in read-only mode were showing `code` instead of `label`. Use `createValuesForSubmit` and `createInitialValuesFromSavedValues` to mimic save behavior better
* Add "edit draft" button to preview page per spec

## Type of change
- [x] Bug fix
- [x] New feature (adds functionality)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
