### PR TITLE
Make first pass at toolbar mobile usability

### DIFF
--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -1,15 +1,7 @@
-import {
-  AppBar,
-  Box,
-  CssBaseline,
-  SxProps,
-  Theme,
-  Toolbar,
-} from '@mui/material';
+import MenuIcon from '@mui/icons-material/Menu';
+import { AppBar, Box, CssBaseline, IconButton, Toolbar } from '@mui/material';
+import { Stack } from '@mui/system';
 import * as React from 'react';
-
-import { useLocation } from 'react-router-dom';
-import ButtonLink from '../elements/ButtonLink';
 import RouterLink from '../elements/RouterLink';
 
 import {
@@ -17,24 +9,27 @@ import {
   OP_LINK_BAR_HEIGHT,
   SHOW_OP_LINK_BAR,
 } from './layoutConstants';
+import UserMenu from './nav/UserMenu';
 import PrintViewButton from './PrintViewButton';
-import UserMenu from './UserMenu';
 import WarehouseLinkBar from './WarehouseLinkBar';
 
 import Loading from '@/components/elements/Loading';
+import MobileMenu from '@/components/layout/nav/MobileMenu';
+import ToolbarMenu from '@/components/layout/nav/ToolbarMenu';
+import { useIsDashboard } from '@/components/layout/nav/useIsDashboard';
+import { MobileMenuContext } from '@/components/layout/nav/useMobileMenuContext';
+import { useIsMobile } from '@/hooks/useIsMobile';
 import useIsPrintView from '@/hooks/useIsPrintView';
-import { PERMISSIONS_GRANTING_ADMIN_DASHBOARD_ACCESS } from '@/modules/admin/components/AdminDashboard';
 import { useHmisAppSettings } from '@/modules/hmisAppSettings/useHmisAppSettings';
-import { RootPermissionsFilter } from '@/modules/permissions/PermissionsFilters';
 import OmniSearch from '@/modules/search/components/OmniSearch';
-import { Routes } from '@/routes/routes';
 import { useGetRootPermissionsQuery } from '@/types/gqlTypes';
 
 interface Props {
+  mobileMenuContext: MobileMenuContext;
   children: React.ReactNode;
 }
 
-const MainLayout: React.FC<Props> = ({ children }) => {
+const MainLayout: React.FC<Props> = ({ mobileMenuContext, children }) => {
   const { appName } = useHmisAppSettings();
   const isPrint = useIsPrintView();
 
@@ -45,24 +40,10 @@ const MainLayout: React.FC<Props> = ({ children }) => {
     error,
   } = useGetRootPermissionsQuery();
 
-  const { pathname } = useLocation();
-  const activeItem = React.useMemo(() => {
-    const val = pathname.split('/').find((s) => !!s);
-    switch (val) {
-      case undefined:
-      case 'client':
-        return 'client';
-      case 'projects':
-      case 'organizations':
-        return 'project';
-      case 'admin':
-        return 'admin';
-      case 'my-dashboard':
-        return 'my-dashboard';
-      default:
-        return null;
-    }
-  }, [pathname]);
+  const isMobile = useIsMobile();
+  const { mobileNavIsOpen, handleOpenMobileMenu, handleCloseMobileMenu } =
+    mobileMenuContext;
+  const isDashboard = useIsDashboard();
 
   if (error) throw error;
 
@@ -94,15 +75,6 @@ const MainLayout: React.FC<Props> = ({ children }) => {
       </>
     );
 
-  const navItemSx = (enabled: boolean): SxProps<Theme> => ({
-    fontWeight: 600,
-    fontSize: 14,
-    px: 2,
-    ml: 1,
-    color: 'text.primary',
-    backgroundColor: enabled ? (theme) => theme.palette.grey[100] : undefined,
-  });
-
   return (
     <React.Fragment>
       {SHOW_OP_LINK_BAR && <WarehouseLinkBar />}
@@ -115,10 +87,14 @@ const MainLayout: React.FC<Props> = ({ children }) => {
           borderBottom: (theme) => `1px solid ${theme.palette.divider}`,
           top: SHOW_OP_LINK_BAR ? OP_LINK_BAR_HEIGHT : 0,
           backgroundColor: 'white',
+          '&.MuiPaper-root': {
+            borderLeft: 'unset',
+            borderRight: 'unset',
+            borderTop: 'unset',
+          },
         }}
       >
-        {/* fixme: make responsive */}
-        <Toolbar sx={{ flexWrap: 'noWrap', overflow: 'hidden', gap: 1 }}>
+        <Toolbar sx={{ px: 3, minHeight: APP_BAR_HEIGHT }}>
           <RouterLink
             variant='h1'
             noWrap
@@ -133,49 +109,31 @@ const MainLayout: React.FC<Props> = ({ children }) => {
             {appName || 'Open Path HMIS'}
           </RouterLink>
           <Box display='flex' sx={{ flexGrow: 1 }}></Box>
-          <RootPermissionsFilter permissions={'canEditEnrollments'}>
-            <ButtonLink
-              variant='text'
-              to={Routes.MY_DASHBOARD}
-              data-testid='navToMyDashboard'
-              sx={navItemSx(activeItem === 'my-dashboard')}
-            >
-              My Dashboard
-            </ButtonLink>
-          </RootPermissionsFilter>
-          <RootPermissionsFilter permissions={'canViewClients'}>
-            <ButtonLink
-              variant='text'
-              to='/'
-              data-testid='navToClients'
-              sx={navItemSx(activeItem === 'client')}
-            >
-              Clients
-            </ButtonLink>
-          </RootPermissionsFilter>
-          <ButtonLink
-            variant='text'
-            to={Routes.ALL_PROJECTS}
-            data-testid='navToProjects'
-            sx={navItemSx(activeItem === 'project')}
-          >
-            Projects
-          </ButtonLink>
-          <RootPermissionsFilter
-            permissions={PERMISSIONS_GRANTING_ADMIN_DASHBOARD_ACCESS}
-            mode='any'
-          >
-            <ButtonLink
-              variant='text'
-              to={Routes.ADMIN}
-              data-testid='navToAdmin'
-              sx={navItemSx(activeItem === 'admin')}
-            >
-              Admin
-            </ButtonLink>
-          </RootPermissionsFilter>
-          <OmniSearch />
-          <UserMenu />
+          {!isMobile && (
+            <Stack direction='row' spacing={{ md: 0.5, lg: 2 }}>
+              <ToolbarMenu />
+              <OmniSearch />
+              <UserMenu />
+            </Stack>
+          )}
+          {isMobile && (
+            <>
+              <IconButton
+                aria-label='Navigation'
+                sx={{ color: 'text.primary' }}
+                onClick={() => handleOpenMobileMenu()}
+              >
+                <MenuIcon />
+              </IconButton>
+              {!isDashboard && (
+                // Dashboards render their own Mobile Menus with additional nav elements inside.
+                <MobileMenu
+                  mobileNavIsOpen={mobileNavIsOpen}
+                  handleCloseMobileMenu={handleCloseMobileMenu}
+                />
+              )}
+            </>
+          )}
         </Toolbar>
       </AppBar>
       <CssBaseline />

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -129,7 +129,7 @@ const MainLayout: React.FC<Props> = ({ mobileMenuContext, children }) => {
                 // Dashboards render their own Mobile Menus with additional nav elements inside.
                 <MobileMenu
                   mobileNavIsOpen={mobileNavIsOpen}
-                  handleCloseMobileMenu={handleCloseMobileMenu}
+                  onCloseMobileMenu={handleCloseMobileMenu}
                 />
               )}
             </>

--- a/src/components/layout/dashboard/DashboardContentNav.tsx
+++ b/src/components/layout/dashboard/DashboardContentNav.tsx
@@ -68,13 +68,14 @@ const DashboardContentNav: React.FC<Props> = ({
 }) => {
   const headerHeight = `${STICKY_BAR_HEIGHT}px`;
   const height = `calc(100vh - ${headerHeight})`;
+
   return (
     <Box
       sx={{ display: 'flex', top: headerHeight, position: 'sticky', height }}
     >
       <MobileMenu
         mobileNavIsOpen={mobileNavIsOpen}
-        handleCloseMobileMenu={handleCloseMobileMenu}
+        onCloseMobileMenu={handleCloseMobileMenu}
         label={label}
       >
         {children}

--- a/src/components/layout/dashboard/DashboardContentNav.tsx
+++ b/src/components/layout/dashboard/DashboardContentNav.tsx
@@ -7,6 +7,8 @@ import {
   DESKTOP_NAV_SIDEBAR_WIDTH,
   STICKY_BAR_HEIGHT,
 } from '../layoutConstants';
+import MobileMenu from '@/components/layout/nav/MobileMenu';
+
 interface Props {
   children: ReactNode;
   navHeader: ReactNode;
@@ -14,7 +16,6 @@ interface Props {
   mobileNavIsOpen: boolean;
   handleCloseMobileMenu: VoidFunction;
   handleCloseDesktopMenu: VoidFunction;
-  window?: () => Window;
   label?: string;
 }
 
@@ -63,34 +64,21 @@ const DashboardContentNav: React.FC<Props> = ({
   mobileNavIsOpen,
   handleCloseMobileMenu,
   handleCloseDesktopMenu,
-  window,
   label,
 }) => {
-  const container =
-    window !== undefined ? () => window().document.body : undefined;
   const headerHeight = `${STICKY_BAR_HEIGHT}px`;
   const height = `calc(100vh - ${headerHeight})`;
   return (
     <Box
       sx={{ display: 'flex', top: headerHeight, position: 'sticky', height }}
     >
-      <Drawer
-        data-testid='mobileNav'
-        container={container}
-        variant='temporary'
-        open={mobileNavIsOpen}
-        onClose={handleCloseMobileMenu}
-        ModalProps={{
-          keepMounted: true, // Better open performance on mobile.
-        }}
-        sx={{
-          zIndex: 1300,
-          display: { md: 'block', lg: 'none' },
-        }}
+      <MobileMenu
+        mobileNavIsOpen={mobileNavIsOpen}
+        handleCloseMobileMenu={handleCloseMobileMenu}
+        label={label}
       >
-        <CloseMenuRow onClose={handleCloseMobileMenu} label={label} />
-        <Box>{children}</Box>
-      </Drawer>
+        {children}
+      </MobileMenu>
       <Drawer
         data-testid='desktopNav'
         anchor='left'

--- a/src/components/layout/dashboard/contextHeader/ContextHeader.tsx
+++ b/src/components/layout/dashboard/contextHeader/ContextHeader.tsx
@@ -8,8 +8,6 @@ import {
   CONTEXT_HEADER_HEIGHT,
   STICKY_BAR_HEIGHT,
 } from '../../layoutConstants';
-
-import { useIsMobile } from '@/hooks/useIsMobile';
 import useSafeParams from '@/hooks/useSafeParams';
 import { useClientName } from '@/modules/dataFetching/hooks/useClientName';
 import { clientBriefName } from '@/modules/hmis/hmisUtil';
@@ -34,6 +32,7 @@ export const ContextHeaderAppBar: React.FC<{ children: ReactNode }> = ({
     sx={{
       borderTop: 'unset',
       borderLeft: 'unset',
+      borderRight: 'unset',
       height: CONTEXT_HEADER_HEIGHT,
       alignItems: 'stretch',
       justifyContent: 'center',
@@ -56,7 +55,6 @@ const ContextHeader: React.FC<Props> = ({
   isOpen,
   handleOpenMenu,
 }) => {
-  const isMobile = useIsMobile();
   const { clientId, enrollmentId } = useSafeParams();
   const { client } = useClientName(clientId);
   const navigate = useNavigate();
@@ -117,7 +115,7 @@ const ContextHeader: React.FC<Props> = ({
         </Box>
       ) : (
         <Box display='flex' alignItems='stretch' width='100%' flex={1}>
-          {(!isOpen || isMobile) && (
+          {!isOpen && (
             <Box
               sx={{
                 display: 'flex',

--- a/src/components/layout/dashboard/sideNav/SideNavMenu.tsx
+++ b/src/components/layout/dashboard/sideNav/SideNavMenu.tsx
@@ -7,7 +7,7 @@ import { NavItem } from './types';
 
 interface SideNavMenuProps<T> {
   items: NavItem<T>[];
-  access: T;
+  access?: T;
   pathParams?: Record<string, string>;
 }
 

--- a/src/components/layout/nav/MobileMenu.tsx
+++ b/src/components/layout/nav/MobileMenu.tsx
@@ -1,0 +1,90 @@
+import { Close } from '@mui/icons-material';
+import { Box, Drawer, IconButton, Typography } from '@mui/material';
+import React, { ReactNode } from 'react';
+import UserMenu from './UserMenu';
+import ToolbarMenu from '@/components/layout/nav/ToolbarMenu';
+import OmniSearch from '@/modules/search/components/OmniSearch';
+
+interface Props {
+  window?: () => Window;
+  children?: ReactNode;
+  mobileNavIsOpen: boolean;
+  handleCloseMobileMenu: VoidFunction;
+  navHeader?: ReactNode;
+  label?: string;
+}
+
+const MobileMenu: React.FC<Props> = ({
+  window,
+  children,
+  mobileNavIsOpen,
+  handleCloseMobileMenu,
+  label,
+}) => {
+  const container =
+    window !== undefined ? () => window().document.body : undefined;
+
+  return (
+    <Drawer
+      data-testid='mobileNav'
+      anchor='right'
+      container={container}
+      variant='temporary'
+      open={mobileNavIsOpen}
+      onClose={handleCloseMobileMenu}
+      ModalProps={{
+        keepMounted: true, // Better open performance on mobile.
+      }}
+      sx={{
+        zIndex: 1300,
+        display: { md: 'block', lg: 'none' },
+        minWidth: '320px',
+      }}
+    >
+      <Box component='span' sx={{ position: 'absolute', right: 4, top: 4 }}>
+        <IconButton
+          aria-label='copy'
+          onClick={handleCloseMobileMenu}
+          sx={{ fontSize: 'inherit' }}
+          size='large'
+        >
+          <Close fontSize='inherit' />
+        </IconButton>
+      </Box>
+
+      <Box>
+        <Typography component='h2' variant='overline' sx={{ px: 3, mt: 2 }}>
+          Site Navigation
+        </Typography>
+        <ToolbarMenu />
+
+        <Box sx={{ p: 2 }}>
+          <OmniSearch />
+        </Box>
+
+        {children && (
+          <Box
+            sx={{
+              m: 2,
+              pt: 2,
+              borderRadius: 1,
+              border: (theme) => `1px solid ${theme.palette.grey[200]}`,
+            }}
+          >
+            <Typography component='h2' variant='h5' sx={{ px: 3 }}>
+              {label}
+            </Typography>
+            {children}
+          </Box>
+        )}
+
+        <Typography component='h2' variant='overline' sx={{ px: 3 }}>
+          User
+        </Typography>
+        <UserMenu />
+      </Box>
+    </Drawer>
+  );
+};
+
+export default MobileMenu;

--- a/src/components/layout/nav/MobileMenuItem.tsx
+++ b/src/components/layout/nav/MobileMenuItem.tsx
@@ -1,0 +1,18 @@
+import { ListItemButton, ListItemText } from '@mui/material';
+import React from 'react';
+import RouterLink from '@/components/elements/RouterLink';
+
+interface Props {
+  title: string;
+  selected: boolean;
+  path?: string;
+}
+
+const MobileMenuItem: React.FC<Props> = ({ title, selected, path }) => {
+  return (
+    <ListItemButton component={RouterLink} to={path} selected={selected}>
+      <ListItemText primary={title} />
+    </ListItemButton>
+  );
+};
+export default MobileMenuItem;

--- a/src/components/layout/nav/MobileUserMenu.tsx
+++ b/src/components/layout/nav/MobileUserMenu.tsx
@@ -1,0 +1,20 @@
+import { ExpandLess, ExpandMore } from '@mui/icons-material';
+import { Collapse, ListItemButton, ListItemText } from '@mui/material';
+import React, { useState } from 'react';
+import UserMenu from '@/components/layout/nav/UserMenu';
+
+const MobileUserMenu: React.FC = () => {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <ListItemButton onClick={() => setOpen((v) => !v)} divider={open}>
+        <ListItemText primary='User' />
+        {open ? <ExpandLess /> : <ExpandMore />}
+      </ListItemButton>
+      <Collapse in={open} timeout='auto' unmountOnExit>
+        <UserMenu />
+      </Collapse>
+    </>
+  );
+};
+export default MobileUserMenu;

--- a/src/components/layout/nav/ToolbarMenu.tsx
+++ b/src/components/layout/nav/ToolbarMenu.tsx
@@ -1,0 +1,141 @@
+import { alpha, lighten, MenuItem, SxProps, Theme } from '@mui/material';
+import React, { useCallback } from 'react';
+import { useLocation } from 'react-router-dom';
+import ButtonLink from '@/components/elements/ButtonLink';
+import RouterLink from '@/components/elements/RouterLink';
+import { NavItem } from '@/components/layout/dashboard/sideNav/types';
+import { useIsMobile } from '@/hooks/useIsMobile';
+import { PERMISSIONS_GRANTING_ADMIN_DASHBOARD_ACCESS } from '@/modules/admin/components/AdminDashboard';
+import { RootPermissionsFilter } from '@/modules/permissions/PermissionsFilters';
+import { Routes } from '@/routes/routes';
+import { RootPermissionsFragment } from '@/types/gqlTypes';
+
+const TOOLBAR_MENU_ITEMS: (NavItem<RootPermissionsFragment> & {
+  activeItemPathIncludes: string;
+})[] = [
+  {
+    permissions: ['canEditEnrollments'],
+    path: Routes.MY_DASHBOARD,
+    id: 'navToMyDashboard',
+    activeItemPathIncludes: 'my-dashboard',
+    title: 'My Dashboard',
+  },
+  {
+    permissions: ['canViewClients'],
+    path: '/',
+    id: 'navToClients',
+    activeItemPathIncludes: 'client',
+    title: 'Clients',
+  },
+  {
+    path: Routes.ALL_PROJECTS,
+    id: 'navToProjects',
+    activeItemPathIncludes: 'project',
+    title: 'Projects',
+  },
+  {
+    permissions: PERMISSIONS_GRANTING_ADMIN_DASHBOARD_ACCESS,
+    path: Routes.ADMIN,
+    permissionMode: 'any',
+    id: 'navToAdmin',
+    activeItemPathIncludes: 'admin',
+    title: 'Admin',
+  },
+];
+
+const ToolbarMenu: React.FC = () => {
+  const { pathname } = useLocation();
+  const activeItem = React.useMemo(() => {
+    const val = pathname.split('/').find((s) => !!s);
+    switch (val) {
+      case undefined:
+      case 'client':
+        return 'client';
+      case 'projects':
+      case 'organizations':
+        return 'project';
+      case 'admin':
+        return 'admin';
+      case 'my-dashboard':
+        return 'my-dashboard';
+      default:
+        return null;
+    }
+  }, [pathname]);
+
+  const isMobile = useIsMobile();
+
+  const navItemSx = useCallback(
+    (selected: boolean): SxProps<Theme> => {
+      return isMobile
+        ? {
+            py: 1,
+            px: 3,
+            textDecoration: 'none',
+            textOverflow: 'ellipsis',
+            overflowX: 'hidden',
+            whiteSpace: 'nowrap',
+            display: 'block',
+            color: selected ? 'primary.main' : 'text.primary',
+            fontWeight: selected ? 600 : 400,
+            '&.Mui-focusVisible': {
+              outlineOffset: '-2px',
+            },
+            backgroundColor: selected
+              ? (theme: Theme) => lighten(theme.palette.primary.light, 0.9)
+              : undefined,
+            border: '2px solid transparent',
+          }
+        : {
+            fontWeight: 600,
+            fontSize: 14,
+            px: { xs: 0.5, lg: 2 },
+            color: 'text.primary',
+            backgroundColor: selected
+              ? (theme: Theme) => alpha(theme.palette.primary.light, 0.12)
+              : undefined,
+          };
+    },
+    [isMobile]
+  );
+
+  return TOOLBAR_MENU_ITEMS.map((item) => {
+    let navItem = isMobile ? (
+      <MenuItem
+        component={RouterLink}
+        to={item.path}
+        sx={navItemSx(activeItem === item.activeItemPathIncludes)}
+        data-testid={item.id}
+        key={item.id}
+      >
+        {item.title}
+      </MenuItem>
+    ) : (
+      <ButtonLink
+        variant='text'
+        to={item.path}
+        data-testid={item.id}
+        sx={navItemSx(activeItem === item.activeItemPathIncludes)}
+        key={item.id}
+      >
+        {item.title}
+      </ButtonLink>
+    );
+
+    if (item.permissions) {
+      navItem = (
+        <RootPermissionsFilter
+          key={item.id}
+          permissions={item.permissions}
+          mode={item.permissionMode}
+        >
+          {navItem}
+        </RootPermissionsFilter>
+      );
+    }
+
+    return navItem;
+  });
+};
+
+export default ToolbarMenu;

--- a/src/components/layout/nav/ToolbarMenu.tsx
+++ b/src/components/layout/nav/ToolbarMenu.tsx
@@ -10,7 +10,7 @@ import { RootPermissionsFilter } from '@/modules/permissions/PermissionsFilters'
 import { Routes } from '@/routes/routes';
 import { RootPermissionsFragment } from '@/types/gqlTypes';
 
-const TOOLBAR_MENU_ITEMS: (NavItem<RootPermissionsFragment> & {
+export const TOOLBAR_MENU_ITEMS: (NavItem<RootPermissionsFragment> & {
   activeItemPathIncludes: string;
 })[] = [
   {
@@ -43,9 +43,9 @@ const TOOLBAR_MENU_ITEMS: (NavItem<RootPermissionsFragment> & {
   },
 ];
 
-const ToolbarMenu: React.FC = () => {
+export const useActiveNaveItem = () => {
   const { pathname } = useLocation();
-  const activeItem = React.useMemo(() => {
+  return React.useMemo(() => {
     const val = pathname.split('/').find((s) => !!s);
     switch (val) {
       case undefined:
@@ -62,7 +62,10 @@ const ToolbarMenu: React.FC = () => {
         return null;
     }
   }, [pathname]);
+};
 
+const ToolbarMenu: React.FC = () => {
+  const activeItem = useActiveNaveItem();
   const isMobile = useIsMobile();
 
   const navItemSx = useCallback(

--- a/src/components/layout/nav/UserMenu.tsx
+++ b/src/components/layout/nav/UserMenu.tsx
@@ -18,8 +18,8 @@ import {
   bindTrigger,
   usePopupState,
 } from 'material-ui-popup-state/hooks';
-import React from 'react';
-
+import React, { ReactNode, useMemo } from 'react';
+import { useIsMobile } from '@/hooks/useIsMobile';
 import useAuth from '@/modules/auth/hooks/useAuth';
 import { useHmisAppSettings } from '@/modules/hmisAppSettings/useHmisAppSettings';
 
@@ -28,6 +28,69 @@ const UserMenu: React.FC = () => {
   const { user, logoutUser } = useAuth();
   const { manageAccountUrl, warehouseUrl, warehouseName } =
     useHmisAppSettings();
+  const isMobile = useIsMobile();
+
+  const menuItems = useMemo(() => {
+    const items: ReactNode[] = [];
+    if (!user || user.impersonating) return items;
+
+    const sx = isMobile
+      ? {
+          py: 1,
+          px: 3,
+          border: '2px solid transparent',
+        }
+      : {};
+
+    if (manageAccountUrl) {
+      items.push(
+        <MenuItem
+          sx={sx}
+          component={Link}
+          href={manageAccountUrl}
+          target='_blank'
+          key='manage account'
+        >
+          <ListItemIcon>
+            <OpenInNewIcon fontSize='small' sx={{ color: 'links' }} />
+          </ListItemIcon>
+          <ListItemText>Manage Account</ListItemText>
+        </MenuItem>
+      );
+    }
+    if (warehouseUrl && warehouseName) {
+      items.push(
+        <MenuItem
+          sx={sx}
+          component={Link}
+          href={warehouseUrl}
+          target='_blank'
+          key='warehouse'
+        >
+          <ListItemIcon>
+            <OpenInNewIcon fontSize='small' sx={{ color: 'links' }} />
+          </ListItemIcon>
+          <ListItemText>{warehouseName}</ListItemText>
+        </MenuItem>
+      );
+    }
+    items.push(
+      <MenuItem sx={sx} onClick={logoutUser} key='logout'>
+        <ListItemIcon>
+          <LogoutIcon fontSize='small' />
+        </ListItemIcon>
+        <ListItemText>Sign Out</ListItemText>
+      </MenuItem>
+    );
+    return items;
+  }, [
+    isMobile,
+    logoutUser,
+    manageAccountUrl,
+    user,
+    warehouseName,
+    warehouseUrl,
+  ]);
 
   if (!user) return null;
 
@@ -51,6 +114,10 @@ const UserMenu: React.FC = () => {
         <AlertTitle sx={{ mb: 0 }}>{`Acting as ${user.name}`}</AlertTitle>
       </Alert>
     );
+  }
+
+  if (isMobile) {
+    return menuItems;
   }
 
   return (
@@ -78,29 +145,7 @@ const UserMenu: React.FC = () => {
         PaperProps={{ sx: { borderTopLeftRadius: 0, borderTopRightRadius: 0 } }}
         {...bindMenu(popupState)}
       >
-        {manageAccountUrl && (
-          <MenuItem component={Link} href={manageAccountUrl} target='_blank'>
-            <ListItemIcon>
-              <OpenInNewIcon fontSize='small' sx={{ color: 'links' }} />
-            </ListItemIcon>
-            <ListItemText>Manage Account</ListItemText>
-          </MenuItem>
-        )}
-        {warehouseUrl && warehouseName && (
-          <MenuItem component={Link} href={warehouseUrl} target='_blank'>
-            <ListItemIcon>
-              <OpenInNewIcon fontSize='small' sx={{ color: 'links' }} />
-            </ListItemIcon>
-            <ListItemText>{warehouseName}</ListItemText>
-          </MenuItem>
-        )}
-
-        <MenuItem onClick={logoutUser}>
-          <ListItemIcon>
-            <LogoutIcon fontSize='small' />
-          </ListItemIcon>
-          <ListItemText>Sign Out</ListItemText>
-        </MenuItem>
+        {menuItems}
       </Menu>
     </>
   );

--- a/src/components/layout/nav/useIsDashboard.tsx
+++ b/src/components/layout/nav/useIsDashboard.tsx
@@ -1,0 +1,20 @@
+import useCurrentPath from '@/hooks/useCurrentPath';
+import {
+  AdminDashboardRoutes,
+  ClientDashboardRoutes,
+  EnrollmentDashboardRoutes,
+  ProjectDashboardRoutes,
+} from '@/routes/routes';
+
+export const useIsDashboard = () => {
+  const currentPath = useCurrentPath();
+
+  if (!currentPath) return false;
+
+  return (
+    Object.values(AdminDashboardRoutes).includes(currentPath) ||
+    Object.values(ProjectDashboardRoutes).includes(currentPath) ||
+    Object.values(ClientDashboardRoutes).includes(currentPath) ||
+    Object.values(EnrollmentDashboardRoutes).includes(currentPath)
+  );
+};

--- a/src/components/layout/nav/useMobileMenuContext.tsx
+++ b/src/components/layout/nav/useMobileMenuContext.tsx
@@ -1,0 +1,24 @@
+import { useCallback, useState } from 'react';
+import { useOutletContext } from 'react-router-dom';
+
+export type MobileMenuContext = {
+  mobileNavIsOpen: boolean;
+  handleCloseMobileMenu: VoidFunction;
+  handleOpenMobileMenu: VoidFunction;
+};
+
+export const useMobileMenuContext = (): MobileMenuContext => {
+  const [mobileNavIsOpen, setMobileNavState] = useState(false);
+  const handleCloseMobileMenu = useCallback(() => {
+    setMobileNavState(false);
+  }, []);
+  const handleOpenMobileMenu = useCallback(() => {
+    setMobileNavState(true);
+  }, []);
+
+  return { mobileNavIsOpen, handleCloseMobileMenu, handleOpenMobileMenu };
+};
+
+export function useMobileMenu() {
+  return useOutletContext<MobileMenuContext>();
+}

--- a/src/hooks/useDashboardState.tsx
+++ b/src/hooks/useDashboardState.tsx
@@ -1,14 +1,15 @@
 import { useCallback, useEffect, useState } from 'react';
-
 import useCurrentPath from './useCurrentPath';
-
+import { useMobileMenu } from '@/components/layout/nav/useMobileMenuContext';
 import { FOCUS_MODE_ROUTES, HIDE_NAV_ROUTES } from '@/routes/routes';
 
 export function useDashboardState() {
   const currentPath = useCurrentPath();
 
+  const { mobileNavIsOpen, handleCloseMobileMenu, handleOpenMobileMenu } =
+    useMobileMenu();
+
   const [desktopNavIsOpen, setDesktopNavState] = useState(true);
-  const [mobileNavIsOpen, setMobileNavState] = useState(false);
   const [focusMode, setFocusMode] = useState<string | undefined>();
 
   useEffect(() => {
@@ -30,12 +31,6 @@ export function useDashboardState() {
     }
   }, [currentPath]);
 
-  const handleCloseMobileMenu = useCallback(() => {
-    setMobileNavState(false);
-  }, []);
-  const handleOpenMobileMenu = useCallback(() => {
-    setMobileNavState(true);
-  }, []);
   const handleCloseDesktopMenu = useCallback(() => {
     setDesktopNavState(false);
   }, []);

--- a/src/modules/admin/components/AdminDashboard.tsx
+++ b/src/modules/admin/components/AdminDashboard.tsx
@@ -15,6 +15,7 @@ import { NavItem } from '@/components/layout/dashboard/sideNav/types';
 import NotFound from '@/components/pages/NotFound';
 import useCurrentPath from '@/hooks/useCurrentPath';
 import { useDashboardState } from '@/hooks/useDashboardState';
+import { useIsMobile } from '@/hooks/useIsMobile';
 import { useRootPermissions } from '@/modules/permissions/useHasPermissionsHooks';
 import { AdminDashboardRoutes } from '@/routes/routes';
 import { RootPermissionsFragment } from '@/types/gqlTypes';
@@ -113,6 +114,7 @@ const AdminDashboard: React.FC = () => {
   const dashboardState = useDashboardState();
   const breadCrumbConfig = useAdminBreadcrumbConfig();
   const breadcrumbs = useDashboardBreadcrumbs(breadCrumbConfig);
+  const isMobile = useIsMobile();
 
   const formEditorContentSx = {
     px: 0,
@@ -140,6 +142,7 @@ const AdminDashboard: React.FC = () => {
           ? formEditorContentSx
           : {}
       }
+      navLabel={isMobile ? 'Admin' : ''}
       {...dashboardState}
     >
       <Container

--- a/src/modules/search/components/OmniSearch.tsx
+++ b/src/modules/search/components/OmniSearch.tsx
@@ -19,6 +19,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 
 import TextInput from '@/components/elements/input/TextInput';
 import useDebouncedState from '@/hooks/useDebouncedState';
+import { useIsMobile } from '@/hooks/useIsMobile';
 import ClientName from '@/modules/client/components/ClientName';
 import ApolloErrorAlert from '@/modules/errors/components/ApolloErrorAlert';
 import { Routes } from '@/routes/routes';
@@ -41,6 +42,7 @@ const MIN_CHAR_LENGTH_FOR_SEE_MORE = 3;
 const OmniSearch: React.FC = () => {
   const navigate = useNavigate();
   const location = useLocation();
+  const isMobile = useIsMobile();
 
   const [value, setValue, debouncedSearch] = useDebouncedState<
     string | undefined
@@ -240,7 +242,10 @@ const OmniSearch: React.FC = () => {
           open={values.popupOpen}
           anchorEl={values.anchorEl}
           placement='bottom-end'
-          sx={{ zIndex: (theme) => theme.zIndex.modal, minWidth: '350px' }}
+          sx={{
+            zIndex: (theme) => theme.zIndex.modal,
+            minWidth: isMobile ? '' : '350px',
+          }}
         >
           <Paper
             sx={{
@@ -391,7 +396,9 @@ const OmniSearch: React.FC = () => {
   return (
     <>
       <ApolloErrorAlert error={error} />
-      <Box sx={{ mx: 2, height: '44px', div: { height: '100%' } }}>
+      <Box
+        sx={{ px: { md: 1, lg: 2 }, height: '44px', div: { height: '100%' } }}
+      >
         {content}
       </Box>
     </>

--- a/src/routes/protected.tsx
+++ b/src/routes/protected.tsx
@@ -23,6 +23,10 @@ import Profile from '@/components/clientDashboard/Profile';
 import Loading from '@/components/elements/Loading';
 import PathHandler from '@/components/elements/PathHandler';
 import MainLayout from '@/components/layout/MainLayout';
+import {
+  MobileMenuContext,
+  useMobileMenuContext,
+} from '@/components/layout/nav/useMobileMenuContext';
 import AllProjects from '@/components/pages/AllProjects';
 import ClientDashboard from '@/components/pages/ClientDashboard';
 import ClientSearchPage from '@/components/pages/ClientSearchPage';
@@ -104,11 +108,22 @@ import SystemStatus from '@/modules/systemStatus/components/SystemStatus';
 import Units from '@/modules/units/components/Units';
 
 const App = () => {
+  // Setup mobile menu context - open/closed state and handlers
+  const mobileMenuContext = useMobileMenuContext();
+
   return (
-    <MainLayout>
+    <MainLayout
+      // Provide mobile menu context directly to the Main Layout for rendering the non-Dashboard nav.
+      // Can't use `useMobileMenu` hook for the context provided by the Outlet, since this is outside the Outlet.
+      mobileMenuContext={mobileMenuContext}
+    >
       <Suspense fallback={<Loading />}>
         <SentryErrorBoundary>
-          <Outlet />
+          <Outlet
+            // Provide mobile menu context to the children via Outlet so that Dashboard components
+            // can use the same menu component but inject their own navigational elements
+            context={mobileMenuContext satisfies MobileMenuContext}
+          />
         </SentryErrorBoundary>
       </Suspense>
     </MainLayout>


### PR DESCRIPTION
## Description

GH issue: https://github.com/open-path/Green-River/issues/6433
See latest design thinking: https://greenriver.slack.com/archives/C033YNSN0Q1/p1722449528561929

I have several worries about this approach, but it is more functional that the current mobile toolbar especially with the recent addition of 'My Dashboard' as a fourth tab.

Worries/things to improve:
- Is there a better alternative to the way I've injected the dashboard navigational elements into the mobile menu? For example, would it be better if we have just 1 place where the MobileMenu component is rendered, and make it learn about what children nav elements it should render using path parameters directly?
- Can we make a more consistent treatment between the different types of NavItems? (user nav, toolbar nav, and dashboard nav)
- Can we improve the mobile experience for search? (mui's Autocomplete component seems to be very geared towards popover behavior; would it be better to remove reliance on Autocomplete entirely on mobile?)
- There are some weird bugs with scroll behavior that we should investigate more

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (eslint)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
