### PR TITLE
Update schema, show validation errors on publish

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -1454,6 +1454,18 @@
             "deprecationReason": null
           },
           {
+            "name": "createdBy",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ApplicationUser",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "customDataElements",
             "description": null,
             "args": [],
@@ -3083,6 +3095,18 @@
             "deprecationReason": null
           },
           {
+            "name": "createdBy",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ApplicationUser",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "dateCreated",
             "description": null,
             "args": [],
@@ -3347,6 +3371,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "ISO8601Date",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdBy",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ApplicationUser",
               "ofType": null
             },
             "isDeprecated": false,
@@ -4042,6 +4078,18 @@
                   }
                 }
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdBy",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ApplicationUser",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -5918,6 +5966,18 @@
             "deprecationReason": null
           },
           {
+            "name": "createdBy",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ApplicationUser",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "dateCreated",
             "description": null,
             "args": [],
@@ -6745,6 +6805,18 @@
             "deprecationReason": null
           },
           {
+            "name": "createdBy",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ApplicationUser",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "dateCreated",
             "description": null,
             "args": [],
@@ -7333,6 +7405,18 @@
                 "name": "Client",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdBy",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ApplicationUser",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -8975,6 +9059,18 @@
             "deprecationReason": null
           },
           {
+            "name": "createdBy",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ApplicationUser",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "currentLivingSituation",
             "description": null,
             "args": [],
@@ -9579,6 +9675,18 @@
             "deprecationReason": null
           },
           {
+            "name": "createdBy",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ApplicationUser",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "customDataElements",
             "description": null,
             "args": [],
@@ -10065,6 +10173,18 @@
         "name": "CustomDataElementValue",
         "description": null,
         "fields": [
+          {
+            "name": "createdBy",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ApplicationUser",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "dateCreated",
             "description": null,
@@ -13145,6 +13265,18 @@
             "deprecationReason": null
           },
           {
+            "name": "createdBy",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ApplicationUser",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "dataCollectionStage",
             "description": null,
             "args": [],
@@ -13927,6 +14059,18 @@
                 "name": "Client",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdBy",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ApplicationUser",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -14853,6 +14997,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdBy",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ApplicationUser",
               "ofType": null
             },
             "isDeprecated": false,
@@ -18101,6 +18257,18 @@
             "deprecationReason": null
           },
           {
+            "name": "createdBy",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ApplicationUser",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "dateCreated",
             "description": null,
             "args": [],
@@ -18744,6 +18912,18 @@
             "type": {
               "kind": "ENUM",
               "name": "CountExchangeForSex",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdBy",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ApplicationUser",
               "ofType": null
             },
             "isDeprecated": false,
@@ -22683,6 +22863,18 @@
             "deprecationReason": null
           },
           {
+            "name": "createdBy",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ApplicationUser",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "customDataElements",
             "description": null,
             "args": [],
@@ -23521,6 +23713,18 @@
             "deprecationReason": null
           },
           {
+            "name": "createdBy",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ApplicationUser",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "currentlyFleeing",
             "description": null,
             "args": [],
@@ -23931,6 +24135,18 @@
         "name": "HmisParticipation",
         "description": null,
         "fields": [
+          {
+            "name": "createdBy",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ApplicationUser",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "dateCreated",
             "description": null,
@@ -24990,6 +25206,18 @@
             "type": {
               "kind": "ENUM",
               "name": "NoYesReasonsForMissingData",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdBy",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ApplicationUser",
               "ofType": null
             },
             "isDeprecated": false,
@@ -26338,6 +26566,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdBy",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ApplicationUser",
               "ofType": null
             },
             "isDeprecated": false,
@@ -30060,6 +30300,18 @@
             "deprecationReason": null
           },
           {
+            "name": "createdBy",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ApplicationUser",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "customDataElements",
             "description": null,
             "args": [],
@@ -33313,6 +33565,18 @@
             "deprecationReason": null
           },
           {
+            "name": "createdBy",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ApplicationUser",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "currentLivingSituations",
             "description": null,
             "args": [
@@ -34724,6 +34988,18 @@
             "deprecationReason": null
           },
           {
+            "name": "createdBy",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ApplicationUser",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "dateCreated",
             "description": null,
             "args": [],
@@ -35845,13 +36121,9 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "FormIdentifier",
-                "ofType": null
-              }
+              "kind": "OBJECT",
+              "name": "FormIdentifier",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -41313,6 +41585,18 @@
             "deprecationReason": null
           },
           {
+            "name": "createdBy",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ApplicationUser",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "customDataElements",
             "description": null,
             "args": [],
@@ -41690,6 +41974,18 @@
         "name": "ServiceCategory",
         "description": null,
         "fields": [
+          {
+            "name": "createdBy",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ApplicationUser",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "dateCreated",
             "description": null,
@@ -42342,6 +42638,18 @@
                 "name": "String",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdBy",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ApplicationUser",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -47391,6 +47699,18 @@
                 "name": "Client",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdBy",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ApplicationUser",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/src/api/operations/form.operations.graphql
+++ b/src/api/operations/form.operations.graphql
@@ -56,6 +56,9 @@ mutation PublishFormDefinition($id: ID!) {
     formIdentifier {
       ...FormIdentifierDetails
     }
+    errors {
+      ...ValidationErrorFields
+    }
   }
 }
 

--- a/src/modules/admin/components/forms/FormPreview.tsx
+++ b/src/modules/admin/components/forms/FormPreview.tsx
@@ -141,7 +141,7 @@ const FormPreview = () => {
   ]);
 
   const [confirmOpen, setConfirmOpen] = useState(false);
-  const { publishLoading, onPublishForm } = usePublishForm({
+  const { publishLoading, onPublishForm, publishErrorState } = usePublishForm({
     formId: formDefinition?.id,
     formIdentifier: formDefinition?.identifier,
   });
@@ -198,6 +198,7 @@ const FormPreview = () => {
               onConfirm={onPublishForm}
               onCancel={() => setConfirmOpen(false)}
               loading={publishLoading}
+              errorState={publishErrorState}
             >
               <div>Are you sure you want to publish this form?</div>
             </ConfirmationDialog>

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -243,6 +243,7 @@ export type Assessment = {
   assessmentDate: Scalars['ISO8601Date']['output'];
   ceAssessment?: Maybe<CeAssessment>;
   client: Client;
+  createdBy?: Maybe<ApplicationUser>;
   customDataElements: Array<CustomDataElement>;
   dataCollectionStage?: Maybe<DataCollectionStage>;
   dateCreated?: Maybe<Scalars['ISO8601DateTime']['output']>;
@@ -478,6 +479,7 @@ export type CeAssessment = {
   assessmentLocation: Scalars['String']['output'];
   assessmentType?: Maybe<AssessmentType>;
   client: Client;
+  createdBy?: Maybe<ApplicationUser>;
   dateCreated?: Maybe<Scalars['ISO8601DateTime']['output']>;
   dateDeleted?: Maybe<Scalars['ISO8601DateTime']['output']>;
   dateUpdated?: Maybe<Scalars['ISO8601DateTime']['output']>;
@@ -503,6 +505,7 @@ export type CeParticipation = {
   accessPoint?: Maybe<NoYes>;
   ceParticipationStatusEndDate?: Maybe<Scalars['ISO8601Date']['output']>;
   ceParticipationStatusStartDate?: Maybe<Scalars['ISO8601Date']['output']>;
+  createdBy?: Maybe<ApplicationUser>;
   crisisAssessment?: Maybe<NoYes>;
   dateCreated?: Maybe<Scalars['ISO8601DateTime']['output']>;
   dateDeleted?: Maybe<Scalars['ISO8601DateTime']['output']>;
@@ -561,6 +564,7 @@ export type Client = {
   assessments: AssessmentsPaginated;
   auditHistory: ClientAuditEventsPaginated;
   contactPoints: Array<ClientContactPoint>;
+  createdBy?: Maybe<ApplicationUser>;
   currentLivingSituations: CurrentLivingSituationsPaginated;
   customCaseNotes: CustomCaseNotesPaginated;
   customDataElements: Array<CustomDataElement>;
@@ -773,6 +777,7 @@ export type ClientAddress = {
   city?: Maybe<Scalars['String']['output']>;
   client: Client;
   country?: Maybe<Scalars['String']['output']>;
+  createdBy?: Maybe<ApplicationUser>;
   dateCreated?: Maybe<Scalars['ISO8601DateTime']['output']>;
   dateDeleted?: Maybe<Scalars['ISO8601DateTime']['output']>;
   dateUpdated?: Maybe<Scalars['ISO8601DateTime']['output']>;
@@ -879,6 +884,7 @@ export type ClientAuditEventsPaginated = {
 export type ClientContactPoint = {
   __typename?: 'ClientContactPoint';
   client: Client;
+  createdBy?: Maybe<ApplicationUser>;
   dateCreated?: Maybe<Scalars['ISO8601DateTime']['output']>;
   dateDeleted?: Maybe<Scalars['ISO8601DateTime']['output']>;
   dateUpdated?: Maybe<Scalars['ISO8601DateTime']['output']>;
@@ -961,6 +967,7 @@ export type ClientMergeInput = {
 export type ClientName = {
   __typename?: 'ClientName';
   client: Client;
+  createdBy?: Maybe<ApplicationUser>;
   dateCreated?: Maybe<Scalars['ISO8601DateTime']['output']>;
   dateDeleted?: Maybe<Scalars['ISO8601DateTime']['output']>;
   dateUpdated?: Maybe<Scalars['ISO8601DateTime']['output']>;
@@ -1288,6 +1295,7 @@ export type CurrentLivingSituation = {
   __typename?: 'CurrentLivingSituation';
   client: Client;
   clsSubsidyType?: Maybe<RentalSubsidyType>;
+  createdBy?: Maybe<ApplicationUser>;
   currentLivingSituation: CurrentLivingSituationOptions;
   customDataElements: Array<CustomDataElement>;
   dateCreated?: Maybe<Scalars['ISO8601DateTime']['output']>;
@@ -1397,6 +1405,7 @@ export type CustomCaseNote = {
   __typename?: 'CustomCaseNote';
   client: Client;
   content: Scalars['String']['output'];
+  createdBy?: Maybe<ApplicationUser>;
   customDataElements: Array<CustomDataElement>;
   dateCreated?: Maybe<Scalars['ISO8601DateTime']['output']>;
   dateDeleted?: Maybe<Scalars['ISO8601DateTime']['output']>;
@@ -1454,6 +1463,7 @@ export enum CustomDataElementType {
 
 export type CustomDataElementValue = {
   __typename?: 'CustomDataElementValue';
+  createdBy?: Maybe<ApplicationUser>;
   dateCreated?: Maybe<Scalars['ISO8601DateTime']['output']>;
   dateDeleted?: Maybe<Scalars['ISO8601DateTime']['output']>;
   dateUpdated?: Maybe<Scalars['ISO8601DateTime']['output']>;
@@ -1994,6 +2004,7 @@ export type Disability = {
   __typename?: 'Disability';
   antiRetroviral?: Maybe<NoYesReasonsForMissingData>;
   client: Client;
+  createdBy?: Maybe<ApplicationUser>;
   dataCollectionStage: DataCollectionStage;
   dateCreated?: Maybe<Scalars['ISO8601DateTime']['output']>;
   dateDeleted?: Maybe<Scalars['ISO8601DateTime']['output']>;
@@ -2121,6 +2132,7 @@ export enum DisplayHook {
 export type EmploymentEducation = {
   __typename?: 'EmploymentEducation';
   client: Client;
+  createdBy?: Maybe<ApplicationUser>;
   dataCollectionStage: DataCollectionStage;
   dateCreated?: Maybe<Scalars['ISO8601DateTime']['output']>;
   dateDeleted?: Maybe<Scalars['ISO8601DateTime']['output']>;
@@ -2223,6 +2235,7 @@ export type Enrollment = {
   clientLeaseholder?: Maybe<NoYesMissing>;
   cocPrioritized?: Maybe<NoYesMissing>;
   countOutreachReferralApproaches?: Maybe<Scalars['Int']['output']>;
+  createdBy?: Maybe<ApplicationUser>;
   criminalRecord?: Maybe<NoYesMissing>;
   currentLivingSituations: CurrentLivingSituationsPaginated;
   currentPregnant?: Maybe<NoYesMissing>;
@@ -2598,6 +2611,7 @@ export type EsgFundingService = {
 export type Event = {
   __typename?: 'Event';
   client: Client;
+  createdBy?: Maybe<ApplicationUser>;
   dateCreated?: Maybe<Scalars['ISO8601DateTime']['output']>;
   dateDeleted?: Maybe<Scalars['ISO8601DateTime']['output']>;
   dateUpdated?: Maybe<Scalars['ISO8601DateTime']['output']>;
@@ -2698,6 +2712,7 @@ export type Exit = {
   counselingMethods?: Maybe<Array<CounselingMethod>>;
   counselingReceived?: Maybe<NoYesMissing>;
   countOfExchangeForSex?: Maybe<CountExchangeForSex>;
+  createdBy?: Maybe<ApplicationUser>;
   customDataElements: Array<CustomDataElement>;
   dateCreated?: Maybe<Scalars['ISO8601DateTime']['output']>;
   dateDeleted?: Maybe<Scalars['ISO8601DateTime']['output']>;
@@ -3200,6 +3215,7 @@ export enum FormStatus {
 export type Funder = {
   __typename?: 'Funder';
   active: Scalars['Boolean']['output'];
+  createdBy?: Maybe<ApplicationUser>;
   customDataElements: Array<CustomDataElement>;
   dateCreated?: Maybe<Scalars['ISO8601DateTime']['output']>;
   dateDeleted?: Maybe<Scalars['ISO8601DateTime']['output']>;
@@ -3404,6 +3420,7 @@ export enum HopwaMedAssistedLivingFac {
 export type HealthAndDv = {
   __typename?: 'HealthAndDv';
   client: Client;
+  createdBy?: Maybe<ApplicationUser>;
   currentlyFleeing?: Maybe<NoYesReasonsForMissingData>;
   dataCollectionStage: DataCollectionStage;
   dateCreated?: Maybe<Scalars['ISO8601DateTime']['output']>;
@@ -3457,6 +3474,7 @@ export enum HealthStatus {
 
 export type HmisParticipation = {
   __typename?: 'HmisParticipation';
+  createdBy?: Maybe<ApplicationUser>;
   dateCreated?: Maybe<Scalars['ISO8601DateTime']['output']>;
   dateDeleted?: Maybe<Scalars['ISO8601DateTime']['output']>;
   dateUpdated?: Maybe<Scalars['ISO8601DateTime']['output']>;
@@ -3617,6 +3635,7 @@ export type IncomeBenefit = {
   client: Client;
   cobra?: Maybe<NoYesMissing>;
   connectionWithSoar?: Maybe<NoYesReasonsForMissingData>;
+  createdBy?: Maybe<ApplicationUser>;
   customDataElements: Array<CustomDataElement>;
   dataCollectionStage: DataCollectionStage;
   dateCreated?: Maybe<Scalars['ISO8601DateTime']['output']>;
@@ -3746,6 +3765,7 @@ export type Inventory = {
   chVetBedInventory?: Maybe<Scalars['Int']['output']>;
   chYouthBedInventory?: Maybe<Scalars['Int']['output']>;
   cocCode?: Maybe<Scalars['String']['output']>;
+  createdBy?: Maybe<ApplicationUser>;
   customDataElements: Array<CustomDataElement>;
   dateCreated?: Maybe<Scalars['ISO8601DateTime']['output']>;
   dateDeleted?: Maybe<Scalars['ISO8601DateTime']['output']>;
@@ -4427,6 +4447,7 @@ export type Organization = {
   __typename?: 'Organization';
   access: OrganizationAccess;
   contactInformation?: Maybe<Scalars['String']['output']>;
+  createdBy?: Maybe<ApplicationUser>;
   customDataElements: Array<CustomDataElement>;
   dateCreated?: Maybe<Scalars['ISO8601DateTime']['output']>;
   dateDeleted?: Maybe<Scalars['ISO8601DateTime']['output']>;
@@ -5321,6 +5342,7 @@ export type Project = {
   ceParticipations: CeParticipationsPaginated;
   contactInformation?: Maybe<Scalars['String']['output']>;
   continuumProject?: Maybe<NoYes>;
+  createdBy?: Maybe<ApplicationUser>;
   currentLivingSituations: CurrentLivingSituationsPaginated;
   customDataElements: Array<CustomDataElement>;
   /** Occurrence Point data collection features that are enabled for this Project (e.g. Current Living Situations, Events) */
@@ -5480,6 +5502,7 @@ export type ProjectCoc = {
   address2?: Maybe<Scalars['String']['output']>;
   city?: Maybe<Scalars['String']['output']>;
   cocCode?: Maybe<Scalars['String']['output']>;
+  createdBy?: Maybe<ApplicationUser>;
   dateCreated?: Maybe<Scalars['ISO8601DateTime']['output']>;
   dateDeleted?: Maybe<Scalars['ISO8601DateTime']['output']>;
   dateUpdated?: Maybe<Scalars['ISO8601DateTime']['output']>;
@@ -5633,7 +5656,7 @@ export type ProjectsPaginated = {
 export type PublishFormDefinitionPayload = {
   __typename?: 'PublishFormDefinitionPayload';
   errors: Array<ValidationError>;
-  formIdentifier: FormIdentifier;
+  formIdentifier?: Maybe<FormIdentifier>;
 };
 
 export type Query = {
@@ -6542,6 +6565,7 @@ export enum SchoolStatus {
 export type Service = {
   __typename?: 'Service';
   client: Client;
+  createdBy?: Maybe<ApplicationUser>;
   customDataElements: Array<CustomDataElement>;
   dateCreated?: Maybe<Scalars['ISO8601DateTime']['output']>;
   dateDeleted?: Maybe<Scalars['ISO8601DateTime']['output']>;
@@ -6575,6 +6599,7 @@ export type ServiceCategoriesPaginated = {
 
 export type ServiceCategory = {
   __typename?: 'ServiceCategory';
+  createdBy?: Maybe<ApplicationUser>;
   dateCreated?: Maybe<Scalars['ISO8601DateTime']['output']>;
   dateDeleted?: Maybe<Scalars['ISO8601DateTime']['output']>;
   dateUpdated?: Maybe<Scalars['ISO8601DateTime']['output']>;
@@ -6704,6 +6729,7 @@ export enum ServiceSubTypeProvided {
 export type ServiceType = {
   __typename?: 'ServiceType';
   category: Scalars['String']['output'];
+  createdBy?: Maybe<ApplicationUser>;
   dateCreated?: Maybe<Scalars['ISO8601DateTime']['output']>;
   dateDeleted?: Maybe<Scalars['ISO8601DateTime']['output']>;
   dateUpdated?: Maybe<Scalars['ISO8601DateTime']['output']>;
@@ -7778,6 +7804,7 @@ export enum WorkerResponse {
 export type YouthEducationStatus = {
   __typename?: 'YouthEducationStatus';
   client: Client;
+  createdBy?: Maybe<ApplicationUser>;
   currentEdStatus?: Maybe<CurrentEdStatus>;
   currentSchoolAttend?: Maybe<CurrentSchoolAttended>;
   dataCollectionStage: DataCollectionStage;
@@ -22859,7 +22886,7 @@ export type PublishFormDefinitionMutation = {
   __typename?: 'Mutation';
   publishFormDefinition?: {
     __typename?: 'PublishFormDefinitionPayload';
-    formIdentifier: {
+    formIdentifier?: {
       __typename?: 'FormIdentifier';
       id: string;
       identifier: string;
@@ -22881,7 +22908,21 @@ export type PublishFormDefinitionMutation = {
         identifier: string;
         status: FormStatus;
       } | null;
-    };
+    } | null;
+    errors: Array<{
+      __typename?: 'ValidationError';
+      type: ValidationType;
+      attribute: string;
+      readableAttribute?: string | null;
+      message: string;
+      fullMessage: string;
+      severity: ValidationSeverity;
+      id?: string | null;
+      recordId?: string | null;
+      linkId?: string | null;
+      section?: string | null;
+      data?: any | null;
+    }>;
   } | null;
 };
 
@@ -39839,9 +39880,13 @@ export const PublishFormDefinitionDocument = gql`
       formIdentifier {
         ...FormIdentifierDetails
       }
+      errors {
+        ...ValidationErrorFields
+      }
     }
   }
   ${FormIdentifierDetailsFragmentDoc}
+  ${ValidationErrorFieldsFragmentDoc}
 `;
 export type PublishFormDefinitionMutationFn = Apollo.MutationFunction<
   PublishFormDefinitionMutation,


### PR DESCRIPTION
## Description

* Codegen changes from https://github.com/greenriver/hmis-warehouse/pull/4555, plus the ability to view the validation errors in the UI. This shouldn't really happen, since the editor UI should guard against these errors, but it could happen if you create a draft of an existing form that has errors, and try to publish it.
* Also contains codegen changes for https://github.com/greenriver/hmis-frontend/pull/846 since the frontend PR is not making it into release-124

<img width="683" alt="Screenshot 2024-07-17 at 10 41 42 AM" src="https://github.com/user-attachments/assets/86a4c97a-74d8-4541-98a5-3c6573711729">


To test: manually break a draft form in the database (I set "required" on a group item) and try to publish it

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
