### PR TITLE
Clean up mobile toolbar

### DIFF
--- a/src/components/layout/nav/MobileMenu.tsx
+++ b/src/components/layout/nav/MobileMenu.tsx
@@ -38,7 +38,7 @@ const MobileMenu: React.FC<Props> = ({
     onCloseMobileMenu();
   }, [pathname, onCloseMobileMenu]);
 
-  // also need hook to scroll to top of menu on open
+  // TODO: hook to scroll to top of menu on open
 
   const nav = (
     <List>

--- a/src/components/layout/nav/MobileMenu.tsx
+++ b/src/components/layout/nav/MobileMenu.tsx
@@ -9,12 +9,8 @@ import {
 } from '@mui/material';
 import React, { ReactNode, useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
-import MobileMenuItem from '@/components/layout/nav/MobileMenuItem';
 import MobileUserMenu from '@/components/layout/nav/MobileUserMenu';
-import {
-  TOOLBAR_MENU_ITEMS,
-  useActiveNaveItem,
-} from '@/components/layout/nav/ToolbarMenu';
+import ToolbarMenu from '@/components/layout/nav/ToolbarMenu';
 import OmniSearch from '@/modules/search/components/OmniSearch';
 
 interface Props {
@@ -44,26 +40,9 @@ const MobileMenu: React.FC<Props> = ({
 
   // also need hook to scroll to top of menu on open
 
-  const activeNavItem = useActiveNaveItem();
   const nav = (
     <List>
-      {TOOLBAR_MENU_ITEMS.map(({ path, id, activeItemPathIncludes, title }) => {
-        const active = activeNavItem === activeItemPathIncludes;
-
-        // fixme
-        //if (! hasPermissionsOnObject([permissions], permissionMode )) {
-        //  return  null
-        //}
-
-        return (
-          <MobileMenuItem
-            key={id}
-            title={title as string}
-            selected={active}
-            path={path}
-          />
-        );
-      })}
+      <ToolbarMenu />
       <MobileUserMenu />
     </List>
   );

--- a/src/components/layout/nav/MobileUserMenu.tsx
+++ b/src/components/layout/nav/MobileUserMenu.tsx
@@ -6,15 +6,15 @@ import UserMenu from '@/components/layout/nav/UserMenu';
 const MobileUserMenu: React.FC = () => {
   const [open, setOpen] = useState(false);
   return (
-    <>
+    <li>
       <ListItemButton onClick={() => setOpen((v) => !v)} divider={open}>
-        <ListItemText primary='User' />
+        <ListItemText primary='My Account' />
         {open ? <ExpandLess /> : <ExpandMore />}
       </ListItemButton>
       <Collapse in={open} timeout='auto' unmountOnExit>
         <UserMenu />
       </Collapse>
-    </>
+    </li>
   );
 };
 export default MobileUserMenu;

--- a/src/components/layout/nav/ToolbarMenu.tsx
+++ b/src/components/layout/nav/ToolbarMenu.tsx
@@ -1,9 +1,9 @@
-import { alpha, lighten, MenuItem, SxProps, Theme } from '@mui/material';
-import React, { useCallback } from 'react';
+import { alpha, Theme } from '@mui/material';
+import React from 'react';
 import { useLocation } from 'react-router-dom';
 import ButtonLink from '@/components/elements/ButtonLink';
-import RouterLink from '@/components/elements/RouterLink';
 import { NavItem } from '@/components/layout/dashboard/sideNav/types';
+import MobileMenuItem from '@/components/layout/nav/MobileMenuItem';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { PERMISSIONS_GRANTING_ADMIN_DASHBOARD_ACCESS } from '@/modules/admin/components/AdminDashboard';
 import { RootPermissionsFilter } from '@/modules/permissions/PermissionsFilters';
@@ -43,7 +43,7 @@ export const TOOLBAR_MENU_ITEMS: (NavItem<RootPermissionsFragment> & {
   },
 ];
 
-export const useActiveNaveItem = () => {
+export const useActiveNavItem = () => {
   const { pathname } = useLocation();
   return React.useMemo(() => {
     const val = pathname.split('/').find((s) => !!s);
@@ -65,60 +65,32 @@ export const useActiveNaveItem = () => {
 };
 
 const ToolbarMenu: React.FC = () => {
-  const activeItem = useActiveNaveItem();
+  const activeItem = useActiveNavItem();
   const isMobile = useIsMobile();
-
-  const navItemSx = useCallback(
-    (selected: boolean): SxProps<Theme> => {
-      return isMobile
-        ? {
-            py: 1,
-            px: 3,
-            textDecoration: 'none',
-            textOverflow: 'ellipsis',
-            overflowX: 'hidden',
-            whiteSpace: 'nowrap',
-            display: 'block',
-            color: selected ? 'primary.main' : 'text.primary',
-            fontWeight: selected ? 600 : 400,
-            '&.Mui-focusVisible': {
-              outlineOffset: '-2px',
-            },
-            backgroundColor: selected
-              ? (theme: Theme) => lighten(theme.palette.primary.light, 0.9)
-              : undefined,
-            border: '2px solid transparent',
-          }
-        : {
-            fontWeight: 600,
-            fontSize: 14,
-            px: { xs: 0.5, lg: 2 },
-            color: 'text.primary',
-            backgroundColor: selected
-              ? (theme: Theme) => alpha(theme.palette.primary.light, 0.12)
-              : undefined,
-          };
-    },
-    [isMobile]
-  );
 
   return TOOLBAR_MENU_ITEMS.map((item) => {
     let navItem = isMobile ? (
-      <MenuItem
-        component={RouterLink}
-        to={item.path}
-        sx={navItemSx(activeItem === item.activeItemPathIncludes)}
-        data-testid={item.id}
+      <MobileMenuItem
         key={item.id}
-      >
-        {item.title}
-      </MenuItem>
+        title={item.title as string}
+        selected={activeItem === item.activeItemPathIncludes}
+        path={item.path}
+      />
     ) : (
       <ButtonLink
         variant='text'
         to={item.path}
         data-testid={item.id}
-        sx={navItemSx(activeItem === item.activeItemPathIncludes)}
+        sx={{
+          fontWeight: 600,
+          fontSize: 14,
+          px: { xs: 0.5, lg: 2 },
+          color: 'text.primary',
+          backgroundColor:
+            activeItem === item.activeItemPathIncludes
+              ? (theme: Theme) => alpha(theme.palette.primary.light, 0.12)
+              : undefined,
+        }}
         key={item.id}
       >
         {item.title}

--- a/src/components/layout/nav/ToolbarMenu.tsx
+++ b/src/components/layout/nav/ToolbarMenu.tsx
@@ -70,19 +70,20 @@ const ToolbarMenu: React.FC = () => {
 
   return TOOLBAR_MENU_ITEMS.map((item) => {
     let navItem = isMobile ? (
-      <MobileMenuItem
-        key={item.id}
-        title={item.title as string}
-        selected={activeItem === item.activeItemPathIncludes}
-        path={item.path}
-      />
+      <li key={item.id}>
+        <MobileMenuItem
+          title={item.title as string}
+          selected={activeItem === item.activeItemPathIncludes}
+          path={item.path}
+        />
+      </li>
     ) : (
       <ButtonLink
         variant='text'
         to={item.path}
         data-testid={item.id}
         sx={{
-          fontWeight: 600,
+          fontWeight: 600, // FIXME custom typography, should standardize
           fontSize: 14,
           px: { xs: 0.5, lg: 2 },
           color: 'text.primary',

--- a/src/modules/admin/components/AdminDashboard.tsx
+++ b/src/modules/admin/components/AdminDashboard.tsx
@@ -142,6 +142,8 @@ const AdminDashboard: React.FC = () => {
           ? formEditorContentSx
           : {}
       }
+      // On desktop, 'Admin' appears in the ProjectNavHeader, so omit it from the nav label.
+      // On mobile, include it. We can remove this special case if we add the ProjectNavHeader info back on mobile.
       navLabel={isMobile ? 'Admin' : ''}
       {...dashboardState}
     >


### PR DESCRIPTION
## Description

GH issue: https://github.com/open-path/Green-River/issues/6433

This PR
- Renders the toolbar menu on mobile (rather than hand-mapping the toolbar nav elements) so that we can take advantage of its permission filtering
- In the toolbar menu, uses the new `MobileMenuItem` for consistent sx
- Cleans up comments

I think, while we should still consider mobile nav (or just nav in general - see my comment [here](https://github.com/open-path/Green-River/issues/6475#issuecomment-2273634035)) to be an area of tech/design debt, I'd propose considering this PR as closing out the linked ticket, and moving further work based on TBD designs to a future ticket.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
