### PR TITLE
Support Other Funder dropdown in funder setup and rule setup

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -31805,7 +31805,7 @@
           },
           {
             "name": "OTHER_FUNDERS",
-            "description": "OtherFunder values for all active Funders across the installation",
+            "description": "OtherFunder values for all Funders across the installation",
             "isDeprecated": false,
             "deprecationReason": null
           },

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -31804,6 +31804,12 @@
             "deprecationReason": null
           },
           {
+            "name": "OTHER_FUNDERS",
+            "description": "OtherFunder values for all active Funders across the installation",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "POSSIBLE_UNIT_TYPES_FOR_PROJECT",
             "description": "Unit types that are eligible to be added to project",
             "isDeprecated": false,

--- a/src/modules/admin/components/formRules/NewFormRuleDialog.tsx
+++ b/src/modules/admin/components/formRules/NewFormRuleDialog.tsx
@@ -5,12 +5,10 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
-  Grid,
 } from '@mui/material';
 import { Stack } from '@mui/system';
 import React, { useCallback, useMemo, useState } from 'react';
 import CommonDialog from '@/components/elements/CommonDialog';
-import TextInput from '@/components/elements/input/TextInput';
 import theme from '@/config/theme';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { BaseFormRule } from '@/modules/admin/components/formRules/FormRule';
@@ -48,13 +46,12 @@ export interface RuleCondition {
   value: string;
 }
 
-// `otherFunder` is also a condition type, of a sort, but it's left off here because
-// it's dependent on `funder` and it's a TextInput instead of a Select
 export type ConditionType =
   | 'projectId'
   | 'projectType'
   | 'organizationId'
   | 'funder'
+  | 'otherFunder'
   | 'serviceTypeId'
   | 'serviceCategoryId';
 
