### PR TITLE
5727-hmis-graphql-retry

### DIFF
--- a/src/providers/apolloClient.tsx
+++ b/src/providers/apolloClient.tsx
@@ -127,8 +127,8 @@ export const cache = new InMemoryCache({
 
 const retryLink = new RetryLink({
   delay: {
-    initial: 800,
-    max: 2400,
+    initial: 800, // Wait 800ms before the first retry after a failed request
+    max: 1200, // Maximum wait time between retries
     jitter: true,
   },
   attempts: {

--- a/src/providers/apolloClient.tsx
+++ b/src/providers/apolloClient.tsx
@@ -128,7 +128,6 @@ export const cache = new InMemoryCache({
 const retryLink = new RetryLink({
   delay: {
     initial: 800, // Wait 800ms before the first retry after a failed request
-    max: 1200, // Maximum wait time between retries
     jitter: true,
   },
   attempts: {

--- a/src/providers/apolloClient.tsx
+++ b/src/providers/apolloClient.tsx
@@ -125,7 +125,6 @@ export const cache = new InMemoryCache({
   },
 });
 
-// catch 500's inserted by mysterious intermediary
 const retryLink = new RetryLink({
   delay: {
     initial: 800,
@@ -134,7 +133,12 @@ const retryLink = new RetryLink({
   },
   attempts: {
     max: 3,
-    retryIf: (error: CustomFetchNetworkError) => {
+    retryIf: (error: CustomFetchNetworkError, operation) => {
+      // Only retry operations that seem to be queries, like "GetWidgets"
+      // Avoid retries on mutations as they may not be idempotent
+      if (!operation?.operationName?.match(/^(Get)/)) {
+        return false;
+      }
       switch (error?.statusCode) {
         case 401:
         case 403:


### PR DESCRIPTION
## Description
[GH Issue](https://github.com/open-path/Green-River/issues/5727)

Retry graphql queries under certain circumstances. We are only retrying "Get*" queries here but it may also be safe to retry 'update' or 'delete' queries too.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] New feature (adds functionality)


## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
