### PR TITLE
Disallow editing HUD service types from frontend

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -32038,6 +32038,12 @@
             "deprecationReason": null
           },
           {
+            "name": "CUSTOM_SERVICE_CATEGORIES",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "DESTINATION",
             "description": null,
             "isDeprecated": false,

--- a/src/modules/admin/components/services/NewServiceTypeButton.tsx
+++ b/src/modules/admin/components/services/NewServiceTypeButton.tsx
@@ -41,11 +41,11 @@ const NewServiceTypeButton = () => {
   });
 
   const {
-    data: pickListData,
+    data: { pickList } = {},
     loading: pickListLoading,
     error: pickListError,
   } = useGetPickListQuery({
-    variables: { pickListType: PickListType.AllServiceCategories },
+    variables: { pickListType: PickListType.CustomServiceCategories },
   });
 
   if (error) throw error;
@@ -77,7 +77,7 @@ const NewServiceTypeButton = () => {
             />
             <FormSelect
               value={serviceCategory}
-              options={pickListData?.pickList || []}
+              options={pickList || []}
               onChange={(_e, value) => {
                 setServiceCategory(isPickListOption(value) ? value : null);
               }}

--- a/src/modules/admin/components/services/ServiceTypeDetailPage.tsx
+++ b/src/modules/admin/components/services/ServiceTypeDetailPage.tsx
@@ -26,7 +26,11 @@ const ServiceTypeDetailPage = () => {
     serviceTypeId: string;
   };
 
-  const { data, loading, error } = useGetServiceTypeDetailsQuery({
+  const {
+    data: { serviceType } = {},
+    loading,
+    error,
+  } = useGetServiceTypeDetailsQuery({
     variables: { id: serviceTypeId },
   });
 
@@ -35,44 +39,48 @@ const ServiceTypeDetailPage = () => {
   const [updateDialogOpen, setUpdateDialogOpen] = useState(false);
 
   if (error) throw error;
-  if (!data && loading) return <Loading />;
-  if (!data?.serviceType) return <NotFound />;
+  if (!serviceType && loading) return <Loading />;
+  if (!serviceType) return <NotFound />;
 
   return (
     <>
       <PageTitle
         overlineText='Manage Service'
-        title={data.serviceType.name}
+        title={serviceType.name}
         endElement={
-          <EditIconButton
-            title='Edit Service Type'
-            onClick={() => setUpdateDialogOpen(true)}
-            sx={{ ml: 1, mb: 0.5 }}
-          />
+          !serviceType.hud && (
+            <EditIconButton
+              title='Edit Service Type'
+              onClick={() => setUpdateDialogOpen(true)}
+              sx={{ ml: 1, mb: 0.5 }}
+            />
+          )
         }
         actions={
-          <DeleteMutationButton<
-            DeleteServiceTypeMutation,
-            DeleteServiceTypeMutationVariables
-          >
-            queryDocument={DeleteServiceTypeDocument}
-            variables={{ id: data.serviceType.id }}
-            idPath={'deleteServiceType.serviceType.id'}
-            recordName='Service Type'
-            onSuccess={() => {
-              evictQuery('serviceTypes');
-              navigate(
-                generateSafePath(AdminDashboardRoutes.CONFIGURE_SERVICES)
-              );
-            }}
-          >
-            Delete
-          </DeleteMutationButton>
+          !serviceType.hud && (
+            <DeleteMutationButton<
+              DeleteServiceTypeMutation,
+              DeleteServiceTypeMutationVariables
+            >
+              queryDocument={DeleteServiceTypeDocument}
+              variables={{ id: serviceType.id }}
+              idPath={'deleteServiceType.serviceType.id'}
+              recordName='Service Type'
+              onSuccess={() => {
+                evictQuery('serviceTypes');
+                navigate(
+                  generateSafePath(AdminDashboardRoutes.CONFIGURE_SERVICES)
+                );
+              }}
+            >
+              Delete
+            </DeleteMutationButton>
+          )
         }
       />
-      {data.serviceType && (
+      {serviceType && (
         <UpdateServiceTypeDialog
-          serviceType={data.serviceType}
+          serviceType={serviceType}
           dialogOpen={updateDialogOpen}
           closeDialog={() => setUpdateDialogOpen(!updateDialogOpen)}
         />
@@ -81,17 +89,17 @@ const ServiceTypeDetailPage = () => {
         <Paper sx={{ p: 2 }}>
           <Stack gap={1}>
             <CommonLabeledTextBlock title='Service Category'>
-              {data.serviceType.category}
+              {serviceType.category}
             </CommonLabeledTextBlock>
             <CommonLabeledTextBlock title='Service Type'>
-              {data.serviceType.name}
+              {serviceType.name}
             </CommonLabeledTextBlock>
             <CommonLabeledTextBlock title='Supports Bulk Assignment?'>
-              {data.serviceType.supportsBulkAssignment ? 'Yes' : 'No'}
+              {serviceType.supportsBulkAssignment ? 'Yes' : 'No'}
             </CommonLabeledTextBlock>
             <CommonLabeledTextBlock title='Active Forms'>
               <CommonUnstyledList>
-                {data.serviceType.formDefinitions.map((formDef) => (
+                {serviceType.formDefinitions.map((formDef) => (
                   <li key={formDef.id}>
                     <RouterLink
                       to={generatePath(AdminDashboardRoutes.VIEW_FORM, {

--- a/src/modules/admin/components/services/ServiceTypeTable.tsx
+++ b/src/modules/admin/components/services/ServiceTypeTable.tsx
@@ -22,7 +22,7 @@ const columns: ColumnDef<ServiceTypeConfigFieldsFragment>[] = [
     render: 'category',
   },
   {
-    header: 'Type',
+    header: 'HUD or Custom',
     render: ({ hud }) => (
       <Chip
         label={hud ? 'HUD' : 'Custom'}
@@ -34,8 +34,7 @@ const columns: ColumnDef<ServiceTypeConfigFieldsFragment>[] = [
     ),
   },
   {
-    key: 'tags',
-    textAlign: 'right',
+    header: 'Tags',
     render: ({ supportsBulkAssignment }) =>
       supportsBulkAssignment ? (
         <Chip size='small' label='Supports Bulk Assignment' />

--- a/src/types/gqlEnums.ts
+++ b/src/types/gqlEnums.ts
@@ -932,6 +932,7 @@ export const HmisEnums = {
     COC: 'COC',
     CONTINUUM_PROJECTS: 'Continuum Projects',
     CURRENT_LIVING_SITUATION: 'CURRENT_LIVING_SITUATION',
+    CUSTOM_SERVICE_CATEGORIES: 'CUSTOM_SERVICE_CATEGORIES',
     DESTINATION: 'DESTINATION',
     ELIGIBLE_STAFF_ASSIGNMENT_USERS:
       'Current users who are eligible for staff assignment',

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -4678,6 +4678,7 @@ export enum PickListType {
   /** Continuum Projects */
   ContinuumProjects = 'CONTINUUM_PROJECTS',
   CurrentLivingSituation = 'CURRENT_LIVING_SITUATION',
+  CustomServiceCategories = 'CUSTOM_SERVICE_CATEGORIES',
   Destination = 'DESTINATION',
   /** Current users who are eligible for staff assignment */
   EligibleStaffAssignmentUsers = 'ELIGIBLE_STAFF_ASSIGNMENT_USERS',


### PR DESCRIPTION
## Description

GH issue: https://github.com/open-path/Green-River/issues/6831
Depends on hmis-warehouse PR: https://github.com/greenriver/hmis-warehouse/pull/4856

This PR
- updates the New Service Type modal to use the custom-only service category picklist
- updates the Service Type detail page to hide the buttons for Edit and Delete if it's a HUD service type
- modifies column headers on the Service Type table

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