@@ -79,7 +76,6 @@ const NewFormRuleDialog: React.FC<Props> = ({
   const [dataCollectedAbout, setDataCollectedAbout] =
     useState<DataCollectedAbout>(DataCollectedAbout.AllClients);
   const [ruleConditions, setRuleConditions] = useState<RuleCondition[]>([]);
-  const [otherFundingSource, setOtherFundingSource] = useState<string>('');
   const [serviceConditionType, setServiceConditionType] = useState<
     'serviceCategoryId' | 'serviceTypeId'
   >('serviceCategoryId');
@@ -100,20 +96,16 @@ const NewFormRuleDialog: React.FC<Props> = ({
       projectType: conditions.projectType as ProjectType,
       organizationId: conditions.organizationId,
       funder: conditions.funder as FundingSource,
+      otherFunder: conditions.otherFunder as FundingSource,
       serviceTypeId: conditions.serviceTypeId,
       serviceCategoryId: conditions.serviceCategoryId,
       ...(formRole === FormRole.Service
         ? { [serviceConditionType]: serviceConditionValue }
         : {}),
-      ...(conditions.funder === FundingSource.LocalOrOtherFundingSource &&
-      otherFundingSource
-        ? { otherFunder: otherFundingSource }
-        : {}),
     };
   }, [
     dataCollectedAbout,
     ruleConditions,
-    otherFundingSource,
     serviceConditionType,
     serviceConditionValue,
     formRole,
@@ -124,7 +116,6 @@ const NewFormRuleDialog: React.FC<Props> = ({
     // Null out the form values
     setDataCollectedAbout(DataCollectedAbout.AllClients);
     setRuleConditions([]);
-    setOtherFundingSource('');
   }, [onClose]);
 
   const [createFormRule, { loading, error }] = useCreateFormRuleMutation({
@@ -188,6 +179,7 @@ const NewFormRuleDialog: React.FC<Props> = ({
       { code: 'projectType', label: 'Project Type' },
       { code: 'organizationId', label: 'Organization' },
       { code: 'funder', label: 'Funding Source' },
+      { code: 'otherFunder', label: 'Local or Other Funding Source' },
     ];
 
     const conditionsAlreadyInUse = ruleConditions.map(
@@ -237,9 +229,18 @@ const NewFormRuleDialog: React.FC<Props> = ({
     },
   });
 
+  const { pickList: otherFunderPickList } = usePickList({
+    item: {
+      linkId: 'fake',
+      type: ItemType.Choice,
+      pickListReference: PickListType.OtherFunders,
+    },
+  });
+
   const pickListMap: Record<ConditionType, PickListOption[]> = {
     projectType: projectTypePickList || [],
     funder: funderPickList || [],
+    otherFunder: otherFunderPickList || [],
     organizationId: orgList || [],
     projectId: projectList || [],
     serviceTypeId: serviceTypePickList || [],
@@ -437,29 +438,6 @@ const NewFormRuleDialog: React.FC<Props> = ({
               </RemovableCard>
             );
           })}
-
-          {rule.funder === FundingSource.LocalOrOtherFundingSource && (
-            <Card
-              sx={{
-                backgroundColor: theme.palette.grey[100],
-                border: 0,
-                px: 2,
-                py: 1,
-              }}
-            >
-              <Grid container spacing={1}>
-                <Grid item xs={12}>
-                  <TextInput
-                    label='And funding source is'
-                    value={rule.otherFunder || ''}
-                    onChange={(e) => {
-                      setOtherFundingSource(e.target.value);
-                    }}
-                  />
-                </Grid>
-              </Grid>
-            </Card>
-          )}
         </CardGroup>
       </DialogContent>
       <DialogActions>

--- a/src/types/gqlEnums.ts
+++ b/src/types/gqlEnums.ts
@@ -944,6 +944,8 @@ export const HmisEnums = {
     OPEN_HOH_ENROLLMENTS_FOR_PROJECT: 'Open HoH enrollments at the project.',
     OPEN_PROJECTS: 'Open Projects that the user can see',
     ORGANIZATION: 'All Organizations that the User can see',
+    OTHER_FUNDERS:
+      'OtherFunder values for all active Funders across the installation',
     POSSIBLE_UNIT_TYPES_FOR_PROJECT:
       'Unit types that are eligible to be added to project',
     PRIOR_LIVING_SITUATION: 'PRIOR_LIVING_SITUATION',

--- a/src/types/gqlEnums.ts
+++ b/src/types/gqlEnums.ts
@@ -944,8 +944,7 @@ export const HmisEnums = {
     OPEN_HOH_ENROLLMENTS_FOR_PROJECT: 'Open HoH enrollments at the project.',
     OPEN_PROJECTS: 'Open Projects that the user can see',
     ORGANIZATION: 'All Organizations that the User can see',
-    OTHER_FUNDERS:
-      'OtherFunder values for all active Funders across the installation',
+    OTHER_FUNDERS: 'OtherFunder values for all Funders across the installation',
     POSSIBLE_UNIT_TYPES_FOR_PROJECT:
       'Unit types that are eligible to be added to project',
     PRIOR_LIVING_SITUATION: 'PRIOR_LIVING_SITUATION',

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -4655,7 +4655,7 @@ export enum PickListType {
   OpenProjects = 'OPEN_PROJECTS',
   /** All Organizations that the User can see */
   Organization = 'ORGANIZATION',
-  /** OtherFunder values for all active Funders across the installation */
+  /** OtherFunder values for all Funders across the installation */
   OtherFunders = 'OTHER_FUNDERS',
   /** Unit types that are eligible to be added to project */
   PossibleUnitTypesForProject = 'POSSIBLE_UNIT_TYPES_FOR_PROJECT',

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -4655,6 +4655,8 @@ export enum PickListType {
   OpenProjects = 'OPEN_PROJECTS',
   /** All Organizations that the User can see */
   Organization = 'ORGANIZATION',
+  /** OtherFunder values for all active Funders across the installation */
+  OtherFunders = 'OTHER_FUNDERS',
   /** Unit types that are eligible to be added to project */
   PossibleUnitTypesForProject = 'POSSIBLE_UNIT_TYPES_FOR_PROJECT',
   PriorLivingSituation = 'PRIOR_LIVING_SITUATION',


### PR DESCRIPTION
## Description

* When creating or editing a local Funder record, allow user to pick from existing local Funder strings (they can also enter a new one). 
* When adding a form rule, allow user to pick from local funder list. This also removes the behavior where you HAD to select "local or other funder" before entering the local funder value, which I think is fine. it's not necessary to specify both on the rule.

Depends on hmis-warehouse PR: https://github.com/greenriver/hmis-warehouse/pull/4693
Issue: https://github.com/open-path/Green-River/issues/6317

<img width="531" alt="Screenshot 2024-09-12 at 9 41 05 AM" src="https://github.com/user-attachments/assets/bb2a3a0f-fc0a-4337-9642-a9ba48aa56e8">
<img width="540" alt="Screenshot 2024-09-12 at 9 40 38 AM" src="https://github.com/user-attachments/assets/a1ed44b3-f759-4448-a99d-e51843b44a47">
<img width="546" alt="Screenshot 2024-09-12 at 9 40 09 AM" src="https://github.com/user-attachments/assets/155685b0-4ac2-4e35-a32f-8f18faf0f645">



## Type of change
- [x] New feature (adds functionality)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
