### PR TITLE
Show reference pick lists correctly in review modal

### DIFF
--- a/src/modules/projects/components/ExternalSubmissionsViewModal.tsx
+++ b/src/modules/projects/components/ExternalSubmissionsViewModal.tsx
@@ -57,7 +57,7 @@ const ExternalSubmissionsModalContent = ({
         : submission.values[recordAttrKey];
 
       // if item has a picklist, convert value to PickListOption(s) so we can display the readable label
-      if (item.pickListOptions) {
+      if (item.pickListOptions || item.pickListReference) {
         if (Array.isArray(value)) {
           submissionValues[key] = value.map((v) => getOptionValue(v, item));
         } else {


### PR DESCRIPTION
## Description

Relates indirectly to GH issue https://github.com/open-path/Green-River/issues/6733

I noticed this bug while pulling in an old version of the PIT form (https://github.com/open-path/Green-River/issues/6544#issuecomment-2326792270) with disability questions that have pick list reference.

To reproduce
- publish an external form with a pick list reference
- collect a response
- go to the review UI and open the submission, you will see the response collected isn't displayed.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
