### PR TITLE
6240-strict-transport-security

### DIFF
--- a/docker/templates/non_proxy_headers.conf.template
+++ b/docker/templates/non_proxy_headers.conf.template
@@ -3,6 +3,7 @@
 add_header Content-Security-Policy "default-src 'none'; connect-src 'self' *.sentry.io *.s3.amazonaws.com; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' fonts.googleapis.com 'unsafe-inline'; img-src 'self' data: blob: *.s3.amazonaws.com; font-src 'self' fonts.gstatic.com; object-src 'none';" always;
 
 add_header Referrer-Policy "strict-origin-when-cross-origin";
+add_header Strict-Transport-Security "max-age=63072000; includeSubdomains;" always;
 add_header X-Frame-Options "SAMEORIGIN" always;
 add_header X-XSS-Protection "1; mode=block" always;
 add_header X-Content-Type-Options "nosniff" always;


### PR DESCRIPTION
## Description

[GH Issue](https://github.com/open-path/Green-River/issues/6240)

enables HTTP Strict Transport Security (HSTS)

__NOTE:__ I have not tested this yet, it requires deployment


## Testing
```
curl -s -D - https://qa-hmis.example.com/ -o /dev/null | grep -i strict-transport-security
# should return
# strict-transport-security: max-age=63072000; includeSubDomains
```

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (eslint)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
