### PR TITLE
Remove support for horizontal checkboxes and radio groups

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -8472,8 +8472,8 @@
           {
             "name": "RADIO_BUTTONS_VERTICAL",
             "description": "Render a choice input item as vertical radio buttons",
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "All radio buttons are now vertical"
           },
           {
             "name": "SIGNATURE",

--- a/src/components/elements/input/CheckboxGroupInput.tsx
+++ b/src/components/elements/input/CheckboxGroupInput.tsx
@@ -19,7 +19,7 @@ export interface Props {
   name?: string;
   options: Option[];
   onChange: (value?: Option[] | null) => void;
-  row?: boolean;
+  row?: boolean; // Not supported by dynamic forms anymore, but used internally in TableFilterItemCheckboxes
   sx?: SxProps;
   labelSx?: SxProps;
 }

--- a/src/components/elements/input/CheckboxGroupInput.tsx
+++ b/src/components/elements/input/CheckboxGroupInput.tsx
@@ -19,7 +19,6 @@ export interface Props {
   name?: string;
   options: Option[];
   onChange: (value?: Option[] | null) => void;
-  row?: boolean; // Not supported by dynamic forms anymore, but used internally in TableFilterItemCheckboxes
   sx?: SxProps;
   labelSx?: SxProps;
 }
@@ -33,7 +32,6 @@ const CheckboxGroupInput: React.FC<CheckboxGroupInputProps> = ({
   helperText,
   disabled,
   error,
-  row,
   warnIfEmptyTreatment,
   maxWidth,
   sx,
@@ -74,12 +72,9 @@ const CheckboxGroupInput: React.FC<CheckboxGroupInputProps> = ({
           </FormLabel>
         )}
         <FormGroup
-          row={row}
           sx={{
-            ...(!row && {
-              'label:first-of-type': { pt: 1 },
-              '.MuiCheckbox-root': { py: 0.5 },
-            }),
+            'label:first-of-type': { pt: 1 },
+            '.MuiCheckbox-root': { py: 0.5 },
             ...(warnIfEmptyTreatment && {
               '[data-checked="false"] svg': {
                 backgroundColor: 'alerts.low.background',

--- a/src/components/elements/input/RadioGroupInput.tsx
+++ b/src/components/elements/input/RadioGroupInput.tsx
@@ -64,7 +64,6 @@ const RadioGroupInput = ({
   value,
   error,
   warnIfEmptyTreatment,
-  row, // Not supported by dynamic forms anymore, but used internally by YesNoRadio. Support is partial (e.g. helper text is not supported)
   sx,
   clearable,
   helperText,
@@ -109,15 +108,11 @@ const RadioGroupInput = ({
         {label}
       </FormLabel>
       <GroupComponent
-        row={row}
         onChange={() => null}
         sx={{
           width: inputWidth,
-          ...(!row && {
-            'label:first-of-type': { pt: 0.5 },
-            // 'label:last-child': { pb: 1 },
-            'label .MuiRadio-root': { py: 0.5 },
-          }),
+          'label:first-of-type': { pt: 0.5 },
+          'label .MuiRadio-root': { py: 0.5 },
           ...(warnIfEmptyTreatment && {
             '[data-checked="false"] svg': {
               backgroundColor: 'alerts.low.background',

--- a/src/components/elements/input/RadioGroupInput.tsx
+++ b/src/components/elements/input/RadioGroupInput.tsx
@@ -64,7 +64,7 @@ const RadioGroupInput = ({
   value,
   error,
   warnIfEmptyTreatment,
-  row,
+  row, // Not supported by dynamic forms anymore, but used internally by YesNoRadio. Support is partial (e.g. helper text is not supported)
   sx,
   clearable,
   helperText,

--- a/src/components/elements/input/YesNoRadio.tsx
+++ b/src/components/elements/input/YesNoRadio.tsx
@@ -43,7 +43,6 @@ const YesNoRadio = ({ value, onChange, ...props }: Props) => {
       value={fromBoolean(value)}
       onChange={handleChange}
       options={[FALSE_OPT, TRUE_OPT]}
-      row
       clearable
       checkbox
       {...props}

--- a/src/components/elements/tableFilters/filters/items/Checkboxes.tsx
+++ b/src/components/elements/tableFilters/filters/items/Checkboxes.tsx
@@ -15,7 +15,6 @@ const TableFilterItemCheckboxes: React.FC<
       options={options}
       value={selectedOptions}
       onChange={(opt) => onChange(opt?.map((o) => o.code))}
-      row
     />
   );
 };

--- a/src/modules/form/components/DynamicField.tsx
+++ b/src/modules/form/components/DynamicField.tsx
@@ -364,7 +364,6 @@ const DynamicField: React.FC<DynamicFieldProps> = ({
             value={currentValue}
             onChange={onChangeValue}
             options={options || []}
-            row={componentType === Component.RadioButtons}
             {...commonInputProps}
             maxWidth='100%'
             labelSx={{ maxWidth: MAX_INPUT_AND_LABEL_WIDTH }}
@@ -374,7 +373,6 @@ const DynamicField: React.FC<DynamicFieldProps> = ({
             value={currentValue}
             onChange={onChangeValue}
             options={options || []}
-            row={componentType === Component.RadioButtons}
             clearable
             {...commonInputProps}
             maxWidth='100%'

--- a/src/modules/formBuilder/formBuilderUtil.ts
+++ b/src/modules/formBuilder/formBuilderUtil.ts
@@ -64,11 +64,7 @@ export const validComponentsForType = (type: ItemType) => {
     case ItemType.Boolean:
       return [Component.Checkbox];
     case ItemType.Choice:
-      return [
-        Component.Dropdown,
-        Component.RadioButtons,
-        Component.RadioButtonsVertical,
-      ];
+      return [Component.Dropdown, Component.RadioButtons];
     case ItemType.Group:
       return [
         Component.HorizontalGroup,

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -1162,7 +1162,10 @@ export enum Component {
   Phone = 'PHONE',
   /** Render a choice input item as radio buttons */
   RadioButtons = 'RADIO_BUTTONS',
-  /** Render a choice input item as vertical radio buttons */
+  /**
+   * Render a choice input item as vertical radio buttons
+   * @deprecated All radio buttons are now vertical
+   */
   RadioButtonsVertical = 'RADIO_BUTTONS_VERTICAL',
   /** Signature input component */
   Signature = 'SIGNATURE',


### PR DESCRIPTION
## Description

GH issue: https://github.com/open-path/Green-River/issues/6378
Depends on hmis-warehouse PR: https://github.com/greenriver/hmis-warehouse/pull/4605

This PR
- makes codegen updates in accordance w/ the linked backend PR to deprecate RADIO_BUTTONS_VERTICAL
- removes support for the `row` prop in `DynamicField`, so all checkboxes and radio groups will now be rendered vertically
- removes `RadioButtonsVertical` from the list of valid component overrides, so it doesn't show in the dropdown

## Type of change
[//]: # 'remove options that are not relevant'
- [ ] Bug fix
- [ ] New feature (adds functionality)
- [x] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
