### PR TITLE
Dont show form builder for published forms; read-only custom field key in property editor

### DIFF
--- a/src/modules/formBuilder/components/FormBuilderPage.tsx
+++ b/src/modules/formBuilder/components/FormBuilderPage.tsx
@@ -2,7 +2,10 @@ import Loading from '@/components/elements/Loading';
 import NotFound from '@/components/pages/NotFound';
 import useSafeParams from '@/hooks/useSafeParams';
 import FormBuilder from '@/modules/formBuilder/components/FormBuilder';
-import { useGetFormDefinitionFieldsForEditorQuery } from '@/types/gqlTypes';
+import {
+  FormStatus,
+  useGetFormDefinitionFieldsForEditorQuery,
+} from '@/types/gqlTypes';
 
 const FormBuilderPage = () => {
   const { formId } = useSafeParams() as { formId: string };
@@ -18,6 +21,8 @@ const FormBuilderPage = () => {
   if (fetchError) throw fetchError;
   if (!initialFormDefinition && fetchLoading) return <Loading />;
   if (!initialFormDefinition) return <NotFound />;
+
+  if (initialFormDefinition.status !== FormStatus.Draft) return <NotFound />;
 
   return <FormBuilder formDefinition={initialFormDefinition} />;
 };

--- a/src/modules/formBuilder/components/itemEditor/FormEditorItemProperties.tsx
+++ b/src/modules/formBuilder/components/itemEditor/FormEditorItemProperties.tsx
@@ -289,12 +289,26 @@ const FormEditorItemProperties: React.FC<FormEditorItemPropertiesProps> = ({
                 {initialItem.linkId}
               </CommonLabeledTextBlock>
             )}
-            <ControlledTextInput
-              control={control}
-              // TODO(#5776)
-              name='mapping.customFieldKey'
-              label='Mapping for custom field key'
-            />
+            {/* If this is a new item and it's a question, allow user to choose CustomDataElementDefinition key from existing keys. If left empty, a custom_field_key and CDED will be generated when the form is published */}
+            {/* {isNewItem && isQuestionItem && (
+              <ControlledSelect
+                control={control}
+                name='mapping.customFieldKey'
+                label='Field Override'
+                options={definition.eligibleCustomFieldKeyPickList}
+                placeholder='Select field override'
+                helperText='Leave blank to generate a new custom field for this question.'
+              />
+            )} */}
+            {/* If this is an existing item with a mapping, show mapping value as read-only */}
+            {!isNewItem &&
+              (initialItem.mapping?.customFieldKey ||
+                initialItem.mapping?.fieldName) && (
+                <CommonLabeledTextBlock title='Field Key'>
+                  {initialItem.mapping?.customFieldKey ||
+                    initialItem.mapping?.fieldName}
+                </CommonLabeledTextBlock>
+              )}
           </Section>
           <Divider />
           <Section title='Visibility'>


### PR DESCRIPTION
## Description

* disallow accessing form builder for a non-draft form
* show `mapping` values when present

## Type of change
- [x] Bug fix
- [x] New feature (adds functionality)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
