### PR TITLE
Tt/6433 toolbar

### DIFF
--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -129,7 +129,7 @@ const MainLayout: React.FC<Props> = ({ mobileMenuContext, children }) => {
                 // Dashboards render their own Mobile Menus with additional nav elements inside.
                 <MobileMenu
                   mobileNavIsOpen={mobileNavIsOpen}
-                  handleCloseMobileMenu={handleCloseMobileMenu}
+                  onCloseMobileMenu={handleCloseMobileMenu}
                 />
               )}
             </>

--- a/src/components/layout/dashboard/DashboardContentNav.tsx
+++ b/src/components/layout/dashboard/DashboardContentNav.tsx
@@ -68,13 +68,14 @@ const DashboardContentNav: React.FC<Props> = ({
 }) => {
   const headerHeight = `${STICKY_BAR_HEIGHT}px`;
   const height = `calc(100vh - ${headerHeight})`;
+
   return (
     <Box
       sx={{ display: 'flex', top: headerHeight, position: 'sticky', height }}
     >
       <MobileMenu
         mobileNavIsOpen={mobileNavIsOpen}
-        handleCloseMobileMenu={handleCloseMobileMenu}
+        onCloseMobileMenu={handleCloseMobileMenu}
         label={label}
       >
         {children}

--- a/src/components/layout/nav/MobileMenu.tsx
+++ b/src/components/layout/nav/MobileMenu.tsx
@@ -1,5 +1,5 @@
 import { Close } from '@mui/icons-material';
-import { Box, Drawer, IconButton, Typography } from '@mui/material';
+import { Box, Drawer, IconButton, Stack, Typography } from '@mui/material';
 import React, { ReactNode } from 'react';
 import UserMenu from './UserMenu';
 import ToolbarMenu from '@/components/layout/nav/ToolbarMenu';
@@ -35,32 +35,44 @@ const MobileMenu: React.FC<Props> = ({
       ModalProps={{
         keepMounted: true, // Better open performance on mobile.
       }}
-      sx={{
-        zIndex: 1300,
+      sx={({ zIndex }) => ({
+        zIndex: zIndex.modal,
         display: { md: 'block', lg: 'none' },
         minWidth: '320px',
-      }}
+        overflow: 'hidden',
+        height: '100%',
+      })}
     >
-      <Box component='span' sx={{ position: 'absolute', right: 4, top: 4 }}>
+      <Stack
+        direction='row'
+        sx={({ shadows, zIndex }) => ({
+          boxShadow: shadows[2],
+          zIndex: zIndex.appBar,
+        })}
+      >
+        <Typography
+          component='h2'
+          variant='overline'
+          sx={{ ml: 2, mr: 'auto', mt: 1 }}
+        >
+          Site Navigation
+        </Typography>
         <IconButton
-          aria-label='copy'
+          aria-label='close'
           onClick={handleCloseMobileMenu}
           sx={{ fontSize: 'inherit' }}
           size='large'
         >
           <Close fontSize='inherit' />
         </IconButton>
-      </Box>
+      </Stack>
 
-      <Box>
-        <Typography component='h2' variant='overline' sx={{ px: 3, mt: 2 }}>
-          Site Navigation
-        </Typography>
-        <ToolbarMenu />
-
-        <Box sx={{ p: 2 }}>
+      <Box sx={{ flex: '1', overflowY: 'scroll', maxHeight: '100vh', pt: 2 }}>
+        <Box sx={{ mx: 2, mb: 2 }}>
           <OmniSearch />
         </Box>
+
+        <ToolbarMenu />
 
         {children && (
           <Box

--- a/src/components/layout/nav/MobileMenu.tsx
+++ b/src/components/layout/nav/MobileMenu.tsx
@@ -1,15 +1,27 @@
 import { Close } from '@mui/icons-material';
-import { Box, Drawer, IconButton, Stack, Typography } from '@mui/material';
-import React, { ReactNode } from 'react';
-import UserMenu from './UserMenu';
-import ToolbarMenu from '@/components/layout/nav/ToolbarMenu';
+import {
+  Box,
+  Drawer,
+  IconButton,
+  List,
+  Stack,
+  Typography,
+} from '@mui/material';
+import React, { ReactNode, useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+import MobileMenuItem from '@/components/layout/nav/MobileMenuItem';
+import MobileUserMenu from '@/components/layout/nav/MobileUserMenu';
+import {
+  TOOLBAR_MENU_ITEMS,
+  useActiveNaveItem,
+} from '@/components/layout/nav/ToolbarMenu';
 import OmniSearch from '@/modules/search/components/OmniSearch';
 
 interface Props {
   window?: () => Window;
   children?: ReactNode;
   mobileNavIsOpen: boolean;
-  handleCloseMobileMenu: VoidFunction;
+  onCloseMobileMenu: VoidFunction;
   navHeader?: ReactNode;
   label?: string;
 }
@@ -18,12 +30,43 @@ const MobileMenu: React.FC<Props> = ({
   window,
   children,
   mobileNavIsOpen,
-  handleCloseMobileMenu,
+  onCloseMobileMenu,
   label,
 }) => {
   const container =
     window !== undefined ? () => window().document.body : undefined;
 
+  // close the menu on nav
+  const { pathname } = useLocation();
+  useEffect(() => {
+    onCloseMobileMenu();
+  }, [pathname, onCloseMobileMenu]);
+
+  // also need hook to scroll to top of menu on open
+
+  const activeNavItem = useActiveNaveItem();
+  const nav = (
+    <List>
+      {TOOLBAR_MENU_ITEMS.map(({ path, id, activeItemPathIncludes, title }) => {
+        const active = activeNavItem === activeItemPathIncludes;
+
+        // fixme
+        //if (! hasPermissionsOnObject([permissions], permissionMode )) {
+        //  return  null
+        //}
+
+        return (
+          <MobileMenuItem
+            key={id}
+            title={title as string}
+            selected={active}
+            path={path}
+          />
+        );
+      })}
+      <MobileUserMenu />
+    </List>
+  );
   return (
     <Drawer
       data-testid='mobileNav'
@@ -31,35 +74,35 @@ const MobileMenu: React.FC<Props> = ({
       container={container}
       variant='temporary'
       open={mobileNavIsOpen}
-      onClose={handleCloseMobileMenu}
+      onClose={onCloseMobileMenu}
       ModalProps={{
         keepMounted: true, // Better open performance on mobile.
       }}
       sx={({ zIndex }) => ({
         zIndex: zIndex.modal,
         display: { md: 'block', lg: 'none' },
-        minWidth: '320px',
         overflow: 'hidden',
         height: '100%',
       })}
     >
       <Stack
         direction='row'
-        sx={({ shadows, zIndex }) => ({
-          boxShadow: shadows[2],
+        sx={({ zIndex }) => ({
+          boxShadow: children ? 2 : undefined,
           zIndex: zIndex.appBar,
+          minWidth: '320px',
         })}
       >
         <Typography
           component='h2'
           variant='overline'
-          sx={{ ml: 2, mr: 'auto', mt: 1 }}
+          sx={{ ml: 2, mr: 'auto', mt: 0.5 }}
         >
-          Site Navigation
+          {label || 'Site Navigation'}
         </Typography>
         <IconButton
           aria-label='close'
-          onClick={handleCloseMobileMenu}
+          onClick={onCloseMobileMenu}
           sx={{ fontSize: 'inherit' }}
           size='large'
         >
@@ -67,34 +110,35 @@ const MobileMenu: React.FC<Props> = ({
         </IconButton>
       </Stack>
 
-      <Box sx={{ flex: '1', overflowY: 'scroll', maxHeight: '100vh', pt: 2 }}>
-        <Box sx={{ mx: 2, mb: 2 }}>
-          <OmniSearch />
-        </Box>
-
-        <ToolbarMenu />
-
-        {children && (
-          <Box
-            sx={{
-              m: 2,
-              pt: 2,
-              borderRadius: 1,
-              border: (theme) => `1px solid ${theme.palette.grey[200]}`,
-            }}
-          >
-            <Typography component='h2' variant='h5' sx={{ px: 3 }}>
-              {label}
-            </Typography>
-            {children}
+      {children && (
+        <>
+          <Box sx={{ flex: '1', overflowY: 'scroll' }}>
+            <Box sx={({ palette }) => ({ background: palette.grey[100] })}>
+              {children}
+            </Box>
           </Box>
-        )}
-
-        <Typography component='h2' variant='overline' sx={{ px: 3 }}>
-          User
-        </Typography>
-        <UserMenu />
-      </Box>
+          <Box
+            sx={({ palette }) => ({
+              flex: '1',
+              pt: 2,
+              borderTop: `1px solid ${palette.divider}`,
+            })}
+          >
+            <Box sx={{ mx: 2, mb: 0 }}>
+              <OmniSearch />
+            </Box>
+            {nav}
+          </Box>
+        </>
+      )}
+      {!children && (
+        <>
+          <Box sx={{ mx: 2, mb: 0, mt: 2 }}>
+            <OmniSearch />
+          </Box>
+          {nav}
+        </>
+      )}
     </Drawer>
   );
 };

--- a/src/components/layout/nav/MobileMenuItem.tsx
+++ b/src/components/layout/nav/MobileMenuItem.tsx
@@ -1,0 +1,18 @@
+import { ListItemButton, ListItemText } from '@mui/material';
+import React from 'react';
+import RouterLink from '@/components/elements/RouterLink';
+
+interface Props {
+  title: string;
+  selected: boolean;
+  path?: string;
+}
+
+const MobileMenuItem: React.FC<Props> = ({ title, selected, path }) => {
+  return (
+    <ListItemButton component={RouterLink} to={path} selected={selected}>
+      <ListItemText primary={title} />
+    </ListItemButton>
+  );
+};
+export default MobileMenuItem;

--- a/src/components/layout/nav/MobileUserMenu.tsx
+++ b/src/components/layout/nav/MobileUserMenu.tsx
@@ -1,0 +1,20 @@
+import { ExpandLess, ExpandMore } from '@mui/icons-material';
+import { Collapse, ListItemButton, ListItemText } from '@mui/material';
+import React, { useState } from 'react';
+import UserMenu from '@/components/layout/nav/UserMenu';
+
+const MobileUserMenu: React.FC = () => {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <ListItemButton onClick={() => setOpen((v) => !v)} divider={open}>
+        <ListItemText primary='User' />
+        {open ? <ExpandLess /> : <ExpandMore />}
+      </ListItemButton>
+      <Collapse in={open} timeout='auto' unmountOnExit>
+        <UserMenu />
+      </Collapse>
+    </>
+  );
+};
+export default MobileUserMenu;

--- a/src/components/layout/nav/ToolbarMenu.tsx
+++ b/src/components/layout/nav/ToolbarMenu.tsx
@@ -10,7 +10,7 @@ import { RootPermissionsFilter } from '@/modules/permissions/PermissionsFilters'
 import { Routes } from '@/routes/routes';
 import { RootPermissionsFragment } from '@/types/gqlTypes';
 
-const TOOLBAR_MENU_ITEMS: (NavItem<RootPermissionsFragment> & {
+export const TOOLBAR_MENU_ITEMS: (NavItem<RootPermissionsFragment> & {
   activeItemPathIncludes: string;
 })[] = [
   {
@@ -43,9 +43,9 @@ const TOOLBAR_MENU_ITEMS: (NavItem<RootPermissionsFragment> & {
   },
 ];
 
-const ToolbarMenu: React.FC = () => {
+export const useActiveNaveItem = () => {
   const { pathname } = useLocation();
-  const activeItem = React.useMemo(() => {
+  return React.useMemo(() => {
     const val = pathname.split('/').find((s) => !!s);
     switch (val) {
       case undefined:
@@ -62,7 +62,10 @@ const ToolbarMenu: React.FC = () => {
         return null;
     }
   }, [pathname]);
+};
 
+const ToolbarMenu: React.FC = () => {
+  const activeItem = useActiveNaveItem();
   const isMobile = useIsMobile();
 
   const navItemSx = useCallback(


### PR DESCRIPTION
Some thoughts on 6433

* there are two variants, expanded with a scrolling region, and collapsed where just the top-level items are shown
* fix max-width on drawer
* fix scrolling behavior in drawer.
* roll up user menu
* move search above nav items (maybe that's better?)

<img width="809" alt="Screenshot 2024-08-03 at 01 38 12" src="https://github.com/user-attachments/assets/ba2ba4d1-c793-48e2-97c8-406097f54d2e">
<img width="816" alt="Screenshot 2024-08-03 at 01 38 37" src="https://github.com/user-attachments/assets/5bda0be2-5da5-43af-83fc-69313c16b4d4">
