### PR TITLE
Fix bad keys in form builder

### DIFF
--- a/src/modules/formBuilder/components/itemEditor/conditionals/AutofillProperties.tsx
+++ b/src/modules/formBuilder/components/itemEditor/conditionals/AutofillProperties.tsx
@@ -29,7 +29,7 @@ const AutofillProperties: React.FC<AutofillPropertiesProps> = ({
       {fields.map((value, index) => (
         <RemovableCard
           onRemove={() => remove(index)}
-          key={JSON.stringify(value)}
+          key={value.id}
           removeTooltip='Remove Autofill'
         >
           <AutofillValueCard

--- a/src/modules/formBuilder/components/itemEditor/conditionals/EnableWhenCondition.tsx
+++ b/src/modules/formBuilder/components/itemEditor/conditionals/EnableWhenCondition.tsx
@@ -181,7 +181,7 @@ const EnableWhenCondition: React.FC<EnableWhenConditionProps> = ({
                   required: 'Local Constant or Dependent Question is required',
                 }}
                 onChange={() =>
-                  setValue(`${enableWhenPath}.${index}.operator`, undefined)
+                  setValue(`${enableWhenPath}.${index}.operator`, null as any)
                 }
               />
             )}
@@ -197,7 +197,7 @@ const EnableWhenCondition: React.FC<EnableWhenConditionProps> = ({
                 options={localConstantsPickList}
                 helperText='Local constant whose value will determine whether the condition is met'
                 onChange={() =>
-                  setValue(`${enableWhenPath}.${index}.operator`, undefined)
+                  setValue(`${enableWhenPath}.${index}.operator`, null as any)
                 }
               />
             )}

--- a/src/modules/formBuilder/components/itemEditor/conditionals/InitialValue.tsx
+++ b/src/modules/formBuilder/components/itemEditor/conditionals/InitialValue.tsx
@@ -74,7 +74,7 @@ const InitialValue: React.FC<Props> = ({ itemType, control }) => {
       >
         {fields.map((initial, index) => (
           <RemovableCard
-            key={JSON.stringify(initial)} // fixme could be non unique
+            key={initial.id}
             onRemove={() => remove(index)}
             removeTooltip={'Remove Initial Value'}
           >

--- a/src/modules/formBuilder/components/itemEditor/conditionals/ManageEnableWhen.tsx
+++ b/src/modules/formBuilder/components/itemEditor/conditionals/ManageEnableWhen.tsx
@@ -72,7 +72,7 @@ const ManageEnableWhen: React.FC<ManageEnableWhenProps> = ({
       )}
       {fields.map((condition, index) => (
         <RemovableCard
-          key={JSON.stringify(condition)} // fixme could be non unique
+          key={condition.id}
           onRemove={() => remove(index)}
           removeTooltip={'Remove Condition'}
         >

--- a/src/modules/formBuilder/components/itemEditor/conditionals/ValueBounds.tsx
+++ b/src/modules/formBuilder/components/itemEditor/conditionals/ValueBounds.tsx
@@ -32,7 +32,7 @@ const ValueBounds: React.FC<Props> = ({ control, itemMap }) => {
     >
       {fields.map((bound, index) => (
         <RemovableCard
-          key={JSON.stringify(bound)} // fixme could be non unique
+          key={bound.id}
           onRemove={() => remove(index)}
           removeTooltip={'Remove Bound'}
         >


### PR DESCRIPTION
## Description

Fix incorrect keys that were leading to buggy behavior https://github.com/open-path/Green-River/issues/6512
The `id` used in all cases is a unique id generated by useFieldArray: https://react-hook-form.com/docs/usefieldarray


## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
