### PR TITLE
improve-sentry-grouping-for-50X

### DIFF
--- a/src/modules/errors/util.ts
+++ b/src/modules/errors/util.ts
@@ -1,6 +1,7 @@
 import { ApolloError, ServerError, ServerParseError } from '@apollo/client';
 import { partition } from 'lodash-es';
 
+import { CustomFetchNetworkError } from '@/providers/apolloClient';
 import { ValidationError, ValidationSeverity } from '@/types/gqlTypes';
 
 // This message is shown for unhandled exceptions
@@ -20,6 +21,12 @@ export const isServerError = (
   err: Error | ServerParseError | ServerError | null
 ): err is ServerError => {
   return !!(err && err instanceof Error && err.hasOwnProperty('result'));
+};
+
+export const hasStatusCode = (
+  err: Error | ServerParseError | ServerError | CustomFetchNetworkError | null
+): err is CustomFetchNetworkError | ServerError => {
+  return !!(err && err instanceof Error && 'statusCode' in err);
 };
 
 /*** Error State helpers for storing all relevant error state  */

--- a/src/providers/apolloClient.tsx
+++ b/src/providers/apolloClient.tsx
@@ -18,6 +18,17 @@ import { allRoutes } from '@/routes/routes';
 import { getCsrfToken } from '@/utils/csrf';
 import { decodeParams } from '@/utils/pathEncoding';
 
+// adds explicit network status code
+export class CustomFetchNetworkError extends Error {
+  statusCode: number;
+
+  constructor(message: string, statusCode: number) {
+    super(message);
+    this.statusCode = statusCode;
+    this.name = 'CustomFetchNetworkError';
+  }
+}
+
 // https://github.com/apollographql/apollo-feature-requests/issues/153#issuecomment-476832408
 const customFetch: HttpOptions['fetch'] = (uri, options) => {
   return fetch(uri, options).then((response) => {
@@ -25,7 +36,9 @@ const customFetch: HttpOptions['fetch'] = (uri, options) => {
     // This gives us cleaner sentry errors because the error will actually say "504" instead of "unable to parse html"
     // For 500 and under, we expect the response to be JSON.
     if (response.status > 500) {
-      return Promise.reject(new Error(response.status.toString()));
+      return Promise.reject(
+        new CustomFetchNetworkError(response.status.toString(), response.status)
+      );
     }
     return response;
   });

--- a/src/providers/apolloErrorLink.tsx
+++ b/src/providers/apolloErrorLink.tsx
@@ -3,7 +3,7 @@ import * as Sentry from '@sentry/react';
 
 import { sentryUser } from '@/modules/auth/api/sessions';
 import { dispatchSessionTrackingEvent } from '@/modules/auth/events';
-import { isServerError } from '@/modules/errors/util';
+import { hasStatusCode } from '@/modules/errors/util';
 
 /**
  * Handle errors on GraphQL chain.
@@ -25,7 +25,7 @@ function safeStringify(obj: any) {
 
 const apolloErrorLink = onError(
   ({ operation, graphQLErrors, networkError }) => {
-    Sentry.withScope((scope) => {
+    Sentry.withScope((scope): void => {
       scope.setExtra('apolloGraphQLOperation', {
         operationName: operation.operationName,
         // truncate query so as to not exceed Sentry's size limit
@@ -52,25 +52,25 @@ const apolloErrorLink = onError(
       });
 
       if (networkError) {
-        // Not a server error. This is usually 504 or "Network request failed", track in Sentry
-        if (!isServerError(networkError)) {
-          if (recordedErrors === 0) Sentry.captureException(networkError);
-          return;
+        if (hasStatusCode(networkError)) {
+          scope.setTag('status_code', networkError.statusCode);
+          // Not a server error. This is usually 504 or "Network request failed", track in Sentry and group the errors together
+          if (networkError.statusCode > 500) {
+            scope.setTag('errorType', 'ApolloNetworkError');
+            scope.setFingerprint(['hmis-fe-network-errors']);
+            Sentry.captureException(networkError);
+            return;
+          }
+          // session may be invalid on the server. No need to send to Sentry.
+          if (networkError.statusCode === 401) {
+            dispatchSessionTrackingEvent(undefined);
+            return;
+          }
         }
 
-        // session may be invalid on the server. No need to send to Sentry.
-        if (networkError.statusCode === 401) {
-          dispatchSessionTrackingEvent(undefined);
-          return;
-        }
-
+        // this is probably a server error (500)
         if (recordedErrors === 0) {
-          Sentry.captureMessage(networkError.message, {
-            level: 'error',
-            extra: {
-              result: networkError.result,
-            },
-          });
+          Sentry.captureException(networkError);
         }
       }
     });


### PR DESCRIPTION
## Description

use one group in sentry for all client errors with an  HTTP code > 500. Clean up error link

[GH issue
](https://github.com/open-path/Green-River/issues/6291)
## Type of change
[//]: # 'remove options that are not relevant'
- [x] Code clean-up / housekeeping

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
