### PR TITLE
Stop swallowing assessment errors when invalid type is submitted

### DIFF
--- a/src/modules/form/util/formUtil.formValueToGqlValue.test.ts
+++ b/src/modules/form/util/formUtil.formValueToGqlValue.test.ts
@@ -24,8 +24,11 @@ describe('formValueToGqlValue', () => {
     expect(formValueToGqlValue('2020-01-31T05:00:00.000Z', item)).toBe(
       '2020-01-31'
     );
-    expect(formValueToGqlValue('not-a-valid-date', item)).toBe(undefined);
-    expect(formValueToGqlValue(new Date('invalid'), item)).toBe(undefined);
+    expect(formValueToGqlValue('not-a-valid-date', item)).toBe(
+      'not-a-valid-date'
+    );
+    const invalidDate = new Date('invalid');
+    expect(formValueToGqlValue(invalidDate, item)).toBe(invalidDate);
     expect(formValueToGqlValue('', item)).toBe(null);
   });
 
@@ -36,7 +39,7 @@ describe('formValueToGqlValue', () => {
     expect(formValueToGqlValue(0, item)).toBe(0);
     expect(formValueToGqlValue('100', item)).toBe(100);
     expect(formValueToGqlValue('00100', item)).toBe(100);
-    expect(formValueToGqlValue('not a number', item)).toBe(undefined);
+    expect(formValueToGqlValue('not a number', item)).toBe('not a number');
   });
 
   it('transforms single-select choice', () => {

--- a/src/modules/form/util/formUtil.transformSubmitValues.test.ts
+++ b/src/modules/form/util/formUtil.transformSubmitValues.test.ts
@@ -215,20 +215,6 @@ describe('transformSubmitValues', () => {
     expect(result).toStrictEqual(mapValues(values, () => null));
   });
 
-  it('ignores NaNs for numeric types', () => {
-    const values = {
-      '1.4': 'abc',
-      '1.5': '123abc',
-    };
-    const result = transformSubmitValues({
-      definition,
-      values,
-      keyByFieldName: true,
-    });
-
-    expect(result).toStrictEqual({});
-  });
-
   it('replaces empty strings and undefined with nulls', () => {
     const values = {
       '1.1': '',

--- a/src/modules/form/util/formUtil.ts
+++ b/src/modules/form/util/formUtil.ts
@@ -756,11 +756,11 @@ export const formValueToGqlValue = (
     if (typeof date === 'string') {
       date = parseHmisDateString(value);
     }
-    if (date instanceof Date) return formatDateForGql(date) || undefined;
+    if (date instanceof Date) return formatDateForGql(date) || value;
     // This isn't parseable/formattable into a date, so it may cause a backend validation error.
     // Still, return it, so that it doesn't get swallowed without the user's knowledge
     // TODO(#6713) - Frontend should prevent submission of invalid dates
-    return date;
+    return value;
   }
 
   if ([ItemType.Integer, ItemType.Currency].includes(item.type)) {

--- a/src/modules/form/util/formUtil.ts
+++ b/src/modules/form/util/formUtil.ts
@@ -759,13 +759,12 @@ export const formValueToGqlValue = (
     if (date instanceof Date) return formatDateForGql(date) || value;
     // This isn't parseable/formattable into a date, so it may cause a backend validation error.
     // Still, return it, so that it doesn't get swallowed without the user's knowledge
-    // TODO(#6713) - Frontend should prevent submission of invalid dates
     return value;
   }
 
   if ([ItemType.Integer, ItemType.Currency].includes(item.type)) {
     const num = Number(value);
-    // TODO(#6713) - Frontend should prevent submission of invalid numbers
+    // See note above about unparseable date values; the same logic applies here
     return Number.isNaN(num) ? value : num;
   }
 

--- a/src/modules/form/util/formUtil.ts
+++ b/src/modules/form/util/formUtil.ts
@@ -757,14 +757,10 @@ export const formValueToGqlValue = (
       date = parseHmisDateString(value);
     }
     if (date instanceof Date) return formatDateForGql(date) || undefined;
-    // This isn't parseable/formattable into a date, return undefined to ignore it
-    return undefined; // TODO - perhaps preferable to return `date` here and allow the backend to return an error
+    // This isn't parseable/formattable into a date, so it may cause a backend validation error
+    // TODO(#6713) - with client-side validations, the frontend should prevent you from submitting
+    return date;
   }
-
-  // if ([ItemType.Integer, ItemType.Currency].includes(item.type)) {
-  //   const num = Number(value);
-  //   return Number.isNaN(num) ? undefined : num;
-  // }
 
   if (
     item.type === ItemType.Choice &&

--- a/src/modules/form/util/formUtil.ts
+++ b/src/modules/form/util/formUtil.ts
@@ -757,9 +757,16 @@ export const formValueToGqlValue = (
       date = parseHmisDateString(value);
     }
     if (date instanceof Date) return formatDateForGql(date) || undefined;
-    // This isn't parseable/formattable into a date, so it may cause a backend validation error
-    // TODO(#6713) - with client-side validations, the frontend should prevent you from submitting
+    // This isn't parseable/formattable into a date, so it may cause a backend validation error.
+    // Still, return it, so that it doesn't get swallowed without the user's knowledge
+    // TODO(#6713) - Frontend should prevent submission of invalid dates
     return date;
+  }
+
+  if ([ItemType.Integer, ItemType.Currency].includes(item.type)) {
+    const num = Number(value);
+    // TODO(#6713) - Frontend should prevent submission of invalid numbers
+    return Number.isNaN(num) ? value : num;
   }
 
   if (

--- a/src/modules/form/util/formUtil.ts
+++ b/src/modules/form/util/formUtil.ts
@@ -758,13 +758,13 @@ export const formValueToGqlValue = (
     }
     if (date instanceof Date) return formatDateForGql(date) || undefined;
     // This isn't parseable/formattable into a date, return undefined to ignore it
-    return undefined;
+    return undefined; // TODO - perhaps preferable to return `date` here and allow the backend to return an error
   }
 
-  if ([ItemType.Integer, ItemType.Currency].includes(item.type)) {
-    const num = Number(value);
-    return Number.isNaN(num) ? undefined : num;
-  }
+  // if ([ItemType.Integer, ItemType.Currency].includes(item.type)) {
+  //   const num = Number(value);
+  //   return Number.isNaN(num) ? undefined : num;
+  // }
 
   if (
     item.type === ItemType.Choice &&


### PR DESCRIPTION
## Description

GH issue: https://github.com/open-path/Green-River/issues/6855

- If a user tries to submit an int value that's unparseable as an int, return it so the backend errors out.
- Same for dates. I didn't find a way to repro this via the frontend, but I made the code change anyway, on the premise that it's overall preferable to send the data back and cause an explicit error rather than swallowing.
- Add todos related to client-side validation (#6713)

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix - it's kind of a bug fix, or maybe more like a bug exposure
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
