### PR TITLE
Filter form rules by active status

### DIFF
--- a/src/api/operations/form.queries.graphql
+++ b/src/api/operations/form.queries.graphql
@@ -94,7 +94,7 @@ query GetFormIdentifiers(
       displayVersion {
         ...FormDefinitionMetadata
         system
-        formRules(limit: 1) {
+        formRules(limit: 1, filters: { activeStatus: ACTIVE }) {
           nodesCount
         }
       }

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -40289,7 +40289,7 @@ export const GetFormIdentifiersDocument = gql`
         displayVersion {
           ...FormDefinitionMetadata
           system
-          formRules(limit: 1) {
+          formRules(limit: 1, filters: { activeStatus: ACTIVE }) {
             nodesCount
           }
         }


### PR DESCRIPTION
## Description

GH issue: https://github.com/open-path/Green-River/issues/6109

This PR is meant to update the Forms table so that under the Applicability Rules table, it only returns the number of Active rules, now that we are using Inactive as a deletion flag.

Depends on: https://github.com/greenriver/hmis-warehouse/pull/4520

Should target 124?

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
