### PR TITLE
Remove explicit throw from useFormDefinition

### DIFF
--- a/src/modules/form/hooks/useFormDefinition.tsx
+++ b/src/modules/form/hooks/useFormDefinition.tsx
@@ -28,6 +28,7 @@ const useFormDefinition = (
 
   if (error) throw error;
 
+  // TODO(#6159) - turn this explicit error back on?
   // if (!formDefinition && !loading)
   //   throw new Error(`Form not found: ${JSON.stringify(queryVariables)} `);
 

--- a/src/modules/form/hooks/useFormDefinition.tsx
+++ b/src/modules/form/hooks/useFormDefinition.tsx
@@ -28,8 +28,8 @@ const useFormDefinition = (
 
   if (error) throw error;
 
-  if (!formDefinition && !loading)
-    throw new Error(`Form not found: ${JSON.stringify(queryVariables)} `);
+  // if (!formDefinition && !loading)
+  //   throw new Error(`Form not found: ${JSON.stringify(queryVariables)} `);
 
   return { formDefinition, itemMap, loading };
 };


### PR DESCRIPTION
## Description

Sentry thread https://greenriver.slack.com/archives/C050HQ86GBF/p1730221993464009
(No ticket yet)

Targets 138 since this is a bugfix.

To reproduce:
- enable case notes for only 1 project
- create case note for a client
- try to view Client case notes page

@gigxz I reproduced locally and found that removing this explicit throw is a bandaid to fix the error. We introduced this recently, see thread: https://github.com/greenriver/hmis-frontend/pull/959#discussion_r1803965502

What is actually going on? Something like,
- User loads the Client Case Notes page. It makes a `useFormDefinition` query (via `useViewEditRecordDialogs`), providing only `role`, not `project` or `id` as query variables. It doesn't find a form definition
  - With the recently-added explicit throw, it raises an error
  - Otherwise, it just returns a null form definition, and does not raise until the user actually tried to open a dialog
- User clicks in to a Case Note record. **`ViewRecord` now makes another `useFormDefinition` query,** this time passing the ID attached to the record (that's the behavior we added a few weeks ago [here](https://github.com/greenriver/hmis-frontend/pull/951/files#diff-eb5ccea46230abb15a9426f352a3af110e6a922e80c55c2150f4820201d53794R32-R35))
  - This is a bit tough to reason about and maybe should be cleaned up -- or at least, if not, I need to get a better understanding of why the two separate `useFormDefinition` calls are needed! But in the short term...

What do you think about merging this bandaid to reduce user impact, and then,
- reverting it after the coming Data Collection Features pr is merged? The logic [here](https://github.com/greenriver/hmis-warehouse/pull/4867/files#diff-88f6bf8063dd5dfb242c415dbb41b8bd2d36fdb621d555ef684f15adf99a10c4R196-R202) should present a somewhat more sustainable fix, I think.
- and/or creating a follow-up ticket to clean up the confusing logic I described above, as long as I'm not the only one confused by it

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
