### PR TITLE
Dont expect autofill_when to always be present

### DIFF
--- a/src/modules/form/util/formUtil.ts
+++ b/src/modules/form/util/formUtil.ts
@@ -531,26 +531,25 @@ export const autofillValues = ({
     // Skip autofills that should not run on read-only views
     if (viewOnly && !av.autofillReadonly) return false;
 
-    // Evaluate all enableWhen conditions
-    const booleans = av.autofillWhen.map((en) =>
-      evaluateEnableWhen({
-        en,
-        values,
-        itemMap,
-        shouldEnableFn: shouldEnableItem,
-        localConstants,
-      })
-    );
+    // Evaluate enableWhen conditions, if present
+    if (av.autofillWhen && av.autofillWhen.length > 0) {
+      const booleans = av.autofillWhen.map((en) =>
+        evaluateEnableWhen({
+          en,
+          values,
+          itemMap,
+          shouldEnableFn: shouldEnableItem,
+          localConstants,
+        })
+      );
 
-    // If there were no conditions specify, it should always be autofilled
-    if (booleans.length === 0) booleans.push(true);
+      const shouldAutofillValue =
+        av.autofillBehavior === EnableBehavior.Any
+          ? booleans.some(Boolean)
+          : booleans.every(Boolean);
 
-    const shouldAutofillValue =
-      av.autofillBehavior === EnableBehavior.Any
-        ? booleans.some(Boolean)
-        : booleans.every(Boolean);
-
-    if (!shouldAutofillValue) return false;
+      if (!shouldAutofillValue) return false;
+    }
 
     const newValue = getAutofillComparisonValue(av, values, item);
 
@@ -564,7 +563,7 @@ export const autofillValues = ({
       values[item.linkId] = newValue;
     }
 
-    // Stop iterating through enable when conditions
+    // Stop iterating through autofill values
     return true;
   });
 };


### PR DESCRIPTION
## Description

**Previous behavior**: expect `autofillWhen` and `autofillBehavior` to always be present, but it would still default to showing the item if there were no conditions.

**Proposed behavior**: allow `autofillWhen` and `autofillBehavior` to be null, indicating that the autofill should always occur

**Purpose**: this allows us to make those fields nullable on a future release. there are valid use-cases for an autofill that is non-conditional.

This change does NOT depend on https://github.com/greenriver/hmis-warehouse/pull/4534

## Type of change
- [x] Code clean-up / housekeeping

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
