### PR TITLE
Add aria label to warning icon

### DIFF
--- a/src/modules/services/components/bulk/AssignServiceButton.tsx
+++ b/src/modules/services/components/bulk/AssignServiceButton.tsx
@@ -107,7 +107,7 @@ const AssignServiceButton: React.FC<Props> = ({
     isAssignedOnDate && !localDisabled ? (
       <CheckIcon />
     ) : clientAlerts.length > 0 ? (
-      <WarningAmberRoundedIcon />
+      <WarningAmberRoundedIcon aria-label='Client has an active alert' />
     ) : undefined;
 
   const alertModalTitle = `${


### PR DESCRIPTION
## Description

GH issue: https://github.com/open-path/Green-River/issues/6736

This PR adds an accessible label to the warning icon on Bulk Services when a client has an active alert, making it easier to system test this feature, and also making it more accessible.

## Type of change
[//]: # 'remove options that are not relevant'
- [ ] Bug fix
- [ ] New feature (adds functionality)
- [x] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
