### PR TITLE
Enable form item deletion

### DIFF
--- a/src/components/CommonUnorderedList.tsx
+++ b/src/components/CommonUnorderedList.tsx
@@ -1,0 +1,10 @@
+import { styled } from '@mui/material/styles';
+
+export const CommonUnorderedList = styled('ul')(() => ({
+  paddingLeft: '1.2rem',
+  margin: '0',
+  '> li': {
+    marginBottom: '0.5rem',
+    marginTop: '0.5rem',
+  },
+}));

--- a/src/modules/form/util/formUtil.ts
+++ b/src/modules/form/util/formUtil.ts
@@ -948,6 +948,27 @@ export const buildEnabledDependencyMap = (itemMap: ItemMap): LinkIdMap => {
 };
 
 /**
+ * Map { linkId => array of Link IDs that depend on it for min/max bounds }
+ */
+export const buildBoundsDependencyMap = (itemMap: ItemMap): LinkIdMap => {
+  const deps: LinkIdMap = {};
+
+  function addBound(linkId: string, bound: ValueBound) {
+    if (bound.question && itemMap[bound.question]) {
+      if (!deps[bound.question]) deps[bound.question] = [];
+      deps[bound.question].push(linkId);
+    }
+  }
+
+  Object.values(itemMap).forEach((item) => {
+    if (!item.bounds) return;
+    item.bounds.forEach((bound) => addBound(item.linkId, bound));
+  });
+
+  return deps;
+};
+
+/**
  * List of link IDs that should be disabled, based on provided form values
  */
 export const getDisabledLinkIds = ({

--- a/src/modules/formBuilder/components/FormBuilderPalette.tsx
+++ b/src/modules/formBuilder/components/FormBuilderPalette.tsx
@@ -20,7 +20,7 @@ import {
   CONTEXT_HEADER_HEIGHT,
   STICKY_BAR_HEIGHT,
 } from '@/components/layout/layoutConstants';
-import { FormItemPaletteType } from '@/modules/formBuilder/components/formTree/types';
+import { FormItemPaletteType } from '@/modules/formBuilder/types';
 import { ItemType } from '@/types/gqlTypes';
 
 export const FORM_ITEM_PALETTE = {

--- a/src/modules/formBuilder/components/formTree/CannotDeleteItemDialog.tsx
+++ b/src/modules/formBuilder/components/formTree/CannotDeleteItemDialog.tsx
@@ -1,6 +1,7 @@
-import { Alert, List, ListItem } from '@mui/material';
+import { Alert } from '@mui/material';
 import { Box } from '@mui/system';
 import React, { Dispatch, SetStateAction } from 'react';
+import { CommonUnorderedList } from '@/components/CommonUnorderedList';
 import ConfirmationDialog from '@/components/elements/ConfirmationDialog';
 import { ItemMap } from '@/modules/form/types';
 import { displayLabelForItem } from '@/modules/formBuilder/formBuilderUtil';
@@ -13,26 +14,26 @@ const dependentLabelMap: Record<string, string> = {
   boundDependents: 'Items with min/max bound(s)',
 };
 
-interface CannotDeleteItemModalProps {
+interface CannotDeleteItemDialogProps {
   item: FormItem;
   itemMap: ItemMap;
-  itemDependents: ItemDependents;
-  setItemDependents: Dispatch<SetStateAction<ItemDependents | undefined>>;
+  deletionBlockers: ItemDependents;
+  setDeletionBlockers: Dispatch<SetStateAction<ItemDependents | undefined>>;
   ancestorLinkIdMap: Record<string, string[]>;
 }
 
-const CannotDeleteItemModal: React.FC<CannotDeleteItemModalProps> = ({
+const CannotDeleteItemDialog: React.FC<CannotDeleteItemDialogProps> = ({
   item,
   itemMap,
-  itemDependents,
-  setItemDependents,
+  deletionBlockers,
+  setDeletionBlockers,
   ancestorLinkIdMap,
 }) => {
   return (
     <ConfirmationDialog
-      open={!!itemDependents}
+      open={!!deletionBlockers}
       title='Cannot delete item'
-      onConfirm={() => setItemDependents(undefined)}
+      onConfirm={() => setDeletionBlockers(undefined)}
       confirmText='Close'
       loading={false}
       hideCancelButton={true}
@@ -44,29 +45,21 @@ const CannotDeleteItemModal: React.FC<CannotDeleteItemModalProps> = ({
         icon={false}
         sx={{ my: 2, '& .MuiAlert-message': { width: '100%' } }}
       >
-        {Object.entries(itemDependents).map(([key, val]) =>
+        {Object.entries(deletionBlockers).map(([key, val]) =>
           val?.length > 0 ? (
             <Box key={key}>
               {dependentLabelMap[key]}:
-              <List sx={{ listStyleType: 'disc', py: 0 }}>
+              <CommonUnorderedList>
                 {val.map((dep) => (
-                  <ListItem
-                    sx={{
-                      display: 'list-item',
-                      ml: 4,
-                      px: 0,
-                      maxWidth: 'calc(100% - 32px)',
-                    }}
-                    key={dep.linkId}
-                  >
+                  <li key={dep.linkId}>
                     {ancestorLinkIdMap[dep.linkId].map(
                       (ancestor) =>
                         `"${displayLabelForItem(itemMap[ancestor])}" > `
                     )}
                     {`"${displayLabelForItem(dep)}"`}
-                  </ListItem>
+                  </li>
                 ))}
-              </List>
+              </CommonUnorderedList>
             </Box>
           ) : null
         )}
@@ -76,4 +69,4 @@ const CannotDeleteItemModal: React.FC<CannotDeleteItemModalProps> = ({
   );
 };
 
-export default CannotDeleteItemModal;
+export default CannotDeleteItemDialog;

--- a/src/modules/formBuilder/components/formTree/CannotDeleteItemModal.tsx
+++ b/src/modules/formBuilder/components/formTree/CannotDeleteItemModal.tsx
@@ -1,0 +1,79 @@
+import { Alert, List, ListItem } from '@mui/material';
+import { Box } from '@mui/system';
+import React, { Dispatch, SetStateAction } from 'react';
+import ConfirmationDialog from '@/components/elements/ConfirmationDialog';
+import { ItemMap } from '@/modules/form/types';
+import { displayLabelForItem } from '@/modules/formBuilder/formBuilderUtil';
+import { ItemDependents } from '@/modules/formBuilder/types';
+import { FormItem } from '@/types/gqlTypes';
+
+const dependentLabelMap: Record<string, string> = {
+  autofillDependents: 'Items with autofill condition(s)',
+  enableWhenDependents: 'Items with visibility condition(s)',
+  boundDependents: 'Items with min/max bound(s)',
+};
+
+interface CannotDeleteItemModalProps {
+  item: FormItem;
+  itemMap: ItemMap;
+  itemDependents: ItemDependents;
+  setItemDependents: Dispatch<SetStateAction<ItemDependents | undefined>>;
+  ancestorLinkIdMap: Record<string, string[]>;
+}
+
+const CannotDeleteItemModal: React.FC<CannotDeleteItemModalProps> = ({
+  item,
+  itemMap,
+  itemDependents,
+  setItemDependents,
+  ancestorLinkIdMap,
+}) => {
+  return (
+    <ConfirmationDialog
+      open={!!itemDependents}
+      title='Cannot delete item'
+      onConfirm={() => setItemDependents(undefined)}
+      confirmText='Close'
+      loading={false}
+      hideCancelButton={true}
+    >
+      "{displayLabelForItem(item)}" cannot be deleted because it is referenced
+      elsewhere.
+      <Alert
+        color='error'
+        icon={false}
+        sx={{ my: 2, '& .MuiAlert-message': { width: '100%' } }}
+      >
+        {Object.entries(itemDependents).map(([key, val]) =>
+          val?.length > 0 ? (
+            <Box key={key}>
+              {dependentLabelMap[key]}:
+              <List sx={{ listStyleType: 'disc', py: 0 }}>
+                {val.map((dep) => (
+                  <ListItem
+                    sx={{
+                      display: 'list-item',
+                      ml: 4,
+                      px: 0,
+                      maxWidth: 'calc(100% - 32px)',
+                    }}
+                    key={dep.linkId}
+                  >
+                    {ancestorLinkIdMap[dep.linkId].map(
+                      (ancestor) =>
+                        `"${displayLabelForItem(itemMap[ancestor])}" > `
+                    )}
+                    {`"${displayLabelForItem(dep)}"`}
+                  </ListItem>
+                ))}
+              </List>
+            </Box>
+          ) : null
+        )}
+      </Alert>
+      All references to this item must be removed before it can be deleted.
+    </ConfirmationDialog>
+  );
+};
+
+export default CannotDeleteItemModal;

--- a/src/modules/formBuilder/components/formTree/FormTree.tsx
+++ b/src/modules/formBuilder/components/formTree/FormTree.tsx
@@ -1,7 +1,11 @@
 import { RichTreeView } from '@mui/x-tree-view/RichTreeView';
 import React, { useMemo } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
-import { displayLabelForItem, getRhfPathMap } from '../../formBuilderUtil';
+import {
+  displayLabelForItem,
+  getAncestorLinkIdMap,
+  getRhfPathMap,
+} from '../../formBuilderUtil';
 import Loading from '@/components/elements/Loading';
 import { getItemMap } from '@/modules/form/util/formUtil';
 import { FormTreeContext } from '@/modules/formBuilder/components/formTree/FormTreeContext';
@@ -28,6 +32,11 @@ const FormTree: React.FC<FormTreeProps> = ({ onEditClick }) => {
 
   const rhfPathMap = useMemo(() => getRhfPathMap(values.item), [values]);
 
+  const ancestorLinkIdMap = useMemo(
+    () => getAncestorLinkIdMap(values.item),
+    [values]
+  );
+
   const [expandedItems, setExpandedItems] = React.useState<string[]>([]);
 
   const handleExpandedItemsChange = (
@@ -46,14 +55,15 @@ const FormTree: React.FC<FormTreeProps> = ({ onEditClick }) => {
         setExpandedItems((prev) => [...prev, itemId]),
       collapseItem: (itemId: string) =>
         setExpandedItems((prev) => prev.filter((id) => id !== itemId)),
-      // `itemMap` and `rhfPathMap` are both regenerated on every change to the form, due to the `useWatch`.
+      // These maps are regenerated on every change to the form, due to the `useWatch`.
       // This shouldn't cause a perf issue right now, because this context is only consumed by the FormTreeLabel,
       // which is already calling useWatch({ control }) anyway (inside the useUpdateFormStructure hook).
       // But it could cause performance issues if other components consume this context.
       itemMap,
       rhfPathMap,
+      ancestorLinkIdMap,
     }),
-    [onEditClick, itemMap, rhfPathMap]
+    [onEditClick, itemMap, rhfPathMap, ancestorLinkIdMap]
   );
 
   if (!values.item) return <Loading />;

--- a/src/modules/formBuilder/components/formTree/FormTree.tsx
+++ b/src/modules/formBuilder/components/formTree/FormTree.tsx
@@ -44,6 +44,10 @@ const FormTree: React.FC<FormTreeProps> = ({ onEditClick }) => {
         setExpandedItems((prev) => [...prev, itemId]),
       collapseItem: (itemId: string) =>
         setExpandedItems((prev) => prev.filter((id) => id !== itemId)),
+      // `itemMap` and `rhfPathMap` are both regenerated on every change to the form, due to the `useWatch`.
+      // This shouldn't cause a perf issue right now, because this context is only consumed by the FormTreeLabel,
+      // which is already calling useWatch({ control }) anyway (inside the useUpdateFormStructure hook).
+      // But it could cause performance issues if other components consume this context.
       itemMap,
       rhfPathMap,
     }),

--- a/src/modules/formBuilder/components/formTree/FormTree.tsx
+++ b/src/modules/formBuilder/components/formTree/FormTree.tsx
@@ -37,6 +37,8 @@ const FormTree: React.FC<FormTreeProps> = ({ onEditClick }) => {
     setExpandedItems(itemIds);
   };
 
+  // Passing these values via FormTreeContext here enables us to easily pass props down
+  // to the FormTreeItem and FormTreeLabel components, avoiding slotProps and its typescript issues
   const context = React.useMemo(
     () => ({
       openFormItemEditor: (item: FormItem) => onEditClick(item),
@@ -51,7 +53,7 @@ const FormTree: React.FC<FormTreeProps> = ({ onEditClick }) => {
       itemMap,
       rhfPathMap,
     }),
-    [onEditClick, itemMap]
+    [onEditClick, itemMap, rhfPathMap]
   );
 
   if (!values.item) return <Loading />;

--- a/src/modules/formBuilder/components/formTree/FormTree.tsx
+++ b/src/modules/formBuilder/components/formTree/FormTree.tsx
@@ -1,7 +1,7 @@
 import { RichTreeView } from '@mui/x-tree-view/RichTreeView';
 import React, { useMemo } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
-import { displayLabelForItem } from '../../formBuilderUtil';
+import { displayLabelForItem, getRhfPathMap } from '../../formBuilderUtil';
 import Loading from '@/components/elements/Loading';
 import { getItemMap } from '@/modules/form/util/formUtil';
 import { FormTreeContext } from '@/modules/formBuilder/components/formTree/FormTreeContext';
@@ -26,6 +26,8 @@ const FormTree: React.FC<FormTreeProps> = ({ onEditClick }) => {
     [values]
   );
 
+  const rhfPathMap = useMemo(() => getRhfPathMap(values.item), [values]);
+
   const [expandedItems, setExpandedItems] = React.useState<string[]>([]);
 
   const handleExpandedItemsChange = (
@@ -43,6 +45,7 @@ const FormTree: React.FC<FormTreeProps> = ({ onEditClick }) => {
       collapseItem: (itemId: string) =>
         setExpandedItems((prev) => prev.filter((id) => id !== itemId)),
       itemMap,
+      rhfPathMap,
     }),
     [onEditClick, itemMap]
   );

--- a/src/modules/formBuilder/components/formTree/FormTree.tsx
+++ b/src/modules/formBuilder/components/formTree/FormTree.tsx
@@ -13,9 +13,12 @@ interface FormTreeProps {
 }
 const FormTree: React.FC<FormTreeProps> = ({ onEditClick }) => {
   const { control } = useFormContext();
-  const items = useWatch({ name: 'item', control });
+  const values = useWatch({ control });
 
-  const definitionForTree = useMemo(() => getItemsForTree(items), [items]);
+  const definitionForTree = useMemo(
+    () => getItemsForTree(values.item),
+    [values.item]
+  );
 
   const [expandedItems, setExpandedItems] = React.useState<string[]>([]);
 
@@ -37,7 +40,7 @@ const FormTree: React.FC<FormTreeProps> = ({ onEditClick }) => {
     [onEditClick]
   );
 
-  if (!items) return <Loading />;
+  if (!values.item) return <Loading />;
 
   return (
     <FormTreeContext.Provider value={context}>

--- a/src/modules/formBuilder/components/formTree/FormTree.tsx
+++ b/src/modules/formBuilder/components/formTree/FormTree.tsx
@@ -3,10 +3,11 @@ import React, { useMemo } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 import { displayLabelForItem } from '../../formBuilderUtil';
 import Loading from '@/components/elements/Loading';
+import { getItemMap } from '@/modules/form/util/formUtil';
 import { FormTreeContext } from '@/modules/formBuilder/components/formTree/FormTreeContext';
 import FormTreeItem from '@/modules/formBuilder/components/formTree/FormTreeItem';
 import { getItemsForTree } from '@/modules/formBuilder/components/formTree/formTreeUtil';
-import { FormItem } from '@/types/gqlTypes';
+import { FormDefinitionJson, FormItem } from '@/types/gqlTypes';
 
 interface FormTreeProps {
   onEditClick: (item: FormItem) => void;
@@ -18,6 +19,11 @@ const FormTree: React.FC<FormTreeProps> = ({ onEditClick }) => {
   const definitionForTree = useMemo(
     () => getItemsForTree(values.item),
     [values.item]
+  );
+
+  const itemMap = useMemo(
+    () => getItemMap(values as FormDefinitionJson),
+    [values]
   );
 
   const [expandedItems, setExpandedItems] = React.useState<string[]>([]);
@@ -36,8 +42,9 @@ const FormTree: React.FC<FormTreeProps> = ({ onEditClick }) => {
         setExpandedItems((prev) => [...prev, itemId]),
       collapseItem: (itemId: string) =>
         setExpandedItems((prev) => prev.filter((id) => id !== itemId)),
+      itemMap,
     }),
-    [onEditClick]
+    [onEditClick, itemMap]
   );
 
   if (!values.item) return <Loading />;

--- a/src/modules/formBuilder/components/formTree/FormTreeContext.tsx
+++ b/src/modules/formBuilder/components/formTree/FormTreeContext.tsx
@@ -8,10 +8,12 @@ export const FormTreeContext = React.createContext<{
   collapseItem: (itemId: string) => void;
   itemMap: ItemMap;
   rhfPathMap: Record<string, string>;
+  ancestorLinkIdMap: Record<string, string[]>;
 }>({
   openFormItemEditor: () => {},
   expandItem: () => {},
   collapseItem: () => {},
   itemMap: {},
   rhfPathMap: {},
+  ancestorLinkIdMap: {},
 });

--- a/src/modules/formBuilder/components/formTree/FormTreeContext.tsx
+++ b/src/modules/formBuilder/components/formTree/FormTreeContext.tsx
@@ -7,9 +7,11 @@ export const FormTreeContext = React.createContext<{
   expandItem: (itemId: string) => void;
   collapseItem: (itemId: string) => void;
   itemMap: ItemMap;
+  rhfPathMap: Record<string, string>;
 }>({
   openFormItemEditor: () => {},
   expandItem: () => {},
   collapseItem: () => {},
   itemMap: {},
+  rhfPathMap: {},
 });

--- a/src/modules/formBuilder/components/formTree/FormTreeContext.tsx
+++ b/src/modules/formBuilder/components/formTree/FormTreeContext.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
+import { ItemMap } from '@/modules/form/types';
 import { FormItem } from '@/types/gqlTypes';
 
 export const FormTreeContext = React.createContext<{
   openFormItemEditor: (item: FormItem) => void;
   expandItem: (itemId: string) => void;
   collapseItem: (itemId: string) => void;
+  itemMap: ItemMap;
 }>({
   openFormItemEditor: () => {},
   expandItem: () => {},
   collapseItem: () => {},
+  itemMap: {},
 });

--- a/src/modules/formBuilder/components/formTree/FormTreeLabel.tsx
+++ b/src/modules/formBuilder/components/formTree/FormTreeLabel.tsx
@@ -50,7 +50,7 @@ const FormTreeLabel: React.FC<FormTreeLabelProps> = ({
     disabled,
   });
 
-  const { itemMap } = useContext(FormTreeContext);
+  const { itemMap, rhfPathMap } = useContext(FormTreeContext);
   const item = useMemo(() => itemMap[itemId], [itemMap, itemId]);
 
   const displayAttrs = useMemo(
@@ -61,7 +61,7 @@ const FormTreeLabel: React.FC<FormTreeLabelProps> = ({
   const labelProps = getLabelProps();
 
   const { onReorder, onDelete, canMoveUp, canMoveDown } =
-    useUpdateFormStructure(control, itemId, item);
+    useUpdateFormStructure(control, itemId, item, rhfPathMap);
 
   const [errors, setErrors] = useState<Set<string> | undefined>(undefined);
 

--- a/src/modules/formBuilder/components/formTree/FormTreeLabel.tsx
+++ b/src/modules/formBuilder/components/formTree/FormTreeLabel.tsx
@@ -1,4 +1,4 @@
-import { IconButton, List, ListItem, Typography } from '@mui/material';
+import { Alert, IconButton, List, ListItem, Typography } from '@mui/material';
 import { Box, Stack, Theme } from '@mui/system';
 import { TreeItem2Label, UseTreeItem2Parameters } from '@mui/x-tree-view';
 import { useTreeItem2 } from '@mui/x-tree-view/useTreeItem2/useTreeItem2';
@@ -122,20 +122,34 @@ const FormTreeLabel: React.FC<FormTreeLabelProps> = ({
         >
           "{displayLabelForItem(item)}" cannot be deleted because it is
           referenced elsewhere.
-          {Object.entries(itemDependents).map(([key, val]) =>
-            val?.length > 0 ? (
-              <Box sx={{ mt: 1 }} key={key}>
-                {dependentLabelMap[key]}:
-                <List>
-                  {val.map((dep) => (
-                    <ListItem key={dep.linkId}>{`"${displayLabelForItem(
-                      dep
-                    )}"`}</ListItem>
-                  ))}
-                </List>
-              </Box>
-            ) : null
-          )}
+          <Alert
+            color='error'
+            icon={false}
+            sx={{ my: 2, '& .MuiAlert-message': { width: '100%' } }}
+          >
+            {Object.entries(itemDependents).map(([key, val]) =>
+              val?.length > 0 ? (
+                <Box key={key}>
+                  {dependentLabelMap[key]}:
+                  <List sx={{ listStyleType: 'disc', py: 0 }}>
+                    {val.map((dep) => (
+                      <ListItem
+                        sx={{
+                          display: 'list-item',
+                          ml: 4,
+                          px: 0,
+                          maxWidth: 'calc(100% - 32px)',
+                        }}
+                        key={dep.linkId}
+                      >
+                        {`"${displayLabelForItem(dep)}"`}
+                      </ListItem>
+                    ))}
+                  </List>
+                </Box>
+              ) : null
+            )}
+          </Alert>
           All references to this item must be removed before it can be deleted.
         </ConfirmationDialog>
       )}

--- a/src/modules/formBuilder/components/formTree/FormTreeLabel.tsx
+++ b/src/modules/formBuilder/components/formTree/FormTreeLabel.tsx
@@ -14,7 +14,7 @@ import {
   UpIcon,
 } from '@/components/elements/SemanticIcons';
 import { FORM_ITEM_PALETTE } from '@/modules/formBuilder/components/FormBuilderPalette';
-import CannotDeleteItemModal from '@/modules/formBuilder/components/formTree/CannotDeleteItemModal';
+import CannotDeleteItemDialog from '@/modules/formBuilder/components/formTree/CannotDeleteItemDialog';
 import {
   FormItemPaletteType,
   ItemDependents,
@@ -77,7 +77,9 @@ const FormTreeLabel: React.FC<FormTreeLabelProps> = ({
       expandItem
     );
 
-  const [itemDependents, setItemDependents] = useState<
+  // deletionBlockers contains the dependent items that block the deletion action currently being attempted.
+  // Gets reset to `undefined` when the user closes the error modal.
+  const [deletionBlockers, setDeletionBlockers] = useState<
     ItemDependents | undefined
   >(undefined);
 
@@ -91,7 +93,7 @@ const FormTreeLabel: React.FC<FormTreeLabelProps> = ({
       {
         key: 'delete',
         title: 'Delete',
-        onClick: () => onDelete(setItemDependents),
+        onClick: () => onDelete(setDeletionBlockers),
         // disable deletion for groups that contain items
         disabled:
           item?.type === ItemType.Group && !!item?.item && item.item.length > 0,
@@ -110,12 +112,12 @@ const FormTreeLabel: React.FC<FormTreeLabelProps> = ({
         height: '48px',
       }}
     >
-      {!!itemDependents && (
-        <CannotDeleteItemModal
+      {!!deletionBlockers && (
+        <CannotDeleteItemDialog
           item={item}
           itemMap={itemMap}
-          itemDependents={itemDependents}
-          setItemDependents={setItemDependents}
+          deletionBlockers={deletionBlockers}
+          setDeletionBlockers={setDeletionBlockers}
           ancestorLinkIdMap={ancestorLinkIdMap}
         />
       )}

--- a/src/modules/formBuilder/components/formTree/FormTreeLabel.tsx
+++ b/src/modules/formBuilder/components/formTree/FormTreeLabel.tsx
@@ -115,11 +115,12 @@ const FormTreeLabel: React.FC<FormTreeLabelProps> = ({
           title='Cannot delete item'
           onConfirm={() => setItemDependents(undefined)}
           loading={false}
+          hideCancelButton={true}
         >
           "{displayLabelForItem(item)}" cannot be deleted because it is
           referenced elsewhere.
           {Object.entries(itemDependents).map(([key, val]) =>
-            val.length > 0 ? (
+            val?.length > 0 ? (
               <Box sx={{ mt: 1 }} key={key}>
                 {dependentLabelMap[key]}:
                 <List>

--- a/src/modules/formBuilder/components/formTree/FormTreeLabel.tsx
+++ b/src/modules/formBuilder/components/formTree/FormTreeLabel.tsx
@@ -1,4 +1,4 @@
-import { IconButton, Typography } from '@mui/material';
+import { IconButton, List, ListItem, Typography } from '@mui/material';
 import { Box, Stack, Theme } from '@mui/system';
 import { TreeItem2Label, UseTreeItem2Parameters } from '@mui/x-tree-view';
 import { useTreeItem2 } from '@mui/x-tree-view/useTreeItem2/useTreeItem2';
@@ -67,7 +67,7 @@ const FormTreeLabel: React.FC<FormTreeLabelProps> = ({
   const { onReorder, onDelete, canMoveUp, canMoveDown } =
     useUpdateFormStructure(control, itemId, item);
 
-  const [error, setError] = useState<string | undefined>();
+  const [errors, setErrors] = useState<Set<string> | undefined>(undefined);
 
   const menuItems = useMemo(
     () => [
@@ -79,7 +79,7 @@ const FormTreeLabel: React.FC<FormTreeLabelProps> = ({
       {
         key: 'delete',
         title: 'Delete',
-        onClick: () => onDelete(setError),
+        onClick: () => onDelete(setErrors),
       },
     ],
     [item, openFormItemEditor, onDelete]
@@ -96,14 +96,20 @@ const FormTreeLabel: React.FC<FormTreeLabelProps> = ({
       }}
     >
       <ConfirmationDialog
-        open={!!error}
+        open={!!errors}
         title='Cannot delete'
-        onConfirm={() => {
-          setError(undefined);
-        }}
+        onConfirm={() => setErrors(undefined)}
+        onCancel={() => setErrors(undefined)}
         loading={false}
       >
-        {error}
+        Cannot delete this item, because one or more other questions depend on
+        it.
+        <List>
+          {errors &&
+            [...errors].map((error) => (
+              <ListItem key={error}>{error}</ListItem>
+            ))}
+        </List>
       </ConfirmationDialog>
       {displayAttrs && (
         <Stack

--- a/src/modules/formBuilder/components/formTree/FormTreeLabel.tsx
+++ b/src/modules/formBuilder/components/formTree/FormTreeLabel.tsx
@@ -3,8 +3,8 @@ import { Box, Stack, Theme } from '@mui/system';
 import { TreeItem2Label, UseTreeItem2Parameters } from '@mui/x-tree-view';
 import { useTreeItem2 } from '@mui/x-tree-view/useTreeItem2/useTreeItem2';
 import { UseTreeItem2LabelSlotProps } from '@mui/x-tree-view/useTreeItem2/useTreeItem2.types';
-import React, { useMemo, useState } from 'react';
-import { useFormContext, useFormState, useWatch } from 'react-hook-form';
+import React, { useContext, useMemo, useState } from 'react';
+import { useFormContext, useFormState } from 'react-hook-form';
 import { FormTreeContext } from './FormTreeContext';
 import useUpdateFormStructure from './useUpdateFormStructure';
 import CommonHtmlContent from '@/components/elements/CommonHtmlContent';
@@ -15,10 +15,9 @@ import {
   DownIcon,
   UpIcon,
 } from '@/components/elements/SemanticIcons';
-import { getItemMap } from '@/modules/form/util/formUtil';
 import { FORM_ITEM_PALETTE } from '@/modules/formBuilder/components/FormBuilderPalette';
 import { FormItemPaletteType } from '@/modules/formBuilder/components/formTree/types';
-import { FormDefinitionJson, ItemType } from '@/types/gqlTypes';
+import { ItemType } from '@/types/gqlTypes';
 
 export const getItemDisplayAttrs = (type: ItemType): FormItemPaletteType => {
   return FORM_ITEM_PALETTE[type];
@@ -40,7 +39,6 @@ const FormTreeLabel: React.FC<FormTreeLabelProps> = ({
   const { openFormItemEditor } = React.useContext(FormTreeContext);
 
   const { control } = useFormContext();
-  const values = useWatch({ control });
 
   const { isSubmitting } = useFormState({ control });
 
@@ -52,10 +50,7 @@ const FormTreeLabel: React.FC<FormTreeLabelProps> = ({
     disabled,
   });
 
-  const itemMap = useMemo(
-    () => getItemMap(values as FormDefinitionJson),
-    [values]
-  );
+  const { itemMap } = useContext(FormTreeContext);
   const item = useMemo(() => itemMap[itemId], [itemMap, itemId]);
 
   const displayAttrs = useMemo(

--- a/src/modules/formBuilder/components/formTree/FormTreeLabel.tsx
+++ b/src/modules/formBuilder/components/formTree/FormTreeLabel.tsx
@@ -94,6 +94,9 @@ const FormTreeLabel: React.FC<FormTreeLabelProps> = ({
         key: 'delete',
         title: 'Delete',
         onClick: () => onDelete(setItemDependents),
+        // disable deletion for groups that contain items
+        disabled:
+          item.type === ItemType.Group && !!item.item && item.item.length > 0,
       },
     ],
     [item, openFormItemEditor, onDelete]

--- a/src/modules/formBuilder/components/formTree/FormTreeLabel.tsx
+++ b/src/modules/formBuilder/components/formTree/FormTreeLabel.tsx
@@ -1,4 +1,4 @@
-import { Alert, IconButton, List, ListItem, Typography } from '@mui/material';
+import { IconButton, Typography } from '@mui/material';
 import { Box, Stack, Theme } from '@mui/system';
 import { TreeItem2Label, UseTreeItem2Parameters } from '@mui/x-tree-view';
 import { useTreeItem2 } from '@mui/x-tree-view/useTreeItem2/useTreeItem2';
@@ -8,14 +8,13 @@ import { useFormContext, useFormState } from 'react-hook-form';
 import { FormTreeContext } from './FormTreeContext';
 import useUpdateFormStructure from './useUpdateFormStructure';
 import CommonMenuButton from '@/components/elements/CommonMenuButton';
-import ConfirmationDialog from '@/components/elements/ConfirmationDialog';
 import {
   ConditionalIcon,
   DownIcon,
   UpIcon,
 } from '@/components/elements/SemanticIcons';
 import { FORM_ITEM_PALETTE } from '@/modules/formBuilder/components/FormBuilderPalette';
-import { displayLabelForItem } from '@/modules/formBuilder/formBuilderUtil';
+import CannotDeleteItemModal from '@/modules/formBuilder/components/formTree/CannotDeleteItemModal';
 import {
   FormItemPaletteType,
   ItemDependents,
@@ -31,12 +30,6 @@ export interface FormTreeLabelProps
     Omit<UseTreeItem2Parameters, 'children'> {
   itemId: string;
 }
-
-const dependentLabelMap: Record<string, string> = {
-  autofillDependents: 'Items with autofill condition(s)',
-  enableWhenDependents: 'Items with visibility condition(s)',
-  boundDependents: 'Items with min/max bound(s)',
-};
 
 const FormTreeLabel: React.FC<FormTreeLabelProps> = ({
   id,
@@ -118,51 +111,13 @@ const FormTreeLabel: React.FC<FormTreeLabelProps> = ({
       }}
     >
       {!!itemDependents && (
-        <ConfirmationDialog
-          // todo @Martha - move into its own component?
-          open={!!itemDependents}
-          title='Cannot delete item'
-          onConfirm={() => setItemDependents(undefined)}
-          confirmText='Close'
-          loading={false}
-          hideCancelButton={true}
-        >
-          "{displayLabelForItem(item)}" cannot be deleted because it is
-          referenced elsewhere.
-          <Alert
-            color='error'
-            icon={false}
-            sx={{ my: 2, '& .MuiAlert-message': { width: '100%' } }}
-          >
-            {Object.entries(itemDependents).map(([key, val]) =>
-              val?.length > 0 ? (
-                <Box key={key}>
-                  {dependentLabelMap[key]}:
-                  <List sx={{ listStyleType: 'disc', py: 0 }}>
-                    {val.map((dep) => (
-                      <ListItem
-                        sx={{
-                          display: 'list-item',
-                          ml: 4,
-                          px: 0,
-                          maxWidth: 'calc(100% - 32px)',
-                        }}
-                        key={dep.linkId}
-                      >
-                        {ancestorLinkIdMap[dep.linkId].map(
-                          (ancestor) =>
-                            `"${displayLabelForItem(itemMap[ancestor])}" > `
-                        )}
-                        {`"${displayLabelForItem(dep)}"`}
-                      </ListItem>
-                    ))}
-                  </List>
-                </Box>
-              ) : null
-            )}
-          </Alert>
-          All references to this item must be removed before it can be deleted.
-        </ConfirmationDialog>
+        <CannotDeleteItemModal
+          item={item}
+          itemMap={itemMap}
+          itemDependents={itemDependents}
+          setItemDependents={setItemDependents}
+          ancestorLinkIdMap={ancestorLinkIdMap}
+        />
       )}
       {displayAttrs && (
         <Stack

--- a/src/modules/formBuilder/components/formTree/FormTreeLabel.tsx
+++ b/src/modules/formBuilder/components/formTree/FormTreeLabel.tsx
@@ -45,8 +45,13 @@ const FormTreeLabel: React.FC<FormTreeLabelProps> = ({
   disabled,
   children,
 }) => {
-  const { openFormItemEditor, itemMap, rhfPathMap, expandItem } =
-    useContext(FormTreeContext);
+  const {
+    openFormItemEditor,
+    itemMap,
+    rhfPathMap,
+    ancestorLinkIdMap,
+    expandItem,
+  } = useContext(FormTreeContext);
 
   const { control } = useFormContext();
 
@@ -114,9 +119,11 @@ const FormTreeLabel: React.FC<FormTreeLabelProps> = ({
     >
       {!!itemDependents && (
         <ConfirmationDialog
+          // todo @Martha - move into its own component?
           open={!!itemDependents}
           title='Cannot delete item'
           onConfirm={() => setItemDependents(undefined)}
+          confirmText='Close'
           loading={false}
           hideCancelButton={true}
         >
@@ -142,6 +149,10 @@ const FormTreeLabel: React.FC<FormTreeLabelProps> = ({
                         }}
                         key={dep.linkId}
                       >
+                        {ancestorLinkIdMap[dep.linkId].map(
+                          (ancestor) =>
+                            `"${displayLabelForItem(itemMap[ancestor])}" > `
+                        )}
                         {`"${displayLabelForItem(dep)}"`}
                       </ListItem>
                     ))}

--- a/src/modules/formBuilder/components/formTree/FormTreeLabel.tsx
+++ b/src/modules/formBuilder/components/formTree/FormTreeLabel.tsx
@@ -7,6 +7,7 @@ import React, { useMemo, useState } from 'react';
 import { useFormContext, useFormState, useWatch } from 'react-hook-form';
 import { FormTreeContext } from './FormTreeContext';
 import useUpdateFormStructure from './useUpdateFormStructure';
+import CommonHtmlContent from '@/components/elements/CommonHtmlContent';
 import CommonMenuButton from '@/components/elements/CommonMenuButton';
 import ConfirmationDialog from '@/components/elements/ConfirmationDialog';
 import {
@@ -102,12 +103,14 @@ const FormTreeLabel: React.FC<FormTreeLabelProps> = ({
         onCancel={() => setErrors(undefined)}
         loading={false}
       >
-        Cannot delete this item, because one or more other questions depend on
-        it.
+        Cannot delete "{labelProps.children}," because one or more other
+        questions depend on it.
         <List>
           {errors &&
             [...errors].map((error) => (
-              <ListItem key={error}>{error}</ListItem>
+              <ListItem key={error}>
+                <CommonHtmlContent>{error}</CommonHtmlContent>
+              </ListItem>
             ))}
         </List>
       </ConfirmationDialog>

--- a/src/modules/formBuilder/components/formTree/FormTreeLabel.tsx
+++ b/src/modules/formBuilder/components/formTree/FormTreeLabel.tsx
@@ -36,7 +36,8 @@ const FormTreeLabel: React.FC<FormTreeLabelProps> = ({
   disabled,
   children,
 }) => {
-  const { openFormItemEditor } = React.useContext(FormTreeContext);
+  const { openFormItemEditor, itemMap, rhfPathMap } =
+    useContext(FormTreeContext);
 
   const { control } = useFormContext();
 
@@ -50,7 +51,6 @@ const FormTreeLabel: React.FC<FormTreeLabelProps> = ({
     disabled,
   });
 
-  const { itemMap, rhfPathMap } = useContext(FormTreeContext);
   const item = useMemo(() => itemMap[itemId], [itemMap, itemId]);
 
   const displayAttrs = useMemo(

--- a/src/modules/formBuilder/components/formTree/FormTreeLabel.tsx
+++ b/src/modules/formBuilder/components/formTree/FormTreeLabel.tsx
@@ -96,7 +96,7 @@ const FormTreeLabel: React.FC<FormTreeLabelProps> = ({
         onClick: () => onDelete(setItemDependents),
         // disable deletion for groups that contain items
         disabled:
-          item.type === ItemType.Group && !!item.item && item.item.length > 0,
+          item?.type === ItemType.Group && !!item?.item && item.item.length > 0,
       },
     ],
     [item, openFormItemEditor, onDelete]

--- a/src/modules/formBuilder/components/formTree/FormTreeLabel.tsx
+++ b/src/modules/formBuilder/components/formTree/FormTreeLabel.tsx
@@ -3,20 +3,21 @@ import { Box, Stack, Theme } from '@mui/system';
 import { TreeItem2Label, UseTreeItem2Parameters } from '@mui/x-tree-view';
 import { useTreeItem2 } from '@mui/x-tree-view/useTreeItem2/useTreeItem2';
 import { UseTreeItem2LabelSlotProps } from '@mui/x-tree-view/useTreeItem2/useTreeItem2.types';
-import React, { useMemo } from 'react';
-import { useFormContext, useFormState } from 'react-hook-form';
+import React, { useMemo, useState } from 'react';
+import { useFormContext, useFormState, useWatch } from 'react-hook-form';
 import { FormTreeContext } from './FormTreeContext';
-import useReorderItem from './useReorderItem';
+import useUpdateFormStructure from './useUpdateFormStructure';
 import CommonMenuButton from '@/components/elements/CommonMenuButton';
+import ConfirmationDialog from '@/components/elements/ConfirmationDialog';
 import {
   ConditionalIcon,
   DownIcon,
   UpIcon,
 } from '@/components/elements/SemanticIcons';
+import { getItemMap } from '@/modules/form/util/formUtil';
 import { FORM_ITEM_PALETTE } from '@/modules/formBuilder/components/FormBuilderPalette';
-import { getItemFromTree } from '@/modules/formBuilder/components/formTree/formTreeUtil';
 import { FormItemPaletteType } from '@/modules/formBuilder/components/formTree/types';
-import { ItemType } from '@/types/gqlTypes';
+import { FormDefinitionJson, ItemType } from '@/types/gqlTypes';
 
 export const getItemDisplayAttrs = (type: ItemType): FormItemPaletteType => {
   return FORM_ITEM_PALETTE[type];
@@ -38,9 +39,11 @@ const FormTreeLabel: React.FC<FormTreeLabelProps> = ({
   const { openFormItemEditor } = React.useContext(FormTreeContext);
 
   const { control } = useFormContext();
+  const values = useWatch({ control });
+
   const { isSubmitting } = useFormState({ control });
 
-  const { getLabelProps, publicAPI } = useTreeItem2({
+  const { getLabelProps } = useTreeItem2({
     id,
     itemId,
     children,
@@ -48,22 +51,23 @@ const FormTreeLabel: React.FC<FormTreeLabelProps> = ({
     disabled,
   });
 
-  // we could get this from the form instead of from the tree api
-  const treeItem = publicAPI.getItem(itemId);
-  const item = useMemo(() => getItemFromTree(treeItem), [treeItem]);
+  const itemMap = useMemo(
+    () => getItemMap(values as FormDefinitionJson),
+    [values]
+  );
+  const item = useMemo(() => itemMap[itemId], [itemMap, itemId]);
 
   const displayAttrs = useMemo(
-    () => getItemDisplayAttrs(item.type),
-    [item.type]
+    () => getItemDisplayAttrs(item?.type),
+    [item?.type]
   );
 
   const labelProps = getLabelProps();
 
-  const { onReorder, canMoveUp, canMoveDown } = useReorderItem(
-    control,
-    itemId,
-    item
-  );
+  const { onReorder, onDelete, canMoveUp, canMoveDown } =
+    useUpdateFormStructure(control, itemId, item);
+
+  const [error, setError] = useState<string | undefined>();
 
   const menuItems = useMemo(
     () => [
@@ -75,10 +79,10 @@ const FormTreeLabel: React.FC<FormTreeLabelProps> = ({
       {
         key: 'delete',
         title: 'Delete',
-        to: '#', // TODO implement
+        onClick: () => onDelete(setError),
       },
     ],
-    [item, openFormItemEditor]
+    [item, openFormItemEditor, onDelete]
   );
 
   return (
@@ -91,6 +95,16 @@ const FormTreeLabel: React.FC<FormTreeLabelProps> = ({
         height: '48px',
       }}
     >
+      <ConfirmationDialog
+        open={!!error}
+        title='Cannot delete'
+        onConfirm={() => {
+          setError(undefined);
+        }}
+        loading={false}
+      >
+        {error}
+      </ConfirmationDialog>
       {displayAttrs && (
         <Stack
           direction='row'

--- a/src/modules/formBuilder/components/formTree/FormTreeLabel.tsx
+++ b/src/modules/formBuilder/components/formTree/FormTreeLabel.tsx
@@ -36,7 +36,7 @@ const FormTreeLabel: React.FC<FormTreeLabelProps> = ({
   disabled,
   children,
 }) => {
-  const { openFormItemEditor, itemMap, rhfPathMap } =
+  const { openFormItemEditor, itemMap, rhfPathMap, expandItem } =
     useContext(FormTreeContext);
 
   const { control } = useFormContext();
@@ -61,7 +61,7 @@ const FormTreeLabel: React.FC<FormTreeLabelProps> = ({
   const labelProps = getLabelProps();
 
   const { onReorder, onDelete, canMoveUp, canMoveDown } =
-    useUpdateFormStructure(control, itemId, item, rhfPathMap);
+    useUpdateFormStructure(control, itemId, item, rhfPathMap, expandItem);
 
   const [errors, setErrors] = useState<Set<string> | undefined>(undefined);
 

--- a/src/modules/formBuilder/components/formTree/types.ts
+++ b/src/modules/formBuilder/components/formTree/types.ts
@@ -1,8 +1,0 @@
-import { SvgIconComponent } from '@mui/icons-material';
-import { ItemType } from '@/types/gqlTypes';
-
-export type FormItemPaletteType = {
-  itemType: ItemType;
-  displayName: string;
-  IconClass: SvgIconComponent;
-};

--- a/src/modules/formBuilder/components/formTree/useUpdateFormStructure.tsx
+++ b/src/modules/formBuilder/components/formTree/useUpdateFormStructure.tsx
@@ -77,7 +77,7 @@ export default function useUpdateFormStructure(
         remove(thisIndex);
       }
     },
-    [values, itemId, thisIndex]
+    [values, itemId, thisIndex, remove]
   );
 
   const onReorder = useCallback(

--- a/src/modules/formBuilder/components/formTree/useUpdateFormStructure.tsx
+++ b/src/modules/formBuilder/components/formTree/useUpdateFormStructure.tsx
@@ -1,4 +1,4 @@
-import { get, some } from 'lodash-es';
+import { get } from 'lodash-es';
 import { Dispatch, SetStateAction, useCallback, useMemo } from 'react';
 import {
   Control,
@@ -64,13 +64,13 @@ export default function useUpdateFormStructure(
         itemMap,
       });
 
-      if (some([Object.values(dependents)], (depList) => depList.length > 0)) {
+      if (Object.values(dependents).some((depList) => depList.length > 0)) {
         onError(dependents);
       } else {
         remove(thisIndex);
       }
     },
-    [values, itemId, thisIndex, remove, itemMap]
+    [itemId, thisIndex, remove, itemMap]
   );
 
   const onReorder = useCallback(

--- a/src/modules/formBuilder/components/formTree/useUpdateFormStructure.tsx
+++ b/src/modules/formBuilder/components/formTree/useUpdateFormStructure.tsx
@@ -62,18 +62,15 @@ export default function useUpdateFormStructure(
   }, [hasParent, thisIndex]);
 
   const onDelete = useCallback(
-    (onError: Dispatch<SetStateAction<string | undefined>>) => {
-      const { success, error } = validateDeletion({
+    (onError: Dispatch<SetStateAction<Set<string> | undefined>>) => {
+      const { success, errors } = validateDeletion({
         toDelete: itemId,
         definition: values as FormDefinitionJson,
       });
 
-      if (error) {
-        onError(error);
-        return;
-      }
-
-      if (success) {
+      if (!success) {
+        onError(errors);
+      } else {
         remove(thisIndex);
       }
     },

--- a/src/modules/formBuilder/components/formTree/useUpdateFormStructure.tsx
+++ b/src/modules/formBuilder/components/formTree/useUpdateFormStructure.tsx
@@ -47,6 +47,8 @@ export default function useUpdateFormStructure(
   const { swap, remove } = useFieldArray({ control, name: parentArrayPath });
 
   const thisLayer = get(values, parentArrayPath);
+  // `thisLayer` could be undefined if an item was just deleted. https://github.com/greenriver/hmis-frontend/pull/821#issue-2371078251
+
   const hasParent = parentIndex !== -1;
 
   const canMoveDown = useMemo(() => {

--- a/src/modules/formBuilder/components/formTree/useUpdateFormStructure.tsx
+++ b/src/modules/formBuilder/components/formTree/useUpdateFormStructure.tsx
@@ -1,18 +1,11 @@
 import { get } from 'lodash-es';
-import {
-  Dispatch,
-  SetStateAction,
-  useCallback,
-  useContext,
-  useMemo,
-} from 'react';
+import { Dispatch, SetStateAction, useCallback, useMemo } from 'react';
 import {
   Control,
   useFieldArray,
   useFormContext,
   useWatch,
 } from 'react-hook-form';
-import { FormTreeContext } from './FormTreeContext';
 import {
   getPathContext,
   insertItemToDefinition,
@@ -25,11 +18,11 @@ export default function useUpdateFormStructure(
   control: Control,
   itemId: string,
   item: FormItem,
-  rhfPathMap: Record<string, string>
+  rhfPathMap: Record<string, string>,
+  expandItem: (itemId: string) => void
 ) {
   const values = useWatch({ control });
   const { reset } = useFormContext();
-  const { expandItem } = useContext(FormTreeContext);
 
   // Example:
   // itemPath:              item.3.item.1

--- a/src/modules/formBuilder/components/formTree/useUpdateFormStructure.tsx
+++ b/src/modules/formBuilder/components/formTree/useUpdateFormStructure.tsx
@@ -14,7 +14,6 @@ import {
 } from 'react-hook-form';
 import { FormTreeContext } from './FormTreeContext';
 import {
-  getItemIdMap,
   getPathContext,
   insertItemToDefinition,
   removeItemFromDefinition,
@@ -25,20 +24,19 @@ import { FormDefinitionJson, FormItem, ItemType } from '@/types/gqlTypes';
 export default function useUpdateFormStructure(
   control: Control,
   itemId: string,
-  item: FormItem
+  item: FormItem,
+  rhfPathMap: Record<string, string>
 ) {
   const values = useWatch({ control });
   const { reset } = useFormContext();
   const { expandItem } = useContext(FormTreeContext);
-  // Re-generate itemIdMap each time values change (linkId=>position)
-  const itemIdMap = useMemo(() => getItemIdMap(values.item), [values]);
 
   // Example:
   // itemPath:              item.3.item.1
   // parentArrayPath:       item.3.item (thisIndex=1)
   // grandParentArrayPath:  item        (parentIndex=3)
 
-  const itemPath = itemIdMap[itemId];
+  const itemPath = rhfPathMap[itemId];
   const { parentPath: parentArrayPath, index: thisIndex } =
     getPathContext(itemPath);
   const parentItemId = parentArrayPath.replace(/\.item$/, '');
@@ -88,7 +86,7 @@ export default function useUpdateFormStructure(
             // append it to the "sibling" group above it
             console.log('case 1');
             const prevLinkId = prevItem.linkId;
-            const prevItemPath = itemIdMap[prevLinkId] + '.item';
+            const prevItemPath = rhfPathMap[prevLinkId] + '.item';
 
             expandItem(prevLinkId); // expand the group it's moving into
             reset(
@@ -147,7 +145,7 @@ export default function useUpdateFormStructure(
             // prepend it to the "sibling" group below it
             console.log('case 4');
             const nextLinkId = nextItem.linkId;
-            const nextItemPath = itemIdMap[nextLinkId] + '.item';
+            const nextItemPath = rhfPathMap[nextLinkId] + '.item';
 
             expandItem(nextLinkId); // expand the group it's moving into
             reset(
@@ -202,7 +200,7 @@ export default function useUpdateFormStructure(
       thisIndex,
       hasParent,
       thisLayer,
-      itemIdMap,
+      rhfPathMap,
       reset,
       expandItem,
       parentArrayPath,

--- a/src/modules/formBuilder/formBuilderUtil.ts
+++ b/src/modules/formBuilder/formBuilderUtil.ts
@@ -120,7 +120,7 @@ export const slugifyItemLabel = (label: string) => {
  * Maps the item's linkId to the string key that React Hook Forms's useArrayFields hook expects,
  * which looks like: `item`, `item.0`, `item.0.item.1`, etc.
  */
-export const getItemIdMap = (items: FormItem[]) => {
+export const getRhfPathMap = (items: FormItem[]) => {
   const map: Record<string, string> = {};
 
   function recursiveMap(

--- a/src/modules/formBuilder/formBuilderUtil.ts
+++ b/src/modules/formBuilder/formBuilderUtil.ts
@@ -255,3 +255,45 @@ export const getDependentItems = ({
       [],
   };
 };
+
+/**
+ * Given the form items, generates a map of linkIds to a list of all their
+ * ancestor linkIds in the form's nested structure, in order.
+ * For example, if the form structure is something like:
+ * item: {
+ *   linkId: grandparent,
+ *   type: group,
+ *   item: [
+ *     {
+ *       linkId: parent,
+ *       type: group,
+ *       item: [
+ *         { linkId: child }
+ *       ]
+ *     }
+ *   ]
+ * }
+ *
+ * then this ancestorLinkIdMap will look like:
+ * {
+ *   grandparent: [],
+ *   parent: [grandparent],
+ *   child: [grandparent, parent]
+ * }
+ */
+export const getAncestorLinkIdMap = (items: FormItem[]) => {
+  const map: Record<string, string[]> = {};
+
+  function recursiveMap(
+    items: Maybe<FormItem[]> | undefined,
+    ancestors: string[]
+  ) {
+    items?.forEach((item) => {
+      map[item.linkId] = ancestors;
+      recursiveMap(item.item, [...ancestors, item.linkId]);
+    });
+  }
+
+  recursiveMap(items, []);
+  return map;
+};

--- a/src/modules/formBuilder/formBuilderUtil.ts
+++ b/src/modules/formBuilder/formBuilderUtil.ts
@@ -2,6 +2,7 @@ import { cloneDeep, get, kebabCase, set } from 'lodash-es';
 import { ItemMap } from '@/modules/form/types';
 import {
   buildAutofillDependencyMap,
+  buildBoundsDependencyMap,
   buildEnabledDependencyMap,
 } from '@/modules/form/util/formUtil';
 import { ItemDependents } from '@/modules/formBuilder/types';
@@ -238,18 +239,19 @@ export const getDependentItems = ({
   itemMap: ItemMap;
 }): ItemDependents => {
   const autofillDependencyMap = buildAutofillDependencyMap(itemMap);
-  const autofillDependents =
-    autofillDependencyMap[linkId]?.map((dependerId) => itemMap[dependerId]) ||
-    [];
-
   const enableWhenDependencyMap = buildEnabledDependencyMap(itemMap);
-  const enableWhenDependents =
-    enableWhenDependencyMap[linkId]?.map((dependerId) => itemMap[dependerId]) ||
-    [];
+  const boundDependencyMap = buildBoundsDependencyMap(itemMap);
 
   return {
-    autofillDependents,
-    enableWhenDependents,
-    boundDependents: [], // todo @Martha
+    autofillDependents:
+      autofillDependencyMap[linkId]?.map((dependerId) => itemMap[dependerId]) ||
+      [],
+    enableWhenDependents:
+      enableWhenDependencyMap[linkId]?.map(
+        (dependerId) => itemMap[dependerId]
+      ) || [],
+    boundDependents: boundDependencyMap[linkId]?.map(
+      (dependerId) => itemMap[dependerId]
+    ),
   };
 };

--- a/src/modules/formBuilder/formBuilderUtil.ts
+++ b/src/modules/formBuilder/formBuilderUtil.ts
@@ -250,8 +250,8 @@ export const getDependentItems = ({
       enableWhenDependencyMap[linkId]?.map(
         (dependerId) => itemMap[dependerId]
       ) || [],
-    boundDependents: boundDependencyMap[linkId]?.map(
-      (dependerId) => itemMap[dependerId]
-    ),
+    boundDependents:
+      boundDependencyMap[linkId]?.map((dependerId) => itemMap[dependerId]) ||
+      [],
   };
 };

--- a/src/modules/formBuilder/types.ts
+++ b/src/modules/formBuilder/types.ts
@@ -1,0 +1,14 @@
+import { SvgIconComponent } from '@mui/icons-material';
+import { FormItem, ItemType } from '@/types/gqlTypes';
+
+export type FormItemPaletteType = {
+  itemType: ItemType;
+  displayName: string;
+  IconClass: SvgIconComponent;
+};
+
+export type ItemDependents = {
+  enableWhenDependents: FormItem[];
+  autofillDependents: FormItem[];
+  boundDependents: FormItem[];
+};


### PR DESCRIPTION
## Description

GH issue: https://github.com/open-path/Green-River/issues/6165

The solution I've landed on is to enable the `useReorder` hook (here renamed to `useUpdateFormStructure`) to return meaningless values when an item has been deleted, instead of throwing up an error. 

I still haven't figured out why the Mui `RichTree` keeps rendering `FormTreeLabel`s for an item for 1 more render after the item has been deleted from the form definition structure. After pairing with @ttoomey, our thought was that it probably isn't worth sinking more time into. @gigxz happy to defer to you on that though.

Possibly related, I'll record here for posterity that it's still the case that if you set a breakpoint in the browser debugger at line 42 of `useUpdateFormStructure`, you can see the following warning (not visible without breakpoint):

> Warning: Cannot update a component (`ForwardRef(RichTreeView2)`) while rendering a different component (`FormTreeLabel`). To locate the bad setState() call inside `FormTreeLabel`, follow the stack trace as described in https://reactjs.org/link/setstate-in-render

## Type of change
[//]: # 'remove options that are not relevant'
- [ ] Bug fix
- [x] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
