### PR TITLE
Add reviewed local const to external forms review modal

### DIFF
--- a/src/modules/projects/components/tables/ProjectExternalSubmissionsTable.tsx
+++ b/src/modules/projects/components/tables/ProjectExternalSubmissionsTable.tsx
@@ -141,6 +141,9 @@ const ProjectExternalSubmissionsTable = ({
         } as ExternalFormSubmissionInput,
       };
     },
+    localConstants: {
+      reviewed: selected?.status === ExternalFormSubmissionStatus.Reviewed,
+    },
     initialValues: selected
       ? {
           notes: selected.notes,


### PR DESCRIPTION
## Description

This PR adds the `reviewed` local constant to the form dialog for reviewing an external form. It should be merged before https://github.com/greenriver/hmis-warehouse/pull/4713/files, which is why I'm targeting it at release-134 instead of pit-external-forms.

## Type of change
[//]: # 'remove options that are not relevant'
- [ ] Bug fix
- [x] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
