### PR TITLE
Display bulk submission review failure more gracefully

### DIFF
--- a/src/modules/projects/components/tables/ProjectExternalSubmissionsTable.tsx
+++ b/src/modules/projects/components/tables/ProjectExternalSubmissionsTable.tsx
@@ -5,6 +5,7 @@ import LoadingButton from '@/components/elements/LoadingButton';
 import { ColumnDef } from '@/components/elements/table/types';
 import theme from '@/config/theme';
 import GenericTableWithData from '@/modules/dataFetching/components/GenericTableWithData';
+import ApolloErrorAlert from '@/modules/errors/components/ApolloErrorAlert';
 import RelativeDateTableCellContents from '@/modules/hmis/components/RelativeDateTableCellContents';
 import { useFilters } from '@/modules/hmis/filterUtil';
 import ExternalSubmissionsViewModal from '@/modules/projects/components/ExternalSubmissionsViewModal';
@@ -121,8 +122,6 @@ const ProjectExternalSubmissionsTable = ({
     type: 'ExternalFormSubmissionFilterOptions',
   });
 
-  if (bulkError) throw bulkError;
-
   return (
     <>
       <GenericTableWithData<
@@ -179,6 +178,7 @@ const ProjectExternalSubmissionsTable = ({
           onClose={() => setModalOpenId(null)}
         />
       )}
+      {bulkError && <ApolloErrorAlert error={bulkError} />}
     </>
   );
 };


### PR DESCRIPTION
## Description

GH issue: https://github.com/open-path/Green-River/issues/6744
Relates to, but doesn't depend upon, https://github.com/greenriver/hmis-warehouse/pull/4817

This change makes bulk review errors appear in a floating snackbar, as opposed to replacing the contents of the page.

For test instructions, see warehouse PR for how I simulated a problematic submission row that will cause failures.

## Type of change
[//]: # 'remove options that are not relevant'
- UX improvement

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
