### PR TITLE
Fix bug on submitting upgraded assessments

### DIFF
--- a/src/api/operations/assessment.fragments.graphql
+++ b/src/api/operations/assessment.fragments.graphql
@@ -82,12 +82,4 @@ fragment AssessmentWithValues on Assessment {
 fragment FullAssessment on Assessment {
   ...AssessmentWithRecords
   ...AssessmentWithValues
-  # Definition to use for viewing/editing the assessment
-  definition {
-    ...FormDefinitionFields
-  }
-  # Definition to use for editing. Only present if the previous definition is retired.
-  upgradedDefinitionForEditing {
-    ...FormDefinitionFields
-  }
 }

--- a/src/api/operations/assessment.queries.graphql
+++ b/src/api/operations/assessment.queries.graphql
@@ -1,6 +1,14 @@
 query GetAssessment($id: ID!) {
   assessment(id: $id) {
     ...FullAssessment
+    # Definition to use for viewing/editing the assessment
+    definition {
+      ...FormDefinitionFields
+    }
+    # Definition to use for editing. Only present if the previous definition is retired.
+    upgradedDefinitionForEditing {
+      ...FormDefinitionFields
+    }
   }
 }
 

--- a/src/modules/admin/components/denials/AdminReferralPostingForm.tsx
+++ b/src/modules/admin/components/denials/AdminReferralPostingForm.tsx
@@ -45,11 +45,11 @@ const AdminReferralPostingForm: React.FC<Props> = ({
     onError: (apolloError) => setErrors({ ...emptyErrorState, apolloError }),
   });
   const handleSubmit: DynamicFormOnSubmit = useCallback(
-    ({ values }) => {
+    ({ rawValues }) => {
       setErrors(emptyErrorState);
       const input = transformSubmitValues({
         definition: formDefinition,
-        values,
+        values: rawValues,
         keyByFieldName: true,
       }) as ReferralPostingInput;
 

--- a/src/modules/admin/components/forms/JsonFormEditor.tsx
+++ b/src/modules/admin/components/forms/JsonFormEditor.tsx
@@ -317,7 +317,7 @@ const JsonFormEditor: React.FC<FormEditorProps> = ({
               effectiveLocalConstants,
             })}
             definition={currentDefinition}
-            onSubmit={({ values }) => setFormSubmitResult(values)}
+            onSubmit={({ rawValues }) => setFormSubmitResult(rawValues)}
             errors={{ errors: [], warnings: [] }}
             localConstants={effectiveLocalConstants}
             initialValues={effectiveInitialValues}

--- a/src/modules/assessments/components/AssessmentForm.tsx
+++ b/src/modules/assessments/components/AssessmentForm.tsx
@@ -70,7 +70,7 @@ interface Props {
   top?: number;
   embeddedInWorkflow?: boolean;
   FormActionProps?: DynamicFormProps['FormActionProps'];
-  onSubmit: DynamicFormProps['onSubmit'];
+  onSubmit: (formDefinitionId: string) => DynamicFormProps['onSubmit'];
   onSaveDraft?: DynamicFormProps['onSaveDraft'];
   errors: ErrorState;
   onCancelValidations?: VoidFunction;
@@ -395,7 +395,7 @@ const AssessmentForm: React.FC<Props> = ({
             key={`${assessment?.id}-${sourceAssessment?.id}-${reloadInitialValues}`}
             definition={definition.definition}
             ref={formRef}
-            onSubmit={onSubmit}
+            onSubmit={onSubmit(definition.id)}
             onSaveDraft={
               assessment && !assessment.inProgress ? undefined : onSaveDraft
             }

--- a/src/modules/assessments/components/IndividualAssessment.tsx
+++ b/src/modules/assessments/components/IndividualAssessment.tsx
@@ -47,7 +47,7 @@ export interface IndividualAssessmentProps {
   // Props to pass to the FormActions component to specify button layout and actions
   FormActionProps?: DynamicFormProps['FormActionProps'];
   // Submit handler
-  onSubmit: DynamicFormProps['onSubmit'];
+  onSubmit: (formDefinitionId: string) => DynamicFormProps['onSubmit'];
   // Save handler (unsubmitted assessments only)
   onSaveDraft?: DynamicFormProps['onSaveDraft'];
   // Error state

--- a/src/modules/assessments/components/IndividualAssessment.tsx
+++ b/src/modules/assessments/components/IndividualAssessment.tsx
@@ -27,8 +27,10 @@ import {
 } from '@/types/gqlTypes';
 
 export interface IndividualAssessmentProps {
-  // FormDefiniton to use for rendering the assessment
-  definition: FormDefinitionFieldsFragment;
+  // FormDefiniton to use for rendering the assessment in read-only mode
+  viewingDefinition: FormDefinitionFieldsFragment;
+  // FormDefiniton to use for rendering the assessment for editing
+  editingDefinition: FormDefinitionFieldsFragment;
   // Assessment to render. Omit if starting a new assessment.
   assessment?: FullAssessmentFragment;
   enrollmentId: string;
@@ -47,7 +49,7 @@ export interface IndividualAssessmentProps {
   // Props to pass to the FormActions component to specify button layout and actions
   FormActionProps?: DynamicFormProps['FormActionProps'];
   // Submit handler
-  onSubmit: (formDefinitionId: string) => DynamicFormProps['onSubmit'];
+  onSubmit: DynamicFormProps['onSubmit'];
   // Save handler (unsubmitted assessments only)
   onSaveDraft?: DynamicFormProps['onSaveDraft'];
   // Error state
@@ -68,7 +70,8 @@ export interface IndividualAssessmentProps {
  */
 const IndividualAssessment = ({
   enrollmentId,
-  definition,
+  viewingDefinition,
+  editingDefinition,
   assessment,
   embeddedInWorkflow = false,
   client,
@@ -95,13 +98,13 @@ const IndividualAssessment = ({
 
   if (enrollmentLoading) return <Loading />;
   if (!enrollment) return <NotFound />;
-  if (!definition && !assessment) return <NotFound />;
+  if (!viewingDefinition || !editingDefinition) return <NotFound />;
 
   const alertNode = (
     <AssessmentRelatedAnnualsAlert
       enrollmentId={enrollment.id}
       householdId={enrollment.householdId}
-      assessmentRole={definition.role as unknown as AssessmentRole}
+      assessmentRole={viewingDefinition.role as unknown as AssessmentRole}
       embeddedInWorkflow={embeddedInWorkflow}
       assessmentId={assessment?.id}
       householdSize={enrollment.householdSize}
@@ -113,7 +116,8 @@ const IndividualAssessment = ({
       alerts={alertNode}
       client={client}
       key={assessment?.id}
-      definition={definition}
+      viewingDefinition={viewingDefinition}
+      editingDefinition={editingDefinition}
       assessment={assessment}
       enrollment={enrollment}
       top={topOffsetHeight}

--- a/src/modules/assessments/components/IndividualAssessmentFormController.tsx
+++ b/src/modules/assessments/components/IndividualAssessmentFormController.tsx
@@ -20,7 +20,8 @@ import { generateSafePath } from '@/utils/pathEncoding';
 interface Props {
   enrollment: DashboardEnrollment;
   client: EnrolledClientFieldsFragment;
-  definition: FormDefinitionFieldsFragment;
+  viewingDefinition: FormDefinitionFieldsFragment;
+  editingDefinition: FormDefinitionFieldsFragment;
   assessment?: FullAssessmentFragment;
 }
 
@@ -31,7 +32,8 @@ interface Props {
 const IndividualAssessmentFormController: React.FC<Props> = ({
   client,
   enrollment,
-  definition,
+  viewingDefinition,
+  editingDefinition,
   assessment,
 }) => {
   const navigate = useNavigate();
@@ -60,7 +62,7 @@ const IndividualAssessmentFormController: React.FC<Props> = ({
 
   const { submitHandler, saveDraftHandler, mutationLoading, errors } =
     useAssessmentHandlers({
-      definition,
+      definition: editingDefinition,
       enrollmentId: enrollment.id,
       assessmentId: assessment?.id,
       assessmentLockVersion: assessment?.lockVersion,
@@ -100,7 +102,8 @@ const IndividualAssessmentFormController: React.FC<Props> = ({
 
   return (
     <IndividualAssessment
-      definition={definition}
+      viewingDefinition={viewingDefinition}
+      editingDefinition={editingDefinition}
       assessment={assessment}
       enrollmentId={enrollment.id}
       client={client}

--- a/src/modules/assessments/components/IndividualAssessmentFormController.tsx
+++ b/src/modules/assessments/components/IndividualAssessmentFormController.tsx
@@ -62,7 +62,7 @@ const IndividualAssessmentFormController: React.FC<Props> = ({
 
   const { submitHandler, saveDraftHandler, mutationLoading, errors } =
     useAssessmentHandlers({
-      definition: editingDefinition,
+      formDefinitionId: editingDefinition.id,
       enrollmentId: enrollment.id,
       assessmentId: assessment?.id,
       assessmentLockVersion: assessment?.lockVersion,

--- a/src/modules/assessments/components/IndividualAssessmentPage.tsx
+++ b/src/modules/assessments/components/IndividualAssessmentPage.tsx
@@ -45,7 +45,10 @@ const IndividualAssessmentPage = () => {
     <IndividualAssessmentFormController
       enrollment={enrollment}
       client={client}
-      definition={assessment.definition}
+      viewingDefinition={assessment.definition}
+      editingDefinition={
+        assessment.upgradedDefinitionForEditing || assessment.definition
+      }
       assessment={assessment}
     />
   );

--- a/src/modules/assessments/components/NewIndividualAssessmentPage.tsx
+++ b/src/modules/assessments/components/NewIndividualAssessmentPage.tsx
@@ -47,7 +47,8 @@ const NewIndividualAssessmentPage = () => {
     <IndividualAssessmentFormController
       enrollment={enrollment}
       client={client}
-      definition={formDefinition}
+      viewingDefinition={formDefinition}
+      editingDefinition={formDefinition}
     />
   );
 };

--- a/src/modules/assessments/components/household/HouseholdAssessmentTabPanel.tsx
+++ b/src/modules/assessments/components/household/HouseholdAssessmentTabPanel.tsx
@@ -141,7 +141,7 @@ const HouseholdAssessmentTabPanel = memo(
 
     const { submitHandler, saveDraftHandler, mutationLoading, errors } =
       useAssessmentHandlers({
-        definition: editingDefinition,
+        formDefinitionId: editingDefinition?.id || mainFormDefinition.id,
         enrollmentId,
         assessmentId,
         assessmentLockVersion: assessment?.lockVersion,

--- a/src/modules/assessments/components/household/HouseholdAssessmentTabPanel.tsx
+++ b/src/modules/assessments/components/household/HouseholdAssessmentTabPanel.tsx
@@ -98,11 +98,11 @@ const HouseholdAssessmentTabPanel = memo(
     const [viewingDefinition, editingDefinition] = useMemo(() => {
       if (assessmentId && !assessment) return [];
 
+      // If we are loading an existing Assessment, always prefer to use
+      // the FormDefinition that was resolved on the Assessment. This could
+      // be important if it's an older WIP assessment that was saved using a certain
+      // form. (It should be re-opened using the same form).
       if (assessment) {
-        // If we are loading an existing Assessment, always prefer to use
-        // the FormDefinition that was resolved on the Assessment. This could
-        // be important if it's an older WIP assessment that was saved using a certain
-        // form. (It should be re-opened using the same form).
         return [
           assessment.definition,
           assessment.upgradedDefinitionForEditing || assessment.definition,

--- a/src/modules/assessments/hooks/useAssessmentHandlers.tsx
+++ b/src/modules/assessments/hooks/useAssessmentHandlers.tsx
@@ -15,7 +15,6 @@ import {
 } from '@/modules/form/components/DynamicForm';
 import {
   AssessmentInput,
-  FormDefinitionFieldsFragment,
   SaveAssessmentMutation,
   SubmitAssessmentMutation,
   useSaveAssessmentMutation,
@@ -29,7 +28,7 @@ export type AssessmentResponseStatus =
   | 'warning';
 
 type Args = {
-  definition?: FormDefinitionFieldsFragment;
+  formDefinitionId: string;
   enrollmentId: string;
   assessmentId?: string;
   assessmentLockVersion?: number;
@@ -46,14 +45,12 @@ function isSaveMutation(
 }
 
 export function useAssessmentHandlers({
-  definition,
+  formDefinitionId,
   enrollmentId,
   assessmentId,
   assessmentLockVersion,
   onCompletedMutation = () => null,
 }: Args) {
-  const formDefinitionId = definition?.id;
-
   const [errors, setErrors] = useState<ErrorState>(emptyErrorState);
 
   const onCompleted = useCallback(
@@ -107,8 +104,6 @@ export function useAssessmentHandlers({
 
   const submitHandler: DynamicFormOnSubmit = useCallback(
     ({ valuesByLinkId, valuesByFieldName, confirmed = false, onSuccess }) => {
-      if (!definition || !formDefinitionId) return;
-
       const input = {
         assessmentId,
         enrollmentId,
@@ -131,7 +126,6 @@ export function useAssessmentHandlers({
       submitAssessmentMutation,
       assessmentId,
       assessmentLockVersion,
-      definition,
       formDefinitionId,
       enrollmentId,
       onCompleted,
@@ -140,8 +134,6 @@ export function useAssessmentHandlers({
 
   const saveDraftHandler: DynamicFormOnSaveDraft = useCallback(
     ({ valuesByLinkId, valuesByFieldName, onSuccess }) => {
-      if (!definition || !formDefinitionId) return;
-
       const input: AssessmentInput = {
         assessmentId,
         enrollmentId,
@@ -163,7 +155,6 @@ export function useAssessmentHandlers({
       saveAssessmentMutation,
       assessmentId,
       assessmentLockVersion,
-      definition,
       formDefinitionId,
       enrollmentId,
       onCompleted,

--- a/src/modules/external/mci/components/MciClearance.tsx
+++ b/src/modules/external/mci/components/MciClearance.tsx
@@ -296,12 +296,12 @@ const MciClearanceWrapper = ({
  * Wrapper to show existing MCI ID if client already has one.
  */
 const MciClearanceWrapperWithValue = (props: MciClearanceProps) => {
-  const { getCleanedValues, definition } = useDynamicFormContext();
+  const { getValues, definition } = useDynamicFormContext();
 
   // currentMciAttributes gets re-calculated any time one of the dependent values changes (because of enableWhen dependency)
   const [clientId, externalIds, currentMciAttributes] = useMemo(() => {
-    if (!getCleanedValues || !definition) return [];
-    const values = getCleanedValues();
+    if (!getValues || !definition) return [];
+    const values = getValues();
     let byKey = createHudValuesForSubmit(values, definition);
     byKey = transform(
       byKey,
@@ -312,7 +312,7 @@ const MciClearanceWrapperWithValue = (props: MciClearanceProps) => {
     // Check Link ID 'current_mci_id' in values to see if we already have an MCI ID
     // eslint-disable-next-line @typescript-eslint/dot-notation
     return [byKey.id, values['current_mci_id'], mciFields];
-  }, [getCleanedValues, definition]);
+  }, [getValues, definition]);
 
   const previousMciAttributes = usePrevious(currentMciAttributes);
 
@@ -324,7 +324,7 @@ const MciClearanceWrapperWithValue = (props: MciClearanceProps) => {
     if (changed) setHasChanged(true);
   }, [currentMciAttributes, previousMciAttributes]);
 
-  if (!getCleanedValues) return null;
+  if (!getValues) return null;
 
   // If client already has an MCI ID, just show that.
   // Post-MVP: allow re-clear

--- a/src/modules/form/components/DynamicForm.tsx
+++ b/src/modules/form/components/DynamicForm.tsx
@@ -27,9 +27,9 @@ import { formAutoCompleteOff } from '@/modules/form/util/formUtil';
 import { FormDefinitionJson } from '@/types/gqlTypes';
 
 interface DynamicFormSubmitInput {
-  rawValues: FormValues; // { 'favorite_color': { code: 'light_blue', label: 'Light Blue' }
-  valuesByLinkId: FormValues; // { 'favorite_color': 'light_blue' }
-  valuesByFieldName: FormValues; // { 'Client.favorite_color_field_key': 'light_blue' }
+  rawValues: FormValues; // // Example: { 'favorite_color': { code: 'light_blue', label: 'Light Blue' }, 'assessment_date': <JS Date Object> }
+  valuesByLinkId: FormValues; // Example: { 'favorite_color': 'light_blue', 'assessment_date': '2020-09-01' }
+  valuesByFieldName: FormValues; // Example: { 'Client.favorite_color_field_key': 'light_blue', 'assessmentDate': '2020-09-01', 'someOtherHiddenField': '_HIDDEN' }
   confirmed?: boolean;
   event?: React.MouseEvent<HTMLButtonElement>;
   onSuccess?: VoidFunction;
@@ -37,9 +37,9 @@ interface DynamicFormSubmitInput {
 }
 
 interface DynamicFormSaveDraftInput {
-  rawValues: FormValues; // { 'favorite_color': { code: 'light_blue', label: 'Light Blue' }
-  valuesByLinkId: FormValues; // { 'favorite_color': 'light_blue' }
-  valuesByFieldName: FormValues; // { 'Client.favorite_color_field_key': 'light_blue' }
+  rawValues: FormValues;
+  valuesByLinkId: FormValues;
+  valuesByFieldName: FormValues;
   onSuccess?: VoidFunction;
   onError?: VoidFunction;
 }

--- a/src/modules/form/components/DynamicForm.tsx
+++ b/src/modules/form/components/DynamicForm.tsx
@@ -27,14 +27,25 @@ import { formAutoCompleteOff } from '@/modules/form/util/formUtil';
 import { FormDefinitionJson } from '@/types/gqlTypes';
 
 interface DynamicFormSubmitInput {
-  values: FormValues;
+  rawValues: FormValues; // { 'favorite_color': { code: 'light_blue', label: 'Light Blue' }
+  valuesByLinkId: FormValues; // { 'favorite_color': 'light_blue' }
+  valuesByFieldName: FormValues; // { 'Client.favorite_color_field_key': 'light_blue' }
   confirmed?: boolean;
   event?: React.MouseEvent<HTMLButtonElement>;
   onSuccess?: VoidFunction;
   onError?: VoidFunction;
 }
 
+interface DynamicFormSaveDraftInput {
+  rawValues: FormValues; // { 'favorite_color': { code: 'light_blue', label: 'Light Blue' }
+  valuesByLinkId: FormValues; // { 'favorite_color': 'light_blue' }
+  valuesByFieldName: FormValues; // { 'Client.favorite_color_field_key': 'light_blue' }
+  onSuccess?: VoidFunction;
+  onError?: VoidFunction;
+}
+
 export type DynamicFormOnSubmit = (input: DynamicFormSubmitInput) => void;
+export type DynamicFormOnSaveDraft = (input: DynamicFormSaveDraftInput) => void;
 
 export interface DynamicFormProps
   extends Omit<
@@ -44,7 +55,7 @@ export interface DynamicFormProps
   clientId?: string;
   definition: FormDefinitionJson;
   onSubmit: DynamicFormOnSubmit;
-  onSaveDraft?: (values: FormValues, onSuccess?: VoidFunction) => void;
+  onSaveDraft?: DynamicFormOnSaveDraft;
   onDirty?: (value: boolean) => void;
   loading?: boolean;
   initialValues?: Record<string, any>;
@@ -115,31 +126,35 @@ const DynamicForm = forwardRef(
       }
     }, []);
 
-    const { renderFields, getCleanedValues } = useDynamicFields({
-      definition,
-      initialValues,
-      localConstants,
-      onFieldChange,
-    });
+    const { renderFields, getCleanedValues, getValuesForSubmit } =
+      useDynamicFields({
+        definition,
+        initialValues,
+        localConstants,
+        onFieldChange,
+      });
 
     const saveButtonsRef = React.createRef<HTMLDivElement>();
     const isSaveButtonVisible = useElementInView(saveButtonsRef, '200px');
 
     const handleSaveDraft = useCallback(() => {
       if (!onSaveDraft) return;
-      onSaveDraft(getCleanedValues(), () => setDirty(false));
-    }, [onSaveDraft, getCleanedValues]);
+      onSaveDraft({
+        ...getValuesForSubmit(),
+        onSuccess: () => setDirty(false),
+      });
+    }, [onSaveDraft, getValuesForSubmit]);
 
     const handleSubmit = useCallback(
       (event: React.MouseEvent<HTMLButtonElement>) => {
         onSubmit({
-          values: getCleanedValues(),
+          ...getValuesForSubmit(),
           confirmed: false,
           event,
           onSuccess: () => setDirty(false),
         });
       },
-      [onSubmit, getCleanedValues]
+      [onSubmit, getValuesForSubmit]
     );
 
     // Expose handle for parent components to initiate a background save (used for household workflow tabs)
@@ -147,10 +162,7 @@ const DynamicForm = forwardRef(
       ref,
       () => ({
         SubmitForm: () => {
-          onSubmit({
-            values: getCleanedValues(),
-            confirmed: false,
-          });
+          onSubmit({ ...getValuesForSubmit(), confirmed: false });
         },
         SaveIfDirty: () => {
           if (!dirty || locked) return;
@@ -159,13 +171,13 @@ const DynamicForm = forwardRef(
         SubmitIfDirty: (ignoreWarnings: boolean) => {
           if (!onSubmit || !dirty || locked) return;
           onSubmit({
-            values: getCleanedValues(),
+            ...getValuesForSubmit(),
             confirmed: ignoreWarnings,
             onSuccess: () => setDirty(false),
           });
         },
       }),
-      [onSubmit, getCleanedValues, dirty, locked, handleSaveDraft]
+      [onSubmit, getValuesForSubmit, dirty, locked, handleSaveDraft]
     );
 
     useEffect(() => {
@@ -177,13 +189,13 @@ const DynamicForm = forwardRef(
       (event: React.MouseEvent<HTMLButtonElement>) => {
         event.preventDefault();
         onSubmit({
-          values: getCleanedValues(),
+          ...getValuesForSubmit(),
           confirmed: true,
           event,
           onSuccess: () => setDirty(false),
         });
       },
-      [onSubmit, getCleanedValues]
+      [onSubmit, getValuesForSubmit]
     );
 
     const { renderValidationDialog, validationDialogVisible } =

--- a/src/modules/form/components/DynamicForm.tsx
+++ b/src/modules/form/components/DynamicForm.tsx
@@ -27,10 +27,9 @@ import { formAutoCompleteOff } from '@/modules/form/util/formUtil';
 import { FormDefinitionJson } from '@/types/gqlTypes';
 
 interface DynamicFormSubmitInput {
-  values: FormValues; // submittable form values keyed by Link ID
-  hudValues: FormValues; // submittable form values keyed by field name
-  confirmed?: boolean; // whether warning modal has been confirmed
-  event?: React.MouseEvent<HTMLButtonElement>; // submission event
+  values: FormValues;
+  confirmed?: boolean;
+  event?: React.MouseEvent<HTMLButtonElement>;
   onSuccess?: VoidFunction;
   onError?: VoidFunction;
 }
@@ -116,13 +115,12 @@ const DynamicForm = forwardRef(
       }
     }, []);
 
-    const { renderFields, getCleanedValues, getValusForSubmit } =
-      useDynamicFields({
-        definition,
-        initialValues,
-        localConstants,
-        onFieldChange,
-      });
+    const { renderFields, getCleanedValues } = useDynamicFields({
+      definition,
+      initialValues,
+      localConstants,
+      onFieldChange,
+    });
 
     const saveButtonsRef = React.createRef<HTMLDivElement>();
     const isSaveButtonVisible = useElementInView(saveButtonsRef, '200px');
@@ -135,13 +133,13 @@ const DynamicForm = forwardRef(
     const handleSubmit = useCallback(
       (event: React.MouseEvent<HTMLButtonElement>) => {
         onSubmit({
-          ...getValusForSubmit(),
+          values: getCleanedValues(),
           confirmed: false,
           event,
           onSuccess: () => setDirty(false),
         });
       },
-      [onSubmit, getValusForSubmit]
+      [onSubmit, getCleanedValues]
     );
 
     // Expose handle for parent components to initiate a background save (used for household workflow tabs)
@@ -150,7 +148,7 @@ const DynamicForm = forwardRef(
       () => ({
         SubmitForm: () => {
           onSubmit({
-            ...getValusForSubmit(),
+            values: getCleanedValues(),
             confirmed: false,
           });
         },
@@ -161,13 +159,13 @@ const DynamicForm = forwardRef(
         SubmitIfDirty: (ignoreWarnings: boolean) => {
           if (!onSubmit || !dirty || locked) return;
           onSubmit({
-            ...getValusForSubmit(),
+            values: getCleanedValues(),
             confirmed: ignoreWarnings,
             onSuccess: () => setDirty(false),
           });
         },
       }),
-      [onSubmit, getValusForSubmit, dirty, locked, handleSaveDraft]
+      [onSubmit, getCleanedValues, dirty, locked, handleSaveDraft]
     );
 
     useEffect(() => {
@@ -179,13 +177,13 @@ const DynamicForm = forwardRef(
       (event: React.MouseEvent<HTMLButtonElement>) => {
         event.preventDefault();
         onSubmit({
-          ...getValusForSubmit(),
+          values: getCleanedValues(),
           confirmed: true,
           event,
           onSuccess: () => setDirty(false),
         });
       },
-      [onSubmit, getValusForSubmit]
+      [onSubmit, getCleanedValues]
     );
 
     const { renderValidationDialog, validationDialogVisible } =

--- a/src/modules/form/components/DynamicForm.tsx
+++ b/src/modules/form/components/DynamicForm.tsx
@@ -126,13 +126,14 @@ const DynamicForm = forwardRef(
       }
     }, []);
 
-    const { renderFields, getCleanedValues, getValuesForSubmit } =
-      useDynamicFields({
-        definition,
-        initialValues,
-        localConstants,
-        onFieldChange,
-      });
+    // getValues: returns form state (used by some nested components, like MciClearance)
+    // getValuesForSubmit: returns submittable form state (used for onSubmit/onSaveDraft)
+    const { renderFields, getValues, getValuesForSubmit } = useDynamicFields({
+      definition,
+      initialValues,
+      localConstants,
+      onFieldChange,
+    });
 
     const saveButtonsRef = React.createRef<HTMLDivElement>();
     const isSaveButtonVisible = useElementInView(saveButtonsRef, '200px');
@@ -245,7 +246,7 @@ const DynamicForm = forwardRef(
               </Stack>
             </Grid>
           )}
-          <DynamicFormContext.Provider value={{ getCleanedValues, definition }}>
+          <DynamicFormContext.Provider value={{ getValues, definition }}>
             {renderFields({
               itemChanged: handleChangeCallback,
               severalItemsChanged: handleChangeCallback,

--- a/src/modules/form/hooks/useDynamicFields.tsx
+++ b/src/modules/form/hooks/useDynamicFields.tsx
@@ -15,8 +15,6 @@ import {
 import {
   addDescendants,
   autofillValues,
-  createHudValuesForSubmit,
-  createValuesForSubmit,
   dropUnderscorePrefixedKeys,
   getDependentItemsDisabledStatus,
   isShown,
@@ -71,14 +69,6 @@ const useDynamicFields = ({
     const cleaned = omit(values, excluded);
     return dropUnderscorePrefixedKeys(cleaned);
   }, [definition, disabledLinkIds, itemMap, values]);
-
-  const getValusForSubmit = useCallback(() => {
-    const cleaned = getCleanedValues();
-    return {
-      values: createValuesForSubmit(cleaned, definition),
-      hudValues: createHudValuesForSubmit(cleaned, definition),
-    };
-  }, [definition, getCleanedValues]);
 
   const shouldShowItem = useCallback(
     (item: FormItem) => isShown(item, disabledLinkIds),
@@ -268,7 +258,6 @@ const useDynamicFields = ({
     () => ({
       renderFields: viewOnly ? renderViewFields : renderFormFields,
       values,
-      getValusForSubmit,
       getCleanedValues,
       shouldShowItem,
     }),
@@ -277,7 +266,6 @@ const useDynamicFields = ({
       viewOnly,
       renderFormFields,
       renderViewFields,
-      getValusForSubmit,
       getCleanedValues,
       shouldShowItem,
     ]

--- a/src/modules/form/hooks/useDynamicFields.tsx
+++ b/src/modules/form/hooks/useDynamicFields.tsx
@@ -15,6 +15,8 @@ import {
 import {
   addDescendants,
   autofillValues,
+  createHudValuesForSubmit,
+  createValuesForSubmit,
   dropUnderscorePrefixedKeys,
   getDependentItemsDisabledStatus,
   isShown,
@@ -69,6 +71,14 @@ const useDynamicFields = ({
     const cleaned = omit(values, excluded);
     return dropUnderscorePrefixedKeys(cleaned);
   }, [definition, disabledLinkIds, itemMap, values]);
+
+  const getValusForSubmit = useCallback(() => {
+    const cleaned = getCleanedValues();
+    return {
+      values: createValuesForSubmit(cleaned, definition),
+      hudValues: createHudValuesForSubmit(cleaned, definition),
+    };
+  }, [definition, getCleanedValues]);
 
   const shouldShowItem = useCallback(
     (item: FormItem) => isShown(item, disabledLinkIds),
@@ -258,6 +268,7 @@ const useDynamicFields = ({
     () => ({
       renderFields: viewOnly ? renderViewFields : renderFormFields,
       values,
+      getValusForSubmit,
       getCleanedValues,
       shouldShowItem,
     }),
@@ -266,6 +277,7 @@ const useDynamicFields = ({
       viewOnly,
       renderFormFields,
       renderViewFields,
+      getValusForSubmit,
       getCleanedValues,
       shouldShowItem,
     ]

--- a/src/modules/form/hooks/useDynamicFields.tsx
+++ b/src/modules/form/hooks/useDynamicFields.tsx
@@ -15,6 +15,8 @@ import {
 import {
   addDescendants,
   autofillValues,
+  createHudValuesForSubmit,
+  createValuesForSubmit,
   dropUnderscorePrefixedKeys,
   getDependentItemsDisabledStatus,
   isShown,
@@ -69,6 +71,15 @@ const useDynamicFields = ({
     const cleaned = omit(values, excluded);
     return dropUnderscorePrefixedKeys(cleaned);
   }, [definition, disabledLinkIds, itemMap, values]);
+
+  const getValuesForSubmit = useCallback(() => {
+    const cleanedValues = getCleanedValues();
+    return {
+      rawValues: cleanedValues,
+      valuesByLinkId: createValuesForSubmit(cleanedValues, definition),
+      valuesByFieldName: createHudValuesForSubmit(cleanedValues, definition),
+    };
+  }, [definition, getCleanedValues]);
 
   const shouldShowItem = useCallback(
     (item: FormItem) => isShown(item, disabledLinkIds),
@@ -260,6 +271,7 @@ const useDynamicFields = ({
       values,
       getCleanedValues,
       shouldShowItem,
+      getValuesForSubmit,
     }),
     [
       values,
@@ -268,6 +280,7 @@ const useDynamicFields = ({
       renderViewFields,
       getCleanedValues,
       shouldShowItem,
+      getValuesForSubmit,
     ]
   );
 };

--- a/src/modules/form/hooks/useDynamicFields.tsx
+++ b/src/modules/form/hooks/useDynamicFields.tsx
@@ -75,8 +75,13 @@ const useDynamicFields = ({
   const getValuesForSubmit = useCallback(() => {
     const cleanedValues = getCleanedValues();
     return {
+      // Example: { 'favorite_color': { code: 'light_blue', label: 'Light Blue' }, 'assessment_date': <JS Date Object> }
       rawValues: cleanedValues,
+      // Example: { 'favorite_color': 'light_blue', 'assessment_date': '2020-09-01' }
+      // Stored as "values" in FormProcessor, for dynamic form submission
       valuesByLinkId: createValuesForSubmit(cleanedValues, definition),
+      // Example: { 'Client.favorite_color_field_key': 'light_blue', 'assessmentDate': '2020-09-01', 'someOtherHiddenField': '_HIDDEN' }
+      // Stored as "hud_values" in FormProcessor, for dynamic form submission
       valuesByFieldName: createHudValuesForSubmit(cleanedValues, definition),
     };
   }, [definition, getCleanedValues]);

--- a/src/modules/form/hooks/useDynamicFields.tsx
+++ b/src/modules/form/hooks/useDynamicFields.tsx
@@ -59,7 +59,7 @@ const useDynamicFields = ({
   );
 
   // Get form state, with "hidden" fields (and their children) removed
-  const getCleanedValues = useCallback(() => {
+  const getValues = useCallback(() => {
     if (!definition) return values;
 
     // Retain disabled fields that are displayed with a value
@@ -73,18 +73,18 @@ const useDynamicFields = ({
   }, [definition, disabledLinkIds, itemMap, values]);
 
   const getValuesForSubmit = useCallback(() => {
-    const cleanedValues = getCleanedValues();
+    const vals = getValues();
     return {
       // Example: { 'favorite_color': { code: 'light_blue', label: 'Light Blue' }, 'assessment_date': <JS Date Object> }
-      rawValues: cleanedValues,
+      rawValues: vals,
       // Example: { 'favorite_color': 'light_blue', 'assessment_date': '2020-09-01' }
       // Stored as "values" in FormProcessor, for dynamic form submission
-      valuesByLinkId: createValuesForSubmit(cleanedValues, definition),
+      valuesByLinkId: createValuesForSubmit(vals, definition),
       // Example: { 'Client.favorite_color_field_key': 'light_blue', 'assessmentDate': '2020-09-01', 'someOtherHiddenField': '_HIDDEN' }
       // Stored as "hud_values" in FormProcessor, for dynamic form submission
-      valuesByFieldName: createHudValuesForSubmit(cleanedValues, definition),
+      valuesByFieldName: createHudValuesForSubmit(vals, definition),
     };
-  }, [definition, getCleanedValues]);
+  }, [definition, getValues]);
 
   const shouldShowItem = useCallback(
     (item: FormItem) => isShown(item, disabledLinkIds),
@@ -274,7 +274,7 @@ const useDynamicFields = ({
     () => ({
       renderFields: viewOnly ? renderViewFields : renderFormFields,
       values,
-      getCleanedValues,
+      getValues,
       shouldShowItem,
       getValuesForSubmit,
     }),
@@ -283,7 +283,7 @@ const useDynamicFields = ({
       viewOnly,
       renderFormFields,
       renderViewFields,
-      getCleanedValues,
+      getValues,
       shouldShowItem,
       getValuesForSubmit,
     ]

--- a/src/modules/form/hooks/useDynamicFormContext.tsx
+++ b/src/modules/form/hooks/useDynamicFormContext.tsx
@@ -5,7 +5,7 @@ import { FormValues } from '../types';
 import { FormDefinitionJson } from '@/types/gqlTypes';
 
 type DynamicFormContextType = {
-  getCleanedValues?: () => FormValues;
+  getValues?: () => FormValues;
   definition?: FormDefinitionJson;
 };
 

--- a/src/modules/form/hooks/useDynamicFormHandlersForCustomMutation.tsx
+++ b/src/modules/form/hooks/useDynamicFormHandlersForCustomMutation.tsx
@@ -3,7 +3,6 @@ import { RefObject, useCallback, useState } from 'react';
 
 import { DynamicFormOnSubmit } from '../components/DynamicForm';
 import { FormValues } from '../types';
-import { transformSubmitValues } from '../util/formUtil';
 
 import {
   emptyErrorState,
@@ -67,15 +66,10 @@ export function useDynamicFormHandlersForCustomMutation<
   });
 
   const onSubmit: DynamicFormOnSubmit = useCallback(
-    ({ values, confirmed = false }) => {
+    ({ valuesByFieldName, confirmed = false }) => {
       if (!formDefinition) return;
 
-      const input = transformSubmitValues({
-        values,
-        definition: formDefinition.definition,
-        keyByFieldName: true,
-      });
-      const variables = getVariables(input, confirmed);
+      const variables = getVariables(valuesByFieldName, confirmed);
       setErrors(emptyErrorState);
       void mutateFunction({ variables });
     },

--- a/src/modules/form/hooks/useDynamicFormHandlersForCustomMutation.tsx
+++ b/src/modules/form/hooks/useDynamicFormHandlersForCustomMutation.tsx
@@ -4,6 +4,7 @@ import { RefObject, useCallback, useState } from 'react';
 import { DynamicFormOnSubmit } from '../components/DynamicForm';
 import { FormValues } from '../types';
 
+import { transformSubmitValues } from '../util/formUtil';
 import {
   emptyErrorState,
   ErrorState,
@@ -66,10 +67,15 @@ export function useDynamicFormHandlersForCustomMutation<
   });
 
   const onSubmit: DynamicFormOnSubmit = useCallback(
-    ({ valuesByFieldName, confirmed = false }) => {
+    ({ rawValues, confirmed = false }) => {
       if (!formDefinition) return;
 
-      const variables = getVariables(valuesByFieldName, confirmed);
+      const input = transformSubmitValues({
+        values: rawValues,
+        definition: formDefinition.definition,
+        keyByFieldName: true,
+      });
+      const variables = getVariables(input, confirmed);
       setErrors(emptyErrorState);
       void mutateFunction({ variables });
     },

--- a/src/modules/form/hooks/useDynamicFormHandlersForRecord.tsx
+++ b/src/modules/form/hooks/useDynamicFormHandlersForRecord.tsx
@@ -2,12 +2,7 @@ import { RefObject, useCallback, useMemo, useState } from 'react';
 
 import { DynamicFormOnSubmit } from '../components/DynamicForm';
 import { LocalConstants, SubmitFormAllowedTypes } from '../types';
-import {
-  createHudValuesForSubmit,
-  createValuesForSubmit,
-  debugFormValues,
-  getItemMap,
-} from '../util/formUtil';
+import { getItemMap } from '../util/formUtil';
 
 import useInitialFormValues from './useInitialFormValues';
 
@@ -98,24 +93,13 @@ export function useDynamicFormHandlersForRecord<
   });
 
   const onSubmit: DynamicFormOnSubmit = useCallback(
-    ({ event, values, confirmed = false }) => {
+    ({ valuesByLinkId, valuesByFieldName, confirmed = false }) => {
       if (!formDefinition) return;
-      if (
-        event &&
-        debugFormValues(
-          event,
-          values,
-          formDefinition.definition,
-          createValuesForSubmit,
-          createHudValuesForSubmit
-        )
-      )
-        return;
 
       const input = {
         formDefinitionId: formDefinition.id,
-        values: createValuesForSubmit(values, formDefinition.definition),
-        hudValues: createHudValuesForSubmit(values, formDefinition.definition),
+        values: valuesByLinkId,
+        hudValues: valuesByFieldName,
         recordId: record?.id,
         confirmed,
         ...inputVariables,

--- a/src/modules/form/util/formUtil.ts
+++ b/src/modules/form/util/formUtil.ts
@@ -1132,12 +1132,13 @@ type TransformSubmitValuesParams = {
  */
 export const transformSubmitValues = ({
   definition,
-  values,
+  values, // should error if values has any keys that are not linkids?
   includeMissingKeys,
   autofillBooleans = false,
   autofillNotCollected = false,
   keyByFieldName = false,
 }: TransformSubmitValuesParams) => {
+  const seenLinkIds = new Set();
   // Recursive helper for traversing the FormDefinition
   function rescursiveFillMap(
     items: FormItem[],
@@ -1145,6 +1146,8 @@ export const transformSubmitValues = ({
     parentRecordType?: string
   ) {
     items.forEach((item: FormItem) => {
+      seenLinkIds.add(item.linkId);
+
       const mapping = item.mapping || {};
       const recordType = mapping.recordType
         ? HmisEnums.RelatedRecordType[mapping.recordType]
@@ -1205,6 +1208,18 @@ export const transformSubmitValues = ({
 
   const result: Record<string, any> = {};
   rescursiveFillMap(definition.item, result);
+
+  // can't actually do this because I think we expect it in some cases? check mci and addresses
+  // const unrecognizedKeys = Object.keys(values).filter(
+  //   (linkId) => !seenLinkIds.has(linkId)
+  // );
+  // if (unrecognizedKeys.length > 0) {
+  //   throw new Error(
+  //     'Failed to submit form, form values had unrecognized keys: ' +
+  //       unrecognizedKeys.join(', ')
+  //   );
+  // }
+
   return result;
 };
 

--- a/src/modules/form/util/formUtil.ts
+++ b/src/modules/form/util/formUtil.ts
@@ -1133,7 +1133,7 @@ type TransformSubmitValuesParams = {
 export const transformSubmitValues = ({
   definition,
   values, // should error if values has any keys that are not linkids?
-  includeMissingKeys,
+  includeMissingKeys, // check this could be causing issues for DCA rules if the form were transforming on hasnt dropped them yet
   autofillBooleans = false,
   autofillNotCollected = false,
   keyByFieldName = false,
@@ -1331,53 +1331,6 @@ export const createHudValuesForSubmit = (
     keyByFieldName: true,
     includeMissingKeys: 'AS_HIDDEN',
   });
-
-export const debugFormValues = (
-  event: React.MouseEvent<HTMLButtonElement>,
-  values: FormValues,
-  definition: FormDefinitionJson,
-  transformValuesFn?: (
-    values: FormValues,
-    definition: FormDefinitionJson
-  ) => FormValues,
-  transformHudValuesFn?: (
-    values: FormValues,
-    definition: FormDefinitionJson
-  ) => FormValues
-) => {
-  if (import.meta.env.MODE === 'production') return false;
-  if (!event.ctrlKey && !event.metaKey) return false;
-
-  // eslint-disable-next-line no-console
-  console.debug('%c FORM STATE:', 'color: #BB7AFF');
-  if (transformValuesFn) {
-    // eslint-disable-next-line no-console
-    console.debug(transformValuesFn(values, definition));
-  } else {
-    // eslint-disable-next-line no-console
-    console.debug(values);
-  }
-
-  let hudValues = transformSubmitValues({
-    definition,
-    values,
-    autofillNotCollected: true,
-    includeMissingKeys: 'AS_NULL',
-    keyByFieldName: true,
-  });
-
-  if (transformHudValuesFn) {
-    hudValues = transformHudValuesFn(values, definition);
-  }
-
-  window.debug = { hudValues };
-  // eslint-disable-next-line no-console
-  console.debug('%c HUD VALUES BY FIELD NAME:', 'color: #BB7AFF');
-  // eslint-disable-next-line no-console
-  console.debug(hudValues);
-
-  return true;
-};
 
 type GetDependentItemsDisabledStatus = {
   changedLinkIds: string[];

--- a/src/modules/projects/components/ProjectReferralPostingForm.tsx
+++ b/src/modules/projects/components/ProjectReferralPostingForm.tsx
@@ -64,12 +64,12 @@ export const ProjectReferralPostingForm: React.FC<Props> = ({
 
   const handleSubmit: DynamicFormOnSubmit = useCallback(
     ({ rawValues }) => {
+      setErrors(emptyErrorState);
       const input = transformSubmitValues({
         definition,
         values: rawValues,
         keyByFieldName: true,
       }) as ReferralPostingInput;
-      setErrors(emptyErrorState);
       mutate({
         variables: {
           id: referralPosting.id,
@@ -77,7 +77,7 @@ export const ProjectReferralPostingForm: React.FC<Props> = ({
         },
       });
     },
-    [definition, mutate, referralPosting.id]
+    [mutate, definition, referralPosting.id]
   );
 
   const initialValues = useInitialFormValues({

--- a/src/modules/projects/components/ProjectReferralPostingForm.tsx
+++ b/src/modules/projects/components/ProjectReferralPostingForm.tsx
@@ -8,9 +8,13 @@ import DynamicView from '@/modules/form/components/viewable/DynamicView';
 import { ReferralPostingDefinition } from '@/modules/form/data';
 import useInitialFormValues from '@/modules/form/hooks/useInitialFormValues';
 import { SubmitFormAllowedTypes } from '@/modules/form/types';
-import { localResolvePickList } from '@/modules/form/util/formUtil';
+import {
+  localResolvePickList,
+  transformSubmitValues,
+} from '@/modules/form/util/formUtil';
 import {
   ReferralPostingDetailFieldsFragment,
+  ReferralPostingInput,
   ReferralPostingStatus,
   useUpdateReferralPostingMutation,
 } from '@/types/gqlTypes';
@@ -59,16 +63,21 @@ export const ProjectReferralPostingForm: React.FC<Props> = ({
   }, [readOnly, referralPosting]);
 
   const handleSubmit: DynamicFormOnSubmit = useCallback(
-    ({ valuesByFieldName }) => {
+    ({ rawValues }) => {
+      const input = transformSubmitValues({
+        definition,
+        values: rawValues,
+        keyByFieldName: true,
+      }) as ReferralPostingInput;
       setErrors(emptyErrorState);
       mutate({
         variables: {
           id: referralPosting.id,
-          input: valuesByFieldName,
+          input,
         },
       });
     },
-    [mutate, referralPosting.id]
+    [definition, mutate, referralPosting.id]
   );
 
   const initialValues = useInitialFormValues({

--- a/src/modules/projects/components/ProjectReferralPostingForm.tsx
+++ b/src/modules/projects/components/ProjectReferralPostingForm.tsx
@@ -8,13 +8,9 @@ import DynamicView from '@/modules/form/components/viewable/DynamicView';
 import { ReferralPostingDefinition } from '@/modules/form/data';
 import useInitialFormValues from '@/modules/form/hooks/useInitialFormValues';
 import { SubmitFormAllowedTypes } from '@/modules/form/types';
-import {
-  localResolvePickList,
-  transformSubmitValues,
-} from '@/modules/form/util/formUtil';
+import { localResolvePickList } from '@/modules/form/util/formUtil';
 import {
   ReferralPostingDetailFieldsFragment,
-  ReferralPostingInput,
   ReferralPostingStatus,
   useUpdateReferralPostingMutation,
 } from '@/types/gqlTypes';
@@ -63,22 +59,16 @@ export const ProjectReferralPostingForm: React.FC<Props> = ({
   }, [readOnly, referralPosting]);
 
   const handleSubmit: DynamicFormOnSubmit = useCallback(
-    ({ values }) => {
+    ({ valuesByFieldName }) => {
       setErrors(emptyErrorState);
-      const input = transformSubmitValues({
-        definition,
-        values,
-        keyByFieldName: true,
-      }) as ReferralPostingInput;
-
       mutate({
         variables: {
           id: referralPosting.id,
-          input,
+          input: valuesByFieldName,
         },
       });
     },
-    [mutate, definition, referralPosting.id]
+    [mutate, referralPosting.id]
   );
 
   const initialValues = useInitialFormValues({

--- a/src/modules/units/components/Units.tsx
+++ b/src/modules/units/components/Units.tsx
@@ -28,7 +28,6 @@ import DynamicForm, {
 } from '@/modules/form/components/DynamicForm';
 import FormDialogActionContent from '@/modules/form/components/FormDialogActionContent';
 import { UnitsDefinition } from '@/modules/form/data';
-import { transformSubmitValues } from '@/modules/form/util/formUtil';
 import { ProjectPermissionsFilter } from '@/modules/permissions/PermissionsFilters';
 import { evictUnitsQuery } from '@/modules/units/util';
 import { CreateUnitsInput, useCreateUnitsMutation } from '@/types/gqlTypes';
@@ -57,12 +56,8 @@ const Units = () => {
   );
 
   const handleCreateUnits: DynamicFormOnSubmit = useCallback(
-    ({ values }) => {
-      const input = transformSubmitValues({
-        definition: UnitsDefinition,
-        values,
-        keyByFieldName: true,
-      });
+    ({ valuesByFieldName }) => {
+      const input = valuesByFieldName;
       input.projectId = project.id;
       if (!input.prefix) input.prefix = 'Unit';
       createUnits({ variables: { input: { input } as CreateUnitsInput } });

--- a/src/modules/units/components/Units.tsx
+++ b/src/modules/units/components/Units.tsx
@@ -28,6 +28,7 @@ import DynamicForm, {
 } from '@/modules/form/components/DynamicForm';
 import FormDialogActionContent from '@/modules/form/components/FormDialogActionContent';
 import { UnitsDefinition } from '@/modules/form/data';
+import { transformSubmitValues } from '@/modules/form/util/formUtil';
 import { ProjectPermissionsFilter } from '@/modules/permissions/PermissionsFilters';
 import { evictUnitsQuery } from '@/modules/units/util';
 import { CreateUnitsInput, useCreateUnitsMutation } from '@/types/gqlTypes';
@@ -56,8 +57,12 @@ const Units = () => {
   );
 
   const handleCreateUnits: DynamicFormOnSubmit = useCallback(
-    ({ valuesByFieldName }) => {
-      const input = valuesByFieldName;
+    ({ rawValues }) => {
+      const input = transformSubmitValues({
+        definition: UnitsDefinition,
+        values: rawValues,
+        keyByFieldName: true,
+      });
       input.projectId = project.id;
       if (!input.prefix) input.prefix = 'Unit';
       createUnits({ variables: { input: { input } as CreateUnitsInput } });

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -8884,970 +8884,6 @@ export type FullAssessmentFragment = {
   dateUpdated?: string | null;
   dateDeleted?: string | null;
   role: AssessmentRole;
-  definition: {
-    __typename?: 'FormDefinition';
-    id: string;
-    cacheKey: string;
-    title: string;
-    role: FormRole;
-    identifier: string;
-    status: FormStatus;
-    definition: {
-      __typename?: 'FormDefinitionJson';
-      item: Array<{
-        __typename: 'FormItem';
-        linkId: string;
-        type: ItemType;
-        component?: Component | null;
-        prefix?: string | null;
-        text?: string | null;
-        briefText?: string | null;
-        readonlyText?: string | null;
-        helperText?: string | null;
-        required?: boolean | null;
-        warnIfEmpty?: boolean | null;
-        hidden?: boolean | null;
-        readOnly?: boolean | null;
-        repeats?: boolean | null;
-        pickListReference?: string | null;
-        size?: InputSize | null;
-        assessmentDate?: boolean | null;
-        prefill?: boolean | null;
-        dataCollectedAbout?: DataCollectedAbout | null;
-        disabledDisplay?: DisabledDisplay | null;
-        enableBehavior?: EnableBehavior | null;
-        item?: Array<{
-          __typename: 'FormItem';
-          linkId: string;
-          type: ItemType;
-          component?: Component | null;
-          prefix?: string | null;
-          text?: string | null;
-          briefText?: string | null;
-          readonlyText?: string | null;
-          helperText?: string | null;
-          required?: boolean | null;
-          warnIfEmpty?: boolean | null;
-          hidden?: boolean | null;
-          readOnly?: boolean | null;
-          repeats?: boolean | null;
-          pickListReference?: string | null;
-          size?: InputSize | null;
-          assessmentDate?: boolean | null;
-          prefill?: boolean | null;
-          dataCollectedAbout?: DataCollectedAbout | null;
-          disabledDisplay?: DisabledDisplay | null;
-          enableBehavior?: EnableBehavior | null;
-          item?: Array<{
-            __typename: 'FormItem';
-            linkId: string;
-            type: ItemType;
-            component?: Component | null;
-            prefix?: string | null;
-            text?: string | null;
-            briefText?: string | null;
-            readonlyText?: string | null;
-            helperText?: string | null;
-            required?: boolean | null;
-            warnIfEmpty?: boolean | null;
-            hidden?: boolean | null;
-            readOnly?: boolean | null;
-            repeats?: boolean | null;
-            pickListReference?: string | null;
-            size?: InputSize | null;
-            assessmentDate?: boolean | null;
-            prefill?: boolean | null;
-            dataCollectedAbout?: DataCollectedAbout | null;
-            disabledDisplay?: DisabledDisplay | null;
-            enableBehavior?: EnableBehavior | null;
-            item?: Array<{
-              __typename: 'FormItem';
-              linkId: string;
-              type: ItemType;
-              component?: Component | null;
-              prefix?: string | null;
-              text?: string | null;
-              briefText?: string | null;
-              readonlyText?: string | null;
-              helperText?: string | null;
-              required?: boolean | null;
-              warnIfEmpty?: boolean | null;
-              hidden?: boolean | null;
-              readOnly?: boolean | null;
-              repeats?: boolean | null;
-              pickListReference?: string | null;
-              size?: InputSize | null;
-              assessmentDate?: boolean | null;
-              prefill?: boolean | null;
-              dataCollectedAbout?: DataCollectedAbout | null;
-              disabledDisplay?: DisabledDisplay | null;
-              enableBehavior?: EnableBehavior | null;
-              item?: Array<{
-                __typename: 'FormItem';
-                linkId: string;
-                type: ItemType;
-                component?: Component | null;
-                prefix?: string | null;
-                text?: string | null;
-                briefText?: string | null;
-                readonlyText?: string | null;
-                helperText?: string | null;
-                required?: boolean | null;
-                warnIfEmpty?: boolean | null;
-                hidden?: boolean | null;
-                readOnly?: boolean | null;
-                repeats?: boolean | null;
-                pickListReference?: string | null;
-                size?: InputSize | null;
-                assessmentDate?: boolean | null;
-                prefill?: boolean | null;
-                dataCollectedAbout?: DataCollectedAbout | null;
-                disabledDisplay?: DisabledDisplay | null;
-                enableBehavior?: EnableBehavior | null;
-                mapping?: {
-                  __typename?: 'FieldMapping';
-                  recordType?: RelatedRecordType | null;
-                  fieldName?: string | null;
-                  customFieldKey?: string | null;
-                } | null;
-                bounds?: Array<{
-                  __typename?: 'ValueBound';
-                  id: string;
-                  severity: ValidationSeverity;
-                  type: BoundType;
-                  question?: string | null;
-                  valueNumber?: number | null;
-                  valueDate?: string | null;
-                  valueLocalConstant?: string | null;
-                  offset?: number | null;
-                }> | null;
-                pickListOptions?: Array<{
-                  __typename?: 'PickListOption';
-                  code: string;
-                  label?: string | null;
-                  secondaryLabel?: string | null;
-                  groupLabel?: string | null;
-                  groupCode?: string | null;
-                  initialSelected?: boolean | null;
-                  helperText?: string | null;
-                  numericValue?: number | null;
-                }> | null;
-                initial?: Array<{
-                  __typename?: 'InitialValue';
-                  valueCode?: string | null;
-                  valueBoolean?: boolean | null;
-                  valueNumber?: number | null;
-                  valueLocalConstant?: string | null;
-                  initialBehavior: InitialBehavior;
-                }> | null;
-                enableWhen?: Array<{
-                  __typename?: 'EnableWhen';
-                  question?: string | null;
-                  localConstant?: string | null;
-                  operator: EnableOperator;
-                  answerCode?: string | null;
-                  answerCodes?: Array<string> | null;
-                  answerNumber?: number | null;
-                  answerBoolean?: boolean | null;
-                  answerGroupCode?: string | null;
-                  compareQuestion?: string | null;
-                }> | null;
-                autofillValues?: Array<{
-                  __typename?: 'AutofillValue';
-                  valueCode?: string | null;
-                  valueQuestion?: string | null;
-                  valueBoolean?: boolean | null;
-                  valueNumber?: number | null;
-                  sumQuestions?: Array<string> | null;
-                  formula?: string | null;
-                  autofillBehavior: EnableBehavior;
-                  autofillReadonly?: boolean | null;
-                  autofillWhen: Array<{
-                    __typename?: 'EnableWhen';
-                    question?: string | null;
-                    localConstant?: string | null;
-                    operator: EnableOperator;
-                    answerCode?: string | null;
-                    answerCodes?: Array<string> | null;
-                    answerNumber?: number | null;
-                    answerBoolean?: boolean | null;
-                    answerGroupCode?: string | null;
-                    compareQuestion?: string | null;
-                  }>;
-                }> | null;
-              }> | null;
-              mapping?: {
-                __typename?: 'FieldMapping';
-                recordType?: RelatedRecordType | null;
-                fieldName?: string | null;
-                customFieldKey?: string | null;
-              } | null;
-              bounds?: Array<{
-                __typename?: 'ValueBound';
-                id: string;
-                severity: ValidationSeverity;
-                type: BoundType;
-                question?: string | null;
-                valueNumber?: number | null;
-                valueDate?: string | null;
-                valueLocalConstant?: string | null;
-                offset?: number | null;
-              }> | null;
-              pickListOptions?: Array<{
-                __typename?: 'PickListOption';
-                code: string;
-                label?: string | null;
-                secondaryLabel?: string | null;
-                groupLabel?: string | null;
-                groupCode?: string | null;
-                initialSelected?: boolean | null;
-                helperText?: string | null;
-                numericValue?: number | null;
-              }> | null;
-              initial?: Array<{
-                __typename?: 'InitialValue';
-                valueCode?: string | null;
-                valueBoolean?: boolean | null;
-                valueNumber?: number | null;
-                valueLocalConstant?: string | null;
-                initialBehavior: InitialBehavior;
-              }> | null;
-              enableWhen?: Array<{
-                __typename?: 'EnableWhen';
-                question?: string | null;
-                localConstant?: string | null;
-                operator: EnableOperator;
-                answerCode?: string | null;
-                answerCodes?: Array<string> | null;
-                answerNumber?: number | null;
-                answerBoolean?: boolean | null;
-                answerGroupCode?: string | null;
-                compareQuestion?: string | null;
-              }> | null;
-              autofillValues?: Array<{
-                __typename?: 'AutofillValue';
-                valueCode?: string | null;
-                valueQuestion?: string | null;
-                valueBoolean?: boolean | null;
-                valueNumber?: number | null;
-                sumQuestions?: Array<string> | null;
-                formula?: string | null;
-                autofillBehavior: EnableBehavior;
-                autofillReadonly?: boolean | null;
-                autofillWhen: Array<{
-                  __typename?: 'EnableWhen';
-                  question?: string | null;
-                  localConstant?: string | null;
-                  operator: EnableOperator;
-                  answerCode?: string | null;
-                  answerCodes?: Array<string> | null;
-                  answerNumber?: number | null;
-                  answerBoolean?: boolean | null;
-                  answerGroupCode?: string | null;
-                  compareQuestion?: string | null;
-                }>;
-              }> | null;
-            }> | null;
-            mapping?: {
-              __typename?: 'FieldMapping';
-              recordType?: RelatedRecordType | null;
-              fieldName?: string | null;
-              customFieldKey?: string | null;
-            } | null;
-            bounds?: Array<{
-              __typename?: 'ValueBound';
-              id: string;
-              severity: ValidationSeverity;
-              type: BoundType;
-              question?: string | null;
-              valueNumber?: number | null;
-              valueDate?: string | null;
-              valueLocalConstant?: string | null;
-              offset?: number | null;
-            }> | null;
-            pickListOptions?: Array<{
-              __typename?: 'PickListOption';
-              code: string;
-              label?: string | null;
-              secondaryLabel?: string | null;
-              groupLabel?: string | null;
-              groupCode?: string | null;
-              initialSelected?: boolean | null;
-              helperText?: string | null;
-              numericValue?: number | null;
-            }> | null;
-            initial?: Array<{
-              __typename?: 'InitialValue';
-              valueCode?: string | null;
-              valueBoolean?: boolean | null;
-              valueNumber?: number | null;
-              valueLocalConstant?: string | null;
-              initialBehavior: InitialBehavior;
-            }> | null;
-            enableWhen?: Array<{
-              __typename?: 'EnableWhen';
-              question?: string | null;
-              localConstant?: string | null;
-              operator: EnableOperator;
-              answerCode?: string | null;
-              answerCodes?: Array<string> | null;
-              answerNumber?: number | null;
-              answerBoolean?: boolean | null;
-              answerGroupCode?: string | null;
-              compareQuestion?: string | null;
-            }> | null;
-            autofillValues?: Array<{
-              __typename?: 'AutofillValue';
-              valueCode?: string | null;
-              valueQuestion?: string | null;
-              valueBoolean?: boolean | null;
-              valueNumber?: number | null;
-              sumQuestions?: Array<string> | null;
-              formula?: string | null;
-              autofillBehavior: EnableBehavior;
-              autofillReadonly?: boolean | null;
-              autofillWhen: Array<{
-                __typename?: 'EnableWhen';
-                question?: string | null;
-                localConstant?: string | null;
-                operator: EnableOperator;
-                answerCode?: string | null;
-                answerCodes?: Array<string> | null;
-                answerNumber?: number | null;
-                answerBoolean?: boolean | null;
-                answerGroupCode?: string | null;
-                compareQuestion?: string | null;
-              }>;
-            }> | null;
-          }> | null;
-          mapping?: {
-            __typename?: 'FieldMapping';
-            recordType?: RelatedRecordType | null;
-            fieldName?: string | null;
-            customFieldKey?: string | null;
-          } | null;
-          bounds?: Array<{
-            __typename?: 'ValueBound';
-            id: string;
-            severity: ValidationSeverity;
-            type: BoundType;
-            question?: string | null;
-            valueNumber?: number | null;
-            valueDate?: string | null;
-            valueLocalConstant?: string | null;
-            offset?: number | null;
-          }> | null;
-          pickListOptions?: Array<{
-            __typename?: 'PickListOption';
-            code: string;
-            label?: string | null;
-            secondaryLabel?: string | null;
-            groupLabel?: string | null;
-            groupCode?: string | null;
-            initialSelected?: boolean | null;
-            helperText?: string | null;
-            numericValue?: number | null;
-          }> | null;
-          initial?: Array<{
-            __typename?: 'InitialValue';
-            valueCode?: string | null;
-            valueBoolean?: boolean | null;
-            valueNumber?: number | null;
-            valueLocalConstant?: string | null;
-            initialBehavior: InitialBehavior;
-          }> | null;
-          enableWhen?: Array<{
-            __typename?: 'EnableWhen';
-            question?: string | null;
-            localConstant?: string | null;
-            operator: EnableOperator;
-            answerCode?: string | null;
-            answerCodes?: Array<string> | null;
-            answerNumber?: number | null;
-            answerBoolean?: boolean | null;
-            answerGroupCode?: string | null;
-            compareQuestion?: string | null;
-          }> | null;
-          autofillValues?: Array<{
-            __typename?: 'AutofillValue';
-            valueCode?: string | null;
-            valueQuestion?: string | null;
-            valueBoolean?: boolean | null;
-            valueNumber?: number | null;
-            sumQuestions?: Array<string> | null;
-            formula?: string | null;
-            autofillBehavior: EnableBehavior;
-            autofillReadonly?: boolean | null;
-            autofillWhen: Array<{
-              __typename?: 'EnableWhen';
-              question?: string | null;
-              localConstant?: string | null;
-              operator: EnableOperator;
-              answerCode?: string | null;
-              answerCodes?: Array<string> | null;
-              answerNumber?: number | null;
-              answerBoolean?: boolean | null;
-              answerGroupCode?: string | null;
-              compareQuestion?: string | null;
-            }>;
-          }> | null;
-        }> | null;
-        mapping?: {
-          __typename?: 'FieldMapping';
-          recordType?: RelatedRecordType | null;
-          fieldName?: string | null;
-          customFieldKey?: string | null;
-        } | null;
-        bounds?: Array<{
-          __typename?: 'ValueBound';
-          id: string;
-          severity: ValidationSeverity;
-          type: BoundType;
-          question?: string | null;
-          valueNumber?: number | null;
-          valueDate?: string | null;
-          valueLocalConstant?: string | null;
-          offset?: number | null;
-        }> | null;
-        pickListOptions?: Array<{
-          __typename?: 'PickListOption';
-          code: string;
-          label?: string | null;
-          secondaryLabel?: string | null;
-          groupLabel?: string | null;
-          groupCode?: string | null;
-          initialSelected?: boolean | null;
-          helperText?: string | null;
-          numericValue?: number | null;
-        }> | null;
-        initial?: Array<{
-          __typename?: 'InitialValue';
-          valueCode?: string | null;
-          valueBoolean?: boolean | null;
-          valueNumber?: number | null;
-          valueLocalConstant?: string | null;
-          initialBehavior: InitialBehavior;
-        }> | null;
-        enableWhen?: Array<{
-          __typename?: 'EnableWhen';
-          question?: string | null;
-          localConstant?: string | null;
-          operator: EnableOperator;
-          answerCode?: string | null;
-          answerCodes?: Array<string> | null;
-          answerNumber?: number | null;
-          answerBoolean?: boolean | null;
-          answerGroupCode?: string | null;
-          compareQuestion?: string | null;
-        }> | null;
-        autofillValues?: Array<{
-          __typename?: 'AutofillValue';
-          valueCode?: string | null;
-          valueQuestion?: string | null;
-          valueBoolean?: boolean | null;
-          valueNumber?: number | null;
-          sumQuestions?: Array<string> | null;
-          formula?: string | null;
-          autofillBehavior: EnableBehavior;
-          autofillReadonly?: boolean | null;
-          autofillWhen: Array<{
-            __typename?: 'EnableWhen';
-            question?: string | null;
-            localConstant?: string | null;
-            operator: EnableOperator;
-            answerCode?: string | null;
-            answerCodes?: Array<string> | null;
-            answerNumber?: number | null;
-            answerBoolean?: boolean | null;
-            answerGroupCode?: string | null;
-            compareQuestion?: string | null;
-          }>;
-        }> | null;
-      }>;
-    };
-  };
-  upgradedDefinitionForEditing?: {
-    __typename?: 'FormDefinition';
-    id: string;
-    role: FormRole;
-    title: string;
-    cacheKey: string;
-    identifier: string;
-    status: FormStatus;
-    definition: {
-      __typename?: 'FormDefinitionJson';
-      item: Array<{
-        __typename: 'FormItem';
-        linkId: string;
-        type: ItemType;
-        component?: Component | null;
-        prefix?: string | null;
-        text?: string | null;
-        briefText?: string | null;
-        readonlyText?: string | null;
-        helperText?: string | null;
-        required?: boolean | null;
-        warnIfEmpty?: boolean | null;
-        hidden?: boolean | null;
-        readOnly?: boolean | null;
-        repeats?: boolean | null;
-        pickListReference?: string | null;
-        size?: InputSize | null;
-        assessmentDate?: boolean | null;
-        prefill?: boolean | null;
-        dataCollectedAbout?: DataCollectedAbout | null;
-        disabledDisplay?: DisabledDisplay | null;
-        enableBehavior?: EnableBehavior | null;
-        item?: Array<{
-          __typename: 'FormItem';
-          linkId: string;
-          type: ItemType;
-          component?: Component | null;
-          prefix?: string | null;
-          text?: string | null;
-          briefText?: string | null;
-          readonlyText?: string | null;
-          helperText?: string | null;
-          required?: boolean | null;
-          warnIfEmpty?: boolean | null;
-          hidden?: boolean | null;
-          readOnly?: boolean | null;
-          repeats?: boolean | null;
-          pickListReference?: string | null;
-          size?: InputSize | null;
-          assessmentDate?: boolean | null;
-          prefill?: boolean | null;
-          dataCollectedAbout?: DataCollectedAbout | null;
-          disabledDisplay?: DisabledDisplay | null;
-          enableBehavior?: EnableBehavior | null;
-          item?: Array<{
-            __typename: 'FormItem';
-            linkId: string;
-            type: ItemType;
-            component?: Component | null;
-            prefix?: string | null;
-            text?: string | null;
-            briefText?: string | null;
-            readonlyText?: string | null;
-            helperText?: string | null;
-            required?: boolean | null;
-            warnIfEmpty?: boolean | null;
-            hidden?: boolean | null;
-            readOnly?: boolean | null;
-            repeats?: boolean | null;
-            pickListReference?: string | null;
-            size?: InputSize | null;
-            assessmentDate?: boolean | null;
-            prefill?: boolean | null;
-            dataCollectedAbout?: DataCollectedAbout | null;
-            disabledDisplay?: DisabledDisplay | null;
-            enableBehavior?: EnableBehavior | null;
-            item?: Array<{
-              __typename: 'FormItem';
-              linkId: string;
-              type: ItemType;
-              component?: Component | null;
-              prefix?: string | null;
-              text?: string | null;
-              briefText?: string | null;
-              readonlyText?: string | null;
-              helperText?: string | null;
-              required?: boolean | null;
-              warnIfEmpty?: boolean | null;
-              hidden?: boolean | null;
-              readOnly?: boolean | null;
-              repeats?: boolean | null;
-              pickListReference?: string | null;
-              size?: InputSize | null;
-              assessmentDate?: boolean | null;
-              prefill?: boolean | null;
-              dataCollectedAbout?: DataCollectedAbout | null;
-              disabledDisplay?: DisabledDisplay | null;
-              enableBehavior?: EnableBehavior | null;
-              item?: Array<{
-                __typename: 'FormItem';
-                linkId: string;
-                type: ItemType;
-                component?: Component | null;
-                prefix?: string | null;
-                text?: string | null;
-                briefText?: string | null;
-                readonlyText?: string | null;
-                helperText?: string | null;
-                required?: boolean | null;
-                warnIfEmpty?: boolean | null;
-                hidden?: boolean | null;
-                readOnly?: boolean | null;
-                repeats?: boolean | null;
-                pickListReference?: string | null;
-                size?: InputSize | null;
-                assessmentDate?: boolean | null;
-                prefill?: boolean | null;
-                dataCollectedAbout?: DataCollectedAbout | null;
-                disabledDisplay?: DisabledDisplay | null;
-                enableBehavior?: EnableBehavior | null;
-                mapping?: {
-                  __typename?: 'FieldMapping';
-                  recordType?: RelatedRecordType | null;
-                  fieldName?: string | null;
-                  customFieldKey?: string | null;
-                } | null;
-                bounds?: Array<{
-                  __typename?: 'ValueBound';
-                  id: string;
-                  severity: ValidationSeverity;
-                  type: BoundType;
-                  question?: string | null;
-                  valueNumber?: number | null;
-                  valueDate?: string | null;
-                  valueLocalConstant?: string | null;
-                  offset?: number | null;
-                }> | null;
-                pickListOptions?: Array<{
-                  __typename?: 'PickListOption';
-                  code: string;
-                  label?: string | null;
-                  secondaryLabel?: string | null;
-                  groupLabel?: string | null;
-                  groupCode?: string | null;
-                  initialSelected?: boolean | null;
-                  helperText?: string | null;
-                  numericValue?: number | null;
-                }> | null;
-                initial?: Array<{
-                  __typename?: 'InitialValue';
-                  valueCode?: string | null;
-                  valueBoolean?: boolean | null;
-                  valueNumber?: number | null;
-                  valueLocalConstant?: string | null;
-                  initialBehavior: InitialBehavior;
-                }> | null;
-                enableWhen?: Array<{
-                  __typename?: 'EnableWhen';
-                  question?: string | null;
-                  localConstant?: string | null;
-                  operator: EnableOperator;
-                  answerCode?: string | null;
-                  answerCodes?: Array<string> | null;
-                  answerNumber?: number | null;
-                  answerBoolean?: boolean | null;
-                  answerGroupCode?: string | null;
-                  compareQuestion?: string | null;
-                }> | null;
-                autofillValues?: Array<{
-                  __typename?: 'AutofillValue';
-                  valueCode?: string | null;
-                  valueQuestion?: string | null;
-                  valueBoolean?: boolean | null;
-                  valueNumber?: number | null;
-                  sumQuestions?: Array<string> | null;
-                  formula?: string | null;
-                  autofillBehavior: EnableBehavior;
-                  autofillReadonly?: boolean | null;
-                  autofillWhen: Array<{
-                    __typename?: 'EnableWhen';
-                    question?: string | null;
-                    localConstant?: string | null;
-                    operator: EnableOperator;
-                    answerCode?: string | null;
-                    answerCodes?: Array<string> | null;
-                    answerNumber?: number | null;
-                    answerBoolean?: boolean | null;
-                    answerGroupCode?: string | null;
-                    compareQuestion?: string | null;
-                  }>;
-                }> | null;
-              }> | null;
-              mapping?: {
-                __typename?: 'FieldMapping';
-                recordType?: RelatedRecordType | null;
-                fieldName?: string | null;
-                customFieldKey?: string | null;
-              } | null;
-              bounds?: Array<{
-                __typename?: 'ValueBound';
-                id: string;
-                severity: ValidationSeverity;
-                type: BoundType;
-                question?: string | null;
-                valueNumber?: number | null;
-                valueDate?: string | null;
-                valueLocalConstant?: string | null;
-                offset?: number | null;
-              }> | null;
-              pickListOptions?: Array<{
-                __typename?: 'PickListOption';
-                code: string;
-                label?: string | null;
-                secondaryLabel?: string | null;
-                groupLabel?: string | null;
-                groupCode?: string | null;
-                initialSelected?: boolean | null;
-                helperText?: string | null;
-                numericValue?: number | null;
-              }> | null;
-              initial?: Array<{
-                __typename?: 'InitialValue';
-                valueCode?: string | null;
-                valueBoolean?: boolean | null;
-                valueNumber?: number | null;
-                valueLocalConstant?: string | null;
-                initialBehavior: InitialBehavior;
-              }> | null;
-              enableWhen?: Array<{
-                __typename?: 'EnableWhen';
-                question?: string | null;
-                localConstant?: string | null;
-                operator: EnableOperator;
-                answerCode?: string | null;
-                answerCodes?: Array<string> | null;
-                answerNumber?: number | null;
-                answerBoolean?: boolean | null;
-                answerGroupCode?: string | null;
-                compareQuestion?: string | null;
-              }> | null;
-              autofillValues?: Array<{
-                __typename?: 'AutofillValue';
-                valueCode?: string | null;
-                valueQuestion?: string | null;
-                valueBoolean?: boolean | null;
-                valueNumber?: number | null;
-                sumQuestions?: Array<string> | null;
-                formula?: string | null;
-                autofillBehavior: EnableBehavior;
-                autofillReadonly?: boolean | null;
-                autofillWhen: Array<{
-                  __typename?: 'EnableWhen';
-                  question?: string | null;
-                  localConstant?: string | null;
-                  operator: EnableOperator;
-                  answerCode?: string | null;
-                  answerCodes?: Array<string> | null;
-                  answerNumber?: number | null;
-                  answerBoolean?: boolean | null;
-                  answerGroupCode?: string | null;
-                  compareQuestion?: string | null;
-                }>;
-              }> | null;
-            }> | null;
-            mapping?: {
-              __typename?: 'FieldMapping';
-              recordType?: RelatedRecordType | null;
-              fieldName?: string | null;
-              customFieldKey?: string | null;
-            } | null;
-            bounds?: Array<{
-              __typename?: 'ValueBound';
-              id: string;
-              severity: ValidationSeverity;
-              type: BoundType;
-              question?: string | null;
-              valueNumber?: number | null;
-              valueDate?: string | null;
-              valueLocalConstant?: string | null;
-              offset?: number | null;
-            }> | null;
-            pickListOptions?: Array<{
-              __typename?: 'PickListOption';
-              code: string;
-              label?: string | null;
-              secondaryLabel?: string | null;
-              groupLabel?: string | null;
-              groupCode?: string | null;
-              initialSelected?: boolean | null;
-              helperText?: string | null;
-              numericValue?: number | null;
-            }> | null;
-            initial?: Array<{
-              __typename?: 'InitialValue';
-              valueCode?: string | null;
-              valueBoolean?: boolean | null;
-              valueNumber?: number | null;
-              valueLocalConstant?: string | null;
-              initialBehavior: InitialBehavior;
-            }> | null;
-            enableWhen?: Array<{
-              __typename?: 'EnableWhen';
-              question?: string | null;
-              localConstant?: string | null;
-              operator: EnableOperator;
-              answerCode?: string | null;
-              answerCodes?: Array<string> | null;
-              answerNumber?: number | null;
-              answerBoolean?: boolean | null;
-              answerGroupCode?: string | null;
-              compareQuestion?: string | null;
-            }> | null;
-            autofillValues?: Array<{
-              __typename?: 'AutofillValue';
-              valueCode?: string | null;
-              valueQuestion?: string | null;
-              valueBoolean?: boolean | null;
-              valueNumber?: number | null;
-              sumQuestions?: Array<string> | null;
-              formula?: string | null;
-              autofillBehavior: EnableBehavior;
-              autofillReadonly?: boolean | null;
-              autofillWhen: Array<{
-                __typename?: 'EnableWhen';
-                question?: string | null;
-                localConstant?: string | null;
-                operator: EnableOperator;
-                answerCode?: string | null;
-                answerCodes?: Array<string> | null;
-                answerNumber?: number | null;
-                answerBoolean?: boolean | null;
-                answerGroupCode?: string | null;
-                compareQuestion?: string | null;
-              }>;
-            }> | null;
-          }> | null;
-          mapping?: {
-            __typename?: 'FieldMapping';
-            recordType?: RelatedRecordType | null;
-            fieldName?: string | null;
-            customFieldKey?: string | null;
-          } | null;
-          bounds?: Array<{
-            __typename?: 'ValueBound';
-            id: string;
-            severity: ValidationSeverity;
-            type: BoundType;
-            question?: string | null;
-            valueNumber?: number | null;
-            valueDate?: string | null;
-            valueLocalConstant?: string | null;
-            offset?: number | null;
-          }> | null;
-          pickListOptions?: Array<{
-            __typename?: 'PickListOption';
-            code: string;
-            label?: string | null;
-            secondaryLabel?: string | null;
-            groupLabel?: string | null;
-            groupCode?: string | null;
-            initialSelected?: boolean | null;
-            helperText?: string | null;
-            numericValue?: number | null;
-          }> | null;
-          initial?: Array<{
-            __typename?: 'InitialValue';
-            valueCode?: string | null;
-            valueBoolean?: boolean | null;
-            valueNumber?: number | null;
-            valueLocalConstant?: string | null;
-            initialBehavior: InitialBehavior;
-          }> | null;
-          enableWhen?: Array<{
-            __typename?: 'EnableWhen';
-            question?: string | null;
-            localConstant?: string | null;
-            operator: EnableOperator;
-            answerCode?: string | null;
-            answerCodes?: Array<string> | null;
-            answerNumber?: number | null;
-            answerBoolean?: boolean | null;
-            answerGroupCode?: string | null;
-            compareQuestion?: string | null;
-          }> | null;
-          autofillValues?: Array<{
-            __typename?: 'AutofillValue';
-            valueCode?: string | null;
-            valueQuestion?: string | null;
-            valueBoolean?: boolean | null;
-            valueNumber?: number | null;
-            sumQuestions?: Array<string> | null;
-            formula?: string | null;
-            autofillBehavior: EnableBehavior;
-            autofillReadonly?: boolean | null;
-            autofillWhen: Array<{
-              __typename?: 'EnableWhen';
-              question?: string | null;
-              localConstant?: string | null;
-              operator: EnableOperator;
-              answerCode?: string | null;
-              answerCodes?: Array<string> | null;
-              answerNumber?: number | null;
-              answerBoolean?: boolean | null;
-              answerGroupCode?: string | null;
-              compareQuestion?: string | null;
-            }>;
-          }> | null;
-        }> | null;
-        mapping?: {
-          __typename?: 'FieldMapping';
-          recordType?: RelatedRecordType | null;
-          fieldName?: string | null;
-          customFieldKey?: string | null;
-        } | null;
-        bounds?: Array<{
-          __typename?: 'ValueBound';
-          id: string;
-          severity: ValidationSeverity;
-          type: BoundType;
-          question?: string | null;
-          valueNumber?: number | null;
-          valueDate?: string | null;
-          valueLocalConstant?: string | null;
-          offset?: number | null;
-        }> | null;
-        pickListOptions?: Array<{
-          __typename?: 'PickListOption';
-          code: string;
-          label?: string | null;
-          secondaryLabel?: string | null;
-          groupLabel?: string | null;
-          groupCode?: string | null;
-          initialSelected?: boolean | null;
-          helperText?: string | null;
-          numericValue?: number | null;
-        }> | null;
-        initial?: Array<{
-          __typename?: 'InitialValue';
-          valueCode?: string | null;
-          valueBoolean?: boolean | null;
-          valueNumber?: number | null;
-          valueLocalConstant?: string | null;
-          initialBehavior: InitialBehavior;
-        }> | null;
-        enableWhen?: Array<{
-          __typename?: 'EnableWhen';
-          question?: string | null;
-          localConstant?: string | null;
-          operator: EnableOperator;
-          answerCode?: string | null;
-          answerCodes?: Array<string> | null;
-          answerNumber?: number | null;
-          answerBoolean?: boolean | null;
-          answerGroupCode?: string | null;
-          compareQuestion?: string | null;
-        }> | null;
-        autofillValues?: Array<{
-          __typename?: 'AutofillValue';
-          valueCode?: string | null;
-          valueQuestion?: string | null;
-          valueBoolean?: boolean | null;
-          valueNumber?: number | null;
-          sumQuestions?: Array<string> | null;
-          formula?: string | null;
-          autofillBehavior: EnableBehavior;
-          autofillReadonly?: boolean | null;
-          autofillWhen: Array<{
-            __typename?: 'EnableWhen';
-            question?: string | null;
-            localConstant?: string | null;
-            operator: EnableOperator;
-            answerCode?: string | null;
-            answerCodes?: Array<string> | null;
-            answerNumber?: number | null;
-            answerBoolean?: boolean | null;
-            answerGroupCode?: string | null;
-            compareQuestion?: string | null;
-          }>;
-        }> | null;
-      }>;
-    };
-  } | null;
   enrollment: {
     __typename?: 'Enrollment';
     id: string;
@@ -10366,6 +9402,12 @@ export type FullAssessmentFragment = {
     lastName?: string | null;
     email: string;
   } | null;
+  definition: {
+    __typename?: 'FormDefinition';
+    id: string;
+    cacheKey: string;
+    title: string;
+  };
 };
 
 export type GetAssessmentQueryVariables = Exact<{
@@ -35492,153 +34534,13 @@ export const AssessmentWithValuesFragmentDoc = gql`
   }
   ${AssessmentFieldsFragmentDoc}
 `;
-export const FormDefinitionMetadataFragmentDoc = gql`
-  fragment FormDefinitionMetadata on FormDefinition {
-    id
-    role
-    title
-    cacheKey
-    identifier
-    status
-  }
-`;
-export const PickListOptionFieldsFragmentDoc = gql`
-  fragment PickListOptionFields on PickListOption {
-    code
-    label
-    secondaryLabel
-    groupLabel
-    groupCode
-    initialSelected
-    helperText
-    numericValue
-  }
-`;
-export const EnableWhenFieldsFragmentDoc = gql`
-  fragment EnableWhenFields on EnableWhen {
-    question
-    localConstant
-    operator
-    answerCode
-    answerCodes
-    answerNumber
-    answerBoolean
-    answerGroupCode
-    compareQuestion
-  }
-`;
-export const ItemFieldsFragmentDoc = gql`
-  fragment ItemFields on FormItem {
-    __typename
-    linkId
-    type
-    component
-    prefix
-    text
-    briefText
-    readonlyText
-    helperText
-    required
-    warnIfEmpty
-    hidden
-    readOnly
-    repeats
-    mapping {
-      recordType
-      fieldName
-      customFieldKey
-    }
-    pickListReference
-    size
-    assessmentDate
-    prefill
-    bounds {
-      id
-      severity
-      type
-      question
-      valueNumber
-      valueDate
-      valueLocalConstant
-      offset
-    }
-    pickListOptions {
-      ...PickListOptionFields
-    }
-    initial {
-      valueCode
-      valueBoolean
-      valueNumber
-      valueLocalConstant
-      initialBehavior
-    }
-    dataCollectedAbout
-    disabledDisplay
-    enableBehavior
-    enableWhen {
-      ...EnableWhenFields
-    }
-    autofillValues {
-      valueCode
-      valueQuestion
-      valueBoolean
-      valueNumber
-      sumQuestions
-      formula
-      autofillBehavior
-      autofillReadonly
-      autofillWhen {
-        ...EnableWhenFields
-      }
-    }
-  }
-  ${PickListOptionFieldsFragmentDoc}
-  ${EnableWhenFieldsFragmentDoc}
-`;
-export const FormDefinitionJsonFieldsFragmentDoc = gql`
-  fragment FormDefinitionJsonFields on FormDefinitionJson {
-    item {
-      ...ItemFields
-      item {
-        ...ItemFields
-        item {
-          ...ItemFields
-          item {
-            ...ItemFields
-            item {
-              ...ItemFields
-            }
-          }
-        }
-      }
-    }
-  }
-  ${ItemFieldsFragmentDoc}
-`;
-export const FormDefinitionFieldsFragmentDoc = gql`
-  fragment FormDefinitionFields on FormDefinition {
-    ...FormDefinitionMetadata
-    definition {
-      ...FormDefinitionJsonFields
-    }
-  }
-  ${FormDefinitionMetadataFragmentDoc}
-  ${FormDefinitionJsonFieldsFragmentDoc}
-`;
 export const FullAssessmentFragmentDoc = gql`
   fragment FullAssessment on Assessment {
     ...AssessmentWithRecords
     ...AssessmentWithValues
-    definition {
-      ...FormDefinitionFields
-    }
-    upgradedDefinitionForEditing {
-      ...FormDefinitionFields
-    }
   }
   ${AssessmentWithRecordsFragmentDoc}
   ${AssessmentWithValuesFragmentDoc}
-  ${FormDefinitionFieldsFragmentDoc}
 `;
 export const ProjectNameAndTypeFragmentDoc = gql`
   fragment ProjectNameAndType on Project {
@@ -36292,6 +35194,139 @@ export const DataCollectionFeatureFieldsFragmentDoc = gql`
     dataCollectedAbout
     legacy
   }
+`;
+export const FormDefinitionMetadataFragmentDoc = gql`
+  fragment FormDefinitionMetadata on FormDefinition {
+    id
+    role
+    title
+    cacheKey
+    identifier
+    status
+  }
+`;
+export const PickListOptionFieldsFragmentDoc = gql`
+  fragment PickListOptionFields on PickListOption {
+    code
+    label
+    secondaryLabel
+    groupLabel
+    groupCode
+    initialSelected
+    helperText
+    numericValue
+  }
+`;
+export const EnableWhenFieldsFragmentDoc = gql`
+  fragment EnableWhenFields on EnableWhen {
+    question
+    localConstant
+    operator
+    answerCode
+    answerCodes
+    answerNumber
+    answerBoolean
+    answerGroupCode
+    compareQuestion
+  }
+`;
+export const ItemFieldsFragmentDoc = gql`
+  fragment ItemFields on FormItem {
+    __typename
+    linkId
+    type
+    component
+    prefix
+    text
+    briefText
+    readonlyText
+    helperText
+    required
+    warnIfEmpty
+    hidden
+    readOnly
+    repeats
+    mapping {
+      recordType
+      fieldName
+      customFieldKey
+    }
+    pickListReference
+    size
+    assessmentDate
+    prefill
+    bounds {
+      id
+      severity
+      type
+      question
+      valueNumber
+      valueDate
+      valueLocalConstant
+      offset
+    }
+    pickListOptions {
+      ...PickListOptionFields
+    }
+    initial {
+      valueCode
+      valueBoolean
+      valueNumber
+      valueLocalConstant
+      initialBehavior
+    }
+    dataCollectedAbout
+    disabledDisplay
+    enableBehavior
+    enableWhen {
+      ...EnableWhenFields
+    }
+    autofillValues {
+      valueCode
+      valueQuestion
+      valueBoolean
+      valueNumber
+      sumQuestions
+      formula
+      autofillBehavior
+      autofillReadonly
+      autofillWhen {
+        ...EnableWhenFields
+      }
+    }
+  }
+  ${PickListOptionFieldsFragmentDoc}
+  ${EnableWhenFieldsFragmentDoc}
+`;
+export const FormDefinitionJsonFieldsFragmentDoc = gql`
+  fragment FormDefinitionJsonFields on FormDefinitionJson {
+    item {
+      ...ItemFields
+      item {
+        ...ItemFields
+        item {
+          ...ItemFields
+          item {
+            ...ItemFields
+            item {
+              ...ItemFields
+            }
+          }
+        }
+      }
+    }
+  }
+  ${ItemFieldsFragmentDoc}
+`;
+export const FormDefinitionFieldsFragmentDoc = gql`
+  fragment FormDefinitionFields on FormDefinition {
+    ...FormDefinitionMetadata
+    definition {
+      ...FormDefinitionJsonFields
+    }
+  }
+  ${FormDefinitionMetadataFragmentDoc}
+  ${FormDefinitionJsonFieldsFragmentDoc}
 `;
 export const OccurrencePointFormFieldsFragmentDoc = gql`
   fragment OccurrencePointFormFields on OccurrencePointForm {
@@ -37464,9 +36499,16 @@ export const GetAssessmentDocument = gql`
   query GetAssessment($id: ID!) {
     assessment(id: $id) {
       ...FullAssessment
+      definition {
+        ...FormDefinitionFields
+      }
+      upgradedDefinitionForEditing {
+        ...FormDefinitionFields
+      }
     }
   }
   ${FullAssessmentFragmentDoc}
+  ${FormDefinitionFieldsFragmentDoc}
 `;
 
 /**


### PR DESCRIPTION
## Description


Requires backend PR: https://github.com/greenriver/hmis-warehouse/pull/4649


* Patch bug: https://github.com/open-path/Green-River/issues/6112#issuecomment-2302737952 Fix:
  * Always pass the Form Definition ID of the "editingDefinition" to the `useAssessmentHandlers` hook, so that when an assessment is submitted it is always submitted as using the "editing" definition
  * Raise an error if you try to submit form state that has keys that are not present as link_ids in the underlying definition. (We already do this check on the backend in the Form Processor, but this was dropping them silently during the transformation).
 
* Patch another bug (also introduced in 129) whereby the submitted values for assessments would have some extra hidden fields, because the `createHudValuesForSubmit` transformation was being called with a definition that had NOT been yet transformed  (e.g. it still had adult-only questions even if form was for a child). I don't have a regression test for this yet. The impact could be that some empty records are unnecessarily created, I think. Fix:
  * Move values transformation (`createHudValuesForSubmit`) into the `useDynamicFields` hook so that the DynamicForm is responsible for transforming the form state into a "submittable" shape, using the same FormDefinition it used for editing it. I think this is a cleaner API, and makes sense since the DynamicForm already knows about the definition.

#### How to Test
* Follow script in https://github.com/open-path/Green-River/issues/6112#issuecomment-2302737952
* and "how to QA" section of https://github.com/open-path/Green-River/issues/6112#issuecomment-2302737952

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
