### PR TITLE
Update schema for super admin mode

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -29907,6 +29907,29 @@
       },
       {
         "kind": "ENUM",
+        "name": "NonAdminFormRole",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "CUSTOM_ASSESSMENT",
+            "description": "Custom assessment",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SERVICE",
+            "description": "Service",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
         "name": "NotEmployedReason",
         "description": "HUD NotEmployedReason (R6.B)",
         "fields": null,
@@ -36892,6 +36915,22 @@
             "deprecationReason": null
           },
           {
+            "name": "nonAdminFormRole",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "NonAdminFormRole",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "organization",
             "description": "Organization lookup",
             "args": [
@@ -37638,6 +37677,22 @@
         "fields": [
           {
             "name": "canAdministerHmis",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "canAdministrateConfig",
             "description": null,
             "args": [],
             "type": {

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -29907,29 +29907,6 @@
       },
       {
         "kind": "ENUM",
-        "name": "NonAdminFormRole",
-        "description": null,
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": [
-          {
-            "name": "CUSTOM_ASSESSMENT",
-            "description": "Custom assessment",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "SERVICE",
-            "description": "Service",
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "possibleTypes": null
-      },
-      {
-        "kind": "ENUM",
         "name": "NotEmployedReason",
         "description": "HUD NotEmployedReason (R6.B)",
         "fields": null,
@@ -30837,6 +30814,12 @@
           {
             "name": "EXTERNAL_FORM_TYPES_FOR_PROJECT",
             "description": "External form types for the project.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "FORM_TYPES",
+            "description": "Form Types",
             "isDeprecated": false,
             "deprecationReason": null
           },
@@ -36908,22 +36891,6 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "ClientMergeCandidatesPaginated",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "nonAdminFormRole",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "ENUM",
-                "name": "NonAdminFormRole",
                 "ofType": null
               }
             },

--- a/src/api/operations/access.fragments.graphql
+++ b/src/api/operations/access.fragments.graphql
@@ -34,6 +34,7 @@ fragment RootPermissions on QueryAccess {
   canSplitHouseholds
   canConfigureDataCollection
   canManageForms
+  canAdministrateConfig
   canViewClientAlerts
   canManageExternalFormSubmissions
 }

--- a/src/modules/admin/components/forms/FormDefinitionDetailPage.tsx
+++ b/src/modules/admin/components/forms/FormDefinitionDetailPage.tsx
@@ -135,12 +135,14 @@ const FormDefinitionDetailPage = () => {
                     editorType={FormEditorType.FormBuilder}
                     variant='outlined'
                   />
-                  <EditFormButton
-                    formIdentifier={formIdentifier}
-                    text={hasDraft ? 'Edit Draft (JSON)' : 'New Draft (JSON)'}
-                    editorType={FormEditorType.JsonEditor}
-                    variant='outlined'
-                  />
+                  <RootPermissionsFilter permissions='canAdministrateConfig'>
+                    <EditFormButton
+                      formIdentifier={formIdentifier}
+                      text={hasDraft ? 'Edit Draft (JSON)' : 'New Draft (JSON)'}
+                      editorType={FormEditorType.JsonEditor}
+                      variant='outlined'
+                    />
+                  </RootPermissionsFilter>
                 </RootPermissionsFilter>
                 <ButtonLink
                   to={generatePath(AdminDashboardRoutes.PREVIEW_FORM, {

--- a/src/routes/protected.tsx
+++ b/src/routes/protected.tsx
@@ -767,7 +767,7 @@ export const protectedRoutes: RouteNode[] = [
           {
             path: AdminDashboardRoutes.JSON_EDIT_FORM,
             element: (
-              <RootPermissionsFilter permissions='canManageForms'>
+              <RootPermissionsFilter permissions='canAdministrateConfig'>
                 <JsonFormEditorPage />
               </RootPermissionsFilter>
             ),

--- a/src/types/gqlEnums.ts
+++ b/src/types/gqlEnums.ts
@@ -890,10 +890,6 @@ export const HmisEnums = {
     CLIENT_DOESN_T_KNOW: "Client doesn't know",
     DATA_NOT_COLLECTED: 'Data not collected',
   },
-  NonAdminFormRole: {
-    CUSTOM_ASSESSMENT: 'Custom assessment',
-    SERVICE: 'Service',
-  },
   NotEmployedReason: {
     INVALID: 'Invalid Value',
     LOOKING_FOR_WORK: 'Looking for work',
@@ -939,6 +935,7 @@ export const HmisEnums = {
       'Enrollments for the client, including WIP and Exited.',
     ENROLLMENT_AUDIT_EVENT_RECORD_TYPES: 'ENROLLMENT_AUDIT_EVENT_RECORD_TYPES',
     EXTERNAL_FORM_TYPES_FOR_PROJECT: 'External form types for the project.',
+    FORM_TYPES: 'Form Types',
     GEOCODE: 'GEOCODE',
     OPEN_HOH_ENROLLMENTS_FOR_PROJECT: 'Open HoH enrollments at the project.',
     OPEN_PROJECTS: 'Open Projects that the user can see',

--- a/src/types/gqlEnums.ts
+++ b/src/types/gqlEnums.ts
@@ -890,6 +890,10 @@ export const HmisEnums = {
     CLIENT_DOESN_T_KNOW: "Client doesn't know",
     DATA_NOT_COLLECTED: 'Data not collected',
   },
+  NonAdminFormRole: {
+    CUSTOM_ASSESSMENT: 'Custom assessment',
+    SERVICE: 'Service',
+  },
   NotEmployedReason: {
     INVALID: 'Invalid Value',
     LOOKING_FOR_WORK: 'Looking for work',

--- a/src/types/gqlObjects.ts
+++ b/src/types/gqlObjects.ts
@@ -4865,6 +4865,14 @@ export const HmisObjectSchemas: GqlSchema[] = [
         },
       },
       {
+        name: 'canAdministrateConfig',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'Boolean', ofType: null },
+        },
+      },
+      {
         name: 'canAuditClients',
         type: {
           kind: 'NON_NULL',

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -4399,6 +4399,13 @@ export enum NoYesReasonsForMissingData {
   Yes = 'YES',
 }
 
+export enum NonAdminFormRole {
+  /** Custom assessment */
+  CustomAssessment = 'CUSTOM_ASSESSMENT',
+  /** Service */
+  Service = 'SERVICE',
+}
+
 /** HUD NotEmployedReason (R6.B) */
 export enum NotEmployedReason {
   /** (99) Data not collected */
@@ -5672,6 +5679,7 @@ export type Query = {
   inventory?: Maybe<Inventory>;
   mergeAuditHistory: MergeAuditEventsPaginated;
   mergeCandidates: ClientMergeCandidatesPaginated;
+  nonAdminFormRole: NonAdminFormRole;
   /** Organization lookup */
   organization?: Maybe<Organization>;
   organizations: OrganizationsPaginated;
@@ -5905,6 +5913,7 @@ export type QueryUserArgs = {
 export type QueryAccess = {
   __typename?: 'QueryAccess';
   canAdministerHmis: Scalars['Boolean']['output'];
+  canAdministrateConfig: Scalars['Boolean']['output'];
   canAuditClients: Scalars['Boolean']['output'];
   canAuditEnrollments: Scalars['Boolean']['output'];
   canAuditUsers: Scalars['Boolean']['output'];
@@ -7839,6 +7848,7 @@ export type RootPermissionsFragment = {
   canSplitHouseholds: boolean;
   canConfigureDataCollection: boolean;
   canManageForms: boolean;
+  canAdministrateConfig: boolean;
   canViewClientAlerts: boolean;
   canManageExternalFormSubmissions: boolean;
 };
@@ -7953,6 +7963,7 @@ export type GetRootPermissionsQuery = {
     canSplitHouseholds: boolean;
     canConfigureDataCollection: boolean;
     canManageForms: boolean;
+    canAdministrateConfig: boolean;
     canViewClientAlerts: boolean;
     canManageExternalFormSubmissions: boolean;
   };
@@ -32409,6 +32420,7 @@ export const RootPermissionsFragmentDoc = gql`
     canSplitHouseholds
     canConfigureDataCollection
     canManageForms
+    canAdministrateConfig
     canViewClientAlerts
     canManageExternalFormSubmissions
   }

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -4399,13 +4399,6 @@ export enum NoYesReasonsForMissingData {
   Yes = 'YES',
 }
 
-export enum NonAdminFormRole {
-  /** Custom assessment */
-  CustomAssessment = 'CUSTOM_ASSESSMENT',
-  /** Service */
-  Service = 'SERVICE',
-}
-
 /** HUD NotEmployedReason (R6.B) */
 export enum NotEmployedReason {
   /** (99) Data not collected */
@@ -4560,6 +4553,8 @@ export enum PickListType {
   EnrollmentAuditEventRecordTypes = 'ENROLLMENT_AUDIT_EVENT_RECORD_TYPES',
   /** External form types for the project. */
   ExternalFormTypesForProject = 'EXTERNAL_FORM_TYPES_FOR_PROJECT',
+  /** Form Types */
+  FormTypes = 'FORM_TYPES',
   Geocode = 'GEOCODE',
   /** Open HoH enrollments at the project. */
   OpenHohEnrollmentsForProject = 'OPEN_HOH_ENROLLMENTS_FOR_PROJECT',
@@ -5679,7 +5674,6 @@ export type Query = {
   inventory?: Maybe<Inventory>;
   mergeAuditHistory: MergeAuditEventsPaginated;
   mergeCandidates: ClientMergeCandidatesPaginated;
-  nonAdminFormRole: NonAdminFormRole;
   /** Organization lookup */
   organization?: Maybe<Organization>;
   organizations: OrganizationsPaginated;


### PR DESCRIPTION
## Description

GH issue: https://github.com/open-path/Green-River/issues/6218
Depends on hmis-warehouse PR: https://github.com/greenriver/hmis-warehouse/pull/4531

- Update schema 
- Add permission filter around the JSON editor button. This is only accessible by those with `canAdministerConfig` permission

## Type of change
[//]: # 'remove options that are not relevant'
- [ ] Bug fix
- [x] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
