### PR TITLE
Make exhaustive-deps a lint error, not warning

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -113,6 +113,7 @@ module.exports = {
     'react/display-name': 'off',
     'react/no-children-prop': 'error',
     'react/no-danger-with-children': 'error',
+    'react-hooks/exhaustive-deps': 'error',
     'no-restricted-imports': [
       'warn',
       {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "lint-staged": {
     "*.{js,ts,jsx,tsx}": [
-      "eslint --fix --ignore-path .gitignore --max-warnings=0"
+      "eslint --fix --ignore-path .gitignore"
     ],
     "*": [
       "prettier --write"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "lint-staged": {
     "*.{js,ts,jsx,tsx}": [
-      "eslint --fix --ignore-path .gitignore"
+      "eslint --fix --ignore-path .gitignore --max-warnings=0"
     ],
     "*": [
       "prettier --write"


### PR DESCRIPTION
## Description

I'm proposing to add a flag to the eslint step that runs on pre-commit, failing the commit if there are warnings (not just errors) from eslint.

Follow-up from https://github.com/greenriver/hmis-frontend/pull/831#discussion_r1664261298, moved to its own PR so as not to block unrelated work from being merged.

## Type of change
[//]: # 'remove options that are not relevant'
- [ ] Bug fix
- [ ] New feature (adds functionality)
- [x] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (eslint)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
