### PR TITLE
Add tooltip with additional staff assignment names

### DIFF
--- a/src/modules/enrollment/components/staffAssignment/NewStaffAssignmentForm.tsx
+++ b/src/modules/enrollment/components/staffAssignment/NewStaffAssignmentForm.tsx
@@ -75,7 +75,8 @@ const NewStaffAssignmentForm: React.FC<NewStaffAssignmentFormProps> = ({
         } else if (data.assignStaff?.staffAssignment) {
           setErrors(emptyErrorState);
           setAssigneeId(null);
-          if (relationshipPickList.length > 1) setRelationshipId(null);
+          if (relationshipPickList && relationshipPickList.length > 1)
+            setRelationshipId(null);
         }
       },
     });

--- a/src/modules/enrollment/components/staffAssignment/NewStaffAssignmentForm.tsx
+++ b/src/modules/enrollment/components/staffAssignment/NewStaffAssignmentForm.tsx
@@ -75,7 +75,7 @@ const NewStaffAssignmentForm: React.FC<NewStaffAssignmentFormProps> = ({
         } else if (data.assignStaff?.staffAssignment) {
           setErrors(emptyErrorState);
           setAssigneeId(null);
-          setRelationshipId(null);
+          if (relationshipPickList.length > 1) setRelationshipId(null);
         }
       },
     });

--- a/src/modules/projects/components/tables/ProjectHouseholdsTable.tsx
+++ b/src/modules/projects/components/tables/ProjectHouseholdsTable.tsx
@@ -1,4 +1,4 @@
-import { Chip, Stack, Typography } from '@mui/material';
+import { Chip, Stack, Tooltip, Typography } from '@mui/material';
 import { ReactNode, useMemo } from 'react';
 
 import { ColumnDef } from '@/components/elements/table/types';
@@ -42,13 +42,21 @@ export const ASSIGNED_STAFF_COL = {
     if (!hh.staffAssignments?.nodes.length) return;
 
     const first = hh.staffAssignments.nodes[0].user.name;
-    const rest = hh.staffAssignments.nodesCount - 1;
+    const rest = hh.staffAssignments.nodes
+      .slice(1)
+      .map((staffAssignment) => staffAssignment.user.name);
 
     return (
       <>
         {first}{' '}
-        {rest > 0 && (
-          <Chip sx={{ mb: 0.5 }} size='small' label={`+${rest} more`} />
+        {rest.length > 0 && (
+          <Tooltip arrow title={rest.join(', ')}>
+            <Chip
+              sx={{ mb: 0.5 }}
+              size='small'
+              label={`+${rest.length} more`}
+            />
+          </Tooltip>
         )}
       </>
     );
@@ -171,7 +179,7 @@ const ProjectHouseholdsTable = ({
   } = useProjectDashboardContext();
 
   const defaultColumns: ColumnDef<HouseholdFields>[] = useMemo(() => {
-    const c: ColumnDef<HouseholdFields>[] = [
+    const cols: ColumnDef<HouseholdFields>[] = [
       HOUSEHOLD_COLUMNS.hohIndicator,
       HOUSEHOLD_COLUMNS.clients,
       HOUSEHOLD_COLUMNS.relationshipToHoH,
@@ -180,9 +188,9 @@ const ProjectHouseholdsTable = ({
       HOUSEHOLD_COLUMNS.householdId,
     ];
 
-    if (staffAssignmentsEnabled) c.push(HOUSEHOLD_COLUMNS.assignedStaff);
+    if (staffAssignmentsEnabled) cols.push(HOUSEHOLD_COLUMNS.assignedStaff);
 
-    return c;
+    return cols;
   }, [staffAssignmentsEnabled]);
 
   const filters = useFilters({


### PR DESCRIPTION
## Description

GH issue: https://github.com/open-path/Green-River/issues/6336

This PR implements the suggestion from this QA comment: https://github.com/open-path/Green-River/issues/6336#issuecomment-2274445317

<img width="385" alt="Screenshot 2024-08-08 at 9 18 37 AM" src="https://github.com/user-attachments/assets/b349b70b-002e-4135-b3ac-f571c58643e8">

Also,
- Code cleanup to rename unclear variable name `c` -> `cols`
- When the New Staff Assignment form is submitted, only null out the form state's relationship if there are several relationships in the pick list

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [x] New feature (adds functionality)
- [x] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
