### PR TITLE
6239 adjust vite proxy for insufficient rate limiting

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -35,10 +35,6 @@ export default defineConfig(({ command, mode }) => {
     target: env.HMIS_SERVER_URL || DEFAULT_WAREHOUSE_SERVER,
     xfwd: true,
     changeOrigin: true, // sets Host header
-    headers: {
-      Origin: env.HMIS_SERVER_URL || DEFAULT_WAREHOUSE_SERVER,
-      'X-Proxy-Secret': env.HMIS_PROXY_SECRET,
-    },
     secure: false,
   };
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -33,9 +33,11 @@ export default defineConfig(({ command, mode }) => {
 
   const warehouseProxyServer = {
     target: env.HMIS_SERVER_URL || DEFAULT_WAREHOUSE_SERVER,
+    xfwd: true,
     changeOrigin: true, // sets Host header
     headers: {
       Origin: env.HMIS_SERVER_URL || DEFAULT_WAREHOUSE_SERVER,
+      'X-Proxy-Secret': env.HMIS_PROXY_SECRET,
     },
     secure: false,
   };


### PR DESCRIPTION

## Notes:
* this is a development only fix. The production configuration in `docker/templates/proxy_headers.conf.template` appears to already be sending all the XFF headers. So with this change the vite proxy more closely mirrors production behavior
* it's likely that the value for DataSource.hmis will need to be updated in the local database because rails will use the X-Forwarded-Host value to set request.origin

## Description
* Adjust vite (http-proxy) to send x-forward-* headers
* Don't set an origin. To pass csrf validation, the request.origin and base_url must match. Due to sending X-Forwarded-Host and X-Forwarded-Proto these seem to be mismatched with the manual origin header. In theory, we shouldn't need to set it since the forwarded headers should match with the origin header send by the browser. This was quite hard to track down as it surfaces as generic CSRF issue


[//]: # 'remove if not applicable'
Depends on hmis-warehouse PR: [4514](https://github.com/greenriver/hmis-warehouse/pull/4514) 

## Type of change
[//]: # 'remove options that are not relevant'
- [x] New feature (adds functionality)


## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
