### PR TITLE
Patch MCI component that depends on link_id

### DIFF
--- a/src/modules/external/mci/components/MciClearance.tsx
+++ b/src/modules/external/mci/components/MciClearance.tsx
@@ -291,7 +291,8 @@ const MciClearanceWrapperWithValue = (props: MciClearanceProps) => {
 
     const mciFields = pick(byKey, MCI_CLEARANCE_FIELDS);
     // Check Link ID 'current_mci_id' in values to see if we already have an MCI ID
-    return [byKey.id, values.current_mci_id, mciFields];
+    // eslint-disable-next-line @typescript-eslint/dot-notation
+    return [byKey.id, values['current_mci_id'], mciFields];
   }, [getCleanedValues, definition]);
 
   const previousMciAttributes = usePrevious(currentMciAttributes);

--- a/src/modules/external/mci/components/MciClearance.tsx
+++ b/src/modules/external/mci/components/MciClearance.tsx
@@ -290,7 +290,8 @@ const MciClearanceWrapperWithValue = (props: MciClearanceProps) => {
     );
 
     const mciFields = pick(byKey, MCI_CLEARANCE_FIELDS);
-    return [byKey.id, values['current-mci-id'], mciFields];
+    // Check Link ID 'current_mci_id' in values to see if we already have an MCI ID
+    return [byKey.id, values.current_mci_id, mciFields];
   }, [getCleanedValues, definition]);
 
   const previousMciAttributes = usePrevious(currentMciAttributes);


### PR DESCRIPTION
## Description

This code expects a certain link id to be present, which is defined in the environment's client form definition. Not a great way of doing it, but so it is. The link ID changed with the migration, which caused this to break. Updating it here.

https://green-river.sentry.io/issues/5611993216/?alert_rule_id=12523843&alert_type=issue&environment=production&notification_uuid=61142d0e-c579-4e12-a9e5-5551a80ef2a8&project=4503977346662400&referrer=slack

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
