### PR TITLE
Propose approach for themeable nav link background color

### DIFF
--- a/src/components/layout/dashboard/sideNav/ItemBase.tsx
+++ b/src/components/layout/dashboard/sideNav/ItemBase.tsx
@@ -89,7 +89,12 @@ const ItemBase = <T extends object>({
                 }
               : undefined,
           backgroundColor: (theme) =>
-            isSelected ? lighten(theme.palette.primary.light, 0.9) : undefined,
+            isSelected
+              ? lighten(
+                  theme.palette.primary.light,
+                  theme.palette.lightenCoefficient || 0.9
+                )
+              : undefined,
         }}
       >
         {item.title && (

--- a/src/components/layout/nav/MobileMenuItem.tsx
+++ b/src/components/layout/nav/MobileMenuItem.tsx
@@ -1,4 +1,4 @@
-import { ListItemButton, ListItemText } from '@mui/material';
+import { lighten, ListItemButton, ListItemText } from '@mui/material';
 import React from 'react';
 import RouterLink from '@/components/elements/RouterLink';
 
@@ -20,6 +20,11 @@ const MobileMenuItem: React.FC<Props> = ({ title, selected, path }) => {
           // matches styling in `ItemBase` which is used for desktop nav menu items
           color: 'primary.main',
           fontWeight: 600,
+          backgroundColor: (theme) =>
+            lighten(
+              theme.palette.primary.light,
+              theme.palette.lightenCoefficient || 0.9
+            ),
         },
       }}
     >

--- a/src/components/layout/nav/ToolbarMenu.tsx
+++ b/src/components/layout/nav/ToolbarMenu.tsx
@@ -1,4 +1,4 @@
-import { alpha, Theme } from '@mui/material';
+import { lighten } from '@mui/material';
 import React from 'react';
 import { useLocation } from 'react-router-dom';
 import ButtonLink from '@/components/elements/ButtonLink';
@@ -91,9 +91,12 @@ const ToolbarMenu: React.FC<ToolbarMenuProps> = ({ mobile }) => {
           fontSize: 14,
           px: { xs: 0.5, lg: 2 },
           color: 'text.primary',
-          backgroundColor:
+          backgroundColor: (theme) =>
             activeItem === item.activeItemPathIncludes
-              ? (theme: Theme) => alpha(theme.palette.links, 0.1)
+              ? lighten(
+                  theme.palette.primary.light,
+                  theme.palette.lightenCoefficient || 0.9
+                )
               : undefined,
         }}
         key={item.id}

--- a/src/config/theme.ts
+++ b/src/config/theme.ts
@@ -1,9 +1,9 @@
 import { Theme } from '@mui/material';
 import {
+  createTheme,
   PaletteColor,
   SimplePaletteColorOptions,
   ThemeOptions,
-  createTheme,
 } from '@mui/material/styles';
 import { deepmerge } from '@mui/utils';
 
@@ -58,12 +58,14 @@ declare module '@mui/material/styles' {
   interface Palette {
     borders: PaletteColor;
     alerts: AlertPriorityColorOptions;
+    lightenCoefficient?: number;
     links: string;
     activeStatus: string;
   }
   interface PaletteOptions {
     borders: SimplePaletteColorOptions;
     alerts: AlertPriorityColorOptions;
+    lightenCoefficient?: number;
     links: string;
     activeStatus: string;
   }
@@ -95,6 +97,7 @@ export const baseThemeDef: ThemeOptions = {
     primary: {
       main: '#1976D2',
     },
+    lightenCoefficient: 0.9,
     background: {
       default: '#FCFCFC',
     },


### PR DESCRIPTION
## Description

GH issue: https://github.com/open-path/Green-River/issues/6659

This PR proposes the following changes:
- Add a new variable to our Palette options, `lightenCoefficient`. This would allow the amount by which the `primary.light` color is lightened to be configurable per client theme. The prior value, `0.9`, stays the default.
  - This is only a good idea if it's ok to change the `primary.light` and evade the default MUI behavior of having it depend on `primary.main`, which I'm not sure how I feel about. I guess the alternative is to add a new (`tertiary`?) color? 
- Update the background for Toolbar links and Mobile links so that they also use this same background color. Otherwise, they use a very lightened version of the Links color, which ends up being a just-slightly-different shade of blue, and I found it a bit jarring. I realize this is something of a can of worms especially on mobile, so let's discuss before merging.

Script I ran locally, and plan to run in client env:
```ruby
new_color_1 = '#1d5ea2'
new_color_2 = '#c5dfee'
theme = GrdaWarehouse::Theme.where.not(hmis_value: nil).sole
value = theme.hmis_value
value['palette']['primary']['main'] = new_color_1
value['palette']['primary']['light'] = new_color_2
value['palette']['lightenCoefficient'] = 0.6 # to discuss, see below
value['palette']['links'] = new_color_1
theme.hmis_value = value
theme.save!
```

## Type of change
[//]: # 'remove options that are not relevant'
- [ ] Bug fix
- [x] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
