### PR TITLE
Make UX improvements to form tree reordering

### DIFF
--- a/src/modules/formBuilder/components/formTree/FormTree.tsx
+++ b/src/modules/formBuilder/components/formTree/FormTree.tsx
@@ -39,6 +39,11 @@ const FormTree: React.FC<FormTreeProps> = ({ onEditClick }) => {
 
   const [expandedItems, setExpandedItems] = React.useState<string[]>([]);
 
+  // For a better ux when reordering form items, we hijack control of the focused button. See useEffect in FormTreeLabel
+  const [focusedTreeButton, setFocusedTreeButton] = React.useState<
+    string | null
+  >(null);
+
   const handleExpandedItemsChange = (
     event: React.SyntheticEvent,
     itemIds: string[]
@@ -62,6 +67,8 @@ const FormTree: React.FC<FormTreeProps> = ({ onEditClick }) => {
       itemMap,
       rhfPathMap,
       ancestorLinkIdMap,
+      focusedTreeButton,
+      setFocusedTreeButton,
     }),
     [onEditClick, itemMap, rhfPathMap, ancestorLinkIdMap]
   );

--- a/src/modules/formBuilder/components/formTree/FormTree.tsx
+++ b/src/modules/formBuilder/components/formTree/FormTree.tsx
@@ -70,7 +70,14 @@ const FormTree: React.FC<FormTreeProps> = ({ onEditClick }) => {
       focusedTreeButton,
       setFocusedTreeButton,
     }),
-    [onEditClick, itemMap, rhfPathMap, ancestorLinkIdMap]
+    [
+      onEditClick,
+      itemMap,
+      rhfPathMap,
+      ancestorLinkIdMap,
+      focusedTreeButton,
+      setFocusedTreeButton,
+    ]
   );
 
   if (!values.item) return <Loading />;

--- a/src/modules/formBuilder/components/formTree/FormTreeContext.tsx
+++ b/src/modules/formBuilder/components/formTree/FormTreeContext.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Dispatch, SetStateAction } from 'react';
 import { ItemMap } from '@/modules/form/types';
 import { FormItem } from '@/types/gqlTypes';
 
