### PR TITLE
Make form rules dialog more accessible and consistent

### DIFF
--- a/src/modules/admin/components/formRules/FormRule.tsx
+++ b/src/modules/admin/components/formRules/FormRule.tsx
@@ -25,54 +25,43 @@ const nonClientFormRoles = [
 
 const nonProjectFormRoles = [FormRole.Organization];
 
-interface Props {
-  rule: FormRuleFieldsFragment | ProjectConfigFieldsFragment;
+interface BaseFormRuleProps {
+  projectType?: string;
+  project?: string;
+  organization?: string;
+  dataCollectedAbout?: string;
+  funder?: string;
+  otherFunder?: string | null;
+  serviceCategory?: string;
+  serviceType?: string;
   formRole?: FormRole;
   actionButtons?: ReactNode;
 }
 
-function isFormRuleFragment(
-  obj: FormRuleFieldsFragment | ProjectConfigFieldsFragment
-): obj is FormRuleFieldsFragment {
-  return obj && obj.hasOwnProperty('funder');
-}
-
-const FormRule: React.FC<Props> = ({ rule, formRole, actionButtons }) => {
-  // Fields that are shared across Project Configs and Form Rules
-  const { projectType, project, organization } = rule;
-
-  // Fields that are specific to Form Rules
-  let dataCollectedAbout;
-  let funder;
-  let otherFunder;
-  let serviceCategory;
-  let serviceType;
-  if (isFormRuleFragment(rule)) {
-    dataCollectedAbout = rule.dataCollectedAbout;
-    funder = rule.funder;
-    otherFunder = rule.otherFunder;
-    serviceCategory = rule.serviceCategory;
-    serviceType = rule.serviceType;
-  }
-
+export const BaseFormRule: React.FC<BaseFormRuleProps> = ({
+  projectType,
+  project,
+  organization,
+  dataCollectedAbout = HmisEnums.DataCollectedAbout.ALL_CLIENTS,
+  funder,
+  otherFunder,
+  serviceCategory,
+  serviceType,
+  formRole,
+  actionButtons,
+}) => {
   const conditions: Record<string, ReactNode> = {};
 
   if (!formRole || !nonProjectFormRoles.includes(formRole)) {
     if (projectType)
       conditions.projectType = (
-        <FormRuleChip
-          label={`Project Type is ${HmisEnums.ProjectType[projectType]}`}
-        />
+        <FormRuleChip label={`Project Type is ${projectType}`} />
       );
     if (project)
-      conditions.project = (
-        <FormRuleChip label={`Project is ${project.projectName}`} />
-      );
+      conditions.project = <FormRuleChip label={`Project is ${project}`} />;
     if (organization)
       conditions.organization = (
-        <FormRuleChip
-          label={`Organization is ${organization.organizationName}`}
-        />
+        <FormRuleChip label={`Organization is ${organization}`} />
       );
     if (otherFunder) {
       conditions.otherFunder = (
@@ -80,9 +69,7 @@ const FormRule: React.FC<Props> = ({ rule, formRole, actionButtons }) => {
       );
     } else if (funder) {
       conditions.funder = (
-        <FormRuleChip
-          label={`Funding Source is ${HmisEnums.FundingSource[funder]}`}
-        />
+        <FormRuleChip label={`Funding Source is ${funder}`} />
       );
     }
   }
@@ -100,9 +87,7 @@ const FormRule: React.FC<Props> = ({ rule, formRole, actionButtons }) => {
         {isServiceForm ? (
           <>
             Collects{' '}
-            <FormRuleChip
-              label={serviceType?.name || serviceCategory?.name || 'Service'}
-            />{' '}
+            <FormRuleChip label={serviceType || serviceCategory || 'Service'} />{' '}
             for{' '}
           </>
         ) : (
@@ -110,13 +95,7 @@ const FormRule: React.FC<Props> = ({ rule, formRole, actionButtons }) => {
         )}
         {isClientForm && (
           <>
-            <FormRuleChip
-              label={
-                dataCollectedAbout
-                  ? HmisEnums.DataCollectedAbout[dataCollectedAbout]
-                  : HmisEnums.DataCollectedAbout.ALL_CLIENTS
-              }
-            />{' '}
+            <FormRuleChip label={dataCollectedAbout} />{' '}
           </>
         )}
         {conditionCount === 0 && (
@@ -143,4 +122,57 @@ const FormRule: React.FC<Props> = ({ rule, formRole, actionButtons }) => {
   );
 };
 
-export default FormRule;
+interface FormRuleProps {
+  rule: FormRuleFieldsFragment;
+  formRole?: FormRole;
+  actionButtons?: ReactNode;
+}
+export const FormRule: React.FC<FormRuleProps> = ({
+  rule,
+  formRole,
+  actionButtons,
+}) => {
+  return (
+    <BaseFormRule
+      project={rule.project?.projectName}
+      projectType={
+        rule.projectType ? HmisEnums.ProjectType[rule.projectType] : ''
+      }
+      organization={rule.organization?.organizationName}
+      dataCollectedAbout={
+        rule.dataCollectedAbout
+          ? HmisEnums.DataCollectedAbout[rule.dataCollectedAbout]
+          : HmisEnums.DataCollectedAbout.ALL_CLIENTS
+      }
+      funder={rule.funder ? HmisEnums.FundingSource[rule.funder] : ''}
+      otherFunder={rule.otherFunder}
+      serviceCategory={rule.serviceCategory?.name}
+      serviceType={rule.serviceType?.name}
+      formRole={formRole}
+      actionButtons={actionButtons}
+    />
+  );
+};
+
+interface ProjectConfigFormRuleProps {
+  rule: ProjectConfigFieldsFragment;
+  formRole?: FormRole;
+  actionButtons?: ReactNode;
+}
+export const ProjectConfigFormRule: React.FC<ProjectConfigFormRuleProps> = ({
+  rule,
+  formRole,
+  actionButtons,
+}) => {
+  return (
+    <BaseFormRule
+      project={rule.project?.projectName}
+      projectType={
+        rule.projectType ? HmisEnums.ProjectType[rule.projectType] : ''
+      }
+      organization={rule.organization?.organizationName}
+      formRole={formRole}
+      actionButtons={actionButtons}
+    />
+  );
+};

--- a/src/modules/admin/components/formRules/FormRule.tsx
+++ b/src/modules/admin/components/formRules/FormRule.tsx
@@ -2,9 +2,12 @@ import { Chip, Stack, Typography } from '@mui/material';
 import React, { ReactNode } from 'react';
 import { HmisEnums } from '@/types/gqlEnums';
 import {
+  DataCollectedAbout,
   FormRole,
   FormRuleFieldsFragment,
+  FundingSource,
   ProjectConfigFieldsFragment,
+  ProjectType,
 } from '@/types/gqlTypes';
 
 const FormRuleChip: React.FC<{ label: string }> = ({ label }) => {
@@ -26,27 +29,27 @@ const nonClientFormRoles = [
 const nonProjectFormRoles = [FormRole.Organization];
 
 interface BaseFormRuleProps {
-  projectType?: string;
-  project?: string;
-  organization?: string;
-  dataCollectedAbout?: string;
-  funder?: string;
-  otherFunder?: string | null;
-  serviceCategory?: string;
-  serviceType?: string;
+  projectType?: ProjectType;
+  projectName?: string;
+  organizationName?: string;
+  dataCollectedAbout?: DataCollectedAbout;
+  funder?: FundingSource;
+  otherFunder?: string;
+  serviceCategoryName?: string;
+  serviceTypeName?: string;
   formRole?: FormRole;
   actionButtons?: ReactNode;
 }
 
 export const BaseFormRule: React.FC<BaseFormRuleProps> = ({
   projectType,
-  project,
-  organization,
-  dataCollectedAbout = HmisEnums.DataCollectedAbout.ALL_CLIENTS,
+  projectName,
+  organizationName,
+  dataCollectedAbout = DataCollectedAbout.AllClients,
   funder,
   otherFunder,
-  serviceCategory,
-  serviceType,
+  serviceCategoryName,
+  serviceTypeName,
   formRole,
   actionButtons,
 }) => {
@@ -55,13 +58,15 @@ export const BaseFormRule: React.FC<BaseFormRuleProps> = ({
   if (!formRole || !nonProjectFormRoles.includes(formRole)) {
     if (projectType)
       conditions.projectType = (
-        <FormRuleChip label={`Project Type is ${projectType}`} />
+        <FormRuleChip
+          label={`Project Type is ${projectType ? HmisEnums.ProjectType[projectType] : ''}`}
+        />
       );
-    if (project)
-      conditions.project = <FormRuleChip label={`Project is ${project}`} />;
-    if (organization)
+    if (projectName)
+      conditions.project = <FormRuleChip label={`Project is ${projectName}`} />;
+    if (organizationName)
       conditions.organization = (
-        <FormRuleChip label={`Organization is ${organization}`} />
+        <FormRuleChip label={`Organization is ${organizationName}`} />
       );
     if (otherFunder) {
       conditions.otherFunder = (
@@ -69,13 +74,15 @@ export const BaseFormRule: React.FC<BaseFormRuleProps> = ({
       );
     } else if (funder) {
       conditions.funder = (
-        <FormRuleChip label={`Funding Source is ${funder}`} />
+        <FormRuleChip
+          label={`Funding Source is ${funder ? HmisEnums.FundingSource[funder] : ''}`}
+        />
       );
     }
   }
 
   const isServiceForm =
-    formRole === FormRole.Service && (serviceType || serviceCategory);
+    formRole === FormRole.Service && (serviceTypeName || serviceCategoryName);
 
   const isClientForm = formRole && !nonClientFormRoles.includes(formRole);
 
@@ -87,7 +94,9 @@ export const BaseFormRule: React.FC<BaseFormRuleProps> = ({
         {isServiceForm ? (
           <>
             Collects{' '}
-            <FormRuleChip label={serviceType || serviceCategory || 'Service'} />{' '}
+            <FormRuleChip
+              label={serviceTypeName || serviceCategoryName || 'Service'}
+            />{' '}
             for{' '}
           </>
         ) : (
@@ -95,7 +104,9 @@ export const BaseFormRule: React.FC<BaseFormRuleProps> = ({
         )}
         {isClientForm && (
           <>
-            <FormRuleChip label={dataCollectedAbout} />{' '}
+            <FormRuleChip
+              label={HmisEnums.DataCollectedAbout[dataCollectedAbout]}
+            />{' '}
           </>
         )}
         {conditionCount === 0 && (
@@ -134,20 +145,14 @@ export const FormRule: React.FC<FormRuleProps> = ({
 }) => {
   return (
     <BaseFormRule
-      project={rule.project?.projectName}
-      projectType={
-        rule.projectType ? HmisEnums.ProjectType[rule.projectType] : ''
-      }
-      organization={rule.organization?.organizationName}
-      dataCollectedAbout={
-        rule.dataCollectedAbout
-          ? HmisEnums.DataCollectedAbout[rule.dataCollectedAbout]
-          : HmisEnums.DataCollectedAbout.ALL_CLIENTS
-      }
-      funder={rule.funder ? HmisEnums.FundingSource[rule.funder] : ''}
-      otherFunder={rule.otherFunder}
-      serviceCategory={rule.serviceCategory?.name}
-      serviceType={rule.serviceType?.name}
+      projectName={rule.project?.projectName}
+      projectType={rule.projectType || undefined}
+      organizationName={rule.organization?.organizationName}
+      dataCollectedAbout={rule.dataCollectedAbout || undefined}
+      funder={rule.funder || undefined}
+      otherFunder={rule.otherFunder || undefined}
+      serviceCategoryName={rule.serviceCategory?.name}
+      serviceTypeName={rule.serviceType?.name}
       formRole={formRole}
       actionButtons={actionButtons}
     />
@@ -166,11 +171,9 @@ export const ProjectConfigFormRule: React.FC<ProjectConfigFormRuleProps> = ({
 }) => {
   return (
     <BaseFormRule
-      project={rule.project?.projectName}
-      projectType={
-        rule.projectType ? HmisEnums.ProjectType[rule.projectType] : ''
-      }
-      organization={rule.organization?.organizationName}
+      projectName={rule.project?.projectName}
+      projectType={rule.projectType || undefined}
+      organizationName={rule.organization?.organizationName}
       formRole={formRole}
       actionButtons={actionButtons}
     />

--- a/src/modules/admin/components/formRules/FormRuleCondition.tsx
+++ b/src/modules/admin/components/formRules/FormRuleCondition.tsx
@@ -1,0 +1,88 @@
+import { Grid, Typography } from '@mui/material';
+import { SxProps } from '@mui/system';
+import { startCase } from 'lodash-es';
+import React, { ReactNode } from 'react';
+import { useIsMobile } from '@/hooks/useIsMobile';
+import { ConditionType } from '@/modules/admin/components/formRules/NewFormRuleDialog';
+import FormSelect from '@/modules/form/components/FormSelect';
+import { isPickListOption } from '@/modules/form/types';
+import { PickListOption } from '@/types/gqlTypes';
+
+const FormRuleLabelTypography = ({
+  sx,
+  children,
+}: {
+  sx?: SxProps;
+  children: ReactNode;
+}) => (
+  <Typography variant='body2' sx={{ pt: 4.25, ...sx }}>
+    {children}
+  </Typography>
+);
+
+interface Props {
+  prefixText: string;
+  joiningText?: string;
+  index?: number;
+  conditionType: ConditionType;
+  conditionTypePickList: PickListOption[];
+  setConditionType: (conditionType: ConditionType) => void;
+  value: string | null;
+  valuePickList: PickListOption[];
+  setValue: (value: string) => void;
+}
+const FormRuleCondition: React.FC<Props> = ({
+  prefixText,
+  index,
+  conditionType,
+  conditionTypePickList,
+  setConditionType,
+  value,
+  valuePickList,
+  setValue,
+  joiningText = 'is',
+}) => {
+  const isTiny = useIsMobile('sm');
+  const conditionTypeLabel = startCase(conditionType.replace(/Id$/, ''));
+
+  return (
+    <Grid container spacing={1}>
+      <Grid item xs={2} sm={1}>
+        <FormRuleLabelTypography>{prefixText}</FormRuleLabelTypography>
+      </Grid>
+      <Grid item xs={9} sm={4}>
+        <FormSelect
+          label={index ? `Condition Type ${index}` : 'Condition Type'}
+          disableClearable
+          value={{ code: conditionType }}
+          options={conditionTypePickList}
+          onChange={(_, option) => {
+            if (isPickListOption(option)) {
+              setConditionType(option.code as ConditionType);
+            }
+          }}
+        />
+      </Grid>
+      <Grid item xs={2} sm={1}>
+        <FormRuleLabelTypography sx={isTiny ? {} : { textAlign: 'center' }}>
+          {joiningText}
+        </FormRuleLabelTypography>
+      </Grid>
+      <Grid item xs={10} sm={5}>
+        <FormSelect
+          label={conditionTypeLabel}
+          value={value ? { code: value } : null}
+          placeholder={`Select ${conditionTypeLabel}`}
+          options={valuePickList}
+          onChange={(_, option) => {
+            if (isPickListOption(option)) {
+              setValue(option.code);
+            }
+          }}
+        />
+      </Grid>
+    </Grid>
+  );
+};
+
+export default FormRuleCondition;

--- a/src/modules/admin/components/formRules/FormRuleCondition.tsx
+++ b/src/modules/admin/components/formRules/FormRuleCondition.tsx
@@ -30,6 +30,7 @@ interface Props {
   value: string | null;
   valuePickList: PickListOption[];
   setValue: (value: string) => void;
+  valueError?: boolean;
 }
 const FormRuleCondition: React.FC<Props> = ({
   prefixText,
@@ -41,6 +42,7 @@ const FormRuleCondition: React.FC<Props> = ({
   valuePickList,
   setValue,
   joiningText = 'is',
+  valueError = false,
 }) => {
   const isTiny = useIsMobile('sm');
   const conditionTypeLabel = startCase(conditionType.replace(/Id$/, ''));
@@ -70,6 +72,7 @@ const FormRuleCondition: React.FC<Props> = ({
       </Grid>
       <Grid item xs={10} sm={5}>
         <FormSelect
+          error={valueError}
           label={conditionTypeLabel}
           value={value ? { code: value } : null}
           placeholder={`Select ${conditionTypeLabel}`}

--- a/src/modules/admin/components/formRules/FormRuleCondition.tsx
+++ b/src/modules/admin/components/formRules/FormRuleCondition.tsx
@@ -15,7 +15,7 @@ const FormRuleLabelTypography = ({
   sx?: SxProps;
   children: ReactNode;
 }) => (
-  <Typography variant='body2' sx={{ pt: 4.25, ...sx }}>
+  <Typography variant='body2' sx={{ py: 1, fontWeight: 600, ...sx }}>
     {children}
   </Typography>
 );
@@ -46,7 +46,7 @@ const FormRuleCondition: React.FC<Props> = ({
   const conditionTypeLabel = startCase(conditionType.replace(/Id$/, ''));
 
   return (
-    <Grid container spacing={1}>
+    <Grid container spacing={1} sx={{ alignItems: 'flex-end' }}>
       <Grid item xs={2} sm={1}>
         <FormRuleLabelTypography>{prefixText}</FormRuleLabelTypography>
       </Grid>

--- a/src/modules/admin/components/formRules/FormRuleTable.tsx
+++ b/src/modules/admin/components/formRules/FormRuleTable.tsx
@@ -2,7 +2,7 @@ import DeleteIcon from '@mui/icons-material/Delete';
 import { IconButton, TableCell, TableRow } from '@mui/material';
 import React from 'react';
 import ButtonTooltipContainer from '@/components/elements/ButtonTooltipContainer';
-import FormRule from '@/modules/admin/components/formRules/FormRule';
+import { FormRule } from '@/modules/admin/components/formRules/FormRule';
 import GenericTableWithData from '@/modules/dataFetching/components/GenericTableWithData';
 import { cache } from '@/providers/apolloClient';
 import {
@@ -53,7 +53,7 @@ const FormRuleTable: React.FC<Props> = ({ formId, formRole, formCacheKey }) => {
         paginationItemName='rule'
         noSort
         defaultPageSize={100} // Forms aren't expected to have 100s of rules, pagination is unlikely to show up
-        renderRow={(rule) => (
+        renderRow={(rule: FormRuleFieldsFragment) => (
           <TableRow key={rule.id}>
             <TableCell sx={{ py: 1 }}>
               <FormRule

--- a/src/modules/admin/components/formRules/NewFormRuleDialog.tsx
+++ b/src/modules/admin/components/formRules/NewFormRuleDialog.tsx
@@ -92,7 +92,7 @@ const NewFormRuleDialog: React.FC<Props> = ({
       ({ conditionType, value }) => (conditions[conditionType] = value)
     );
 
-    const newRule: FormRuleInput = {
+    return {
       activeStatus: ActiveStatus.Active,
       dataCollectedAbout: dataCollectedAbout,
       projectId: conditions.projectId,
@@ -109,7 +109,6 @@ const NewFormRuleDialog: React.FC<Props> = ({
         ? { otherFunder: otherFundingSource }
         : {}),
     };
-    return newRule;
   }, [
     dataCollectedAbout,
     ruleConditions,

--- a/src/modules/admin/components/formRules/NewFormRuleDialog.tsx
+++ b/src/modules/admin/components/formRules/NewFormRuleDialog.tsx
@@ -1,4 +1,5 @@
 import {
+  Alert,
   Box,
   Card,
   DialogActions,
@@ -160,6 +161,22 @@ const NewFormRuleDialog: React.FC<Props> = ({
     },
   });
 
+  // This would be better handled with real form validation
+  const [validationError, setValidationError] = useState<string>();
+  const handleSubmit = () => {
+    let error: string | undefined = undefined;
+    if (formRole === FormRole.Service) {
+      if (!(rule.serviceCategoryId || rule.serviceTypeId)) {
+        error = 'One of either Service Category or Service Type is required';
+      }
+    }
+
+    setValidationError(error);
+    if (!error) {
+      createFormRule();
+    }
+  };
+
   const serviceConditionTypePickList = [
     { code: 'serviceTypeId', label: 'Service Type' },
     { code: 'serviceCategoryId', label: 'Service Category' },
@@ -283,6 +300,7 @@ const NewFormRuleDialog: React.FC<Props> = ({
               formRole={formRole}
             />
           </Card>
+          {validationError && <Alert severity='error'>{validationError}</Alert>}
           {formRole === FormRole.Service && (
             <Box
               sx={{
@@ -309,6 +327,11 @@ const NewFormRuleDialog: React.FC<Props> = ({
                   setServiceConditionValue(conditionValue)
                 }
                 valuePickList={pickListMap[serviceConditionType]}
+                valueError={
+                  !!validationError &&
+                  !rule.serviceCategoryId &&
+                  !rule.serviceTypeId
+                }
               />
             </Box>
           )}
@@ -442,7 +465,7 @@ const NewFormRuleDialog: React.FC<Props> = ({
       <DialogActions>
         <FormDialogActionContent
           submitButtonText='Create Rule'
-          onSubmit={() => createFormRule()}
+          onSubmit={handleSubmit}
           onDiscard={onCloseDialog}
           submitLoading={loading}
         />

--- a/src/modules/admin/components/formRules/NewFormRuleDialog.tsx
+++ b/src/modules/admin/components/formRules/NewFormRuleDialog.tsx
@@ -1,4 +1,5 @@
 import {
+  Box,
   Card,
   DialogActions,
   DialogContent,
@@ -22,7 +23,6 @@ import CardGroup, {
   RemovableCard,
 } from '@/modules/formBuilder/components/itemEditor/conditionals/CardGroup';
 import { cache } from '@/providers/apolloClient';
-import { HmisEnums } from '@/types/gqlEnums';
 import {
   ActiveStatus,
   DataCollectedAbout,
@@ -272,25 +272,26 @@ const NewFormRuleDialog: React.FC<Props> = ({
             sx={{ backgroundColor: theme.palette.background.default, p: 2 }}
           >
             <BaseFormRule
-              dataCollectedAbout={
-                rule.dataCollectedAbout
-                  ? HmisEnums.DataCollectedAbout[rule.dataCollectedAbout]
-                  : HmisEnums.DataCollectedAbout.ALL_CLIENTS
-              }
-              projectType={
-                rule.projectType ? HmisEnums.ProjectType[rule.projectType] : ''
-              }
-              funder={rule.funder ? HmisEnums.FundingSource[rule.funder] : ''}
-              otherFunder={rule.otherFunder || ''}
-              project={projectName || ''}
-              organization={organizationName || ''}
-              serviceType={serviceTypeName || ''}
-              serviceCategory={serviceCategoryName || ''}
+              dataCollectedAbout={rule.dataCollectedAbout || undefined}
+              projectType={rule.projectType || undefined}
+              funder={rule.funder || undefined}
+              otherFunder={rule.otherFunder || undefined}
+              projectName={projectName || undefined}
+              organizationName={organizationName || undefined}
+              serviceTypeName={serviceTypeName || undefined}
+              serviceCategoryName={serviceCategoryName || undefined}
               formRole={formRole}
             />
           </Card>
           {formRole === FormRole.Service && (
-            <>
+            <Box
+              sx={{
+                backgroundColor: theme.palette.grey[100],
+                borderRadius: 1,
+                py: 1,
+                px: 2,
+              }}
+            >
               <FormRuleCondition
                 prefixText='Collects'
                 joiningText={'of'}
@@ -309,7 +310,7 @@ const NewFormRuleDialog: React.FC<Props> = ({
                 }
                 valuePickList={pickListMap[serviceConditionType]}
               />
-            </>
+            </Box>
           )}
           <FormSelect
             label={

--- a/src/modules/admin/components/projectConfig/ProjectConfigTable.tsx
+++ b/src/modules/admin/components/projectConfig/ProjectConfigTable.tsx
@@ -2,7 +2,7 @@ import { Box } from '@mui/material';
 
 import { Stack } from '@mui/system';
 import { capitalize } from 'lodash-es';
-import FormRule from '../formRules/FormRule';
+import { ProjectConfigFormRule } from '../formRules/FormRule';
 import NotCollectedText from '@/components/elements/NotCollectedText';
 import { ColumnDef } from '@/components/elements/table/types';
 import DeleteMutationButton from '@/modules/dataFetching/components/DeleteMutationButton';
@@ -30,7 +30,7 @@ const columns: ColumnDef<ProjectConfigFieldsFragment>[] = [
   },
   {
     header: 'Applicability Rule',
-    render: (config) => <FormRule rule={config} />,
+    render: (config) => <ProjectConfigFormRule rule={config} />,
   },
   {
     header: 'Options',


### PR DESCRIPTION
## Description

GH issue: https://github.com/open-path/Green-River/issues/6474

This PR
- Modifies the `FormRule` component so it exposes a couple of distinct interfaces for different contexts where it might be used.
- Extracts a new `FormRuleCondition` component, basically comprising 2 dropdowns for Condition Type (e.g. project, organization) and Condition Value (e.g. project ID, organization ID). This component is now used by both regular conditions and service-related conditions. I added labels to both dropdowns to improve accessibility
- Modifies the `NewFormRuleDialog` to store the form state separately and then use an effect to update the form rule. It also now reflects the current state of the form rule so the user can hopefully better understand the changes they are making.

~I'm stuck on a typescript bug which is marked with a todo.~ Otherwise, I'd be very grateful for feedback about both the implementation and changes to design, please do let me know what you think.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [x] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
