### PR TITLE
Enable date comparison in EnableWhen condition

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -14901,6 +14901,18 @@
             "deprecationReason": null
           },
           {
+            "name": "answerDate",
+            "description": "If question is date type, value for comparison",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "ISO8601Date",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "answerGroupCode",
             "description": "If question is choice type and has grouped options, value for comparison",
             "args": [],

--- a/src/api/operations/form.fragments.graphql
+++ b/src/api/operations/form.fragments.graphql
@@ -32,6 +32,7 @@ fragment EnableWhenFields on EnableWhen {
   answerNumber
   answerBoolean
   answerGroupCode
+  answerDate
   compareQuestion
 }
 fragment ItemFields on FormItem {

--- a/src/modules/form/util/formUtil.ts
+++ b/src/modules/form/util/formUtil.ts
@@ -2,6 +2,7 @@ import {
   add,
   getYear,
   isDate,
+  isEqual,
   isValid,
   max,
   min,
@@ -320,6 +321,7 @@ const evaluateEnableWhen = ({
       en.answerGroupCode,
       en.answerNumber,
       en.answerCodes,
+      en.answerDate ? parseHmisDateString(en.answerDate) : undefined,
       en.compareQuestion ? values[en.compareQuestion] : undefined,
     ].filter((e) => !isNil(e))[0];
   }
@@ -327,7 +329,11 @@ const evaluateEnableWhen = ({
   let result;
   switch (en.operator) {
     case EnableOperator.Equal:
-      result = currentValue === comparisonValue;
+      if (isDate(currentValue)) {
+        result = isEqual(currentValue, comparisonValue);
+      } else {
+        result = currentValue === comparisonValue;
+      }
       break;
     case EnableOperator.NotEqual:
       result = currentValue !== comparisonValue;

--- a/src/modules/formBuilder/components/itemEditor/conditionals/EnableWhenCondition.tsx
+++ b/src/modules/formBuilder/components/itemEditor/conditionals/EnableWhenCondition.tsx
@@ -16,6 +16,7 @@ import {
   getItemCategory,
 } from '@/modules/formBuilder/formBuilderUtil';
 import { formatDateForGql, parseHmisDateString } from '@/modules/hmis/hmisUtil';
+import { RootPermissionsFilter } from '@/modules/permissions/PermissionsFilters';
 import { HmisEnums } from '@/types/gqlEnums';
 import {
   EnableOperator,
@@ -304,21 +305,26 @@ const EnableWhenCondition: React.FC<EnableWhenConditionProps> = ({
           </Stack>
         </Grid>
       </Grid>
-      <Box sx={{ mt: 2 }}>
-        <Typography typography='body2' fontWeight={600}>
-          Advanced Options
-        </Typography>
-        <Stack>
-          <LabeledCheckbox
-            label='Compare with a Local Constant instead of a Dependent Question'
-            checked={advanced.localConstant}
-            sx={{ width: 'fit-content' }}
-            onChange={(evt, checked) =>
-              setAdvanced((old) => ({ ...old, localConstant: checked }))
-            }
-          />
-        </Stack>
-      </Box>
+      {/* TODO: Add typing for local constants (treat `today` as a date)
+      and add other useful local constants such as project ID.
+      Hiding this behind a super-admin-only curtain for now.*/}
+      <RootPermissionsFilter permissions='canAdministrateConfig'>
+        <Box sx={{ mt: 2 }}>
+          <Typography typography='body2' fontWeight={600}>
+            Advanced Options
+          </Typography>
+          <Stack>
+            <LabeledCheckbox
+              label='Compare with a Local Constant instead of a Dependent Question'
+              checked={advanced.localConstant}
+              sx={{ width: 'fit-content' }}
+              onChange={(evt, checked) =>
+                setAdvanced((old) => ({ ...old, localConstant: checked }))
+              }
+            />
+          </Stack>
+        </Box>
+      </RootPermissionsFilter>
     </Stack>
   );
 };

--- a/src/modules/formBuilder/components/itemEditor/conditionals/EnableWhenCondition.tsx
+++ b/src/modules/formBuilder/components/itemEditor/conditionals/EnableWhenCondition.tsx
@@ -1,9 +1,10 @@
 import { Box, Grid, Stack, Typography } from '@mui/material';
 import { startCase } from 'lodash-es';
 import { useMemo, useState } from 'react';
-import { UseFormSetValue, useWatch } from 'react-hook-form';
+import { Controller, UseFormSetValue, useWatch } from 'react-hook-form';
 import { FormItemControl, FormItemState } from '../types';
 import { useLocalConstantsPickList } from '../useLocalConstantsPickList';
+import DatePicker from '@/components/elements/input/DatePicker';
 import LabeledCheckbox from '@/components/elements/input/LabeledCheckbox';
 import { FALSE_OPT, TRUE_OPT } from '@/components/elements/input/YesNoRadio';
 import ControlledSelect from '@/modules/form/components/rhf/ControlledSelect';
@@ -14,6 +15,7 @@ import {
   COMPARABLE_ITEM_TYPES,
   getItemCategory,
 } from '@/modules/formBuilder/formBuilderUtil';
+import { formatDateForGql, parseHmisDateString } from '@/modules/hmis/hmisUtil';
 import { HmisEnums } from '@/types/gqlEnums';
 import {
   EnableOperator,
@@ -82,6 +84,8 @@ export const determineEnableWhenComparisonField = (
     case ItemType.Integer:
     case ItemType.Currency:
       return 'answerNumber';
+    case ItemType.Date:
+      return 'answerDate';
     default:
       // not handled: compareQuestion
       return 'answerCode';
@@ -254,6 +258,21 @@ const EnableWhenCondition: React.FC<EnableWhenConditionProps> = ({
                   required
                 />
               ))}
+            {answerInputType === 'answerDate' && (
+              <Controller
+                name={`${enableWhenPath}.${index}.answerDate`}
+                control={control}
+                render={({ field: { ref, ...field } }) => (
+                  <DatePicker
+                    value={parseHmisDateString(field.value)}
+                    onChange={(date) =>
+                      field.onChange(date ? formatDateForGql(date) : '')
+                    }
+                    label={`Response Value (Date)`}
+                  />
+                )}
+              />
+            )}
             {answerInputType === 'answerCodes' && (
               <ControlledTextInput
                 name={`${enableWhenPath}.${index}.answerCodes`}

--- a/src/types/gqlObjects.ts
+++ b/src/types/gqlObjects.ts
@@ -1996,6 +1996,10 @@ export const HmisObjectSchemas: GqlSchema[] = [
         },
       },
       {
+        name: 'answerDate',
+        type: { kind: 'SCALAR', name: 'ISO8601Date', ofType: null },
+      },
+      {
         name: 'answerGroupCode',
         type: { kind: 'SCALAR', name: 'String', ofType: null },
       },

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -2240,6 +2240,8 @@ export type EnableWhen = {
   answerCode?: Maybe<Scalars['String']['output']>;
   /** If question is choice type, and operator is IN, values for comparison */
   answerCodes?: Maybe<Array<Scalars['String']['output']>>;
+  /** If question is date type, value for comparison */
+  answerDate?: Maybe<Scalars['ISO8601Date']['output']>;
   /** If question is choice type and has grouped options, value for comparison */
   answerGroupCode?: Maybe<Scalars['String']['output']>;
   /** If question is numeric, value for comparison */
@@ -9050,6 +9052,7 @@ export type FullAssessmentFragment = {
                   answerNumber?: number | null;
                   answerBoolean?: boolean | null;
                   answerGroupCode?: string | null;
+                  answerDate?: string | null;
                   compareQuestion?: string | null;
                 }> | null;
                 autofillValues?: Array<{
@@ -9072,6 +9075,7 @@ export type FullAssessmentFragment = {
                     answerNumber?: number | null;
                     answerBoolean?: boolean | null;
                     answerGroupCode?: string | null;
+                    answerDate?: string | null;
                     compareQuestion?: string | null;
                   }>;
                 }> | null;
@@ -9122,6 +9126,7 @@ export type FullAssessmentFragment = {
                 answerNumber?: number | null;
                 answerBoolean?: boolean | null;
                 answerGroupCode?: string | null;
+                answerDate?: string | null;
                 compareQuestion?: string | null;
               }> | null;
               autofillValues?: Array<{
@@ -9144,6 +9149,7 @@ export type FullAssessmentFragment = {
                   answerNumber?: number | null;
                   answerBoolean?: boolean | null;
                   answerGroupCode?: string | null;
+                  answerDate?: string | null;
                   compareQuestion?: string | null;
                 }>;
               }> | null;
@@ -9194,6 +9200,7 @@ export type FullAssessmentFragment = {
               answerNumber?: number | null;
               answerBoolean?: boolean | null;
               answerGroupCode?: string | null;
+              answerDate?: string | null;
               compareQuestion?: string | null;
             }> | null;
             autofillValues?: Array<{
@@ -9216,6 +9223,7 @@ export type FullAssessmentFragment = {
                 answerNumber?: number | null;
                 answerBoolean?: boolean | null;
                 answerGroupCode?: string | null;
+                answerDate?: string | null;
                 compareQuestion?: string | null;
               }>;
             }> | null;
@@ -9266,6 +9274,7 @@ export type FullAssessmentFragment = {
             answerNumber?: number | null;
             answerBoolean?: boolean | null;
             answerGroupCode?: string | null;
+            answerDate?: string | null;
             compareQuestion?: string | null;
           }> | null;
           autofillValues?: Array<{
@@ -9288,6 +9297,7 @@ export type FullAssessmentFragment = {
               answerNumber?: number | null;
               answerBoolean?: boolean | null;
               answerGroupCode?: string | null;
+              answerDate?: string | null;
               compareQuestion?: string | null;
             }>;
           }> | null;
@@ -9338,6 +9348,7 @@ export type FullAssessmentFragment = {
           answerNumber?: number | null;
           answerBoolean?: boolean | null;
           answerGroupCode?: string | null;
+          answerDate?: string | null;
           compareQuestion?: string | null;
         }> | null;
         autofillValues?: Array<{
@@ -9360,6 +9371,7 @@ export type FullAssessmentFragment = {
             answerNumber?: number | null;
             answerBoolean?: boolean | null;
             answerGroupCode?: string | null;
+            answerDate?: string | null;
             compareQuestion?: string | null;
           }>;
         }> | null;
@@ -9532,6 +9544,7 @@ export type FullAssessmentFragment = {
                   answerNumber?: number | null;
                   answerBoolean?: boolean | null;
                   answerGroupCode?: string | null;
+                  answerDate?: string | null;
                   compareQuestion?: string | null;
                 }> | null;
                 autofillValues?: Array<{
@@ -9554,6 +9567,7 @@ export type FullAssessmentFragment = {
                     answerNumber?: number | null;
                     answerBoolean?: boolean | null;
                     answerGroupCode?: string | null;
+                    answerDate?: string | null;
                     compareQuestion?: string | null;
                   }>;
                 }> | null;
@@ -9604,6 +9618,7 @@ export type FullAssessmentFragment = {
                 answerNumber?: number | null;
                 answerBoolean?: boolean | null;
                 answerGroupCode?: string | null;
+                answerDate?: string | null;
                 compareQuestion?: string | null;
               }> | null;
               autofillValues?: Array<{
@@ -9626,6 +9641,7 @@ export type FullAssessmentFragment = {
                   answerNumber?: number | null;
                   answerBoolean?: boolean | null;
                   answerGroupCode?: string | null;
+                  answerDate?: string | null;
                   compareQuestion?: string | null;
                 }>;
               }> | null;
@@ -9676,6 +9692,7 @@ export type FullAssessmentFragment = {
               answerNumber?: number | null;
               answerBoolean?: boolean | null;
               answerGroupCode?: string | null;
+              answerDate?: string | null;
               compareQuestion?: string | null;
             }> | null;
             autofillValues?: Array<{
@@ -9698,6 +9715,7 @@ export type FullAssessmentFragment = {
                 answerNumber?: number | null;
                 answerBoolean?: boolean | null;
                 answerGroupCode?: string | null;
+                answerDate?: string | null;
                 compareQuestion?: string | null;
               }>;
             }> | null;
@@ -9748,6 +9766,7 @@ export type FullAssessmentFragment = {
             answerNumber?: number | null;
             answerBoolean?: boolean | null;
             answerGroupCode?: string | null;
+            answerDate?: string | null;
             compareQuestion?: string | null;
           }> | null;
           autofillValues?: Array<{
@@ -9770,6 +9789,7 @@ export type FullAssessmentFragment = {
               answerNumber?: number | null;
               answerBoolean?: boolean | null;
               answerGroupCode?: string | null;
+              answerDate?: string | null;
               compareQuestion?: string | null;
             }>;
           }> | null;
@@ -9820,6 +9840,7 @@ export type FullAssessmentFragment = {
           answerNumber?: number | null;
           answerBoolean?: boolean | null;
           answerGroupCode?: string | null;
+          answerDate?: string | null;
           compareQuestion?: string | null;
         }> | null;
         autofillValues?: Array<{
@@ -9842,6 +9863,7 @@ export type FullAssessmentFragment = {
             answerNumber?: number | null;
             answerBoolean?: boolean | null;
             answerGroupCode?: string | null;
+            answerDate?: string | null;
             compareQuestion?: string | null;
           }>;
         }> | null;
@@ -10552,6 +10574,7 @@ export type GetAssessmentQuery = {
                     answerNumber?: number | null;
                     answerBoolean?: boolean | null;
                     answerGroupCode?: string | null;
+                    answerDate?: string | null;
                     compareQuestion?: string | null;
                   }> | null;
                   autofillValues?: Array<{
@@ -10574,6 +10597,7 @@ export type GetAssessmentQuery = {
                       answerNumber?: number | null;
                       answerBoolean?: boolean | null;
                       answerGroupCode?: string | null;
+                      answerDate?: string | null;
                       compareQuestion?: string | null;
                     }>;
                   }> | null;
@@ -10624,6 +10648,7 @@ export type GetAssessmentQuery = {
                   answerNumber?: number | null;
                   answerBoolean?: boolean | null;
                   answerGroupCode?: string | null;
+                  answerDate?: string | null;
                   compareQuestion?: string | null;
                 }> | null;
                 autofillValues?: Array<{
@@ -10646,6 +10671,7 @@ export type GetAssessmentQuery = {
                     answerNumber?: number | null;
                     answerBoolean?: boolean | null;
                     answerGroupCode?: string | null;
+                    answerDate?: string | null;
                     compareQuestion?: string | null;
                   }>;
                 }> | null;
@@ -10696,6 +10722,7 @@ export type GetAssessmentQuery = {
                 answerNumber?: number | null;
                 answerBoolean?: boolean | null;
                 answerGroupCode?: string | null;
+                answerDate?: string | null;
                 compareQuestion?: string | null;
               }> | null;
               autofillValues?: Array<{
@@ -10718,6 +10745,7 @@ export type GetAssessmentQuery = {
                   answerNumber?: number | null;
                   answerBoolean?: boolean | null;
                   answerGroupCode?: string | null;
+                  answerDate?: string | null;
                   compareQuestion?: string | null;
                 }>;
               }> | null;
@@ -10768,6 +10796,7 @@ export type GetAssessmentQuery = {
               answerNumber?: number | null;
               answerBoolean?: boolean | null;
               answerGroupCode?: string | null;
+              answerDate?: string | null;
               compareQuestion?: string | null;
             }> | null;
             autofillValues?: Array<{
@@ -10790,6 +10819,7 @@ export type GetAssessmentQuery = {
                 answerNumber?: number | null;
                 answerBoolean?: boolean | null;
                 answerGroupCode?: string | null;
+                answerDate?: string | null;
                 compareQuestion?: string | null;
               }>;
             }> | null;
@@ -10840,6 +10870,7 @@ export type GetAssessmentQuery = {
             answerNumber?: number | null;
             answerBoolean?: boolean | null;
             answerGroupCode?: string | null;
+            answerDate?: string | null;
             compareQuestion?: string | null;
           }> | null;
           autofillValues?: Array<{
@@ -10862,6 +10893,7 @@ export type GetAssessmentQuery = {
               answerNumber?: number | null;
               answerBoolean?: boolean | null;
               answerGroupCode?: string | null;
+              answerDate?: string | null;
               compareQuestion?: string | null;
             }>;
           }> | null;
@@ -11034,6 +11066,7 @@ export type GetAssessmentQuery = {
                     answerNumber?: number | null;
                     answerBoolean?: boolean | null;
                     answerGroupCode?: string | null;
+                    answerDate?: string | null;
                     compareQuestion?: string | null;
                   }> | null;
                   autofillValues?: Array<{
@@ -11056,6 +11089,7 @@ export type GetAssessmentQuery = {
                       answerNumber?: number | null;
                       answerBoolean?: boolean | null;
                       answerGroupCode?: string | null;
+                      answerDate?: string | null;
                       compareQuestion?: string | null;
                     }>;
                   }> | null;
@@ -11106,6 +11140,7 @@ export type GetAssessmentQuery = {
                   answerNumber?: number | null;
                   answerBoolean?: boolean | null;
                   answerGroupCode?: string | null;
+                  answerDate?: string | null;
                   compareQuestion?: string | null;
                 }> | null;
                 autofillValues?: Array<{
@@ -11128,6 +11163,7 @@ export type GetAssessmentQuery = {
                     answerNumber?: number | null;
                     answerBoolean?: boolean | null;
                     answerGroupCode?: string | null;
+                    answerDate?: string | null;
                     compareQuestion?: string | null;
                   }>;
                 }> | null;
@@ -11178,6 +11214,7 @@ export type GetAssessmentQuery = {
                 answerNumber?: number | null;
                 answerBoolean?: boolean | null;
                 answerGroupCode?: string | null;
+                answerDate?: string | null;
                 compareQuestion?: string | null;
               }> | null;
               autofillValues?: Array<{
@@ -11200,6 +11237,7 @@ export type GetAssessmentQuery = {
                   answerNumber?: number | null;
                   answerBoolean?: boolean | null;
                   answerGroupCode?: string | null;
+                  answerDate?: string | null;
                   compareQuestion?: string | null;
                 }>;
               }> | null;
@@ -11250,6 +11288,7 @@ export type GetAssessmentQuery = {
               answerNumber?: number | null;
               answerBoolean?: boolean | null;
               answerGroupCode?: string | null;
+              answerDate?: string | null;
               compareQuestion?: string | null;
             }> | null;
             autofillValues?: Array<{
@@ -11272,6 +11311,7 @@ export type GetAssessmentQuery = {
                 answerNumber?: number | null;
                 answerBoolean?: boolean | null;
                 answerGroupCode?: string | null;
+                answerDate?: string | null;
                 compareQuestion?: string | null;
               }>;
             }> | null;
@@ -11322,6 +11362,7 @@ export type GetAssessmentQuery = {
             answerNumber?: number | null;
             answerBoolean?: boolean | null;
             answerGroupCode?: string | null;
+            answerDate?: string | null;
             compareQuestion?: string | null;
           }> | null;
           autofillValues?: Array<{
@@ -11344,6 +11385,7 @@ export type GetAssessmentQuery = {
               answerNumber?: number | null;
               answerBoolean?: boolean | null;
               answerGroupCode?: string | null;
+              answerDate?: string | null;
               compareQuestion?: string | null;
             }>;
           }> | null;
@@ -16146,6 +16188,7 @@ export type ClientDetailFormsQuery = {
                     answerNumber?: number | null;
                     answerBoolean?: boolean | null;
                     answerGroupCode?: string | null;
+                    answerDate?: string | null;
                     compareQuestion?: string | null;
                   }> | null;
                   autofillValues?: Array<{
@@ -16168,6 +16211,7 @@ export type ClientDetailFormsQuery = {
                       answerNumber?: number | null;
                       answerBoolean?: boolean | null;
                       answerGroupCode?: string | null;
+                      answerDate?: string | null;
                       compareQuestion?: string | null;
                     }>;
                   }> | null;
@@ -16218,6 +16262,7 @@ export type ClientDetailFormsQuery = {
                   answerNumber?: number | null;
                   answerBoolean?: boolean | null;
                   answerGroupCode?: string | null;
+                  answerDate?: string | null;
                   compareQuestion?: string | null;
                 }> | null;
                 autofillValues?: Array<{
@@ -16240,6 +16285,7 @@ export type ClientDetailFormsQuery = {
                     answerNumber?: number | null;
                     answerBoolean?: boolean | null;
                     answerGroupCode?: string | null;
+                    answerDate?: string | null;
                     compareQuestion?: string | null;
                   }>;
                 }> | null;
@@ -16290,6 +16336,7 @@ export type ClientDetailFormsQuery = {
                 answerNumber?: number | null;
                 answerBoolean?: boolean | null;
                 answerGroupCode?: string | null;
+                answerDate?: string | null;
                 compareQuestion?: string | null;
               }> | null;
               autofillValues?: Array<{
@@ -16312,6 +16359,7 @@ export type ClientDetailFormsQuery = {
                   answerNumber?: number | null;
                   answerBoolean?: boolean | null;
                   answerGroupCode?: string | null;
+                  answerDate?: string | null;
                   compareQuestion?: string | null;
                 }>;
               }> | null;
@@ -16362,6 +16410,7 @@ export type ClientDetailFormsQuery = {
               answerNumber?: number | null;
               answerBoolean?: boolean | null;
               answerGroupCode?: string | null;
+              answerDate?: string | null;
               compareQuestion?: string | null;
             }> | null;
             autofillValues?: Array<{
@@ -16384,6 +16433,7 @@ export type ClientDetailFormsQuery = {
                 answerNumber?: number | null;
                 answerBoolean?: boolean | null;
                 answerGroupCode?: string | null;
+                answerDate?: string | null;
                 compareQuestion?: string | null;
               }>;
             }> | null;
@@ -16434,6 +16484,7 @@ export type ClientDetailFormsQuery = {
             answerNumber?: number | null;
             answerBoolean?: boolean | null;
             answerGroupCode?: string | null;
+            answerDate?: string | null;
             compareQuestion?: string | null;
           }> | null;
           autofillValues?: Array<{
@@ -16456,6 +16507,7 @@ export type ClientDetailFormsQuery = {
               answerNumber?: number | null;
               answerBoolean?: boolean | null;
               answerGroupCode?: string | null;
+              answerDate?: string | null;
               compareQuestion?: string | null;
             }>;
           }> | null;
@@ -18901,6 +18953,7 @@ export type AllEnrollmentDetailsFragment = {
                       answerNumber?: number | null;
                       answerBoolean?: boolean | null;
                       answerGroupCode?: string | null;
+                      answerDate?: string | null;
                       compareQuestion?: string | null;
                     }> | null;
                     autofillValues?: Array<{
@@ -18923,6 +18976,7 @@ export type AllEnrollmentDetailsFragment = {
                         answerNumber?: number | null;
                         answerBoolean?: boolean | null;
                         answerGroupCode?: string | null;
+                        answerDate?: string | null;
                         compareQuestion?: string | null;
                       }>;
                     }> | null;
@@ -18973,6 +19027,7 @@ export type AllEnrollmentDetailsFragment = {
                     answerNumber?: number | null;
                     answerBoolean?: boolean | null;
                     answerGroupCode?: string | null;
+                    answerDate?: string | null;
                     compareQuestion?: string | null;
                   }> | null;
                   autofillValues?: Array<{
@@ -18995,6 +19050,7 @@ export type AllEnrollmentDetailsFragment = {
                       answerNumber?: number | null;
                       answerBoolean?: boolean | null;
                       answerGroupCode?: string | null;
+                      answerDate?: string | null;
                       compareQuestion?: string | null;
                     }>;
                   }> | null;
@@ -19045,6 +19101,7 @@ export type AllEnrollmentDetailsFragment = {
                   answerNumber?: number | null;
                   answerBoolean?: boolean | null;
                   answerGroupCode?: string | null;
+                  answerDate?: string | null;
                   compareQuestion?: string | null;
                 }> | null;
                 autofillValues?: Array<{
@@ -19067,6 +19124,7 @@ export type AllEnrollmentDetailsFragment = {
                     answerNumber?: number | null;
                     answerBoolean?: boolean | null;
                     answerGroupCode?: string | null;
+                    answerDate?: string | null;
                     compareQuestion?: string | null;
                   }>;
                 }> | null;
@@ -19117,6 +19175,7 @@ export type AllEnrollmentDetailsFragment = {
                 answerNumber?: number | null;
                 answerBoolean?: boolean | null;
                 answerGroupCode?: string | null;
+                answerDate?: string | null;
                 compareQuestion?: string | null;
               }> | null;
               autofillValues?: Array<{
@@ -19139,6 +19198,7 @@ export type AllEnrollmentDetailsFragment = {
                   answerNumber?: number | null;
                   answerBoolean?: boolean | null;
                   answerGroupCode?: string | null;
+                  answerDate?: string | null;
                   compareQuestion?: string | null;
                 }>;
               }> | null;
@@ -19189,6 +19249,7 @@ export type AllEnrollmentDetailsFragment = {
               answerNumber?: number | null;
               answerBoolean?: boolean | null;
               answerGroupCode?: string | null;
+              answerDate?: string | null;
               compareQuestion?: string | null;
             }> | null;
             autofillValues?: Array<{
@@ -19211,6 +19272,7 @@ export type AllEnrollmentDetailsFragment = {
                 answerNumber?: number | null;
                 answerBoolean?: boolean | null;
                 answerGroupCode?: string | null;
+                answerDate?: string | null;
                 compareQuestion?: string | null;
               }>;
             }> | null;
@@ -20008,6 +20070,7 @@ export type GetEnrollmentDetailsQuery = {
                         answerNumber?: number | null;
                         answerBoolean?: boolean | null;
                         answerGroupCode?: string | null;
+                        answerDate?: string | null;
                         compareQuestion?: string | null;
                       }> | null;
                       autofillValues?: Array<{
@@ -20030,6 +20093,7 @@ export type GetEnrollmentDetailsQuery = {
                           answerNumber?: number | null;
                           answerBoolean?: boolean | null;
                           answerGroupCode?: string | null;
+                          answerDate?: string | null;
                           compareQuestion?: string | null;
                         }>;
                       }> | null;
@@ -20080,6 +20144,7 @@ export type GetEnrollmentDetailsQuery = {
                       answerNumber?: number | null;
                       answerBoolean?: boolean | null;
                       answerGroupCode?: string | null;
+                      answerDate?: string | null;
                       compareQuestion?: string | null;
                     }> | null;
                     autofillValues?: Array<{
@@ -20102,6 +20167,7 @@ export type GetEnrollmentDetailsQuery = {
                         answerNumber?: number | null;
                         answerBoolean?: boolean | null;
                         answerGroupCode?: string | null;
+                        answerDate?: string | null;
                         compareQuestion?: string | null;
                       }>;
                     }> | null;
@@ -20152,6 +20218,7 @@ export type GetEnrollmentDetailsQuery = {
                     answerNumber?: number | null;
                     answerBoolean?: boolean | null;
                     answerGroupCode?: string | null;
+                    answerDate?: string | null;
                     compareQuestion?: string | null;
                   }> | null;
                   autofillValues?: Array<{
@@ -20174,6 +20241,7 @@ export type GetEnrollmentDetailsQuery = {
                       answerNumber?: number | null;
                       answerBoolean?: boolean | null;
                       answerGroupCode?: string | null;
+                      answerDate?: string | null;
                       compareQuestion?: string | null;
                     }>;
                   }> | null;
@@ -20224,6 +20292,7 @@ export type GetEnrollmentDetailsQuery = {
                   answerNumber?: number | null;
                   answerBoolean?: boolean | null;
                   answerGroupCode?: string | null;
+                  answerDate?: string | null;
                   compareQuestion?: string | null;
                 }> | null;
                 autofillValues?: Array<{
@@ -20246,6 +20315,7 @@ export type GetEnrollmentDetailsQuery = {
                     answerNumber?: number | null;
                     answerBoolean?: boolean | null;
                     answerGroupCode?: string | null;
+                    answerDate?: string | null;
                     compareQuestion?: string | null;
                   }>;
                 }> | null;
@@ -20296,6 +20366,7 @@ export type GetEnrollmentDetailsQuery = {
                 answerNumber?: number | null;
                 answerBoolean?: boolean | null;
                 answerGroupCode?: string | null;
+                answerDate?: string | null;
                 compareQuestion?: string | null;
               }> | null;
               autofillValues?: Array<{
@@ -20318,6 +20389,7 @@ export type GetEnrollmentDetailsQuery = {
                   answerNumber?: number | null;
                   answerBoolean?: boolean | null;
                   answerGroupCode?: string | null;
+                  answerDate?: string | null;
                   compareQuestion?: string | null;
                 }>;
               }> | null;
@@ -21311,6 +21383,7 @@ export type GetExternalFormDefinitionQuery = {
                   answerNumber?: number | null;
                   answerBoolean?: boolean | null;
                   answerGroupCode?: string | null;
+                  answerDate?: string | null;
                   compareQuestion?: string | null;
                 }> | null;
                 autofillValues?: Array<{
@@ -21333,6 +21406,7 @@ export type GetExternalFormDefinitionQuery = {
                     answerNumber?: number | null;
                     answerBoolean?: boolean | null;
                     answerGroupCode?: string | null;
+                    answerDate?: string | null;
                     compareQuestion?: string | null;
                   }>;
                 }> | null;
@@ -21383,6 +21457,7 @@ export type GetExternalFormDefinitionQuery = {
                 answerNumber?: number | null;
                 answerBoolean?: boolean | null;
                 answerGroupCode?: string | null;
+                answerDate?: string | null;
                 compareQuestion?: string | null;
               }> | null;
               autofillValues?: Array<{
@@ -21405,6 +21480,7 @@ export type GetExternalFormDefinitionQuery = {
                   answerNumber?: number | null;
                   answerBoolean?: boolean | null;
                   answerGroupCode?: string | null;
+                  answerDate?: string | null;
                   compareQuestion?: string | null;
                 }>;
               }> | null;
@@ -21455,6 +21531,7 @@ export type GetExternalFormDefinitionQuery = {
               answerNumber?: number | null;
               answerBoolean?: boolean | null;
               answerGroupCode?: string | null;
+              answerDate?: string | null;
               compareQuestion?: string | null;
             }> | null;
             autofillValues?: Array<{
@@ -21477,6 +21554,7 @@ export type GetExternalFormDefinitionQuery = {
                 answerNumber?: number | null;
                 answerBoolean?: boolean | null;
                 answerGroupCode?: string | null;
+                answerDate?: string | null;
                 compareQuestion?: string | null;
               }>;
             }> | null;
@@ -21527,6 +21605,7 @@ export type GetExternalFormDefinitionQuery = {
             answerNumber?: number | null;
             answerBoolean?: boolean | null;
             answerGroupCode?: string | null;
+            answerDate?: string | null;
             compareQuestion?: string | null;
           }> | null;
           autofillValues?: Array<{
@@ -21549,6 +21628,7 @@ export type GetExternalFormDefinitionQuery = {
               answerNumber?: number | null;
               answerBoolean?: boolean | null;
               answerGroupCode?: string | null;
+              answerDate?: string | null;
               compareQuestion?: string | null;
             }>;
           }> | null;
@@ -21599,6 +21679,7 @@ export type GetExternalFormDefinitionQuery = {
           answerNumber?: number | null;
           answerBoolean?: boolean | null;
           answerGroupCode?: string | null;
+          answerDate?: string | null;
           compareQuestion?: string | null;
         }> | null;
         autofillValues?: Array<{
@@ -21621,6 +21702,7 @@ export type GetExternalFormDefinitionQuery = {
             answerNumber?: number | null;
             answerBoolean?: boolean | null;
             answerGroupCode?: string | null;
+            answerDate?: string | null;
             compareQuestion?: string | null;
           }>;
         }> | null;
@@ -21703,6 +21785,7 @@ export type EnableWhenFieldsFragment = {
   answerNumber?: number | null;
   answerBoolean?: boolean | null;
   answerGroupCode?: string | null;
+  answerDate?: string | null;
   compareQuestion?: string | null;
 };
 
@@ -21774,6 +21857,7 @@ export type ItemFieldsFragment = {
     answerNumber?: number | null;
     answerBoolean?: boolean | null;
     answerGroupCode?: string | null;
+    answerDate?: string | null;
     compareQuestion?: string | null;
   }> | null;
   autofillValues?: Array<{
@@ -21796,6 +21880,7 @@ export type ItemFieldsFragment = {
       answerNumber?: number | null;
       answerBoolean?: boolean | null;
       answerGroupCode?: string | null;
+      answerDate?: string | null;
       compareQuestion?: string | null;
     }>;
   }> | null;
@@ -21959,6 +22044,7 @@ export type FormDefinitionJsonFieldsFragment = {
               answerNumber?: number | null;
               answerBoolean?: boolean | null;
               answerGroupCode?: string | null;
+              answerDate?: string | null;
               compareQuestion?: string | null;
             }> | null;
             autofillValues?: Array<{
@@ -21981,6 +22067,7 @@ export type FormDefinitionJsonFieldsFragment = {
                 answerNumber?: number | null;
                 answerBoolean?: boolean | null;
                 answerGroupCode?: string | null;
+                answerDate?: string | null;
                 compareQuestion?: string | null;
               }>;
             }> | null;
@@ -22031,6 +22118,7 @@ export type FormDefinitionJsonFieldsFragment = {
             answerNumber?: number | null;
             answerBoolean?: boolean | null;
             answerGroupCode?: string | null;
+            answerDate?: string | null;
             compareQuestion?: string | null;
           }> | null;
           autofillValues?: Array<{
@@ -22053,6 +22141,7 @@ export type FormDefinitionJsonFieldsFragment = {
               answerNumber?: number | null;
               answerBoolean?: boolean | null;
               answerGroupCode?: string | null;
+              answerDate?: string | null;
               compareQuestion?: string | null;
             }>;
           }> | null;
@@ -22103,6 +22192,7 @@ export type FormDefinitionJsonFieldsFragment = {
           answerNumber?: number | null;
           answerBoolean?: boolean | null;
           answerGroupCode?: string | null;
+          answerDate?: string | null;
           compareQuestion?: string | null;
         }> | null;
         autofillValues?: Array<{
@@ -22125,6 +22215,7 @@ export type FormDefinitionJsonFieldsFragment = {
             answerNumber?: number | null;
             answerBoolean?: boolean | null;
             answerGroupCode?: string | null;
+            answerDate?: string | null;
             compareQuestion?: string | null;
           }>;
         }> | null;
@@ -22175,6 +22266,7 @@ export type FormDefinitionJsonFieldsFragment = {
         answerNumber?: number | null;
         answerBoolean?: boolean | null;
         answerGroupCode?: string | null;
+        answerDate?: string | null;
         compareQuestion?: string | null;
       }> | null;
       autofillValues?: Array<{
@@ -22197,6 +22289,7 @@ export type FormDefinitionJsonFieldsFragment = {
           answerNumber?: number | null;
           answerBoolean?: boolean | null;
           answerGroupCode?: string | null;
+          answerDate?: string | null;
           compareQuestion?: string | null;
         }>;
       }> | null;
@@ -22247,6 +22340,7 @@ export type FormDefinitionJsonFieldsFragment = {
       answerNumber?: number | null;
       answerBoolean?: boolean | null;
       answerGroupCode?: string | null;
+      answerDate?: string | null;
       compareQuestion?: string | null;
     }> | null;
     autofillValues?: Array<{
@@ -22269,6 +22363,7 @@ export type FormDefinitionJsonFieldsFragment = {
         answerNumber?: number | null;
         answerBoolean?: boolean | null;
         answerGroupCode?: string | null;
+        answerDate?: string | null;
         compareQuestion?: string | null;
       }>;
     }> | null;
@@ -22451,6 +22546,7 @@ export type FormDefinitionFieldsFragment = {
                 answerNumber?: number | null;
                 answerBoolean?: boolean | null;
                 answerGroupCode?: string | null;
+                answerDate?: string | null;
                 compareQuestion?: string | null;
               }> | null;
               autofillValues?: Array<{
@@ -22473,6 +22569,7 @@ export type FormDefinitionFieldsFragment = {
                   answerNumber?: number | null;
                   answerBoolean?: boolean | null;
                   answerGroupCode?: string | null;
+                  answerDate?: string | null;
                   compareQuestion?: string | null;
                 }>;
               }> | null;
@@ -22523,6 +22620,7 @@ export type FormDefinitionFieldsFragment = {
               answerNumber?: number | null;
               answerBoolean?: boolean | null;
               answerGroupCode?: string | null;
+              answerDate?: string | null;
               compareQuestion?: string | null;
             }> | null;
             autofillValues?: Array<{
@@ -22545,6 +22643,7 @@ export type FormDefinitionFieldsFragment = {
                 answerNumber?: number | null;
                 answerBoolean?: boolean | null;
                 answerGroupCode?: string | null;
+                answerDate?: string | null;
                 compareQuestion?: string | null;
               }>;
             }> | null;
@@ -22595,6 +22694,7 @@ export type FormDefinitionFieldsFragment = {
             answerNumber?: number | null;
             answerBoolean?: boolean | null;
             answerGroupCode?: string | null;
+            answerDate?: string | null;
             compareQuestion?: string | null;
           }> | null;
           autofillValues?: Array<{
@@ -22617,6 +22717,7 @@ export type FormDefinitionFieldsFragment = {
               answerNumber?: number | null;
               answerBoolean?: boolean | null;
               answerGroupCode?: string | null;
+              answerDate?: string | null;
               compareQuestion?: string | null;
             }>;
           }> | null;
@@ -22667,6 +22768,7 @@ export type FormDefinitionFieldsFragment = {
           answerNumber?: number | null;
           answerBoolean?: boolean | null;
           answerGroupCode?: string | null;
+          answerDate?: string | null;
           compareQuestion?: string | null;
         }> | null;
         autofillValues?: Array<{
@@ -22689,6 +22791,7 @@ export type FormDefinitionFieldsFragment = {
             answerNumber?: number | null;
             answerBoolean?: boolean | null;
             answerGroupCode?: string | null;
+            answerDate?: string | null;
             compareQuestion?: string | null;
           }>;
         }> | null;
@@ -22739,6 +22842,7 @@ export type FormDefinitionFieldsFragment = {
         answerNumber?: number | null;
         answerBoolean?: boolean | null;
         answerGroupCode?: string | null;
+        answerDate?: string | null;
         compareQuestion?: string | null;
       }> | null;
       autofillValues?: Array<{
@@ -22761,6 +22865,7 @@ export type FormDefinitionFieldsFragment = {
           answerNumber?: number | null;
           answerBoolean?: boolean | null;
           answerGroupCode?: string | null;
+          answerDate?: string | null;
           compareQuestion?: string | null;
         }>;
       }> | null;
@@ -22935,6 +23040,7 @@ export type FormDefinitionFieldsForJsonEditorFragment = {
                 answerNumber?: number | null;
                 answerBoolean?: boolean | null;
                 answerGroupCode?: string | null;
+                answerDate?: string | null;
                 compareQuestion?: string | null;
               }> | null;
               autofillValues?: Array<{
@@ -22957,6 +23063,7 @@ export type FormDefinitionFieldsForJsonEditorFragment = {
                   answerNumber?: number | null;
                   answerBoolean?: boolean | null;
                   answerGroupCode?: string | null;
+                  answerDate?: string | null;
                   compareQuestion?: string | null;
                 }>;
               }> | null;
@@ -23007,6 +23114,7 @@ export type FormDefinitionFieldsForJsonEditorFragment = {
               answerNumber?: number | null;
               answerBoolean?: boolean | null;
               answerGroupCode?: string | null;
+              answerDate?: string | null;
               compareQuestion?: string | null;
             }> | null;
             autofillValues?: Array<{
@@ -23029,6 +23137,7 @@ export type FormDefinitionFieldsForJsonEditorFragment = {
                 answerNumber?: number | null;
                 answerBoolean?: boolean | null;
                 answerGroupCode?: string | null;
+                answerDate?: string | null;
                 compareQuestion?: string | null;
               }>;
             }> | null;
@@ -23079,6 +23188,7 @@ export type FormDefinitionFieldsForJsonEditorFragment = {
             answerNumber?: number | null;
             answerBoolean?: boolean | null;
             answerGroupCode?: string | null;
+            answerDate?: string | null;
             compareQuestion?: string | null;
           }> | null;
           autofillValues?: Array<{
@@ -23101,6 +23211,7 @@ export type FormDefinitionFieldsForJsonEditorFragment = {
               answerNumber?: number | null;
               answerBoolean?: boolean | null;
               answerGroupCode?: string | null;
+              answerDate?: string | null;
               compareQuestion?: string | null;
             }>;
           }> | null;
@@ -23151,6 +23262,7 @@ export type FormDefinitionFieldsForJsonEditorFragment = {
           answerNumber?: number | null;
           answerBoolean?: boolean | null;
           answerGroupCode?: string | null;
+          answerDate?: string | null;
           compareQuestion?: string | null;
         }> | null;
         autofillValues?: Array<{
@@ -23173,6 +23285,7 @@ export type FormDefinitionFieldsForJsonEditorFragment = {
             answerNumber?: number | null;
             answerBoolean?: boolean | null;
             answerGroupCode?: string | null;
+            answerDate?: string | null;
             compareQuestion?: string | null;
           }>;
         }> | null;
@@ -23223,6 +23336,7 @@ export type FormDefinitionFieldsForJsonEditorFragment = {
         answerNumber?: number | null;
         answerBoolean?: boolean | null;
         answerGroupCode?: string | null;
+        answerDate?: string | null;
         compareQuestion?: string | null;
       }> | null;
       autofillValues?: Array<{
@@ -23245,6 +23359,7 @@ export type FormDefinitionFieldsForJsonEditorFragment = {
           answerNumber?: number | null;
           answerBoolean?: boolean | null;
           answerGroupCode?: string | null;
+          answerDate?: string | null;
           compareQuestion?: string | null;
         }>;
       }> | null;
@@ -23418,6 +23533,7 @@ export type FormDefinitionFieldsForEditorFragment = {
                 answerNumber?: number | null;
                 answerBoolean?: boolean | null;
                 answerGroupCode?: string | null;
+                answerDate?: string | null;
                 compareQuestion?: string | null;
               }> | null;
               autofillValues?: Array<{
@@ -23440,6 +23556,7 @@ export type FormDefinitionFieldsForEditorFragment = {
                   answerNumber?: number | null;
                   answerBoolean?: boolean | null;
                   answerGroupCode?: string | null;
+                  answerDate?: string | null;
                   compareQuestion?: string | null;
                 }>;
               }> | null;
@@ -23490,6 +23607,7 @@ export type FormDefinitionFieldsForEditorFragment = {
               answerNumber?: number | null;
               answerBoolean?: boolean | null;
               answerGroupCode?: string | null;
+              answerDate?: string | null;
               compareQuestion?: string | null;
             }> | null;
             autofillValues?: Array<{
@@ -23512,6 +23630,7 @@ export type FormDefinitionFieldsForEditorFragment = {
                 answerNumber?: number | null;
                 answerBoolean?: boolean | null;
                 answerGroupCode?: string | null;
+                answerDate?: string | null;
                 compareQuestion?: string | null;
               }>;
             }> | null;
@@ -23562,6 +23681,7 @@ export type FormDefinitionFieldsForEditorFragment = {
             answerNumber?: number | null;
             answerBoolean?: boolean | null;
             answerGroupCode?: string | null;
+            answerDate?: string | null;
             compareQuestion?: string | null;
           }> | null;
           autofillValues?: Array<{
@@ -23584,6 +23704,7 @@ export type FormDefinitionFieldsForEditorFragment = {
               answerNumber?: number | null;
               answerBoolean?: boolean | null;
               answerGroupCode?: string | null;
+              answerDate?: string | null;
               compareQuestion?: string | null;
             }>;
           }> | null;
@@ -23634,6 +23755,7 @@ export type FormDefinitionFieldsForEditorFragment = {
           answerNumber?: number | null;
           answerBoolean?: boolean | null;
           answerGroupCode?: string | null;
+          answerDate?: string | null;
           compareQuestion?: string | null;
         }> | null;
         autofillValues?: Array<{
@@ -23656,6 +23778,7 @@ export type FormDefinitionFieldsForEditorFragment = {
             answerNumber?: number | null;
             answerBoolean?: boolean | null;
             answerGroupCode?: string | null;
+            answerDate?: string | null;
             compareQuestion?: string | null;
           }>;
         }> | null;
@@ -23706,6 +23829,7 @@ export type FormDefinitionFieldsForEditorFragment = {
         answerNumber?: number | null;
         answerBoolean?: boolean | null;
         answerGroupCode?: string | null;
+        answerDate?: string | null;
         compareQuestion?: string | null;
       }> | null;
       autofillValues?: Array<{
@@ -23728,6 +23852,7 @@ export type FormDefinitionFieldsForEditorFragment = {
           answerNumber?: number | null;
           answerBoolean?: boolean | null;
           answerGroupCode?: string | null;
+          answerDate?: string | null;
           compareQuestion?: string | null;
         }>;
       }> | null;
@@ -23934,6 +24059,7 @@ export type UpdateFormDefinitionMutation = {
                     answerNumber?: number | null;
                     answerBoolean?: boolean | null;
                     answerGroupCode?: string | null;
+                    answerDate?: string | null;
                     compareQuestion?: string | null;
                   }> | null;
                   autofillValues?: Array<{
@@ -23956,6 +24082,7 @@ export type UpdateFormDefinitionMutation = {
                       answerNumber?: number | null;
                       answerBoolean?: boolean | null;
                       answerGroupCode?: string | null;
+                      answerDate?: string | null;
                       compareQuestion?: string | null;
                     }>;
                   }> | null;
@@ -24006,6 +24133,7 @@ export type UpdateFormDefinitionMutation = {
                   answerNumber?: number | null;
                   answerBoolean?: boolean | null;
                   answerGroupCode?: string | null;
+                  answerDate?: string | null;
                   compareQuestion?: string | null;
                 }> | null;
                 autofillValues?: Array<{
@@ -24028,6 +24156,7 @@ export type UpdateFormDefinitionMutation = {
                     answerNumber?: number | null;
                     answerBoolean?: boolean | null;
                     answerGroupCode?: string | null;
+                    answerDate?: string | null;
                     compareQuestion?: string | null;
                   }>;
                 }> | null;
@@ -24078,6 +24207,7 @@ export type UpdateFormDefinitionMutation = {
                 answerNumber?: number | null;
                 answerBoolean?: boolean | null;
                 answerGroupCode?: string | null;
+                answerDate?: string | null;
                 compareQuestion?: string | null;
               }> | null;
               autofillValues?: Array<{
@@ -24100,6 +24230,7 @@ export type UpdateFormDefinitionMutation = {
                   answerNumber?: number | null;
                   answerBoolean?: boolean | null;
                   answerGroupCode?: string | null;
+                  answerDate?: string | null;
                   compareQuestion?: string | null;
                 }>;
               }> | null;
@@ -24150,6 +24281,7 @@ export type UpdateFormDefinitionMutation = {
               answerNumber?: number | null;
               answerBoolean?: boolean | null;
               answerGroupCode?: string | null;
+              answerDate?: string | null;
               compareQuestion?: string | null;
             }> | null;
             autofillValues?: Array<{
@@ -24172,6 +24304,7 @@ export type UpdateFormDefinitionMutation = {
                 answerNumber?: number | null;
                 answerBoolean?: boolean | null;
                 answerGroupCode?: string | null;
+                answerDate?: string | null;
                 compareQuestion?: string | null;
               }>;
             }> | null;
@@ -24222,6 +24355,7 @@ export type UpdateFormDefinitionMutation = {
             answerNumber?: number | null;
             answerBoolean?: boolean | null;
             answerGroupCode?: string | null;
+            answerDate?: string | null;
             compareQuestion?: string | null;
           }> | null;
           autofillValues?: Array<{
@@ -24244,6 +24378,7 @@ export type UpdateFormDefinitionMutation = {
               answerNumber?: number | null;
               answerBoolean?: boolean | null;
               answerGroupCode?: string | null;
+              answerDate?: string | null;
               compareQuestion?: string | null;
             }>;
           }> | null;
@@ -24443,6 +24578,7 @@ export type UpdateFormDefinitionFromJsonEditorMutation = {
                     answerNumber?: number | null;
                     answerBoolean?: boolean | null;
                     answerGroupCode?: string | null;
+                    answerDate?: string | null;
                     compareQuestion?: string | null;
                   }> | null;
                   autofillValues?: Array<{
@@ -24465,6 +24601,7 @@ export type UpdateFormDefinitionFromJsonEditorMutation = {
                       answerNumber?: number | null;
                       answerBoolean?: boolean | null;
                       answerGroupCode?: string | null;
+                      answerDate?: string | null;
                       compareQuestion?: string | null;
                     }>;
                   }> | null;
@@ -24515,6 +24652,7 @@ export type UpdateFormDefinitionFromJsonEditorMutation = {
                   answerNumber?: number | null;
                   answerBoolean?: boolean | null;
                   answerGroupCode?: string | null;
+                  answerDate?: string | null;
                   compareQuestion?: string | null;
                 }> | null;
                 autofillValues?: Array<{
@@ -24537,6 +24675,7 @@ export type UpdateFormDefinitionFromJsonEditorMutation = {
                     answerNumber?: number | null;
                     answerBoolean?: boolean | null;
                     answerGroupCode?: string | null;
+                    answerDate?: string | null;
                     compareQuestion?: string | null;
                   }>;
                 }> | null;
@@ -24587,6 +24726,7 @@ export type UpdateFormDefinitionFromJsonEditorMutation = {
                 answerNumber?: number | null;
                 answerBoolean?: boolean | null;
                 answerGroupCode?: string | null;
+                answerDate?: string | null;
                 compareQuestion?: string | null;
               }> | null;
               autofillValues?: Array<{
@@ -24609,6 +24749,7 @@ export type UpdateFormDefinitionFromJsonEditorMutation = {
                   answerNumber?: number | null;
                   answerBoolean?: boolean | null;
                   answerGroupCode?: string | null;
+                  answerDate?: string | null;
                   compareQuestion?: string | null;
                 }>;
               }> | null;
@@ -24659,6 +24800,7 @@ export type UpdateFormDefinitionFromJsonEditorMutation = {
               answerNumber?: number | null;
               answerBoolean?: boolean | null;
               answerGroupCode?: string | null;
+              answerDate?: string | null;
               compareQuestion?: string | null;
             }> | null;
             autofillValues?: Array<{
@@ -24681,6 +24823,7 @@ export type UpdateFormDefinitionFromJsonEditorMutation = {
                 answerNumber?: number | null;
                 answerBoolean?: boolean | null;
                 answerGroupCode?: string | null;
+                answerDate?: string | null;
                 compareQuestion?: string | null;
               }>;
             }> | null;
@@ -24731,6 +24874,7 @@ export type UpdateFormDefinitionFromJsonEditorMutation = {
             answerNumber?: number | null;
             answerBoolean?: boolean | null;
             answerGroupCode?: string | null;
+            answerDate?: string | null;
             compareQuestion?: string | null;
           }> | null;
           autofillValues?: Array<{
@@ -24753,6 +24897,7 @@ export type UpdateFormDefinitionFromJsonEditorMutation = {
               answerNumber?: number | null;
               answerBoolean?: boolean | null;
               answerGroupCode?: string | null;
+              answerDate?: string | null;
               compareQuestion?: string | null;
             }>;
           }> | null;
@@ -25109,6 +25254,7 @@ export type GetFormDefinitionQuery = {
                   answerNumber?: number | null;
                   answerBoolean?: boolean | null;
                   answerGroupCode?: string | null;
+                  answerDate?: string | null;
                   compareQuestion?: string | null;
                 }> | null;
                 autofillValues?: Array<{
@@ -25131,6 +25277,7 @@ export type GetFormDefinitionQuery = {
                     answerNumber?: number | null;
                     answerBoolean?: boolean | null;
                     answerGroupCode?: string | null;
+                    answerDate?: string | null;
                     compareQuestion?: string | null;
                   }>;
                 }> | null;
@@ -25181,6 +25328,7 @@ export type GetFormDefinitionQuery = {
                 answerNumber?: number | null;
                 answerBoolean?: boolean | null;
                 answerGroupCode?: string | null;
+                answerDate?: string | null;
                 compareQuestion?: string | null;
               }> | null;
               autofillValues?: Array<{
@@ -25203,6 +25351,7 @@ export type GetFormDefinitionQuery = {
                   answerNumber?: number | null;
                   answerBoolean?: boolean | null;
                   answerGroupCode?: string | null;
+                  answerDate?: string | null;
                   compareQuestion?: string | null;
                 }>;
               }> | null;
@@ -25253,6 +25402,7 @@ export type GetFormDefinitionQuery = {
               answerNumber?: number | null;
               answerBoolean?: boolean | null;
               answerGroupCode?: string | null;
+              answerDate?: string | null;
               compareQuestion?: string | null;
             }> | null;
             autofillValues?: Array<{
@@ -25275,6 +25425,7 @@ export type GetFormDefinitionQuery = {
                 answerNumber?: number | null;
                 answerBoolean?: boolean | null;
                 answerGroupCode?: string | null;
+                answerDate?: string | null;
                 compareQuestion?: string | null;
               }>;
             }> | null;
@@ -25325,6 +25476,7 @@ export type GetFormDefinitionQuery = {
             answerNumber?: number | null;
             answerBoolean?: boolean | null;
             answerGroupCode?: string | null;
+            answerDate?: string | null;
             compareQuestion?: string | null;
           }> | null;
           autofillValues?: Array<{
@@ -25347,6 +25499,7 @@ export type GetFormDefinitionQuery = {
               answerNumber?: number | null;
               answerBoolean?: boolean | null;
               answerGroupCode?: string | null;
+              answerDate?: string | null;
               compareQuestion?: string | null;
             }>;
           }> | null;
@@ -25397,6 +25550,7 @@ export type GetFormDefinitionQuery = {
           answerNumber?: number | null;
           answerBoolean?: boolean | null;
           answerGroupCode?: string | null;
+          answerDate?: string | null;
           compareQuestion?: string | null;
         }> | null;
         autofillValues?: Array<{
@@ -25419,6 +25573,7 @@ export type GetFormDefinitionQuery = {
             answerNumber?: number | null;
             answerBoolean?: boolean | null;
             answerGroupCode?: string | null;
+            answerDate?: string | null;
             compareQuestion?: string | null;
           }>;
         }> | null;
@@ -25599,6 +25754,7 @@ export type GetStaticFormDefinitionQuery = {
                   answerNumber?: number | null;
                   answerBoolean?: boolean | null;
                   answerGroupCode?: string | null;
+                  answerDate?: string | null;
                   compareQuestion?: string | null;
                 }> | null;
                 autofillValues?: Array<{
@@ -25621,6 +25777,7 @@ export type GetStaticFormDefinitionQuery = {
                     answerNumber?: number | null;
                     answerBoolean?: boolean | null;
                     answerGroupCode?: string | null;
+                    answerDate?: string | null;
                     compareQuestion?: string | null;
                   }>;
                 }> | null;
@@ -25671,6 +25828,7 @@ export type GetStaticFormDefinitionQuery = {
                 answerNumber?: number | null;
                 answerBoolean?: boolean | null;
                 answerGroupCode?: string | null;
+                answerDate?: string | null;
                 compareQuestion?: string | null;
               }> | null;
               autofillValues?: Array<{
@@ -25693,6 +25851,7 @@ export type GetStaticFormDefinitionQuery = {
                   answerNumber?: number | null;
                   answerBoolean?: boolean | null;
                   answerGroupCode?: string | null;
+                  answerDate?: string | null;
                   compareQuestion?: string | null;
                 }>;
               }> | null;
@@ -25743,6 +25902,7 @@ export type GetStaticFormDefinitionQuery = {
               answerNumber?: number | null;
               answerBoolean?: boolean | null;
               answerGroupCode?: string | null;
+              answerDate?: string | null;
               compareQuestion?: string | null;
             }> | null;
             autofillValues?: Array<{
@@ -25765,6 +25925,7 @@ export type GetStaticFormDefinitionQuery = {
                 answerNumber?: number | null;
                 answerBoolean?: boolean | null;
                 answerGroupCode?: string | null;
+                answerDate?: string | null;
                 compareQuestion?: string | null;
               }>;
             }> | null;
@@ -25815,6 +25976,7 @@ export type GetStaticFormDefinitionQuery = {
             answerNumber?: number | null;
             answerBoolean?: boolean | null;
             answerGroupCode?: string | null;
+            answerDate?: string | null;
             compareQuestion?: string | null;
           }> | null;
           autofillValues?: Array<{
@@ -25837,6 +25999,7 @@ export type GetStaticFormDefinitionQuery = {
               answerNumber?: number | null;
               answerBoolean?: boolean | null;
               answerGroupCode?: string | null;
+              answerDate?: string | null;
               compareQuestion?: string | null;
             }>;
           }> | null;
@@ -25887,6 +26050,7 @@ export type GetStaticFormDefinitionQuery = {
           answerNumber?: number | null;
           answerBoolean?: boolean | null;
           answerGroupCode?: string | null;
+          answerDate?: string | null;
           compareQuestion?: string | null;
         }> | null;
         autofillValues?: Array<{
@@ -25909,6 +26073,7 @@ export type GetStaticFormDefinitionQuery = {
             answerNumber?: number | null;
             answerBoolean?: boolean | null;
             answerGroupCode?: string | null;
+            answerDate?: string | null;
             compareQuestion?: string | null;
           }>;
         }> | null;
@@ -26090,6 +26255,7 @@ export type GetServiceFormDefinitionQuery = {
                   answerNumber?: number | null;
                   answerBoolean?: boolean | null;
                   answerGroupCode?: string | null;
+                  answerDate?: string | null;
                   compareQuestion?: string | null;
                 }> | null;
                 autofillValues?: Array<{
@@ -26112,6 +26278,7 @@ export type GetServiceFormDefinitionQuery = {
                     answerNumber?: number | null;
                     answerBoolean?: boolean | null;
                     answerGroupCode?: string | null;
+                    answerDate?: string | null;
                     compareQuestion?: string | null;
                   }>;
                 }> | null;
@@ -26162,6 +26329,7 @@ export type GetServiceFormDefinitionQuery = {
                 answerNumber?: number | null;
                 answerBoolean?: boolean | null;
                 answerGroupCode?: string | null;
+                answerDate?: string | null;
                 compareQuestion?: string | null;
               }> | null;
               autofillValues?: Array<{
@@ -26184,6 +26352,7 @@ export type GetServiceFormDefinitionQuery = {
                   answerNumber?: number | null;
                   answerBoolean?: boolean | null;
                   answerGroupCode?: string | null;
+                  answerDate?: string | null;
                   compareQuestion?: string | null;
                 }>;
               }> | null;
@@ -26234,6 +26403,7 @@ export type GetServiceFormDefinitionQuery = {
               answerNumber?: number | null;
               answerBoolean?: boolean | null;
               answerGroupCode?: string | null;
+              answerDate?: string | null;
               compareQuestion?: string | null;
             }> | null;
             autofillValues?: Array<{
@@ -26256,6 +26426,7 @@ export type GetServiceFormDefinitionQuery = {
                 answerNumber?: number | null;
                 answerBoolean?: boolean | null;
                 answerGroupCode?: string | null;
+                answerDate?: string | null;
                 compareQuestion?: string | null;
               }>;
             }> | null;
@@ -26306,6 +26477,7 @@ export type GetServiceFormDefinitionQuery = {
             answerNumber?: number | null;
             answerBoolean?: boolean | null;
             answerGroupCode?: string | null;
+            answerDate?: string | null;
             compareQuestion?: string | null;
           }> | null;
           autofillValues?: Array<{
@@ -26328,6 +26500,7 @@ export type GetServiceFormDefinitionQuery = {
               answerNumber?: number | null;
               answerBoolean?: boolean | null;
               answerGroupCode?: string | null;
+              answerDate?: string | null;
               compareQuestion?: string | null;
             }>;
           }> | null;
@@ -26378,6 +26551,7 @@ export type GetServiceFormDefinitionQuery = {
           answerNumber?: number | null;
           answerBoolean?: boolean | null;
           answerGroupCode?: string | null;
+          answerDate?: string | null;
           compareQuestion?: string | null;
         }> | null;
         autofillValues?: Array<{
@@ -26400,6 +26574,7 @@ export type GetServiceFormDefinitionQuery = {
             answerNumber?: number | null;
             answerBoolean?: boolean | null;
             answerGroupCode?: string | null;
+            answerDate?: string | null;
             compareQuestion?: string | null;
           }>;
         }> | null;
@@ -26583,6 +26758,7 @@ export type GetAssessmentFormDefinitionQuery = {
                   answerNumber?: number | null;
                   answerBoolean?: boolean | null;
                   answerGroupCode?: string | null;
+                  answerDate?: string | null;
                   compareQuestion?: string | null;
                 }> | null;
                 autofillValues?: Array<{
@@ -26605,6 +26781,7 @@ export type GetAssessmentFormDefinitionQuery = {
                     answerNumber?: number | null;
                     answerBoolean?: boolean | null;
                     answerGroupCode?: string | null;
+                    answerDate?: string | null;
                     compareQuestion?: string | null;
                   }>;
                 }> | null;
@@ -26655,6 +26832,7 @@ export type GetAssessmentFormDefinitionQuery = {
                 answerNumber?: number | null;
                 answerBoolean?: boolean | null;
                 answerGroupCode?: string | null;
+                answerDate?: string | null;
                 compareQuestion?: string | null;
               }> | null;
               autofillValues?: Array<{
@@ -26677,6 +26855,7 @@ export type GetAssessmentFormDefinitionQuery = {
                   answerNumber?: number | null;
                   answerBoolean?: boolean | null;
                   answerGroupCode?: string | null;
+                  answerDate?: string | null;
                   compareQuestion?: string | null;
                 }>;
               }> | null;
@@ -26727,6 +26906,7 @@ export type GetAssessmentFormDefinitionQuery = {
               answerNumber?: number | null;
               answerBoolean?: boolean | null;
               answerGroupCode?: string | null;
+              answerDate?: string | null;
               compareQuestion?: string | null;
             }> | null;
             autofillValues?: Array<{
@@ -26749,6 +26929,7 @@ export type GetAssessmentFormDefinitionQuery = {
                 answerNumber?: number | null;
                 answerBoolean?: boolean | null;
                 answerGroupCode?: string | null;
+                answerDate?: string | null;
                 compareQuestion?: string | null;
               }>;
             }> | null;
@@ -26799,6 +26980,7 @@ export type GetAssessmentFormDefinitionQuery = {
             answerNumber?: number | null;
             answerBoolean?: boolean | null;
             answerGroupCode?: string | null;
+            answerDate?: string | null;
             compareQuestion?: string | null;
           }> | null;
           autofillValues?: Array<{
@@ -26821,6 +27003,7 @@ export type GetAssessmentFormDefinitionQuery = {
               answerNumber?: number | null;
               answerBoolean?: boolean | null;
               answerGroupCode?: string | null;
+              answerDate?: string | null;
               compareQuestion?: string | null;
             }>;
           }> | null;
@@ -26871,6 +27054,7 @@ export type GetAssessmentFormDefinitionQuery = {
           answerNumber?: number | null;
           answerBoolean?: boolean | null;
           answerGroupCode?: string | null;
+          answerDate?: string | null;
           compareQuestion?: string | null;
         }> | null;
         autofillValues?: Array<{
@@ -26893,6 +27077,7 @@ export type GetAssessmentFormDefinitionQuery = {
             answerNumber?: number | null;
             answerBoolean?: boolean | null;
             answerGroupCode?: string | null;
+            answerDate?: string | null;
             compareQuestion?: string | null;
           }>;
         }> | null;
@@ -28206,6 +28391,7 @@ export type GetFormDefinitionFieldsForEditorQuery = {
                   answerNumber?: number | null;
                   answerBoolean?: boolean | null;
                   answerGroupCode?: string | null;
+                  answerDate?: string | null;
                   compareQuestion?: string | null;
                 }> | null;
                 autofillValues?: Array<{
@@ -28228,6 +28414,7 @@ export type GetFormDefinitionFieldsForEditorQuery = {
                     answerNumber?: number | null;
                     answerBoolean?: boolean | null;
                     answerGroupCode?: string | null;
+                    answerDate?: string | null;
                     compareQuestion?: string | null;
                   }>;
                 }> | null;
@@ -28278,6 +28465,7 @@ export type GetFormDefinitionFieldsForEditorQuery = {
                 answerNumber?: number | null;
                 answerBoolean?: boolean | null;
                 answerGroupCode?: string | null;
+                answerDate?: string | null;
                 compareQuestion?: string | null;
               }> | null;
               autofillValues?: Array<{
@@ -28300,6 +28488,7 @@ export type GetFormDefinitionFieldsForEditorQuery = {
                   answerNumber?: number | null;
                   answerBoolean?: boolean | null;
                   answerGroupCode?: string | null;
+                  answerDate?: string | null;
                   compareQuestion?: string | null;
                 }>;
               }> | null;
@@ -28350,6 +28539,7 @@ export type GetFormDefinitionFieldsForEditorQuery = {
               answerNumber?: number | null;
               answerBoolean?: boolean | null;
               answerGroupCode?: string | null;
+              answerDate?: string | null;
               compareQuestion?: string | null;
             }> | null;
             autofillValues?: Array<{
@@ -28372,6 +28562,7 @@ export type GetFormDefinitionFieldsForEditorQuery = {
                 answerNumber?: number | null;
                 answerBoolean?: boolean | null;
                 answerGroupCode?: string | null;
+                answerDate?: string | null;
                 compareQuestion?: string | null;
               }>;
             }> | null;
@@ -28422,6 +28613,7 @@ export type GetFormDefinitionFieldsForEditorQuery = {
             answerNumber?: number | null;
             answerBoolean?: boolean | null;
             answerGroupCode?: string | null;
+            answerDate?: string | null;
             compareQuestion?: string | null;
           }> | null;
           autofillValues?: Array<{
@@ -28444,6 +28636,7 @@ export type GetFormDefinitionFieldsForEditorQuery = {
               answerNumber?: number | null;
               answerBoolean?: boolean | null;
               answerGroupCode?: string | null;
+              answerDate?: string | null;
               compareQuestion?: string | null;
             }>;
           }> | null;
@@ -28494,6 +28687,7 @@ export type GetFormDefinitionFieldsForEditorQuery = {
           answerNumber?: number | null;
           answerBoolean?: boolean | null;
           answerGroupCode?: string | null;
+          answerDate?: string | null;
           compareQuestion?: string | null;
         }> | null;
         autofillValues?: Array<{
@@ -28516,6 +28710,7 @@ export type GetFormDefinitionFieldsForEditorQuery = {
             answerNumber?: number | null;
             answerBoolean?: boolean | null;
             answerGroupCode?: string | null;
+            answerDate?: string | null;
             compareQuestion?: string | null;
           }>;
         }> | null;
@@ -28697,6 +28892,7 @@ export type GetFormDefinitionFieldsForJsonEditorQuery = {
                   answerNumber?: number | null;
                   answerBoolean?: boolean | null;
                   answerGroupCode?: string | null;
+                  answerDate?: string | null;
                   compareQuestion?: string | null;
                 }> | null;
                 autofillValues?: Array<{
@@ -28719,6 +28915,7 @@ export type GetFormDefinitionFieldsForJsonEditorQuery = {
                     answerNumber?: number | null;
                     answerBoolean?: boolean | null;
                     answerGroupCode?: string | null;
+                    answerDate?: string | null;
                     compareQuestion?: string | null;
                   }>;
                 }> | null;
@@ -28769,6 +28966,7 @@ export type GetFormDefinitionFieldsForJsonEditorQuery = {
                 answerNumber?: number | null;
                 answerBoolean?: boolean | null;
                 answerGroupCode?: string | null;
+                answerDate?: string | null;
                 compareQuestion?: string | null;
               }> | null;
               autofillValues?: Array<{
@@ -28791,6 +28989,7 @@ export type GetFormDefinitionFieldsForJsonEditorQuery = {
                   answerNumber?: number | null;
                   answerBoolean?: boolean | null;
                   answerGroupCode?: string | null;
+                  answerDate?: string | null;
                   compareQuestion?: string | null;
                 }>;
               }> | null;
@@ -28841,6 +29040,7 @@ export type GetFormDefinitionFieldsForJsonEditorQuery = {
               answerNumber?: number | null;
               answerBoolean?: boolean | null;
               answerGroupCode?: string | null;
+              answerDate?: string | null;
               compareQuestion?: string | null;
             }> | null;
             autofillValues?: Array<{
@@ -28863,6 +29063,7 @@ export type GetFormDefinitionFieldsForJsonEditorQuery = {
                 answerNumber?: number | null;
                 answerBoolean?: boolean | null;
                 answerGroupCode?: string | null;
+                answerDate?: string | null;
                 compareQuestion?: string | null;
               }>;
             }> | null;
@@ -28913,6 +29114,7 @@ export type GetFormDefinitionFieldsForJsonEditorQuery = {
             answerNumber?: number | null;
             answerBoolean?: boolean | null;
             answerGroupCode?: string | null;
+            answerDate?: string | null;
             compareQuestion?: string | null;
           }> | null;
           autofillValues?: Array<{
@@ -28935,6 +29137,7 @@ export type GetFormDefinitionFieldsForJsonEditorQuery = {
               answerNumber?: number | null;
               answerBoolean?: boolean | null;
               answerGroupCode?: string | null;
+              answerDate?: string | null;
               compareQuestion?: string | null;
             }>;
           }> | null;
@@ -28985,6 +29188,7 @@ export type GetFormDefinitionFieldsForJsonEditorQuery = {
           answerNumber?: number | null;
           answerBoolean?: boolean | null;
           answerGroupCode?: string | null;
+          answerDate?: string | null;
           compareQuestion?: string | null;
         }> | null;
         autofillValues?: Array<{
@@ -29007,6 +29211,7 @@ export type GetFormDefinitionFieldsForJsonEditorQuery = {
             answerNumber?: number | null;
             answerBoolean?: boolean | null;
             answerGroupCode?: string | null;
+            answerDate?: string | null;
             compareQuestion?: string | null;
           }>;
         }> | null;
@@ -29182,6 +29387,7 @@ export type GetParsedFormDefinitionQuery = {
                   answerNumber?: number | null;
                   answerBoolean?: boolean | null;
                   answerGroupCode?: string | null;
+                  answerDate?: string | null;
                   compareQuestion?: string | null;
                 }> | null;
                 autofillValues?: Array<{
@@ -29204,6 +29410,7 @@ export type GetParsedFormDefinitionQuery = {
                     answerNumber?: number | null;
                     answerBoolean?: boolean | null;
                     answerGroupCode?: string | null;
+                    answerDate?: string | null;
                     compareQuestion?: string | null;
                   }>;
                 }> | null;
@@ -29254,6 +29461,7 @@ export type GetParsedFormDefinitionQuery = {
                 answerNumber?: number | null;
                 answerBoolean?: boolean | null;
                 answerGroupCode?: string | null;
+                answerDate?: string | null;
                 compareQuestion?: string | null;
               }> | null;
               autofillValues?: Array<{
@@ -29276,6 +29484,7 @@ export type GetParsedFormDefinitionQuery = {
                   answerNumber?: number | null;
                   answerBoolean?: boolean | null;
                   answerGroupCode?: string | null;
+                  answerDate?: string | null;
                   compareQuestion?: string | null;
                 }>;
               }> | null;
@@ -29326,6 +29535,7 @@ export type GetParsedFormDefinitionQuery = {
               answerNumber?: number | null;
               answerBoolean?: boolean | null;
               answerGroupCode?: string | null;
+              answerDate?: string | null;
               compareQuestion?: string | null;
             }> | null;
             autofillValues?: Array<{
@@ -29348,6 +29558,7 @@ export type GetParsedFormDefinitionQuery = {
                 answerNumber?: number | null;
                 answerBoolean?: boolean | null;
                 answerGroupCode?: string | null;
+                answerDate?: string | null;
                 compareQuestion?: string | null;
               }>;
             }> | null;
@@ -29398,6 +29609,7 @@ export type GetParsedFormDefinitionQuery = {
             answerNumber?: number | null;
             answerBoolean?: boolean | null;
             answerGroupCode?: string | null;
+            answerDate?: string | null;
             compareQuestion?: string | null;
           }> | null;
           autofillValues?: Array<{
@@ -29420,6 +29632,7 @@ export type GetParsedFormDefinitionQuery = {
               answerNumber?: number | null;
               answerBoolean?: boolean | null;
               answerGroupCode?: string | null;
+              answerDate?: string | null;
               compareQuestion?: string | null;
             }>;
           }> | null;
@@ -29470,6 +29683,7 @@ export type GetParsedFormDefinitionQuery = {
           answerNumber?: number | null;
           answerBoolean?: boolean | null;
           answerGroupCode?: string | null;
+          answerDate?: string | null;
           compareQuestion?: string | null;
         }> | null;
         autofillValues?: Array<{
@@ -29492,6 +29706,7 @@ export type GetParsedFormDefinitionQuery = {
             answerNumber?: number | null;
             answerBoolean?: boolean | null;
             answerGroupCode?: string | null;
+            answerDate?: string | null;
             compareQuestion?: string | null;
           }>;
         }> | null;
@@ -30808,6 +31023,7 @@ export type OccurrencePointFormFieldsFragment = {
                   answerNumber?: number | null;
                   answerBoolean?: boolean | null;
                   answerGroupCode?: string | null;
+                  answerDate?: string | null;
                   compareQuestion?: string | null;
                 }> | null;
                 autofillValues?: Array<{
@@ -30830,6 +31046,7 @@ export type OccurrencePointFormFieldsFragment = {
                     answerNumber?: number | null;
                     answerBoolean?: boolean | null;
                     answerGroupCode?: string | null;
+                    answerDate?: string | null;
                     compareQuestion?: string | null;
                   }>;
                 }> | null;
@@ -30880,6 +31097,7 @@ export type OccurrencePointFormFieldsFragment = {
                 answerNumber?: number | null;
                 answerBoolean?: boolean | null;
                 answerGroupCode?: string | null;
+                answerDate?: string | null;
                 compareQuestion?: string | null;
               }> | null;
               autofillValues?: Array<{
@@ -30902,6 +31120,7 @@ export type OccurrencePointFormFieldsFragment = {
                   answerNumber?: number | null;
                   answerBoolean?: boolean | null;
                   answerGroupCode?: string | null;
+                  answerDate?: string | null;
                   compareQuestion?: string | null;
                 }>;
               }> | null;
@@ -30952,6 +31171,7 @@ export type OccurrencePointFormFieldsFragment = {
               answerNumber?: number | null;
               answerBoolean?: boolean | null;
               answerGroupCode?: string | null;
+              answerDate?: string | null;
               compareQuestion?: string | null;
             }> | null;
             autofillValues?: Array<{
@@ -30974,6 +31194,7 @@ export type OccurrencePointFormFieldsFragment = {
                 answerNumber?: number | null;
                 answerBoolean?: boolean | null;
                 answerGroupCode?: string | null;
+                answerDate?: string | null;
                 compareQuestion?: string | null;
               }>;
             }> | null;
@@ -31024,6 +31245,7 @@ export type OccurrencePointFormFieldsFragment = {
             answerNumber?: number | null;
             answerBoolean?: boolean | null;
             answerGroupCode?: string | null;
+            answerDate?: string | null;
             compareQuestion?: string | null;
           }> | null;
           autofillValues?: Array<{
@@ -31046,6 +31268,7 @@ export type OccurrencePointFormFieldsFragment = {
               answerNumber?: number | null;
               answerBoolean?: boolean | null;
               answerGroupCode?: string | null;
+              answerDate?: string | null;
               compareQuestion?: string | null;
             }>;
           }> | null;
@@ -31096,6 +31319,7 @@ export type OccurrencePointFormFieldsFragment = {
           answerNumber?: number | null;
           answerBoolean?: boolean | null;
           answerGroupCode?: string | null;
+          answerDate?: string | null;
           compareQuestion?: string | null;
         }> | null;
         autofillValues?: Array<{
@@ -31118,6 +31342,7 @@ export type OccurrencePointFormFieldsFragment = {
             answerNumber?: number | null;
             answerBoolean?: boolean | null;
             answerGroupCode?: string | null;
+            answerDate?: string | null;
             compareQuestion?: string | null;
           }>;
         }> | null;
@@ -35524,6 +35749,7 @@ export const EnableWhenFieldsFragmentDoc = gql`
     answerNumber
     answerBoolean
     answerGroupCode
+    answerDate
     compareQuestion
   }
 `;


### PR DESCRIPTION
## Description

GH issue: https://github.com/open-path/Green-River/issues/6561
Depends on hmis-warehouse PR: https://github.com/greenriver/hmis-warehouse/pull/4643

This PR
- enables date comparison in EnableWhen condition evaluation logic
- adds the correct date component when creating the EnableWhen in the form builder

## Type of change
[//]: # 'remove options that are not relevant'
- [ ] Bug fix
- [x] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
