### PR TITLE
Clear autofilled value when autofill condition turns false

### DIFF
--- a/src/modules/form/util/formUtil.ts
+++ b/src/modules/form/util/formUtil.ts
@@ -528,7 +528,7 @@ export const autofillValues = ({
   if (!item.autofillValues) return false;
 
   // use `some` to stop iterating when true is returned
-  return item.autofillValues.some((av) => {
+  const autofilled = item.autofillValues.some((av) => {
     // Skip autofills that should not run on read-only views
     if (viewOnly && !av.autofillReadonly) return false;
 
@@ -567,6 +567,17 @@ export const autofillValues = ({
     // Stop iterating through autofill values
     return true;
   });
+
+  // For readonly items, if no autofill condition matched, clear out the item's value.
+  // Don't make any changes if the whole form is in viewOnly mode, though, because
+  // in that case this is being called on form load (not on change of an autofill condition),
+  // so we don't want to clear any form values.
+  if (!autofilled && item.readOnly && !viewOnly) {
+    values[item.linkId] = undefined;
+    return true;
+  }
+
+  return autofilled;
 };
 
 const getBoundValue = (

--- a/src/modules/form/util/formUtil.ts
+++ b/src/modules/form/util/formUtil.ts
@@ -568,11 +568,14 @@ export const autofillValues = ({
     return true;
   });
 
-  // For readonly items, if no autofill condition matched, clear out the item's value.
-  // Don't make any changes if the whole form is in viewOnly mode, though, because
-  // in that case this is being called on form load (not on change of an autofill condition),
-  // so we don't want to clear any form values.
-  if (!autofilled && item.readOnly && !viewOnly) {
+  // For read-only items that are displayed on editable forms, the autofill value should nullify when its conditions are no longer met.
+  // For example, a read-only field showing the sum of 2 input fields should be cleared if the inputs are cleared.
+  // (In that example, we assume the autofill rule for summing has an autofill_when condition requiring the inputs to be present)
+  if (
+    !autofilled &&
+    (item.readOnly || item.type === ItemType.Display) &&
+    !viewOnly
+  ) {
     values[item.linkId] = undefined;
     return true;
   }


### PR DESCRIPTION
## Description

GH issue: https://github.com/open-path/Green-River/issues/5954
This PR enacts the behavior described in this comment: https://github.com/open-path/Green-River/issues/5954#issuecomment-2273975433

To test, I made a form with relevant autofill conditions in QA: https://qa-hmis.openpath.host/admin/forms/marthas_custom_assessment/165/preview-draft

You can copy that form's JSON to a local form, and play around with the behavior on this branch locally.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
