### PR TITLE
Trim search term before checking that its >=3 chars long

### DIFF
--- a/src/modules/search/components/ClientTextSearchForm.tsx
+++ b/src/modules/search/components/ClientTextSearchForm.tsx
@@ -39,11 +39,11 @@ const ClientTextSearchForm: React.FC<Props> = ({
 
   useEffect(() => {
     if (!minChars || !tooShort) return;
-    if (value && value.length >= minChars) setTooShort(false);
+    if (value && value.trim().length >= minChars) setTooShort(false);
   }, [minChars, value, tooShort]);
 
   const handleSearch = useCallback(() => {
-    if (minChars && (value || '').length < minChars) {
+    if (minChars && (value || '').trim().length < minChars) {
       setTooShort(true);
     } else {
       onSearch(value);


### PR DESCRIPTION
## Description

Bug: search for "       " . it will throw an error because of change introduced with https://github.com/greenriver/hmis-warehouse/pull/4684.

New behavior: if you search for "     " or "   ab  " you should get the user-friendly message "Please enter at least 3 characters." 

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
