### PR TITLE
Use `in` instead of `Object.hasOwn` 

### DIFF
--- a/src/modules/hmis/filterUtil.ts
+++ b/src/modules/hmis/filterUtil.ts
@@ -26,7 +26,7 @@ export const getSortOptionForType = (
   recordType: string
 ): Record<string, string> | null => {
   const expectedName = `${recordType}SortOption`;
-  if (Object.hasOwn(HmisEnums, expectedName)) {
+  if (expectedName in HmisEnums) {
     const key = expectedName as keyof typeof HmisEnums;
     return HmisEnums[key];
   }


### PR DESCRIPTION
## Description

GH issue: https://github.com/open-path/Green-River/issues/6333

This PR fixes a browser compatibility issue. We should support Safari above version 14, but `Object.hasOwn` is only available after 15.4.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
