### PR TITLE
Remove parent record type from submitted values

### DIFF
--- a/src/modules/form/util/formUtil.ts
+++ b/src/modules/form/util/formUtil.ts
@@ -1146,25 +1146,21 @@ export const transformSubmitValues = ({
 }: TransformSubmitValuesParams) => {
   const allLinkIds = new Set();
   // Recursive helper for traversing the FormDefinition
-  function rescursiveFillMap(
-    items: FormItem[],
-    result: Record<string, any>,
-    parentRecordType?: string
-  ) {
+  function rescursiveFillMap(items: FormItem[], result: Record<string, any>) {
     items.forEach((item: FormItem) => {
       allLinkIds.add(item.linkId);
 
       const mapping = item.mapping || {};
       const recordType = mapping.recordType
         ? HmisEnums.RelatedRecordType[mapping.recordType]
-        : parentRecordType;
+        : undefined;
 
       if (mapping.recordType && !recordType) {
         throw Error(`Unrecognized record type in form definition: ${mapping}`);
       }
 
       if (Array.isArray(item.item)) {
-        rescursiveFillMap(item.item, result, recordType);
+        rescursiveFillMap(item.item, result);
       }
       const fieldName = mapping.fieldName || mapping.customFieldKey;
       if (!fieldName) return; // If there is no field name, it can't be extracted so don't bother sending it


### PR DESCRIPTION
## Description

Follow-up from https://github.com/greenriver/hmis-frontend/pull/909#discussion_r1744276313

I tested this by creating/enrolling a new client and filling out the intake locally, which looks fine to me, but I'm not sure if there are other steps we should take to test and make sure this won't break anything.

## Type of change
[//]: # 'remove options that are not relevant'
- [ ] Bug fix
- [ ] New feature (adds functionality)
- [x] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
