### PR TITLE
Prevent frontend from swallowing displayable error messages

### DIFF
--- a/src/modules/errors/components/ApolloErrorAlert.tsx
+++ b/src/modules/errors/components/ApolloErrorAlert.tsx
@@ -116,11 +116,7 @@ const ApolloErrorAlert: React.FC<Props> = ({
       }
       return isString(result) ? [result] : result?.errors || [];
     }
-    // don't show graphql errors to user in prod
-    if (showDeveloperInfo) {
-      return error.graphQLErrors;
-    }
-    return [];
+    return error.graphQLErrors;
   }, [error]);
 
   const isNetworkError = error


### PR DESCRIPTION
## Description

GH issue: https://github.com/open-path/Green-River/issues/6886

This is a first stab at solving the bug described in the ticket.

I've tested a couple basic scenarios and I'm happy with the behavior:
- raising `HmisErrors::ApiError` with `display_message` - fixes bug, displays custom error
- raising `HmisErrors::ApiError` with no `display_message` - displays generic error message from [here](https://github.com/greenriver/hmis-warehouse/blob/341367e3474166cd329b3b263ac7dd1212f26d83/drivers/hmis/lib/hmis_errors/api_error.rb#L11)
- raising another runtime error - displays generic error message

However, I don't feel 100% sure that this isn't breaking any carefully considered erroring behavior that I don't know about yet! I also know this isn't compatible with the comment [here](https://github.com/greenriver/hmis-warehouse/blob/341367e3474166cd329b3b263ac7dd1212f26d83/drivers/hmis/lib/hmis_errors/api_error.rb#L10) stating that our goal is to put these error messages into the frontend eventually. So, let's discuss more before merging.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
