### PR TITLE
Throw fetch error object directly

### DIFF
--- a/src/modules/assessments/hooks/useAssessmentFormDefinition.tsx
+++ b/src/modules/assessments/hooks/useAssessmentFormDefinition.tsx
@@ -54,10 +54,7 @@ const useAssessmentFormDefinition = ({
     };
   }, [data]);
 
-  if (error)
-    throw new Error(
-      `Failed to fetch form definition: ${formDefinitionId || role || ''}`
-    );
+  if (error) throw error;
 
   return { formDefinition, itemMap, loading };
 };

--- a/src/modules/form/hooks/useFormDefinition.tsx
+++ b/src/modules/form/hooks/useFormDefinition.tsx
@@ -26,10 +26,7 @@ const useFormDefinition = (
     };
   }, [data?.recordFormDefinition, localDefinition]);
 
-  if (error)
-    throw new Error(
-      `Failed to fetch form definition for role ${queryVariables.role}`
-    );
+  if (error) throw error;
 
   return { formDefinition, itemMap, loading };
 };

--- a/src/modules/form/hooks/useStaticFormDefinition.tsx
+++ b/src/modules/form/hooks/useStaticFormDefinition.tsx
@@ -25,8 +25,7 @@ const useStaticFormDefinition = (
     };
   }, [data, localDefinition]);
 
-  if (error)
-    throw new Error(`Failed to fetch form definition for role ${role}`);
+  if (error) throw error;
 
   return { formDefinition, itemMap, loading };
 };


### PR DESCRIPTION
## Description

These are coming through and are usually network errors, so just throw them directly. There is no need to name them differently in sentry

## Type of change
- [x] Code clean-up / housekeeping

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
