### PR TITLE
Validate that either pick list options or reference exists

### DIFF
--- a/src/modules/formBuilder/components/itemEditor/pickLists/ManagePickListOptions.tsx
+++ b/src/modules/formBuilder/components/itemEditor/pickLists/ManagePickListOptions.tsx
@@ -90,6 +90,11 @@ const ManagePickListOptions: React.FC<ManagePickListOptionsProps> = ({
     [fieldsWatch]
   );
 
+  const eitherOptionsOrReferenceProvided = useMemo(
+    () => !!pickListReference || (fieldsWatch && fieldsWatch.length > 0),
+    [pickListReference, fieldsWatch]
+  );
+
   if (!formItemComponent) return;
 
   return (
@@ -123,6 +128,11 @@ const ManagePickListOptions: React.FC<ManagePickListOptionsProps> = ({
         label='Or, use a reference list for choices'
         placeholder='Select list'
         options={supportedPickListReferencesOptions}
+        rules={{
+          validate: () =>
+            eitherOptionsOrReferenceProvided ||
+            'Required: Either choose a reference list or Add Choice above',
+        }}
       />
     </>
   );


### PR DESCRIPTION
## Description
GH issue: https://github.com/open-path/Green-River/issues/6405

How to test:
- Make a custom form with a choice element that doesn't have any options or a link to a pick list reference
- Try to hit save, you should see a (more) user-friendly error

A few things that are not ideal about this solution
- it doesn't clear out the error after the error condition is no longer true, only on save
- it only selects the dropdown as having an error state, not the 'add condition' button, since 'add condition' is not an RHF controlled component
- on error, it auto-focuses the dropdown of pick list references, which in turn opens the dropdown and covers the actual error message that we want to show

but, given our conversations in the estimation session yesterday, I didn't want to spend a ton more time on it. (Edit: spent about 1 hour troubleshooting the above so far and could not come up with an improvement.) Maybe this is clear enough?  Or @gigxz maybe you can easily see a way to improve this that escaped me?

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
