### PR TITLE
Fix misc Form Builder bugs

### DIFF
--- a/src/modules/form/components/rhf/ControlledSelect.tsx
+++ b/src/modules/form/components/rhf/ControlledSelect.tsx
@@ -21,7 +21,6 @@ export type ControlledSelectProps = Omit<
   helperText?: ReactNode;
   placeholder?: string;
   onChange?: (option: PickListOption | null) => void;
-  shouldUnregister?: boolean;
   setValueAs?: (option: PickListOption | null) => any; // allow transform PickListOption to desired value (to support boolean)
 };
 
@@ -38,7 +37,6 @@ const ControlledSelect: React.FC<ControlledSelectProps> = ({
   helperText,
   onChange,
   setValueAs,
-  shouldUnregister = true,
   ...props
 }) => {
   const {
@@ -47,7 +45,7 @@ const ControlledSelect: React.FC<ControlledSelectProps> = ({
   } = useController({
     name,
     control,
-    shouldUnregister: shouldUnregister,
+    shouldUnregister: true,
     rules: {
       required: required ? 'This field is required' : false,
       ...rules,
@@ -90,7 +88,7 @@ const ControlledSelect: React.FC<ControlledSelectProps> = ({
         helperText: error?.message || helperText,
         error: !!error,
         inputRef: field.ref, // send input ref, so we can focus on input when error appear
-        // required,  // Instead of passing `required` to the input, rely on RHF's required rule, which uses nicer formatting
+        required,
         placeholder,
         ...props.textInputProps, // allow overriding any of the above
       }}

--- a/src/modules/form/components/rhf/ControlledSelect.tsx
+++ b/src/modules/form/components/rhf/ControlledSelect.tsx
@@ -88,7 +88,7 @@ const ControlledSelect: React.FC<ControlledSelectProps> = ({
         helperText: error?.message || helperText,
         error: !!error,
         inputRef: field.ref, // send input ref, so we can focus on input when error appear
-        required,
+        // required, // Instead of passing `required` to the input, rely on RHF's required rule, which uses nicer formatting
         placeholder,
         ...props.textInputProps, // allow overriding any of the above
       }}

--- a/src/modules/form/components/rhf/ControlledSelect.tsx
+++ b/src/modules/form/components/rhf/ControlledSelect.tsx
@@ -21,6 +21,7 @@ export type ControlledSelectProps = Omit<
   helperText?: ReactNode;
   placeholder?: string;
   onChange?: (option: PickListOption | null) => void;
+  shouldUnregister?: boolean;
   setValueAs?: (option: PickListOption | null) => any; // allow transform PickListOption to desired value (to support boolean)
 };
 
@@ -37,6 +38,7 @@ const ControlledSelect: React.FC<ControlledSelectProps> = ({
   helperText,
   onChange,
   setValueAs,
+  shouldUnregister = true,
   ...props
 }) => {
   const {
@@ -45,7 +47,7 @@ const ControlledSelect: React.FC<ControlledSelectProps> = ({
   } = useController({
     name,
     control,
-    shouldUnregister: true,
+    shouldUnregister: shouldUnregister,
     rules: {
       required: required ? 'This field is required' : false,
       ...rules,
@@ -88,7 +90,7 @@ const ControlledSelect: React.FC<ControlledSelectProps> = ({
         helperText: error?.message || helperText,
         error: !!error,
         inputRef: field.ref, // send input ref, so we can focus on input when error appear
-        required,
+        // required,  // Instead of passing `required` to the input, rely on RHF's required rule, which uses nicer formatting
         placeholder,
         ...props.textInputProps, // allow overriding any of the above
       }}

--- a/src/modules/form/components/rhf/ControlledTextInput.tsx
+++ b/src/modules/form/components/rhf/ControlledTextInput.tsx
@@ -19,7 +19,6 @@ const ControlledTextInput: React.FC<ControlledTextInputProps> = ({
   control,
   onBlur,
   rules,
-  required,
   ...props
 }) => {
   const {
@@ -30,7 +29,7 @@ const ControlledTextInput: React.FC<ControlledTextInputProps> = ({
     control,
     shouldUnregister: true,
     rules: {
-      required: required ? 'This field is required' : false,
+      required: props.required ? 'This field is required' : false,
       ...rules,
     },
   });

--- a/src/modules/form/components/rhf/ControlledTextInput.tsx
+++ b/src/modules/form/components/rhf/ControlledTextInput.tsx
@@ -19,6 +19,7 @@ const ControlledTextInput: React.FC<ControlledTextInputProps> = ({
   control,
   onBlur,
   rules,
+  required,
   ...props
 }) => {
   const {
@@ -29,7 +30,7 @@ const ControlledTextInput: React.FC<ControlledTextInputProps> = ({
     control,
     shouldUnregister: true,
     rules: {
-      required: props.required ? 'This field is required' : false,
+      required: required ? 'This field is required' : false,
       ...rules,
     },
   });

--- a/src/modules/formBuilder/components/itemEditor/RequiredOptionalRadio.tsx
+++ b/src/modules/formBuilder/components/itemEditor/RequiredOptionalRadio.tsx
@@ -49,26 +49,27 @@ const RequiredOptionalRadio: React.FC<Props> = ({ control, setValue }) => {
   const handleChange = useCallback(
     (option?: PickListOption | null) => {
       if (!option) return;
+      if (option.code === radioValue) return;
 
       if (option.code === 'required') {
-        setValue('required', true);
-        setValue('warnIfEmpty', false);
-        setValue('readOnly', false);
+        setValue('required', true, { shouldDirty: true });
+        setValue('warnIfEmpty', false, { shouldDirty: true });
+        setValue('readOnly', false, { shouldDirty: true });
       } else if (option.code === 'warnIfEmpty') {
-        setValue('required', false);
-        setValue('warnIfEmpty', true);
-        setValue('readOnly', false);
+        setValue('required', false, { shouldDirty: true });
+        setValue('warnIfEmpty', true, { shouldDirty: true });
+        setValue('readOnly', false, { shouldDirty: true });
       } else if (option.code === 'readOnly') {
-        setValue('required', false);
-        setValue('warnIfEmpty', false);
-        setValue('readOnly', true);
+        setValue('required', false, { shouldDirty: true });
+        setValue('warnIfEmpty', false, { shouldDirty: true });
+        setValue('readOnly', true, { shouldDirty: true });
       } else if (option.code === 'optional') {
-        setValue('required', false);
-        setValue('warnIfEmpty', false);
-        setValue('readOnly', false);
+        setValue('required', false, { shouldDirty: true });
+        setValue('warnIfEmpty', false, { shouldDirty: true });
+        setValue('readOnly', false, { shouldDirty: true });
       }
     },
-    [setValue]
+    [setValue, radioValue]
   );
 
   return (

--- a/src/modules/formBuilder/components/itemEditor/RequiredOptionalRadio.tsx
+++ b/src/modules/formBuilder/components/itemEditor/RequiredOptionalRadio.tsx
@@ -51,6 +51,7 @@ const RequiredOptionalRadio: React.FC<Props> = ({ control, setValue }) => {
       if (!option) return;
       if (option.code === radioValue) return;
 
+      // setValue doesn't dirty the form by default because it's not usually called in response to user input
       if (option.code === 'required') {
         setValue('required', true, { shouldDirty: true });
         setValue('warnIfEmpty', false, { shouldDirty: true });

--- a/src/modules/formBuilder/components/itemEditor/conditionals/AutofillValueCard.tsx
+++ b/src/modules/formBuilder/components/itemEditor/conditionals/AutofillValueCard.tsx
@@ -59,6 +59,7 @@ const AutofillValueCard: React.FC<AutofillValueCardProps> = ({
                 name={`autofillValues.${index}.valueCode`}
                 label='Value'
                 control={control}
+                required
               />
             )}
             {fieldType === 'valueBoolean' && (
@@ -66,6 +67,7 @@ const AutofillValueCard: React.FC<AutofillValueCardProps> = ({
                 name={`autofillValues.${index}.valueBoolean`}
                 control={control}
                 shouldUnregister
+                rules={{ required: 'This field is required' }}
                 render={({
                   field: { ref, disabled, ...field },
                   fieldState: { error },
@@ -85,6 +87,7 @@ const AutofillValueCard: React.FC<AutofillValueCardProps> = ({
                 name={`autofillValues.${index}.valueNumber`}
                 control={control}
                 shouldUnregister
+                rules={{ required: 'This field is required' }}
                 render={({
                   field: { ref, disabled, ...field },
                   fieldState: { error },
@@ -110,6 +113,7 @@ const AutofillValueCard: React.FC<AutofillValueCardProps> = ({
             // TODO: validate formula
             label='Formula'
             helperText="Formula to calculate the value to fill. Use 'value' to refer to the value of the current item."
+            required
           />
         )}
 

--- a/src/modules/formBuilder/components/itemEditor/conditionals/EnableWhenCondition.tsx
+++ b/src/modules/formBuilder/components/itemEditor/conditionals/EnableWhenCondition.tsx
@@ -229,7 +229,13 @@ const EnableWhenCondition: React.FC<EnableWhenConditionProps> = ({
                   return null;
                 }}
                 rules={{
-                  required: 'This field is required',
+                  validate: (value) => {
+                    if (value === null) {
+                      // Requires custom validation to accommodate the valid value `false`
+                      return 'This field is required';
+                    }
+                    return true;
+                  },
                 }}
               />
             )}

--- a/src/modules/formBuilder/components/itemEditor/conditionals/EnableWhenCondition.tsx
+++ b/src/modules/formBuilder/components/itemEditor/conditionals/EnableWhenCondition.tsx
@@ -1,6 +1,6 @@
 import { Box, Grid, Stack, Typography } from '@mui/material';
 import { startCase } from 'lodash-es';
-import { useCallback, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { UseFormSetValue, useWatch } from 'react-hook-form';
 import { FormItemControl, FormItemState } from '../types';
 import { useLocalConstantsPickList } from '../useLocalConstantsPickList';
@@ -163,22 +163,6 @@ const EnableWhenCondition: React.FC<EnableWhenConditionProps> = ({
 
   const localConstantsPickList = useLocalConstantsPickList();
 
-  const clearAnswer = useCallback(() => {
-    setValue(`${enableWhenPath}.${index}.answerCode`, null);
-    setValue(`${enableWhenPath}.${index}.answerCodes`, null);
-    setValue(`${enableWhenPath}.${index}.answerBoolean`, null);
-    setValue(`${enableWhenPath}.${index}.answerNumber`, null);
-    setValue(`${enableWhenPath}.${index}.answerGroupCode`, null);
-  }, [setValue, enableWhenPath, index]);
-
-  const onChangeDependentQuestion = useCallback(() => {
-    // todo @Martha - fix typescript's unhappiness
-    // - by making this not a ControlledSelect after all, so that we can have more granular control?
-    // - by changing the schema so that null is acceptable here?
-    setValue(`${enableWhenPath}.${index}.operator`, null);
-    clearAnswer();
-  }, [setValue, enableWhenPath, index, clearAnswer]);
-
   return (
     <Stack>
       <Grid container gap={2}>
@@ -189,26 +173,32 @@ const EnableWhenCondition: React.FC<EnableWhenConditionProps> = ({
               <ControlledSelect
                 name={`${enableWhenPath}.${index}.question`}
                 control={control}
-                shouldUnregister={false}
                 label='Dependent Question'
                 placeholder='Select question'
                 options={itemPickList}
                 helperText='Question whose response will determine whether the condition is met'
-                onChange={onChangeDependentQuestion}
-                required
+                rules={{
+                  required: 'Local Constant or Dependent Question is required',
+                }}
+                onChange={() =>
+                  setValue(`${enableWhenPath}.${index}.operator`, undefined)
+                }
               />
             )}
             {advanced.localConstant && (
               <ControlledSelect
                 name={`${enableWhenPath}.${index}.localConstant`}
                 control={control}
-                shouldUnregister={false}
                 label='Local Constant'
                 placeholder='Select local constant'
+                rules={{
+                  required: 'Local Constant or Dependent Question is required',
+                }}
                 options={localConstantsPickList}
                 helperText='Local constant whose value will determine whether the condition is met'
-                onChange={onChangeDependentQuestion}
-                required
+                onChange={() =>
+                  setValue(`${enableWhenPath}.${index}.operator`, undefined)
+                }
               />
             )}
           </Stack>
@@ -218,11 +208,9 @@ const EnableWhenCondition: React.FC<EnableWhenConditionProps> = ({
           <ControlledSelect
             name={`${enableWhenPath}.${index}.operator`}
             control={control}
-            shouldUnregister={false}
             label='Operator'
             placeholder='Select operator'
             options={enableOperatorPickList}
-            onChange={clearAnswer}
             required
           />
         </Grid>
@@ -233,7 +221,6 @@ const EnableWhenCondition: React.FC<EnableWhenConditionProps> = ({
               <ControlledSelect
                 name={`${enableWhenPath}.${index}.answerBoolean`}
                 control={control}
-                shouldUnregister={false}
                 label='Value'
                 options={[TRUE_OPT, FALSE_OPT]}
                 setValueAs={(option) => {

--- a/src/modules/formBuilder/components/itemEditor/conditionals/EnableWhenCondition.tsx
+++ b/src/modules/formBuilder/components/itemEditor/conditionals/EnableWhenCondition.tsx
@@ -269,13 +269,18 @@ const EnableWhenCondition: React.FC<EnableWhenConditionProps> = ({
               <Controller
                 name={`${enableWhenPath}.${index}.answerDate`}
                 control={control}
-                render={({ field: { ref, ...field } }) => (
+                rules={{ required: 'This field is required' }}
+                render={({
+                  field: { ref, ...field },
+                  fieldState: { error },
+                }) => (
                   <DatePicker
                     value={parseHmisDateString(field.value)}
                     onChange={(date) =>
                       field.onChange(date ? formatDateForGql(date) : '')
                     }
                     label={`Response Value (Date)`}
+                    error={!!error}
                   />
                 )}
               />

--- a/src/modules/formBuilder/components/itemEditor/conditionals/EnableWhenCondition.tsx
+++ b/src/modules/formBuilder/components/itemEditor/conditionals/EnableWhenCondition.tsx
@@ -1,6 +1,6 @@
 import { Box, Grid, Stack, Typography } from '@mui/material';
 import { startCase } from 'lodash-es';
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { UseFormSetValue, useWatch } from 'react-hook-form';
 import { FormItemControl, FormItemState } from '../types';
 import { useLocalConstantsPickList } from '../useLocalConstantsPickList';
@@ -163,6 +163,22 @@ const EnableWhenCondition: React.FC<EnableWhenConditionProps> = ({
 
   const localConstantsPickList = useLocalConstantsPickList();
 
+  const clearAnswer = useCallback(() => {
+    setValue(`${enableWhenPath}.${index}.answerCode`, null);
+    setValue(`${enableWhenPath}.${index}.answerCodes`, null);
+    setValue(`${enableWhenPath}.${index}.answerBoolean`, null);
+    setValue(`${enableWhenPath}.${index}.answerNumber`, null);
+    setValue(`${enableWhenPath}.${index}.answerGroupCode`, null);
+  }, [setValue, enableWhenPath, index]);
+
+  const onChangeDependentQuestion = useCallback(() => {
+    // todo @Martha - fix typescript's unhappiness
+    // - by making this not a ControlledSelect after all, so that we can have more granular control?
+    // - by changing the schema so that null is acceptable here?
+    setValue(`${enableWhenPath}.${index}.operator`, null);
+    clearAnswer();
+  }, [setValue, enableWhenPath, index, clearAnswer]);
+
   return (
     <Stack>
       <Grid container gap={2}>
@@ -173,32 +189,26 @@ const EnableWhenCondition: React.FC<EnableWhenConditionProps> = ({
               <ControlledSelect
                 name={`${enableWhenPath}.${index}.question`}
                 control={control}
+                shouldUnregister={false}
                 label='Dependent Question'
                 placeholder='Select question'
                 options={itemPickList}
                 helperText='Question whose response will determine whether the condition is met'
-                rules={{
-                  required: 'Local Constant or Dependent Question is required',
-                }}
-                onChange={() =>
-                  setValue(`${enableWhenPath}.${index}.operator`, undefined)
-                }
+                onChange={onChangeDependentQuestion}
+                required
               />
             )}
             {advanced.localConstant && (
               <ControlledSelect
                 name={`${enableWhenPath}.${index}.localConstant`}
                 control={control}
+                shouldUnregister={false}
                 label='Local Constant'
                 placeholder='Select local constant'
-                rules={{
-                  required: 'Local Constant or Dependent Question is required',
-                }}
                 options={localConstantsPickList}
                 helperText='Local constant whose value will determine whether the condition is met'
-                onChange={() =>
-                  setValue(`${enableWhenPath}.${index}.operator`, undefined)
-                }
+                onChange={onChangeDependentQuestion}
+                required
               />
             )}
           </Stack>
@@ -208,9 +218,11 @@ const EnableWhenCondition: React.FC<EnableWhenConditionProps> = ({
           <ControlledSelect
             name={`${enableWhenPath}.${index}.operator`}
             control={control}
+            shouldUnregister={false}
             label='Operator'
             placeholder='Select operator'
             options={enableOperatorPickList}
+            onChange={clearAnswer}
             required
           />
         </Grid>
@@ -221,6 +233,7 @@ const EnableWhenCondition: React.FC<EnableWhenConditionProps> = ({
               <ControlledSelect
                 name={`${enableWhenPath}.${index}.answerBoolean`}
                 control={control}
+                shouldUnregister={false}
                 label='Value'
                 options={[TRUE_OPT, FALSE_OPT]}
                 setValueAs={(option) => {


### PR DESCRIPTION
## Description

GH issue: https://github.com/open-path/Green-River/issues/6512

This PR fixes a couple of straightforward bugs ~and shows some thoughts around the more complicated bug having to do with `ControlledSelect`, default values, and unregistering.~ Edit: See https://github.com/greenriver/hmis-frontend/pull/906 for this one

Simple bugfixes:
- The required/optional radio previously didn't set the form to dirty, so you couldn't save changes to that field unless you also made changes to another field. This is fixed with passing the `shouldDirty` option to `setValue`
- The boolean `ControlledSelect` requires custom validation, otherwise it is considered invalid when the value is set to `false`, which is actually a valid value.

~I'll add a comment thread inline to discuss the other bug 🧵 🐞 ~

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
