### PR TITLE
6913 lock version conflict mitigation

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,6 +24,13 @@ module.exports = {
   },
   overrides: [
     {
+      // storybook files
+      files: ['*.stories.tsx'],
+      rules: {
+        'no-console': 'off',
+      },
+    },
+    {
       files: ['*.ts', '*.tsx'],
       extends: [
         'airbnb-typescript',

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "cert": "rm -rf .cert && mkdir -p .cert && mkcert -key-file ./.cert/key.pem -cert-file ./.cert/cert.pem 'hmis.dev.test'",
     "dedup": "yarn-deduplicate -s highest yarn.lock",
     "postinstall": "husky install",
-    "storybook": "storybook dev -p 6006",
+    "storybook": "storybook dev -p 6006 --no-open",
     "build-storybook": "storybook build",
     "graphql:codegen": "graphql-codegen --config codegen.yml && node scripts/generateEnumDescriptions.js && prettier --write ./src/types/* graphql.schema.json"
   },

--- a/src/components/elements/ConfirmationDialog.tsx
+++ b/src/components/elements/ConfirmationDialog.tsx
@@ -73,7 +73,7 @@ const ConfirmationDialog = ({
               variant='gray'
               data-testid='cancelDialogAction'
             >
-              {cancelText || unconfirmable ? 'Close' : 'Cancel'}
+              {cancelText || (unconfirmable ? 'Close' : 'Cancel')}
             </Button>
           )}
           {!unconfirmable && (

--- a/src/components/elements/SnackbarAlert.stories.tsx
+++ b/src/components/elements/SnackbarAlert.stories.tsx
@@ -1,0 +1,85 @@
+import { Meta, StoryObj } from '@storybook/react';
+import SnackbarAlert from './SnackbarAlert';
+
+const meta: Meta<typeof SnackbarAlert> = {
+  component: SnackbarAlert,
+  parameters: {
+    layout: 'centered',
+  },
+  // Add controls for commonly adjusted props
+  argTypes: {
+    open: {
+      control: 'boolean',
+      description: 'Controls the visibility of the snackbar',
+    },
+    title: {
+      control: 'text',
+      description: 'Optional title text for the alert',
+    },
+    children: {
+      control: 'text',
+      description: 'Main content of the alert',
+    },
+    alertProps: {
+      control: 'object',
+      description: 'Props passed to the underlying MUI Alert component',
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof SnackbarAlert>;
+
+// Basic success message
+export const Success: Story = {
+  args: {
+    open: true,
+    onClose: () => console.info('Close clicked'),
+    children: 'Operation completed successfully',
+    alertProps: {
+      severity: 'success',
+    },
+  },
+};
+
+// Error message with title
+export const Error: Story = {
+  args: {
+    open: true,
+    onClose: () => console.log('Close clicked'),
+    title: 'Error',
+    children: 'Something went wrong. Please try again.',
+    alertProps: {
+      severity: 'error',
+    },
+  },
+};
+
+// Example with no title
+export const NoTitle: Story = {
+  args: {
+    open: true,
+    onClose: () => console.log('Close clicked'),
+    children: 'Simple notification without a title',
+    alertProps: {
+      severity: 'success',
+    },
+  },
+};
+
+// Example with longer content
+export const LongContent: Story = {
+  args: {
+    open: true,
+    onClose: () => console.log('Close clicked'),
+    title: 'System Notification',
+    children: `This is a longer notification message that demonstrates how the SnackbarAlert
+      component handles multiple lines of text. It might contain important information that
+      needs more space to be properly communicated to the user.`,
+    alertProps: {
+      severity: 'info',
+      sx: { height: '100%' },
+    },
+  },
+};

--- a/src/components/elements/SnackbarAlert.tsx
+++ b/src/components/elements/SnackbarAlert.tsx
@@ -1,0 +1,40 @@
+import { Alert, AlertProps, AlertTitle, Snackbar } from '@mui/material';
+
+import { ReactNode } from 'react';
+
+interface Props {
+  open: boolean;
+  onClose: VoidFunction;
+  children?: ReactNode;
+  alertProps?: AlertProps;
+  title?: string;
+}
+const SnackbarAlert: React.FC<Props> = ({
+  open,
+  onClose,
+  children,
+  alertProps,
+  title,
+}) => {
+  return (
+    <Snackbar
+      TransitionProps={{ appear: false }} // transition looks kind of junky
+      open={open}
+      onClose={onClose}
+      anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+      sx={({ shadows }) => ({
+        boxShadow: shadows[6],
+        borderRadius: 2, // matches Alert
+        '.MuiAlertTitle-root': { fontWeight: 600 },
+        marginTop: '100px',
+      })}
+    >
+      <Alert onClose={onClose} {...alertProps}>
+        {title && <AlertTitle sx={{ mb: 0 }}>{title}</AlertTitle>}
+        {children}
+      </Alert>
+    </Snackbar>
+  );
+};
+
+export default SnackbarAlert;

--- a/src/components/elements/SnackbarAlert.tsx
+++ b/src/components/elements/SnackbarAlert.tsx
@@ -18,7 +18,7 @@ const SnackbarAlert: React.FC<Props> = ({
 }) => {
   return (
     <Snackbar
-      TransitionProps={{ appear: false }} // transition looks kind of junky
+      TransitionProps={{ appear: false }} // disabled transition since it looks a bit junky
       open={open}
       onClose={onClose}
       anchorOrigin={{ vertical: 'top', horizontal: 'center' }}

--- a/src/modules/assessments/components/IndividualAssessmentPage.tsx
+++ b/src/modules/assessments/components/IndividualAssessmentPage.tsx
@@ -24,7 +24,6 @@ const IndividualAssessmentPage = () => {
     data: assessmentData,
     loading: assessmentLoading,
     error: assessmentError,
-    refetch,
   } = useGetAssessmentQuery({ variables: { id: assessmentId } });
 
   const assessment = assessmentData?.assessment;
@@ -49,7 +48,6 @@ const IndividualAssessmentPage = () => {
         recordType='Assessment'
         recordId={assessment.id}
         currentVersion={assessment.lockVersion}
-        onReload={refetch}
       />
       <IndividualAssessmentFormController
         enrollment={enrollment}

--- a/src/modules/assessments/components/IndividualAssessmentPage.tsx
+++ b/src/modules/assessments/components/IndividualAssessmentPage.tsx
@@ -4,6 +4,7 @@ import NotFound from '@/components/pages/NotFound';
 import useSafeParams from '@/hooks/useSafeParams';
 import IndividualAssessmentFormController from '@/modules/assessments/components/IndividualAssessmentFormController';
 import useEnrollmentDashboardContext from '@/modules/enrollment/hooks/useEnrollmentDashboardContext';
+import LocalVersionCoordinationPrompt from '@/modules/localVersionCoordination/LocalVersionCoordinationPrompt';
 import { EnrollmentDashboardRoutes } from '@/routes/routes';
 import { useGetAssessmentQuery } from '@/types/gqlTypes';
 
@@ -23,6 +24,7 @@ const IndividualAssessmentPage = () => {
     data: assessmentData,
     loading: assessmentLoading,
     error: assessmentError,
+    refetch,
   } = useGetAssessmentQuery({ variables: { id: assessmentId } });
 
   const assessment = assessmentData?.assessment;
@@ -42,15 +44,23 @@ const IndividualAssessmentPage = () => {
   if (!assessment) return <NotFound />;
 
   return (
-    <IndividualAssessmentFormController
-      enrollment={enrollment}
-      client={client}
-      viewingDefinition={assessment.definition}
-      editingDefinition={
-        assessment.upgradedDefinitionForEditing || assessment.definition
-      }
-      assessment={assessment}
-    />
+    <>
+      <LocalVersionCoordinationPrompt
+        recordType='Assessment'
+        recordId={assessment.id}
+        currentVersion={assessment.lockVersion}
+        onReload={refetch}
+      />
+      <IndividualAssessmentFormController
+        enrollment={enrollment}
+        client={client}
+        viewingDefinition={assessment.definition}
+        editingDefinition={
+          assessment.upgradedDefinitionForEditing || assessment.definition
+        }
+        assessment={assessment}
+      />
+    </>
   );
 };
 

--- a/src/modules/client/components/ClientForceRefetchButton.tsx
+++ b/src/modules/client/components/ClientForceRefetchButton.tsx
@@ -1,0 +1,44 @@
+import { LoadingButton } from '@mui/lab';
+import { ButtonProps } from '@mui/material';
+import React, { useCallback, useRef } from 'react';
+
+import { useGetClientLazyQuery } from '@/types/gqlTypes';
+
+interface Props extends Omit<ButtonProps, 'onClick'> {
+  clientId: string;
+  children: string;
+  onClick: VoidFunction | undefined;
+}
+
+// before on-click, refetch the client to ensure we have the latest values
+const ClientForceRefetchButton: React.FC<Props> = ({
+  clientId,
+  children,
+  onClick,
+  ...buttonProps
+}) => {
+  const activeRequestClientId = useRef<string | null>(null);
+
+  const [getClient, { loading, error }] = useGetClientLazyQuery({
+    fetchPolicy: 'network-only',
+  });
+  if (error) throw error;
+
+  const handleClick = useCallback(() => {
+    activeRequestClientId.current = clientId;
+    getClient({ variables: { id: clientId } }).then(() => {
+      // Only trigger onClick if the clientId hasn't changed
+      if (onClick && activeRequestClientId.current === clientId) {
+        onClick?.();
+      }
+    });
+  }, [clientId, getClient, onClick]);
+
+  return (
+    <LoadingButton loading={loading} onClick={handleClick} {...buttonProps}>
+      {children}
+    </LoadingButton>
+  );
+};
+
+export default ClientForceRefetchButton;

--- a/src/modules/client/components/ClientProfileCard.tsx
+++ b/src/modules/client/components/ClientProfileCard.tsx
@@ -14,15 +14,16 @@ import {
 } from '@mui/material';
 import { useCallback, useRef, useState } from 'react';
 
+import { useNavigate } from 'react-router-dom';
 import ClientAddress from './ClientAddress';
 import ClientCardImageElement from './ClientCardImageElement';
 import ClientContactPoint from './ClientContactPoint';
-import ButtonLink from '@/components/elements/ButtonLink';
 import ExternalIdDisplay from '@/components/elements/ExternalIdDisplay';
 import ClientImageUploadDialog from '@/components/elements/input/ClientImageUploadDialog';
 import NotCollectedText from '@/components/elements/NotCollectedText';
 import SimpleAccordion from '@/components/elements/SimpleAccordion';
 import SimpleTable from '@/components/elements/SimpleTable';
+import ClientForceRefetchButton from '@/modules/client/components/ClientForceRefetchButton';
 import ClientDobAge from '@/modules/hmis/components/ClientDobAge';
 import { ClientSafeSsn } from '@/modules/hmis/components/ClientSsn';
 import HmisEnum, { MultiHmisEnum } from '@/modules/hmis/components/HmisEnum';
@@ -369,6 +370,13 @@ const ClientProfileCard: React.FC<Props> = ({ client }) => {
 
   const size = 175;
 
+  const navigate = useNavigate();
+  const handleOpenClientForm = useCallback(() => {
+    navigate(
+      generateSafePath(ClientDashboardRoutes.EDIT, { clientId: client.id })
+    );
+  }, [navigate, client.id]);
+
   return (
     <Box>
       <Card
@@ -427,18 +435,17 @@ const ClientProfileCard: React.FC<Props> = ({ client }) => {
                   id={client.id}
                   permissions='canEditClient'
                 >
-                  <ButtonLink
+                  <ClientForceRefetchButton
+                    clientId={client.id}
+                    onClick={handleOpenClientForm}
                     data-testid='editClientButton'
                     startIcon={<PersonIcon />}
                     variant='outlined'
                     color='primary'
                     fullWidth
-                    to={generateSafePath(ClientDashboardRoutes.EDIT, {
-                      clientId: client.id,
-                    })}
                   >
                     Update Client Details
-                  </ButtonLink>
+                  </ClientForceRefetchButton>
                 </ClientPermissionsFilter>
                 {client.dateUpdated && (
                   <Typography

--- a/src/modules/client/components/pages/ClientDashboard.tsx
+++ b/src/modules/client/components/pages/ClientDashboard.tsx
@@ -20,6 +20,7 @@ import useIsPrintView from '@/hooks/useIsPrintView';
 import useSafeParams from '@/hooks/useSafeParams';
 import ClientCardMini from '@/modules/client/components/ClientCardMini';
 import ClientPrintHeader from '@/modules/client/components/ClientPrintHeader';
+import LocalVersionCoordinationPrompt from '@/modules/localVersionCoordination/LocalVersionCoordinationPrompt';
 import { ProjectDashboardContext } from '@/modules/projects/components/ProjectDashboard';
 import { ClientFieldsFragment, useGetClientQuery } from '@/types/gqlTypes';
 
@@ -62,6 +63,11 @@ const ClientDashboard: React.FC = () => {
     return (
       <>
         <ClientPrintHeader client={client} />
+        <LocalVersionCoordinationPrompt
+          recordType='Client'
+          recordId={client.id}
+          currentVersion={client.lockVersion}
+        />
         <Outlet context={outletContext} />
       </>
     );

--- a/src/modules/client/components/pages/ClientDashboard.tsx
+++ b/src/modules/client/components/pages/ClientDashboard.tsx
@@ -63,11 +63,6 @@ const ClientDashboard: React.FC = () => {
     return (
       <>
         <ClientPrintHeader client={client} />
-        <LocalVersionCoordinationPrompt
-          recordType='Client'
-          recordId={client.id}
-          currentVersion={client.lockVersion}
-        />
         <Outlet context={outletContext} />
       </>
     );
@@ -88,6 +83,11 @@ const ClientDashboard: React.FC = () => {
       {...dashboardState}
     >
       <Container maxWidth='xl' disableGutters>
+        <LocalVersionCoordinationPrompt
+          recordType='Client'
+          recordId={client.id}
+          currentVersion={client.lockVersion}
+        />
         <Outlet context={outletContext} />
       </Container>
     </DashboardContentContainer>

--- a/src/modules/enrollment/components/EnrollmentQuickActions.tsx
+++ b/src/modules/enrollment/components/EnrollmentQuickActions.tsx
@@ -2,6 +2,7 @@ import { Button } from '@mui/material';
 import { Stack } from '@mui/system';
 import ButtonLink from '@/components/elements/ButtonLink';
 import TitleCard from '@/components/elements/TitleCard';
+import ClientForceRefetchButton from '@/modules/client/components/ClientForceRefetchButton';
 import { useClientFormDialog } from '@/modules/client/hooks/useClientFormDialog';
 import { DashboardEnrollment } from '@/modules/hmis/types';
 import { useHmisAppSettings } from '@/modules/hmisAppSettings/useHmisAppSettings';
@@ -65,12 +66,13 @@ const EnrollmentQuickActions = ({
 
         {/* Edit Client details */}
         {canEditClient && (
-          <Button
-            onClick={clientLoading ? undefined : openClientFormDialog}
+          <ClientForceRefetchButton
+            clientId={enrollment.client.id}
             variant='outlined'
+            onClick={clientLoading ? undefined : openClientFormDialog}
           >
             Update Client Details
-          </Button>
+          </ClientForceRefetchButton>
         )}
 
         {/* View ESG Funding Report */}

--- a/src/modules/enrollment/components/pages/EnrollmentDashboard.tsx
+++ b/src/modules/enrollment/components/pages/EnrollmentDashboard.tsx
@@ -21,6 +21,7 @@ import EnrollmentNavHeader from '@/modules/enrollment/components/EnrollmentNavHe
 import { useDetailedEnrollment } from '@/modules/enrollment/hooks/useDetailedEnrollment';
 import { useEnrollmentDashboardNavItems } from '@/modules/enrollment/hooks/useEnrollmentDashboardNavItems';
 import { DashboardEnrollment } from '@/modules/hmis/types';
+import LocalVersionCoordinationPrompt from '@/modules/localVersionCoordination/LocalVersionCoordinationPrompt';
 import { ProjectDashboardContext } from '@/modules/projects/components/ProjectDashboard';
 import {
   DataCollectionFeature,
@@ -112,6 +113,16 @@ const EnrollmentDashboard: React.FC = () => {
       focusMode={focusMode}
     >
       <Container maxWidth='xl' disableGutters>
+        <LocalVersionCoordinationPrompt
+          recordType='Enrollment'
+          recordId={enrollment.id}
+          currentVersion={enrollment.lockVersion}
+        />
+        <LocalVersionCoordinationPrompt
+          recordType='Client'
+          recordId={client.id}
+          currentVersion={client.lockVersion}
+        />
         <Outlet context={outletContext} />
       </Container>
     </DashboardContentContainer>

--- a/src/modules/localVersionCoordination/LocalVersionCoordinationPrompt.tsx
+++ b/src/modules/localVersionCoordination/LocalVersionCoordinationPrompt.tsx
@@ -1,5 +1,7 @@
+import { LoadingButton } from '@mui/lab';
+import { Box } from '@mui/system';
 import { useCallback, useEffect, useState } from 'react';
-import ConfirmationDialog from '@/components/elements/ConfirmationDialog';
+import SnackbarAlert from '@/components/elements/SnackbarAlert';
 import useLocalVersionCoordination, {
   LocalVersionedRecordType,
 } from '@/modules/localVersionCoordination/hooks/useLocalVersionCoordination';
@@ -51,21 +53,37 @@ const LocalVersionCoordinationPrompt: React.FC<Props> = ({
     latestVersion > Math.max(acknowledgedVersion, currentVersion);
 
   return (
-    <ConfirmationDialog
+    <SnackbarAlert
       open={showPrompt}
-      title={`New ${recordType} data available`}
-      cancelText='Continue anyway'
-      confirmText='Load new data'
-      onConfirm={handleReload}
-      onCancel={handleContinue}
-      loading={loading}
+      onClose={handleContinue}
+      title='New Data available'
+      alertProps={{ severity: 'warning' }}
     >
-      <div>
-        It looks like you have another tab open with newer data for this record.
-        Would you like to load the new data or
-      </div>
-    </ConfirmationDialog>
+      <Box sx={{ my: 1 }}>
+        The data on this page is out-of-date. You won't be able to save changes
+        to this record until you load with new data.
+      </Box>
+      <Box sx={{ mt: 2 }}>
+        <LoadingButton onClick={handleReload} loading={loading}>
+          Reload with New Data
+        </LoadingButton>
+      </Box>
+    </SnackbarAlert>
   );
+
+  //return (
+  //  <ConfirmationDialog
+  //    title={`New ${recordType} data available`}
+  //    cancelText='Continue anyway'
+  //    confirmText='Load new data'
+  //    onConfirm={handleReload}
+  //    onCancel={handleContinue}
+  //    loading={loading}
+  //  >
+  //    <div>
+  //    </div>
+  //  </ConfirmationDialog>
+  //);
 };
 
 export default LocalVersionCoordinationPrompt;

--- a/src/modules/localVersionCoordination/LocalVersionCoordinationPrompt.tsx
+++ b/src/modules/localVersionCoordination/LocalVersionCoordinationPrompt.tsx
@@ -57,16 +57,25 @@ const LocalVersionCoordinationPrompt: React.FC<Props> = ({
       open={showPrompt}
       onClose={handleContinue}
       title='New Data Available'
-      alertProps={{ severity: 'warning' }}
+      alertProps={{
+        severity: 'warning',
+        action: (
+          <LoadingButton
+            onClick={handleReload}
+            loading={loading}
+            variant='outlined'
+            color='warning'
+            // TODO(PR#991) replace with grayscale variant
+            sx={{ backgroundColor: 'transparent', alignSelf: 'center' }}
+          >
+            Load New Data
+          </LoadingButton>
+        ),
+      }}
     >
       <Box sx={{ my: 1 }}>
         The data on this page is out-of-date. You won't be able to save changes
         to this record until you load the new data.
-      </Box>
-      <Box sx={{ mt: 2 }}>
-        <LoadingButton onClick={handleReload} loading={loading}>
-          Load New Data
-        </LoadingButton>
       </Box>
     </SnackbarAlert>
   );

--- a/src/modules/localVersionCoordination/LocalVersionCoordinationPrompt.tsx
+++ b/src/modules/localVersionCoordination/LocalVersionCoordinationPrompt.tsx
@@ -70,20 +70,6 @@ const LocalVersionCoordinationPrompt: React.FC<Props> = ({
       </Box>
     </SnackbarAlert>
   );
-
-  //return (
-  //  <ConfirmationDialog
-  //    title={`New ${recordType} data available`}
-  //    cancelText='Continue anyway'
-  //    confirmText='Load new data'
-  //    onConfirm={handleReload}
-  //    onCancel={handleContinue}
-  //    loading={loading}
-  //  >
-  //    <div>
-  //    </div>
-  //  </ConfirmationDialog>
-  //);
 };
 
 export default LocalVersionCoordinationPrompt;

--- a/src/modules/localVersionCoordination/LocalVersionCoordinationPrompt.tsx
+++ b/src/modules/localVersionCoordination/LocalVersionCoordinationPrompt.tsx
@@ -1,0 +1,71 @@
+import { useCallback, useEffect, useState } from 'react';
+import ConfirmationDialog from '@/components/elements/ConfirmationDialog';
+import useLocalVersionCoordination, {
+  LocalVersionedRecordType,
+} from '@/modules/localVersionCoordination/hooks/useLocalVersionCoordination';
+import { cache } from '@/providers/apolloClient';
+
+interface Props {
+  recordType: LocalVersionedRecordType;
+  recordId: string;
+  currentVersion: number;
+  onReload?: VoidFunction;
+}
+const LocalVersionCoordinationPrompt: React.FC<Props> = ({
+  recordType,
+  recordId,
+  currentVersion,
+  onReload,
+}) => {
+  const [acknowledgedVersion, setAcknowledgedVersion] =
+    useState(currentVersion);
+  const [loading, setLoading] = useState(false);
+  const latestVersion = useLocalVersionCoordination(
+    recordType,
+    recordId,
+    currentVersion
+  );
+
+  const handleReload = useCallback(() => {
+    setLoading(true);
+    if (onReload) {
+      onReload();
+    } else {
+      // default: on reload evict the cache
+      cache.evict({ id: `${recordType}:${recordId}` });
+    }
+  }, [onReload, recordId, recordType]);
+
+  useEffect(() => {
+    if (currentVersion === latestVersion) {
+      setLoading(false);
+    }
+  }, [currentVersion, latestVersion]);
+
+  const handleContinue = () => {
+    setAcknowledgedVersion(latestVersion);
+  };
+
+  // hide prompt if we are on the latest version OR we are on an old version but the user has acknowledged it
+  const showPrompt =
+    latestVersion > Math.max(acknowledgedVersion, currentVersion);
+
+  return (
+    <ConfirmationDialog
+      open={showPrompt}
+      title={`New ${recordType} data available`}
+      cancelText='Continue anyway'
+      confirmText='Load new data'
+      onConfirm={handleReload}
+      onCancel={handleContinue}
+      loading={loading}
+    >
+      <div>
+        It looks like you have another tab open with newer data for this record.
+        Would you like to load the new data or
+      </div>
+    </ConfirmationDialog>
+  );
+};
+
+export default LocalVersionCoordinationPrompt;

--- a/src/modules/localVersionCoordination/LocalVersionCoordinationPrompt.tsx
+++ b/src/modules/localVersionCoordination/LocalVersionCoordinationPrompt.tsx
@@ -56,16 +56,16 @@ const LocalVersionCoordinationPrompt: React.FC<Props> = ({
     <SnackbarAlert
       open={showPrompt}
       onClose={handleContinue}
-      title='New Data available'
+      title='New Data Available'
       alertProps={{ severity: 'warning' }}
     >
       <Box sx={{ my: 1 }}>
         The data on this page is out-of-date. You won't be able to save changes
-        to this record until you load with new data.
+        to this record until you load the new data.
       </Box>
       <Box sx={{ mt: 2 }}>
         <LoadingButton onClick={handleReload} loading={loading}>
-          Reload with New Data
+          Load New Data
         </LoadingButton>
       </Box>
     </SnackbarAlert>

--- a/src/modules/localVersionCoordination/hooks/useLocalVersionCoordination.tsx
+++ b/src/modules/localVersionCoordination/hooks/useLocalVersionCoordination.tsx
@@ -1,0 +1,68 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+
+export type LocalVersionedRecordType = 'Client' | 'Enrollment' | 'Assessment';
+
+const MESSAGE_TYPE = 'VERSION_UPDATE';
+interface RecordVersionMessage {
+  type: typeof MESSAGE_TYPE;
+  payload: { version: number };
+}
+
+const useLocalVersionCoordination = (
+  recordType: LocalVersionedRecordType,
+  recordId: string,
+  currentVersion: number
+) => {
+  const [latestVersion, setLatestVersion] = useState(currentVersion);
+
+  // message event handler
+  const handleMessage = useCallback(
+    (event: MessageEvent<RecordVersionMessage>) => {
+      // console.info(`recieved on ${channel.name}`, event.data)
+      if (
+        event.data.type === MESSAGE_TYPE &&
+        event.data.payload.version > currentVersion
+      ) {
+        setLatestVersion(event.data.payload.version);
+      }
+    },
+    [currentVersion]
+  );
+
+  // manage channel connection
+  const channelRef = useRef<BroadcastChannel | null>(null);
+  useEffect(() => {
+    const channelName = `record-sync-${recordType}-${recordId}`;
+    channelRef.current = new BroadcastChannel(channelName);
+    channelRef.current.addEventListener('message', handleMessage);
+    // console.info(`open channel ${recordType}:${recordId}`)
+
+    return () => {
+      const channel = channelRef.current;
+      if (channel) {
+        channel.removeEventListener('message', handleMessage);
+        channel.close();
+        channelRef.current = null;
+      }
+    };
+  }, [recordType, recordId, handleMessage]);
+
+  // broadcast our current version
+  useEffect(() => {
+    const channel = channelRef.current;
+    if (!channel) {
+      console.error('tried to send on closed channel');
+      return;
+    }
+
+    const message: RecordVersionMessage = {
+      type: MESSAGE_TYPE,
+      payload: { version: currentVersion },
+    };
+    channel.postMessage(message);
+  }, [currentVersion]);
+
+  return latestVersion;
+};
+
+export default useLocalVersionCoordination;


### PR DESCRIPTION
## Description

[GH Issue ](https://github.com/open-path/Green-River/issues/6913)

Two changes to try and reduce occurrence of users encountering lock version errors. Spot checking suggests this is often due to opening the same record in multiple tabs.

1. add cross-tab sync mechanism. When a tab receives a new version (detected via lock-version), surface that on all other tabs (for clients, enrollments, and assessments) and prompt the user to reload
   * This does not address conflicts due to server side changes
   * users can close snack bar alert
   * known issue: if the user has a form open when the reload, their current form data would be lost. Seems like this could be addressed with improved props handling or maybe some way to temporarily save and re-apply form-state
   * The current implementation uses `BroadcastChannel` which is a newer feature. Looks like it's now supported on evergreen browsers
2. when clicking the button to edit the client record, re-fetch the client data (could extend to other pages)
   * this might catch server side changes
   * we could take this approach on other buttons but the client form is the low hanging fruit

misc fix:
* bug fix for ConfirmationDialog not showing cancelText

##testing 
1. testing cross tab sync: open a two tabs with the same client. Update the client record in one, the other tab should display prompt to reload the client record. Reloading should load new data and close the prompt. Clicking continue should close the prompt but not reload.
2. test client refresh: go to the client dash. In the console or else where, update the client (client.touch in rails). Open client details form and save, there should be no lock-version error

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [x] New feature (adds functionality)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
