### PR TITLE
Prevent submitting new draft assessments

### DIFF
--- a/src/modules/assessments/components/NewIndividualAssessmentPage.tsx
+++ b/src/modules/assessments/components/NewIndividualAssessmentPage.tsx
@@ -7,6 +7,7 @@ import IndividualAssessmentFormController from '@/modules/assessments/components
 import MissingDefinitionAlert from '@/modules/assessments/components/MissingDefinitionAlert';
 import useAssessmentFormDefinition from '@/modules/assessments/hooks/useAssessmentFormDefinition';
 import { EnrollmentDashboardRoutes } from '@/routes/routes';
+import { FormStatus } from '@/types/gqlTypes';
 
 /**
  * Renders a blank assessment for an individual.
@@ -37,6 +38,8 @@ const NewIndividualAssessmentPage = () => {
   if (!enrollment) return <NotFound />;
   if (loading && !formDefinition) return <Loading />;
   if (!formDefinition) return <MissingDefinitionAlert />;
+  if ([FormStatus.Draft, FormStatus.Retired].includes(formDefinition.status))
+    return <NotFound />;
 
   return (
     <IndividualAssessmentFormController

--- a/src/modules/assessments/components/NewIndividualAssessmentPage.tsx
+++ b/src/modules/assessments/components/NewIndividualAssessmentPage.tsx
@@ -38,7 +38,9 @@ const NewIndividualAssessmentPage = () => {
   if (!enrollment) return <NotFound />;
   if (loading && !formDefinition) return <Loading />;
   if (!formDefinition) return <MissingDefinitionAlert />;
-  if ([FormStatus.Draft, FormStatus.Retired].includes(formDefinition.status))
+  if (
+    ![FormStatus.Published, FormStatus.Retired].includes(formDefinition.status)
+  )
     return <NotFound />;
 
   return (


### PR DESCRIPTION
## Description

GH issue: https://github.com/open-path/Green-River/issues/6520
Relates to, but doesn't depend on: https://github.com/greenriver/hmis-warehouse/pull/4631

This PR prevents access to the "New Assessment" page if the form definition ID passed is a draft form.

To test,
- Find an assessment that has a draft version, and get its ID
- Go to fill out that assessment for the client
- In the url bar, replace the ID of the published form with the ID of the draft
- Load the page. "Not found" should appear.
- Also, check that submitting a retired form still works (this is because forms that are saved but not submitted before the new version is published can still be submitted under the old version).

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