@@ -9,6 +9,8 @@ export const FormTreeContext = React.createContext<{
   itemMap: ItemMap;
   rhfPathMap: Record<string, string>;
   ancestorLinkIdMap: Record<string, string[]>;
+  focusedTreeButton: string | null;
+  setFocusedTreeButton: Dispatch<SetStateAction<string | null>>;
 }>({
   openFormItemEditor: () => {},
   expandItem: () => {},
@@ -16,4 +18,6 @@ export const FormTreeContext = React.createContext<{
   itemMap: {},
   rhfPathMap: {},
   ancestorLinkIdMap: {},
+  focusedTreeButton: null,
+  setFocusedTreeButton: () => {},
 });

--- a/src/modules/formBuilder/components/formTree/FormTreeLabel.tsx
+++ b/src/modules/formBuilder/components/formTree/FormTreeLabel.tsx
@@ -80,7 +80,7 @@ const FormTreeLabel: React.FC<FormTreeLabelProps> = ({
     } else if (focusedTreeButton === `${itemId}-down`) {
       downRef.current?.focus();
     }
-  }, [upRef, downRef, focusedTreeButton]);
+  }, [itemId, upRef, downRef, focusedTreeButton]);
 
   const { onReorder, onDelete, canMoveUp, canMoveDown } =
     useUpdateFormStructure(

--- a/src/modules/formBuilder/components/formTree/FormTreeLabel.tsx
+++ b/src/modules/formBuilder/components/formTree/FormTreeLabel.tsx
@@ -3,7 +3,7 @@ import { Box, Stack, Theme } from '@mui/system';
 import { TreeItem2Label, UseTreeItem2Parameters } from '@mui/x-tree-view';
 import { useTreeItem2 } from '@mui/x-tree-view/useTreeItem2/useTreeItem2';
 import { UseTreeItem2LabelSlotProps } from '@mui/x-tree-view/useTreeItem2/useTreeItem2.types';
-import React, { useContext, useMemo, useState } from 'react';
+import React, { useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { useFormContext, useFormState } from 'react-hook-form';
 import { FormTreeContext } from './FormTreeContext';
 import useUpdateFormStructure from './useUpdateFormStructure';
@@ -44,6 +44,8 @@ const FormTreeLabel: React.FC<FormTreeLabelProps> = ({
     rhfPathMap,
     ancestorLinkIdMap,
     expandItem,
+    focusedTreeButton,
+    setFocusedTreeButton,
   } = useContext(FormTreeContext);
 
   const { control } = useFormContext();
@@ -66,6 +68,19 @@ const FormTreeLabel: React.FC<FormTreeLabelProps> = ({
   );
 
   const labelProps = getLabelProps();
+
+  const upRef = useRef<HTMLButtonElement | null>(null);
+  const downRef = useRef<HTMLButtonElement | null>(null);
+
+  // When the user reorders form items, we want to maintain focus on the up/down button in question. But, since some
+  // form reorder actions use rhf's `reset` on the whole structure, this refocus lives here in this useEffect.
+  useEffect(() => {
+    if (focusedTreeButton === `${itemId}-up`) {
+      upRef.current?.focus();
+    } else if (focusedTreeButton === `${itemId}-down`) {
+      downRef.current?.focus();
+    }
+  }, [upRef, downRef, focusedTreeButton]);
 
   const { onReorder, onDelete, canMoveUp, canMoveDown } =
     useUpdateFormStructure(
@@ -192,8 +207,10 @@ const FormTreeLabel: React.FC<FormTreeLabelProps> = ({
                 onClick={(e) => {
                   e.stopPropagation();
                   onReorder('up');
+                  setFocusedTreeButton(`${itemId}-up`);
                 }}
                 disabled={isSubmitting || !canMoveUp}
+                ref={upRef}
               >
                 <UpIcon />
               </IconButton>
@@ -202,8 +219,10 @@ const FormTreeLabel: React.FC<FormTreeLabelProps> = ({
                 onClick={(e) => {
                   e.stopPropagation();
                   onReorder('down');
+                  setFocusedTreeButton(`${itemId}-down`);
                 }}
                 disabled={isSubmitting || !canMoveDown}
+                ref={downRef}
               >
                 <DownIcon />
               </IconButton>

--- a/src/modules/formBuilder/components/formTree/useUpdateFormStructure.tsx
+++ b/src/modules/formBuilder/components/formTree/useUpdateFormStructure.tsx
@@ -16,6 +16,8 @@ import {
 import { ItemDependents } from '@/modules/formBuilder/types';
 import { FormDefinitionJson, FormItem, ItemType } from '@/types/gqlTypes';
 
+const MAX_NESTING_DEPTH = 5;
+
 export default function useUpdateFormStructure(
   control: Control,
   itemId: string,
@@ -33,8 +35,11 @@ export default function useUpdateFormStructure(
   // grandParentArrayPath:  item        (parentIndex=3)
 
   const itemPath = rhfPathMap[itemId];
-  const { parentPath: parentArrayPath, index: thisIndex } =
-    getPathContext(itemPath);
+  const {
+    parentPath: parentArrayPath,
+    index: thisIndex,
+    nestingDepth,
+  } = getPathContext(itemPath);
   const parentItemId = parentArrayPath.replace(/\.item$/, '');
   const { parentPath: grandParentArrayPath, index: parentIndex } =
     getPathContext(parentItemId);
@@ -73,16 +78,23 @@ export default function useUpdateFormStructure(
     [itemId, thisIndex, remove, itemMap]
   );
 
+  // This restriction prevents nesting a Group beyond MAX_NESTING_DEPTH - 1.
+  // This way regular (non-group) items can't ever be nested beyond MAX_NESTING_DEPTH.
+  const isMaxDepth = useMemo(
+    () =>
+      item.type === ItemType.Group && nestingDepth === MAX_NESTING_DEPTH - 1,
+    [item.type, nestingDepth]
+  );
+
   const onReorder = useCallback(
     (direction: 'up' | 'down') => {
       if (direction === 'up') {
         // If index > 0, we can move this item up within its existing "layer"
         if (thisIndex > 0) {
           const prevItem = thisLayer[thisIndex - 1]; // sibling above current item
-          if (prevItem.type === ItemType.Group) {
+          if (prevItem.type === ItemType.Group && !isMaxDepth) {
             // CASE 1: If the item above it is a group, we remove this item and
-            // append it to the "sibling" group above it
-            console.log('case 1');
+            // append it to the "sibling" group above it, as long as we haven't reached max depth
             const prevLinkId = prevItem.linkId;
             const prevItemPath = rhfPathMap[prevLinkId] + '.item';
 
@@ -105,14 +117,12 @@ export default function useUpdateFormStructure(
               { keepDefaultValues: true }
             );
           } else {
-            // CASE 2: Swap this item with the (non-group) item above it
-            console.log('case 2');
+            // CASE 2: Swap this item with the item above it
             swap(thisIndex, thisIndex - 1);
           }
         } else if (hasParent) {
           // CASE 3: This item is the first item in its group, so we need to move it "out"
-          // of its group and insert it into it's parent array.
-          console.log('case 3');
+          // of its group and insert it into its parent array.
 
           reset(
             (oldForm) => {
@@ -132,16 +142,15 @@ export default function useUpdateFormStructure(
             { keepDefaultValues: true }
           );
 
-          // else, this is the first item in the top layer, so hitting the 'up' button does nothing.
+          // else, this is the first item in the top layer, so no action can be taken
         }
       } else if (direction === 'down') {
         const nextItem = thisLayer[thisIndex + 1]; // sibling below current item
 
         if (nextItem) {
-          if (nextItem.type === ItemType.Group) {
+          if (nextItem.type === ItemType.Group && !isMaxDepth) {
             // CASE 4: If the item below it is a group, we remove this item and
-            // prepend it to the "sibling" group below it
-            console.log('case 4');
+            // prepend it to the "sibling" group below it, as long as we haven't reached max depth
             const nextLinkId = nextItem.linkId;
             const nextItemPath = rhfPathMap[nextLinkId] + '.item';
 
@@ -164,14 +173,12 @@ export default function useUpdateFormStructure(
               { keepDefaultValues: true }
             );
           } else {
-            // CASE 5: Swap this item with the (non-group) item below it
-            console.log('case 5');
+            // CASE 5: Swap this item with the item below it
             swap(thisIndex, thisIndex + 1);
           }
         } else {
           if (hasParent) {
             // CASE 6: This is the last item at this depth. Move into the parent layer
-            console.log('case 6', parentIndex);
 
             reset(
               (oldForm) => {
@@ -190,7 +197,7 @@ export default function useUpdateFormStructure(
               },
               { keepDefaultValues: true }
             );
-          } // else, this is the last item in the top layer, so hitting the 'down' button does nothing.
+          } // else, this is the last item in the top layer, so no action can be taken
         }
       }
     },

--- a/src/modules/formBuilder/components/formTree/useUpdateFormStructure.tsx
+++ b/src/modules/formBuilder/components/formTree/useUpdateFormStructure.tsx
@@ -213,6 +213,7 @@ export default function useUpdateFormStructure(
       swap,
       grandParentArrayPath,
       parentIndex,
+      isMaxDepth,
     ]
   );
 

--- a/src/modules/formBuilder/formBuilderUtil.ts
+++ b/src/modules/formBuilder/formBuilderUtil.ts
@@ -149,29 +149,37 @@ export const getRhfPathMap = (items: FormItem[]) => {
 /**
  * Helper fn for interacting with the form tree structure as stored in React Hook Forms,
  * which stores item paths like `item`, `item.0`, `item.0.item.1`, etc.
- * Given a form path, return the path to its parent and the index in the parent.
- * For example: if itemPath is `item.0.item.1`, then the parentPath is `item.0.item`
- * and the index is 1.
+ * Given a form path, return the path to its parent, the index in the parent, and nesting depth
+ * For example: if itemPath is `item.0.item.1`
+ * - the parentPath is `item.0.item`
+ * - the index is 1
+ * - the nesting depth is 2 (nesting depth is 1-indexed, not 0-indexed)
  */
 export const getPathContext = (
   itemPath: string
-): { parentPath: string; index: number } => {
+): { parentPath: string; index: number; nestingDepth: number } => {
   if (!itemPath || itemPath === 'item') {
-    return { parentPath: '', index: -1 };
+    return { parentPath: '', index: -1, nestingDepth: 0 };
   }
 
   const components = itemPath.split('.');
   const lastComponent = components[components.length - 1];
 
-  if (lastComponent !== 'item') {
-    const index = components.pop();
-    return {
-      parentPath: components.join('.'),
-      index: Number(index),
-    };
-  } else {
-    throw new Error('shouldnt happen');
+  if (lastComponent === 'item') {
+    throw new Error(
+      '`getPathContext` accepts an item path, such as `item.0.item.1`. It should end in an index, not `item`.'
+    );
   }
+
+  // calculate the nesting depth by how many times 'item' appears in the path
+  const nestingDepth = components.filter((c) => c === 'item').length;
+
+  const index = components.pop();
+  return {
+    parentPath: components.join('.'),
+    index: Number(index),
+    nestingDepth: nestingDepth,
+  };
 };
 
 // mutates definition


### PR DESCRIPTION
## Description

GH issue: https://github.com/open-path/Green-River/issues/6274

- Enforces maximum depth of the form tree at 5
  - I implemented this strictly, by disabling moving a Group item beyond depth 4. Since you can't move an item into a non-Group item, this also has the effect that no item can go beyond depth 5.
- After form reset, re-focuses the most recent up/down button selected so that users can more easily use the keyboard to move an item up or down through a long form.
  - The focus behavior is still a bit unpredictable when you use the keyboard to move an item all the way to the end.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [x] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (eslint)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
