### PR TITLE
Fix bug when MCI clearance auto-clears a duplicate record

### DIFF
--- a/src/modules/external/mci/components/MciClearance.tsx
+++ b/src/modules/external/mci/components/MciClearance.tsx
@@ -239,7 +239,7 @@ const MciClearance = ({
           // Allow them to link to a duplicate MCI ID only if this client has already been saved.
           // That could happen if client was first created as Uncleared, and now they are clearing
           // and realizing that they should get the same MCI ID as an existing Client record.
-          allowSelectingExistingClient={true}
+          allowSelectingExistingClient={existingClient}
         />
       )}
     </>

--- a/src/modules/external/mci/components/MciMatchSelector.tsx
+++ b/src/modules/external/mci/components/MciMatchSelector.tsx
@@ -125,7 +125,6 @@ const MciMatchSelector = ({
   status: ClearanceStatus;
   allowSelectingExistingClient?: boolean;
 }) => {
-  console.log(status);
   const autocleared =
     status === 'auto_cleared' || status === 'auto_cleared_existing_client';
 

--- a/src/modules/external/mci/components/MciMatchSelector.tsx
+++ b/src/modules/external/mci/components/MciMatchSelector.tsx
@@ -155,7 +155,7 @@ const MciMatchSelector = ({
             title={status === 'auto_cleared' ? 'Client auto-cleared' : null}
           >
             <Switch
-              inputProps={{ 'aria-label': 'controlled' }}
+              inputProps={{ 'aria-label': `MCI ID ${m.mciId}` }}
               checked={value === m.mciId}
               onChange={handleChange(m.mciId)}
               disabled={status === 'auto_cleared'}
@@ -205,7 +205,7 @@ const MciMatchSelector = ({
               <TableRow>
                 <TableCell>
                   <Switch
-                    inputProps={{ 'aria-label': 'controlled' }}
+                    inputProps={{ 'aria-label': 'New MCI ID' }}
                     checked={value === NEW_MCI_STRING}
                     onChange={handleChange(NEW_MCI_STRING)}
                     disabled={value === NEW_MCI_STRING && matches.length === 0}

--- a/src/modules/external/mci/components/MciMatchSelector.tsx
+++ b/src/modules/external/mci/components/MciMatchSelector.tsx
@@ -155,7 +155,10 @@ const MciMatchSelector = ({
             title={status === 'auto_cleared' ? 'Client auto-cleared' : null}
           >
             <Switch
-              inputProps={{ 'aria-label': `MCI ID ${m.mciId}` }}
+              inputProps={{
+                'aria-label': `MCI ID ${m.mciId}`,
+                id: `select_mci_${m.mciId}`, // used in capybara tests
+              }}
               checked={value === m.mciId}
               onChange={handleChange(m.mciId)}
               disabled={status === 'auto_cleared'}
@@ -205,7 +208,10 @@ const MciMatchSelector = ({
               <TableRow>
                 <TableCell>
                   <Switch
-                    inputProps={{ 'aria-label': 'New MCI ID' }}
+                    inputProps={{
+                      'aria-label': 'New MCI ID',
+                      id: `select_create_new_mci`, // used in capybara tests
+                    }}
                     checked={value === NEW_MCI_STRING}
                     onChange={handleChange(NEW_MCI_STRING)}
                     disabled={value === NEW_MCI_STRING && matches.length === 0}

--- a/src/modules/external/mci/components/MciMatchSelector.tsx
+++ b/src/modules/external/mci/components/MciMatchSelector.tsx
@@ -1,4 +1,5 @@
 import {
+  Alert,
   Box,
   lighten,
   Stack,
@@ -10,6 +11,7 @@ import {
 import pluralize from 'pluralize';
 import { ReactNode, useMemo } from 'react';
 
+import { ClearanceStatus } from '../types';
 import { NEW_MCI_STRING } from '../util';
 
 import { MciClearanceProps } from './types';
@@ -63,14 +65,18 @@ const MciScoreInfo = ({ match }: { match: MciMatchFieldsFragment }) => {
         {match.mciId}
       </Typography>
       {match.existingClientId && (
-        <RouterLink
-          to={generateSafePath(Routes.CLIENT_DASHBOARD, {
-            clientId: match.existingClientId,
-          })}
-          openInNew
-        >
-          <Typography variant='inherit'>Already in HMIS</Typography>
-        </RouterLink>
+        <Alert severity='warning' sx={{ py: 1, my: 1, maxWidth: 500 }}>
+          Client already exists in HMIS. If this is a match, please cancel and
+          use the{' '}
+          <RouterLink
+            to={generateSafePath(Routes.CLIENT_DASHBOARD, {
+              clientId: match.existingClientId,
+            })}
+            openInNew
+          >
+            <Typography variant='inherit'>existing client record</Typography>
+          </RouterLink>
+        </Alert>
       )}
     </Stack>
   );
@@ -112,13 +118,17 @@ const MciMatchSelector = ({
   value,
   onChange,
   matches,
-  autocleared = false,
+  status,
   allowSelectingExistingClient = false,
 }: Pick<MciClearanceProps, 'value' | 'onChange'> & {
   matches: MciMatchFieldsFragment[];
-  autocleared?: boolean;
+  status: ClearanceStatus;
   allowSelectingExistingClient?: boolean;
 }) => {
+  console.log(status);
+  const autocleared =
+    status === 'auto_cleared' || status === 'auto_cleared_existing_client';
+
   const handleChange =
     (id: string) => (event: React.ChangeEvent<HTMLInputElement>) => {
       if (event.target.checked) {
@@ -133,23 +143,22 @@ const MciMatchSelector = ({
       key: 'toggle',
       width: '10%',
       render: (m) => {
-        const alreadyInHmis =
-          !!m.existingClientId && !allowSelectingExistingClient;
+        if (m.existingClientId && !allowSelectingExistingClient) {
+          return (
+            <Typography color='text.secondary' variant='body2'>
+              Client {m.existingClientId}
+            </Typography>
+          );
+        }
         return (
           <ButtonTooltipContainer
-            title={
-              alreadyInHmis
-                ? 'Client is already in HMIS. Click the link to go to their client record.'
-                : autocleared
-                  ? 'Client auto-cleared'
-                  : null
-            }
+            title={status === 'auto_cleared' ? 'Client auto-cleared' : null}
           >
             <Switch
               inputProps={{ 'aria-label': 'controlled' }}
               checked={value === m.mciId}
               onChange={handleChange(m.mciId)}
-              disabled={autocleared || alreadyInHmis}
+              disabled={status === 'auto_cleared'}
             />
           </ButtonTooltipContainer>
         );

--- a/src/modules/external/mci/components/alerts.tsx
+++ b/src/modules/external/mci/components/alerts.tsx
@@ -6,7 +6,9 @@ import { ClearanceState } from '../types';
 import ExternalIdDisplay from '@/components/elements/ExternalIdDisplay';
 import { ExternalIdentifier } from '@/types/gqlTypes';
 
-export const getClearanceAlertText = (state: ClearanceState) => {
+export const getClearanceAlertText = (
+  state: ClearanceState & { existingClient: boolean }
+) => {
   switch (state.status) {
     case 'initial':
       return {
@@ -25,6 +27,13 @@ export const getClearanceAlertText = (state: ClearanceState) => {
       return {
         title: 'MCI ID Found',
         subtitle: 'An exact match was found.',
+        rightAlignButton: true,
+      };
+    case 'auto_cleared_existing_client':
+      return {
+        title: 'MCI ID Found',
+        // If this is a duplicate but we're editing an existing Client record, skip the message about "cancel and search again", since it doesn't make sense. In this case, the user can create the duplicate MCI ID but the clients should be merged eventually.
+        subtitle: `This client already exists in HMIS. ${state.existingClient ? null : 'Please cancel and search again.'}`,
         rightAlignButton: true,
       };
     case 'one_match':

--- a/src/modules/external/mci/types.ts
+++ b/src/modules/external/mci/types.ts
@@ -5,7 +5,8 @@ export type ClearanceStatus =
   | 'no_matches' // no matches, click to search again, click to
   | 'one_match' // 1 match, click to search again, choose a match
   | 'several_matches' // x matches, click to search again, choose a match
-  | 'auto_cleared'; // auto-cleared
+  | 'auto_cleared' // auto-cleared
+  | 'auto_cleared_existing_client'; // auto-cleared matching a client that already exists in HMIS
 
 export type ClearanceState = {
   status: ClearanceStatus;


### PR DESCRIPTION
## Description

https://github.com/open-path/Green-River/issues/6511

This can't really be tested locally without stubbing out the `Mci` class, which is what I did during local development. Test cases are covered by the system test though: https://github.com/greenriver/hmis-warehouse/pull/4630

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
