### PR TITLE
Update fetch policy on unit summary

### DIFF
--- a/src/modules/units/components/UnitCapacityTable.tsx
+++ b/src/modules/units/components/UnitCapacityTable.tsx
@@ -58,6 +58,7 @@ const CapacityProgressBar = ({ percentFilled }: { percentFilled: number }) => {
 const UnitCapacityTable = ({ projectId }: { projectId: string }) => {
   const { data, error, loading } = useGetProjectUnitTypesQuery({
     variables: { id: projectId },
+    fetchPolicy: 'cache-and-network',
   });
   const columns: ColumnDef<UnitTypeCapacityFieldsFragment>[] = [
     {


### PR DESCRIPTION
## Description

For a project with units, the capacity indicator wouldn't refetch when you navigate between bed night assignment and unit availability. 

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [ ] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
