### PR TITLE
Only show relevant pick list references for custom form building

### DIFF
--- a/src/modules/form/components/rhf/ControlledSelect.tsx
+++ b/src/modules/form/components/rhf/ControlledSelect.tsx
@@ -49,11 +49,16 @@ const ControlledSelect: React.FC<ControlledSelectProps> = ({
   const isGrouped = !!options[0]?.groupLabel;
 
   // The 'value' thats stored in the form state is a string, but the value that gets
-  // passed to GenericSelect is a PickListOption
-  const valueOption = useMemo(
-    () => options.find(({ code }) => code === field.value) || null,
-    [field.value, options]
-  );
+  // passed to GenericSelect is a PickListOption. If the value is not found,
+  // display it anyway as the selected option. This could occur if there is a value
+  // set that is not in the options list.
+  const valueOption = useMemo(() => {
+    if (!field.value) return null;
+
+    return (
+      options.find(({ code }) => code === field.value) || { code: field.value }
+    );
+  }, [field.value, options]);
 
   const getOptionLabel = useCallback(
     (option: PickListOption) => findOptionLabel(option, options),

--- a/src/modules/formBuilder/components/itemEditor/FormEditorItemProperties.tsx
+++ b/src/modules/formBuilder/components/itemEditor/FormEditorItemProperties.tsx
@@ -31,6 +31,7 @@ import {
   determineAutofillField,
   getItemCategory,
   slugifyItemLabel,
+  supportedPickListReferencesOptions,
   validComponentsForType,
 } from '@/modules/formBuilder/formBuilderUtil';
 import { HmisEnums } from '@/types/gqlEnums';
@@ -52,7 +53,7 @@ const inputSizePickList = Object.keys(HmisEnums.InputSize).map((key) => ({
   code: key,
   label: startCase(key.toLowerCase()),
 }));
-const pickListTypesPickList = localResolvePickList('PickListType') || [];
+
 const errorAlertId = 'formItemPropertyErrors';
 
 interface FormEditorItemPropertiesProps {
@@ -319,7 +320,7 @@ const FormEditorItemProperties: React.FC<FormEditorItemPropertiesProps> = ({
                 control={control}
                 label='Reference list for allowed responses'
                 placeholder='Select pick list'
-                options={pickListTypesPickList}
+                options={supportedPickListReferencesOptions}
               />
             </>
           )}

--- a/src/modules/formBuilder/formBuilderUtil.ts
+++ b/src/modules/formBuilder/formBuilderUtil.ts
@@ -1,4 +1,4 @@
-import { cloneDeep, get, kebabCase, set } from 'lodash-es';
+import { cloneDeep, get, kebabCase, set, startCase } from 'lodash-es';
 import { ItemMap } from '@/modules/form/types';
 import {
   buildAutofillDependencyMap,
@@ -34,6 +34,11 @@ export const displayLabelForItem = (item: FormItem, ellipsize = true) => {
 
   return label;
 };
+
+export const supportedPickListReferencesOptions = [
+  'NoYesMissing',
+  'NoYesReasonsForMissingData',
+].map((enumName) => ({ code: enumName, label: startCase(enumName) }));
 
 export const validComponentsForType = (type: ItemType) => {
   /**


### PR DESCRIPTION
## Description

Replace huge list of remote picklists with only pick lists that are likely to be used for custom questions. I think this will meet our needs.. most custom questions will be building their own pick lists, but the no/yes/missing options might be useful as well.

If the item already has a different pick list reference, it is shown. Examples:
<img width="617" alt="Screenshot 2024-07-17 at 1 32 18 PM" src="https://github.com/user-attachments/assets/56918630-8722-434a-8dae-09daa4b1239e">
<img width="594" alt="Screenshot 2024-07-17 at 1 29 54 PM" src="https://github.com/user-attachments/assets/556c3da2-5feb-4c1b-8d75-3dbff33ecb56">



## Type of change
- [x] New feature (adds functionality)
- [x] Code clean-up / housekeeping

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
