### PR TITLE
Warn on referral when client is already enrolled

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -36025,6 +36025,55 @@
             "deprecationReason": null
           },
           {
+            "name": "canProjectAcceptReferral",
+            "description": null,
+            "args": [
+              {
+                "name": "projectId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "referrerEnrollmentId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "client",
             "description": "Client lookup",
             "args": [

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -36025,55 +36025,6 @@
             "deprecationReason": null
           },
           {
-            "name": "canProjectAcceptReferral",
-            "description": null,
-            "args": [
-              {
-                "name": "projectId",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "ID",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "referrerEnrollmentId",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "ID",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "client",
             "description": "Client lookup",
             "args": [
@@ -37177,6 +37128,55 @@
               "kind": "OBJECT",
               "name": "Project",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectCanAcceptReferral",
+            "description": "Whether the destination project is able to accept a referral for the client(s) belonging to the source enrollment",
+            "args": [
+              {
+                "name": "destinationProjectId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "sourceEnrollmentId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -39664,12 +39664,6 @@
         "interfaces": null,
         "enumValues": [
           {
-            "name": "accepted_by_other_program_status",
-            "description": "Accepted By Other Program",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "accepted_pending_status",
             "description": "Accepted Pending",
             "isDeprecated": false,
@@ -39688,12 +39682,6 @@
             "deprecationReason": null
           },
           {
-            "name": "assigned_to_other_program_status",
-            "description": "Assigned To Other Program",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "closed_status",
             "description": "Closed",
             "isDeprecated": false,
@@ -39708,24 +39696,6 @@
           {
             "name": "denied_status",
             "description": "Denied",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "new_status",
-            "description": "New",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "not_selected_status",
-            "description": "Not Selected",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "void_status",
-            "description": "Void",
             "isDeprecated": false,
             "deprecationReason": null
           }

--- a/src/api/operations/referral.operations.graphql
+++ b/src/api/operations/referral.operations.graphql
@@ -9,12 +9,6 @@ mutation VoidReferralRequest($id: ID!) {
   }
 }
 
-query GetReferralPosting($id: ID!) {
-  referralPosting(id: $id) {
-    ...ReferralPostingDetailFields
-  }
-}
-
 mutation UpdateReferralPosting($id: ID!, $input: ReferralPostingInput!) {
   updateReferralPosting(id: $id, input: $input) {
     record {
@@ -22,25 +16,6 @@ mutation UpdateReferralPosting($id: ID!, $input: ReferralPostingInput!) {
     }
     errors {
       ...ValidationErrorFields
-    }
-  }
-}
-
-query GetDeniedPendingReferralPostings(
-  $limit: Int = 10
-  $offset: Int = 0
-  $filters: ReferralPostingFilterOptions
-) {
-  deniedPendingReferralPostings(
-    limit: $limit
-    offset: $offset
-    filters: $filters
-  ) {
-    offset
-    limit
-    nodesCount
-    nodes {
-      ...ReferralPostingFields
     }
   }
 }

--- a/src/api/operations/referral.queries.graphql
+++ b/src/api/operations/referral.queries.graphql
@@ -1,7 +1,10 @@
-query GetCanProjectAcceptReferral($projectId: ID!, $referrerEnrollmentId: ID!) {
-  canProjectAcceptReferral(
-    projectId: $projectId
-    referrerEnrollmentId: $referrerEnrollmentId
+query GetProjectCanAcceptReferral(
+  $sourceEnrollmentId: ID!
+  $destinationProjectId: ID!
+) {
+  projectCanAcceptReferral(
+    sourceEnrollmentId: $sourceEnrollmentId
+    destinationProjectId: $destinationProjectId
   )
 }
 

--- a/src/api/operations/referral.queries.graphql
+++ b/src/api/operations/referral.queries.graphql
@@ -1,0 +1,31 @@
+query GetCanProjectAcceptReferral($projectId: ID!, $referrerEnrollmentId: ID!) {
+  canProjectAcceptReferral(
+    projectId: $projectId
+    referrerEnrollmentId: $referrerEnrollmentId
+  )
+}
+
+query GetReferralPosting($id: ID!) {
+  referralPosting(id: $id) {
+    ...ReferralPostingDetailFields
+  }
+}
+
+query GetDeniedPendingReferralPostings(
+  $limit: Int = 10
+  $offset: Int = 0
+  $filters: ReferralPostingFilterOptions
+) {
+  deniedPendingReferralPostings(
+    limit: $limit
+    offset: $offset
+    filters: $filters
+  ) {
+    offset
+    limit
+    nodesCount
+    nodes {
+      ...ReferralPostingFields
+    }
+  }
+}

--- a/src/modules/projects/components/ProjectOutgoingReferralDetailsSubForm.tsx
+++ b/src/modules/projects/components/ProjectOutgoingReferralDetailsSubForm.tsx
@@ -1,3 +1,4 @@
+import { Alert } from '@mui/material';
 import { Box } from '@mui/system';
 import { useMemo } from 'react';
 
@@ -7,7 +8,10 @@ import { useDynamicFormHandlersForRecord } from '@/modules/form/hooks/useDynamic
 import useFormDefinition from '@/modules/form/hooks/useFormDefinition';
 import { SubmitFormAllowedTypes } from '@/modules/form/types';
 import { AlwaysPresentLocalConstants } from '@/modules/form/util/formUtil';
-import { RecordFormRole } from '@/types/gqlTypes';
+import {
+  RecordFormRole,
+  useGetCanProjectAcceptReferralQuery,
+} from '@/types/gqlTypes';
 
 interface Props {
   enrollmentId: string; // HoH enrollment that is being referred
@@ -57,10 +61,23 @@ const ProjectOutgoingReferralDetailsSubForm: React.FC<Props> = ({
     );
   }
 
+  const { data: receivingProject } = useGetCanProjectAcceptReferralQuery({
+    variables: {
+      projectId: destinationProjectId,
+      referrerEnrollmentId: enrollmentId,
+    },
+  });
+
   return (
     <Box>
       {formDefinitionLoading && (
         <LoadingSkeleton width={'100%'} count={1} sx={{ my: 2 }} />
+      )}
+      {receivingProject && !receivingProject.canProjectAcceptReferral && (
+        <Alert color='warning' sx={{ mb: 2 }}>
+          At least one client in the household already has an open enrollment in
+          this project.
+        </Alert>
       )}
       {formDefinition && (
         <DynamicForm

--- a/src/modules/projects/components/ProjectOutgoingReferralDetailsSubForm.tsx
+++ b/src/modules/projects/components/ProjectOutgoingReferralDetailsSubForm.tsx
@@ -10,7 +10,7 @@ import { SubmitFormAllowedTypes } from '@/modules/form/types';
 import { AlwaysPresentLocalConstants } from '@/modules/form/util/formUtil';
 import {
   RecordFormRole,
-  useGetCanProjectAcceptReferralQuery,
+  useGetProjectCanAcceptReferralQuery,
 } from '@/types/gqlTypes';
 
 interface Props {
@@ -61,10 +61,10 @@ const ProjectOutgoingReferralDetailsSubForm: React.FC<Props> = ({
     );
   }
 
-  const { data: receivingProject } = useGetCanProjectAcceptReferralQuery({
+  const { data } = useGetProjectCanAcceptReferralQuery({
     variables: {
-      projectId: destinationProjectId,
-      referrerEnrollmentId: enrollmentId,
+      destinationProjectId: destinationProjectId,
+      sourceEnrollmentId: enrollmentId,
     },
   });
 
@@ -73,8 +73,8 @@ const ProjectOutgoingReferralDetailsSubForm: React.FC<Props> = ({
       {formDefinitionLoading && (
         <LoadingSkeleton width={'100%'} count={1} sx={{ my: 2 }} />
       )}
-      {receivingProject && !receivingProject.canProjectAcceptReferral && (
-        <Alert color='warning' sx={{ mb: 2 }}>
+      {data && !data.projectCanAcceptReferral && (
+        <Alert severity='warning' sx={{ mb: 2 }}>
           At least one client in the household already has an open enrollment in
           this project.
         </Alert>

--- a/src/types/gqlEnums.ts
+++ b/src/types/gqlEnums.ts
@@ -1462,17 +1462,12 @@ export const HmisEnums = {
     NoLongerInterestedInThisProgram: 'No longer interested in this program',
   },
   ReferralPostingStatus: {
-    accepted_by_other_program_status: 'Accepted By Other Program',
     accepted_pending_status: 'Accepted Pending',
     accepted_status: 'Accepted',
     assigned_status: 'Assigned',
-    assigned_to_other_program_status: 'Assigned To Other Program',
     closed_status: 'Closed',
     denied_pending_status: 'Denied Pending',
     denied_status: 'Denied',
-    new_status: 'New',
-    not_selected_status: 'Not Selected',
-    void_status: 'Void',
   },
   ReferralResult: {
     INVALID: 'Invalid Value',

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -5642,6 +5642,7 @@ export type Query = {
   assessment?: Maybe<Assessment>;
   /** Get the correct Form Definition to use for an assessment, by Role or FormDefinition ID */
   assessmentFormDefinition?: Maybe<FormDefinition>;
+  canProjectAcceptReferral: Scalars['Boolean']['output'];
   /** Client lookup */
   client?: Maybe<Client>;
   /** Custom forms for collecting and/or displaying custom details for a Client (outside of the Client demographics form) */
@@ -5716,6 +5717,11 @@ export type QueryAssessmentFormDefinitionArgs = {
   id?: InputMaybe<Scalars['ID']['input']>;
   projectId: Scalars['ID']['input'];
   role?: InputMaybe<AssessmentRole>;
+};
+
+export type QueryCanProjectAcceptReferralArgs = {
+  projectId: Scalars['ID']['input'];
+  referrerEnrollmentId: Scalars['ID']['input'];
 };
 
 export type QueryClientArgs = {
@@ -30480,172 +30486,6 @@ export type VoidReferralRequestMutation = {
   } | null;
 };
 
-export type GetReferralPostingQueryVariables = Exact<{
-  id: Scalars['ID']['input'];
-}>;
-
-export type GetReferralPostingQuery = {
-  __typename?: 'Query';
-  referralPosting?: {
-    __typename?: 'ReferralPosting';
-    id: string;
-    assignedDate: string;
-    chronic?: boolean | null;
-    hudChronic?: boolean | null;
-    denialNote?: string | null;
-    denialReason?: ReferralPostingDenialReasonType | null;
-    needsWheelchairAccessibleUnit?: boolean | null;
-    postingIdentifier?: string | null;
-    referralDate: string;
-    referralIdentifier?: string | null;
-    referralNotes?: string | null;
-    referralResult?: ReferralResult | null;
-    referredBy: string;
-    referredFrom: string;
-    referredTo?: string | null;
-    resourceCoordinatorNotes?: string | null;
-    score?: number | null;
-    status: ReferralPostingStatus;
-    statusNote?: string | null;
-    statusNoteUpdatedAt?: string | null;
-    statusNoteUpdatedBy?: string | null;
-    statusUpdatedAt?: string | null;
-    statusUpdatedBy?: string | null;
-    referralRequest?: { __typename?: 'ReferralRequest'; id: string } | null;
-    project?: {
-      __typename?: 'Project';
-      id: string;
-      projectType?: ProjectType | null;
-      projectName: string;
-    } | null;
-    organization?: {
-      __typename?: 'Organization';
-      id: string;
-      organizationName: string;
-    } | null;
-    unitType?: {
-      __typename?: 'UnitTypeObject';
-      id: string;
-      description?: string | null;
-    } | null;
-    hohEnrollment?: {
-      __typename?: 'Enrollment';
-      id: string;
-      client: { __typename?: 'Client'; id: string };
-    } | null;
-    householdMembers: Array<{
-      __typename?: 'ReferralHouseholdMember';
-      id: string;
-      relationshipToHoH: RelationshipToHoH;
-      openEnrollmentSummary: Array<{
-        __typename?: 'EnrollmentSummary';
-        id: string;
-        entryDate: string;
-        inProgress: boolean;
-        moveInDate?: string | null;
-        projectId: string;
-        projectName: string;
-        projectType: ProjectType;
-        canViewEnrollment: boolean;
-      }>;
-      client: {
-        __typename?: 'Client';
-        id: string;
-        veteranStatus: NoYesReasonsForMissingData;
-        gender: Array<Gender>;
-        lockVersion: number;
-        firstName?: string | null;
-        middleName?: string | null;
-        lastName?: string | null;
-        nameSuffix?: string | null;
-        dob?: string | null;
-        age?: number | null;
-        ssn?: string | null;
-        access: {
-          __typename?: 'ClientAccess';
-          id: string;
-          canViewFullSsn: boolean;
-          canViewPartialSsn: boolean;
-          canEditClient: boolean;
-          canDeleteClient: boolean;
-          canViewDob: boolean;
-          canViewClientName: boolean;
-          canEditEnrollments: boolean;
-          canDeleteEnrollments: boolean;
-          canViewEnrollmentDetails: boolean;
-          canDeleteAssessments: boolean;
-          canManageAnyClientFiles: boolean;
-          canManageOwnClientFiles: boolean;
-          canViewAnyConfidentialClientFiles: boolean;
-          canViewAnyNonconfidentialClientFiles: boolean;
-          canUploadClientFiles: boolean;
-          canViewAnyFiles: boolean;
-          canAuditClients: boolean;
-          canManageScanCards: boolean;
-          canMergeClients: boolean;
-          canViewClientAlerts: boolean;
-          canManageClientAlerts: boolean;
-        };
-        externalIds: Array<{
-          __typename?: 'ExternalIdentifier';
-          id: string;
-          identifier?: string | null;
-          url?: string | null;
-          label: string;
-          type: ExternalIdentifierType;
-        }>;
-      };
-    }>;
-    customDataElements: Array<{
-      __typename?: 'CustomDataElement';
-      id: string;
-      key: string;
-      label: string;
-      fieldType: CustomDataElementType;
-      repeats: boolean;
-      displayHooks: Array<DisplayHook>;
-      value?: {
-        __typename?: 'CustomDataElementValue';
-        id: string;
-        valueBoolean?: boolean | null;
-        valueDate?: string | null;
-        valueFloat?: number | null;
-        valueInteger?: number | null;
-        valueJson?: any | null;
-        valueString?: string | null;
-        valueText?: string | null;
-        dateCreated?: string | null;
-        dateUpdated?: string | null;
-        user?: {
-          __typename: 'ApplicationUser';
-          id: string;
-          name: string;
-          email: string;
-        } | null;
-      } | null;
-      values?: Array<{
-        __typename?: 'CustomDataElementValue';
-        id: string;
-        valueBoolean?: boolean | null;
-        valueDate?: string | null;
-        valueFloat?: number | null;
-        valueInteger?: number | null;
-        valueJson?: any | null;
-        valueString?: string | null;
-        valueText?: string | null;
-        dateCreated?: string | null;
-        dateUpdated?: string | null;
-        user?: {
-          __typename: 'ApplicationUser';
-          id: string;
-          name: string;
-          email: string;
-        } | null;
-      }> | null;
-    }>;
-  } | null;
-};
-
 export type UpdateReferralPostingMutationVariables = Exact<{
   id: Scalars['ID']['input'];
   input: ReferralPostingInput;
@@ -30826,6 +30666,182 @@ export type UpdateReferralPostingMutation = {
       linkId?: string | null;
       section?: string | null;
       data?: any | null;
+    }>;
+  } | null;
+};
+
+export type GetCanProjectAcceptReferralQueryVariables = Exact<{
+  projectId: Scalars['ID']['input'];
+  referrerEnrollmentId: Scalars['ID']['input'];
+}>;
+
+export type GetCanProjectAcceptReferralQuery = {
+  __typename?: 'Query';
+  canProjectAcceptReferral: boolean;
+};
+
+export type GetReferralPostingQueryVariables = Exact<{
+  id: Scalars['ID']['input'];
+}>;
+
+export type GetReferralPostingQuery = {
+  __typename?: 'Query';
+  referralPosting?: {
+    __typename?: 'ReferralPosting';
+    id: string;
+    assignedDate: string;
+    chronic?: boolean | null;
+    hudChronic?: boolean | null;
+    denialNote?: string | null;
+    denialReason?: ReferralPostingDenialReasonType | null;
+    needsWheelchairAccessibleUnit?: boolean | null;
+    postingIdentifier?: string | null;
+    referralDate: string;
+    referralIdentifier?: string | null;
+    referralNotes?: string | null;
+    referralResult?: ReferralResult | null;
+    referredBy: string;
+    referredFrom: string;
+    referredTo?: string | null;
+    resourceCoordinatorNotes?: string | null;
+    score?: number | null;
+    status: ReferralPostingStatus;
+    statusNote?: string | null;
+    statusNoteUpdatedAt?: string | null;
+    statusNoteUpdatedBy?: string | null;
+    statusUpdatedAt?: string | null;
+    statusUpdatedBy?: string | null;
+    referralRequest?: { __typename?: 'ReferralRequest'; id: string } | null;
+    project?: {
+      __typename?: 'Project';
+      id: string;
+      projectType?: ProjectType | null;
+      projectName: string;
+    } | null;
+    organization?: {
+      __typename?: 'Organization';
+      id: string;
+      organizationName: string;
+    } | null;
+    unitType?: {
+      __typename?: 'UnitTypeObject';
+      id: string;
+      description?: string | null;
+    } | null;
+    hohEnrollment?: {
+      __typename?: 'Enrollment';
+      id: string;
+      client: { __typename?: 'Client'; id: string };
+    } | null;
+    householdMembers: Array<{
+      __typename?: 'ReferralHouseholdMember';
+      id: string;
+      relationshipToHoH: RelationshipToHoH;
+      openEnrollmentSummary: Array<{
+        __typename?: 'EnrollmentSummary';
+        id: string;
+        entryDate: string;
+        inProgress: boolean;
+        moveInDate?: string | null;
+        projectId: string;
+        projectName: string;
+        projectType: ProjectType;
+        canViewEnrollment: boolean;
+      }>;
+      client: {
+        __typename?: 'Client';
+        id: string;
+        veteranStatus: NoYesReasonsForMissingData;
+        gender: Array<Gender>;
+        lockVersion: number;
+        firstName?: string | null;
+        middleName?: string | null;
+        lastName?: string | null;
+        nameSuffix?: string | null;
+        dob?: string | null;
+        age?: number | null;
+        ssn?: string | null;
+        access: {
+          __typename?: 'ClientAccess';
+          id: string;
+          canViewFullSsn: boolean;
+          canViewPartialSsn: boolean;
+          canEditClient: boolean;
+          canDeleteClient: boolean;
+          canViewDob: boolean;
+          canViewClientName: boolean;
+          canEditEnrollments: boolean;
+          canDeleteEnrollments: boolean;
+          canViewEnrollmentDetails: boolean;
+          canDeleteAssessments: boolean;
+          canManageAnyClientFiles: boolean;
+          canManageOwnClientFiles: boolean;
+          canViewAnyConfidentialClientFiles: boolean;
+          canViewAnyNonconfidentialClientFiles: boolean;
+          canUploadClientFiles: boolean;
+          canViewAnyFiles: boolean;
+          canAuditClients: boolean;
+          canManageScanCards: boolean;
+          canMergeClients: boolean;
+          canViewClientAlerts: boolean;
+          canManageClientAlerts: boolean;
+        };
+        externalIds: Array<{
+          __typename?: 'ExternalIdentifier';
+          id: string;
+          identifier?: string | null;
+          url?: string | null;
+          label: string;
+          type: ExternalIdentifierType;
+        }>;
+      };
+    }>;
+    customDataElements: Array<{
+      __typename?: 'CustomDataElement';
+      id: string;
+      key: string;
+      label: string;
+      fieldType: CustomDataElementType;
+      repeats: boolean;
+      displayHooks: Array<DisplayHook>;
+      value?: {
+        __typename?: 'CustomDataElementValue';
+        id: string;
+        valueBoolean?: boolean | null;
+        valueDate?: string | null;
+        valueFloat?: number | null;
+        valueInteger?: number | null;
+        valueJson?: any | null;
+        valueString?: string | null;
+        valueText?: string | null;
+        dateCreated?: string | null;
+        dateUpdated?: string | null;
+        user?: {
+          __typename: 'ApplicationUser';
+          id: string;
+          name: string;
+          email: string;
+        } | null;
+      } | null;
+      values?: Array<{
+        __typename?: 'CustomDataElementValue';
+        id: string;
+        valueBoolean?: boolean | null;
+        valueDate?: string | null;
+        valueFloat?: number | null;
+        valueInteger?: number | null;
+        valueJson?: any | null;
+        valueString?: string | null;
+        valueText?: string | null;
+        dateCreated?: string | null;
+        dateUpdated?: string | null;
+        user?: {
+          __typename: 'ApplicationUser';
+          id: string;
+          name: string;
+          email: string;
+        } | null;
+      }> | null;
     }>;
   } | null;
 };
@@ -43500,6 +43516,127 @@ export type VoidReferralRequestMutationOptions = Apollo.BaseMutationOptions<
   VoidReferralRequestMutation,
   VoidReferralRequestMutationVariables
 >;
+export const UpdateReferralPostingDocument = gql`
+  mutation UpdateReferralPosting($id: ID!, $input: ReferralPostingInput!) {
+    updateReferralPosting(id: $id, input: $input) {
+      record {
+        ...ReferralPostingDetailFields
+      }
+      errors {
+        ...ValidationErrorFields
+      }
+    }
+  }
+  ${ReferralPostingDetailFieldsFragmentDoc}
+  ${ValidationErrorFieldsFragmentDoc}
+`;
+export type UpdateReferralPostingMutationFn = Apollo.MutationFunction<
+  UpdateReferralPostingMutation,
+  UpdateReferralPostingMutationVariables
+>;
+
+/**
+ * __useUpdateReferralPostingMutation__
+ *
+ * To run a mutation, you first call `useUpdateReferralPostingMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useUpdateReferralPostingMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [updateReferralPostingMutation, { data, loading, error }] = useUpdateReferralPostingMutation({
+ *   variables: {
+ *      id: // value for 'id'
+ *      input: // value for 'input'
+ *   },
+ * });
+ */
+export function useUpdateReferralPostingMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    UpdateReferralPostingMutation,
+    UpdateReferralPostingMutationVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<
+    UpdateReferralPostingMutation,
+    UpdateReferralPostingMutationVariables
+  >(UpdateReferralPostingDocument, options);
+}
+export type UpdateReferralPostingMutationHookResult = ReturnType<
+  typeof useUpdateReferralPostingMutation
+>;
+export type UpdateReferralPostingMutationResult =
+  Apollo.MutationResult<UpdateReferralPostingMutation>;
+export type UpdateReferralPostingMutationOptions = Apollo.BaseMutationOptions<
+  UpdateReferralPostingMutation,
+  UpdateReferralPostingMutationVariables
+>;
+export const GetCanProjectAcceptReferralDocument = gql`
+  query GetCanProjectAcceptReferral(
+    $projectId: ID!
+    $referrerEnrollmentId: ID!
+  ) {
+    canProjectAcceptReferral(
+      projectId: $projectId
+      referrerEnrollmentId: $referrerEnrollmentId
+    )
+  }
+`;
+
+/**
+ * __useGetCanProjectAcceptReferralQuery__
+ *
+ * To run a query within a React component, call `useGetCanProjectAcceptReferralQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetCanProjectAcceptReferralQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetCanProjectAcceptReferralQuery({
+ *   variables: {
+ *      projectId: // value for 'projectId'
+ *      referrerEnrollmentId: // value for 'referrerEnrollmentId'
+ *   },
+ * });
+ */
+export function useGetCanProjectAcceptReferralQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    GetCanProjectAcceptReferralQuery,
+    GetCanProjectAcceptReferralQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    GetCanProjectAcceptReferralQuery,
+    GetCanProjectAcceptReferralQueryVariables
+  >(GetCanProjectAcceptReferralDocument, options);
+}
+export function useGetCanProjectAcceptReferralLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GetCanProjectAcceptReferralQuery,
+    GetCanProjectAcceptReferralQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    GetCanProjectAcceptReferralQuery,
+    GetCanProjectAcceptReferralQueryVariables
+  >(GetCanProjectAcceptReferralDocument, options);
+}
+export type GetCanProjectAcceptReferralQueryHookResult = ReturnType<
+  typeof useGetCanProjectAcceptReferralQuery
+>;
+export type GetCanProjectAcceptReferralLazyQueryHookResult = ReturnType<
+  typeof useGetCanProjectAcceptReferralLazyQuery
+>;
+export type GetCanProjectAcceptReferralQueryResult = Apollo.QueryResult<
+  GetCanProjectAcceptReferralQuery,
+  GetCanProjectAcceptReferralQueryVariables
+>;
 export const GetReferralPostingDocument = gql`
   query GetReferralPosting($id: ID!) {
     referralPosting(id: $id) {
@@ -43558,64 +43695,6 @@ export type GetReferralPostingLazyQueryHookResult = ReturnType<
 export type GetReferralPostingQueryResult = Apollo.QueryResult<
   GetReferralPostingQuery,
   GetReferralPostingQueryVariables
->;
-export const UpdateReferralPostingDocument = gql`
-  mutation UpdateReferralPosting($id: ID!, $input: ReferralPostingInput!) {
-    updateReferralPosting(id: $id, input: $input) {
-      record {
-        ...ReferralPostingDetailFields
-      }
-      errors {
-        ...ValidationErrorFields
-      }
-    }
-  }
-  ${ReferralPostingDetailFieldsFragmentDoc}
-  ${ValidationErrorFieldsFragmentDoc}
-`;
-export type UpdateReferralPostingMutationFn = Apollo.MutationFunction<
-  UpdateReferralPostingMutation,
-  UpdateReferralPostingMutationVariables
->;
-
-/**
- * __useUpdateReferralPostingMutation__
- *
- * To run a mutation, you first call `useUpdateReferralPostingMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useUpdateReferralPostingMutation` returns a tuple that includes:
- * - A mutate function that you can call at any time to execute the mutation
- * - An object with fields that represent the current status of the mutation's execution
- *
- * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
- *
- * @example
- * const [updateReferralPostingMutation, { data, loading, error }] = useUpdateReferralPostingMutation({
- *   variables: {
- *      id: // value for 'id'
- *      input: // value for 'input'
- *   },
- * });
- */
-export function useUpdateReferralPostingMutation(
-  baseOptions?: Apollo.MutationHookOptions<
-    UpdateReferralPostingMutation,
-    UpdateReferralPostingMutationVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useMutation<
-    UpdateReferralPostingMutation,
-    UpdateReferralPostingMutationVariables
-  >(UpdateReferralPostingDocument, options);
-}
-export type UpdateReferralPostingMutationHookResult = ReturnType<
-  typeof useUpdateReferralPostingMutation
->;
-export type UpdateReferralPostingMutationResult =
-  Apollo.MutationResult<UpdateReferralPostingMutation>;
-export type UpdateReferralPostingMutationOptions = Apollo.BaseMutationOptions<
-  UpdateReferralPostingMutation,
-  UpdateReferralPostingMutationVariables
 >;
 export const GetDeniedPendingReferralPostingsDocument = gql`
   query GetDeniedPendingReferralPostings(

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -5642,7 +5642,6 @@ export type Query = {
   assessment?: Maybe<Assessment>;
   /** Get the correct Form Definition to use for an assessment, by Role or FormDefinition ID */
   assessmentFormDefinition?: Maybe<FormDefinition>;
-  canProjectAcceptReferral: Scalars['Boolean']['output'];
   /** Client lookup */
   client?: Maybe<Client>;
   /** Custom forms for collecting and/or displaying custom details for a Client (outside of the Client demographics form) */
@@ -5681,6 +5680,8 @@ export type Query = {
   pickList: Array<PickListOption>;
   /** Project lookup */
   project?: Maybe<Project>;
+  /** Whether the destination project is able to accept a referral for the client(s) belonging to the source enrollment */
+  projectCanAcceptReferral: Scalars['Boolean']['output'];
   /** Project CoC lookup */
   projectCoc?: Maybe<ProjectCoc>;
   projectConfigs: ProjectConfigsPaginated;
@@ -5717,11 +5718,6 @@ export type QueryAssessmentFormDefinitionArgs = {
   id?: InputMaybe<Scalars['ID']['input']>;
   projectId: Scalars['ID']['input'];
   role?: InputMaybe<AssessmentRole>;
-};
-
-export type QueryCanProjectAcceptReferralArgs = {
-  projectId: Scalars['ID']['input'];
-  referrerEnrollmentId: Scalars['ID']['input'];
 };
 
 export type QueryClientArgs = {
@@ -5845,6 +5841,11 @@ export type QueryPickListArgs = {
 
 export type QueryProjectArgs = {
   id: Scalars['ID']['input'];
+};
+
+export type QueryProjectCanAcceptReferralArgs = {
+  destinationProjectId: Scalars['ID']['input'];
+  sourceEnrollmentId: Scalars['ID']['input'];
 };
 
 export type QueryProjectCocArgs = {
@@ -6223,28 +6224,18 @@ export type ReferralPostingInput = {
 
 /** Referral Posting Status */
 export enum ReferralPostingStatus {
-  /** Accepted By Other Program */
-  AcceptedByOtherProgramStatus = 'accepted_by_other_program_status',
   /** Accepted Pending */
   AcceptedPendingStatus = 'accepted_pending_status',
   /** Accepted */
   AcceptedStatus = 'accepted_status',
   /** Assigned */
   AssignedStatus = 'assigned_status',
-  /** Assigned To Other Program */
-  AssignedToOtherProgramStatus = 'assigned_to_other_program_status',
   /** Closed */
   ClosedStatus = 'closed_status',
   /** Denied Pending */
   DeniedPendingStatus = 'denied_pending_status',
   /** Denied */
   DeniedStatus = 'denied_status',
-  /** New */
-  NewStatus = 'new_status',
-  /** Not Selected */
-  NotSelectedStatus = 'not_selected_status',
-  /** Void */
-  VoidStatus = 'void_status',
 }
 
 export type ReferralPostingsPaginated = {
@@ -30670,14 +30661,14 @@ export type UpdateReferralPostingMutation = {
   } | null;
 };
 
-export type GetCanProjectAcceptReferralQueryVariables = Exact<{
-  projectId: Scalars['ID']['input'];
-  referrerEnrollmentId: Scalars['ID']['input'];
+export type GetProjectCanAcceptReferralQueryVariables = Exact<{
+  sourceEnrollmentId: Scalars['ID']['input'];
+  destinationProjectId: Scalars['ID']['input'];
 }>;
 
-export type GetCanProjectAcceptReferralQuery = {
+export type GetProjectCanAcceptReferralQuery = {
   __typename?: 'Query';
-  canProjectAcceptReferral: boolean;
+  projectCanAcceptReferral: boolean;
 };
 
 export type GetReferralPostingQueryVariables = Exact<{
@@ -43574,68 +43565,68 @@ export type UpdateReferralPostingMutationOptions = Apollo.BaseMutationOptions<
   UpdateReferralPostingMutation,
   UpdateReferralPostingMutationVariables
 >;
-export const GetCanProjectAcceptReferralDocument = gql`
-  query GetCanProjectAcceptReferral(
-    $projectId: ID!
-    $referrerEnrollmentId: ID!
+export const GetProjectCanAcceptReferralDocument = gql`
+  query GetProjectCanAcceptReferral(
+    $sourceEnrollmentId: ID!
+    $destinationProjectId: ID!
   ) {
-    canProjectAcceptReferral(
-      projectId: $projectId
-      referrerEnrollmentId: $referrerEnrollmentId
+    projectCanAcceptReferral(
+      sourceEnrollmentId: $sourceEnrollmentId
+      destinationProjectId: $destinationProjectId
     )
   }
 `;
 
 /**
- * __useGetCanProjectAcceptReferralQuery__
+ * __useGetProjectCanAcceptReferralQuery__
  *
- * To run a query within a React component, call `useGetCanProjectAcceptReferralQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetCanProjectAcceptReferralQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useGetProjectCanAcceptReferralQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetProjectCanAcceptReferralQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useGetCanProjectAcceptReferralQuery({
+ * const { data, loading, error } = useGetProjectCanAcceptReferralQuery({
  *   variables: {
- *      projectId: // value for 'projectId'
- *      referrerEnrollmentId: // value for 'referrerEnrollmentId'
+ *      sourceEnrollmentId: // value for 'sourceEnrollmentId'
+ *      destinationProjectId: // value for 'destinationProjectId'
  *   },
  * });
  */
-export function useGetCanProjectAcceptReferralQuery(
+export function useGetProjectCanAcceptReferralQuery(
   baseOptions: Apollo.QueryHookOptions<
-    GetCanProjectAcceptReferralQuery,
-    GetCanProjectAcceptReferralQueryVariables
+    GetProjectCanAcceptReferralQuery,
+    GetProjectCanAcceptReferralQueryVariables
   >
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<
-    GetCanProjectAcceptReferralQuery,
-    GetCanProjectAcceptReferralQueryVariables
-  >(GetCanProjectAcceptReferralDocument, options);
+    GetProjectCanAcceptReferralQuery,
+    GetProjectCanAcceptReferralQueryVariables
+  >(GetProjectCanAcceptReferralDocument, options);
 }
-export function useGetCanProjectAcceptReferralLazyQuery(
+export function useGetProjectCanAcceptReferralLazyQuery(
   baseOptions?: Apollo.LazyQueryHookOptions<
-    GetCanProjectAcceptReferralQuery,
-    GetCanProjectAcceptReferralQueryVariables
+    GetProjectCanAcceptReferralQuery,
+    GetProjectCanAcceptReferralQueryVariables
   >
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useLazyQuery<
-    GetCanProjectAcceptReferralQuery,
-    GetCanProjectAcceptReferralQueryVariables
-  >(GetCanProjectAcceptReferralDocument, options);
+    GetProjectCanAcceptReferralQuery,
+    GetProjectCanAcceptReferralQueryVariables
+  >(GetProjectCanAcceptReferralDocument, options);
 }
-export type GetCanProjectAcceptReferralQueryHookResult = ReturnType<
-  typeof useGetCanProjectAcceptReferralQuery
+export type GetProjectCanAcceptReferralQueryHookResult = ReturnType<
+  typeof useGetProjectCanAcceptReferralQuery
 >;
-export type GetCanProjectAcceptReferralLazyQueryHookResult = ReturnType<
-  typeof useGetCanProjectAcceptReferralLazyQuery
+export type GetProjectCanAcceptReferralLazyQueryHookResult = ReturnType<
+  typeof useGetProjectCanAcceptReferralLazyQuery
 >;
-export type GetCanProjectAcceptReferralQueryResult = Apollo.QueryResult<
-  GetCanProjectAcceptReferralQuery,
-  GetCanProjectAcceptReferralQueryVariables
+export type GetProjectCanAcceptReferralQueryResult = Apollo.QueryResult<
+  GetProjectCanAcceptReferralQuery,
+  GetProjectCanAcceptReferralQueryVariables
 >;
 export const GetReferralPostingDocument = gql`
   query GetReferralPosting($id: ID!) {


### PR DESCRIPTION
## Description

GH issue: https://github.com/open-path/Green-River/issues/6
Depends on hmis-warehouse PR: https://github.com/greenriver/hmis-warehouse/pull/4526

This PR
- Adds a query for checking for enrollment conflict in the project receiving the referral
- Adds an alert when that query returns information about a conflict (step 1 of the linked ticket, see screenshot)
- Makes schema updates corresponding to the linked warehouse change
- Moves some referral-related queries from `src/api/operations/referral.operations.graphql` to a new file `src/api/operations/referral.queries.graphql`, which is consistent with our pattern elsewhere

![Screenshot 2024-07-09 at 2 52 16 PM](https://github.com/greenriver/hmis-frontend/assets/16002775/15b90ec7-1128-49ff-aaba-5b99feb8734d)

Note that there's no frontend change needed for step 2 of the linked ticket; that is included in the existing error handling of the referral creation form:

![Screenshot 2024-07-09 at 2 51 42 PM](https://github.com/greenriver/hmis-frontend/assets/16002775/9c0c8c4a-9144-43c0-807d-adc0cfbad1a2)

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
