### PR TITLE
Fix minor form builder bugs

### DIFF
--- a/src/modules/formBuilder/components/FormBuilder.tsx
+++ b/src/modules/formBuilder/components/FormBuilder.tsx
@@ -196,21 +196,29 @@ const FormBuilder: React.FC<FormBuilderProps> = ({
         </Box>
         <FormBuilderPalette
           onItemClick={(itemType) => {
-            const newItem: FormItem = {
-              linkId: `q_${v4().split('-')[0]}`, // Randomly generate a placeholder link ID
-              text: undefined,
-              type: itemType,
-              required: false,
-              warnIfEmpty: false,
-              hidden: false,
-              readOnly: false,
-              repeats: false,
-              prefill: false,
-              disabledDisplay: DisabledDisplay.Hidden,
-              enableBehavior: EnableBehavior.All,
-            };
+            function editNewItem() {
+              const newItem: FormItem = {
+                linkId: `q_${v4().split('-')[0]}`, // Randomly generate a placeholder link ID
+                text: undefined,
+                type: itemType,
+                required: false,
+                warnIfEmpty: false,
+                hidden: false,
+                readOnly: false,
+                repeats: false,
+                prefill: false,
+                disabledDisplay: DisabledDisplay.Hidden,
+                enableBehavior: EnableBehavior.All,
+              };
 
-            setSelectedItem(newItem);
+              setSelectedItem(newItem);
+            }
+
+            if (isDirty) {
+              setBlockedActionFunction(() => editNewItem);
+            } else {
+              editNewItem();
+            }
           }}
         />
       </Box>

--- a/src/modules/formBuilder/components/formTree/useReorderItem.tsx
+++ b/src/modules/formBuilder/components/formTree/useReorderItem.tsx
@@ -81,7 +81,7 @@ export default function useReorderItem(
                 });
                 insertItemToDefinition({
                   insertPath: prevItemPath,
-                  insertAtIndex: get(oldForm, prevItemPath).length,
+                  insertAtIndex: get(oldForm, prevItemPath)?.length || 0,
                   definition: oldForm as FormDefinitionJson,
                   item,
                 });


### PR DESCRIPTION
## Description

this is a quick fix for two things I noticed while working on the [deletion](https://github.com/greenriver/hmis-frontend/pull/821) ticket:
1. Previously the user could click on a palette button to open the editor drawer for a new item, even when there are outstanding unsaved changes in the form structure. Now, that behavior is blocked using `setBlockedActionFunction`, matching the behavior of clicking edit on an existing item.
2. There was a bug in handling of moving an item into a group when the group doesn't yet have any child items. The changed line in `useReorderItem` was throwing `TypeError: Cannot read properties of null (reading 'length')` . To reproduce, try moving 'text' into 'group' in this form: https://qa-hmis.openpath.host/admin/forms/martha_test_3/118/edit

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
