### PR TITLE
7058-input-validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "react-hook-form": "^7.52.1",
     "react-i18next": "^15.0.0",
     "react-imask": "^7.6.1",
+    "react-number-format": "^5.4.2",
     "react-pdf": "^8.0.2",
     "react-router-dom": "^6.25.1",
     "typescript": "^5.5.4",

--- a/src/components/elements/input/NumberInput.stories.tsx
+++ b/src/components/elements/input/NumberInput.stories.tsx
@@ -1,4 +1,4 @@
-import { Box } from '@mui/material';
+import { useArgs } from '@storybook/preview-api';
 import { Meta, StoryObj } from '@storybook/react';
 
 import NumberInput from './NumberInput';
@@ -6,13 +6,11 @@ import NumberInput from './NumberInput';
 export default {
   component: NumberInput,
   argTypes: { label: { control: 'text' } },
-  decorators: [
-    (Story) => (
-      <Box sx={{ width: 400 }}>
-        <Story />
-      </Box>
-    ),
-  ],
+  render: (args: any) => {
+    const [{ value }, updateArgs] = useArgs();
+    const onChange = (event: any) => updateArgs({ value: event.target.value });
+    return <NumberInput {...args} onChange={onChange} value={value} />;
+  },
 } as Meta<typeof NumberInput>;
 
 type Story = StoryObj<typeof NumberInput>;

--- a/src/components/elements/input/NumberInput.tsx
+++ b/src/components/elements/input/NumberInput.tsx
@@ -32,6 +32,7 @@ const NumberInput: React.FC<Props> = ({
   currency = false,
   value,
   error,
+  helperText,
   ariaLabelledBy,
   onChange,
   ...props
@@ -85,7 +86,8 @@ const NumberInput: React.FC<Props> = ({
 
   return (
     <NumericFormat
-      error={error}
+      error={!!(error || errorMessage)}
+      helperText={error ? undefined : errorMessage || helperText}
       customInput={TextInput}
       onValueChange={handleChange}
       onBlur={handleBlur}
@@ -106,8 +108,6 @@ const NumberInput: React.FC<Props> = ({
         startAdornment: prefix ? (
           <InputAdornment position='start'>{prefix}</InputAdornment>
         ) : undefined,
-        error: error || !!errorMessage,
-        helperText: error ? undefined : errorMessage || props.helperText,
         ...InputProps,
       }}
       {...(props as any)}

--- a/src/components/elements/input/NumberInput.tsx
+++ b/src/components/elements/input/NumberInput.tsx
@@ -33,6 +33,47 @@ const NumberInput = ({
       }
     : {};
 
+  const handleKeyDown: KeyboardEventHandler<HTMLInputElement> = useCallback(
+    (event) => {
+      const currentValue = event.currentTarget.value || '';
+      const selectionStart = event.currentTarget.selectionStart;
+      const key = event.key;
+
+      // Handle arrow keys first
+      if (key.match(/(ArrowDown|ArrowUp)/)) {
+        if (disableArrowKeys) event.preventDefault();
+        return;
+      }
+
+      // Allow all other special keys (Tab, Delete, etc.)
+      if (key.length > 1) return;
+
+      // Build what the value would be if we allow this keypress
+      const beforeCursor = currentValue.substring(0, selectionStart || 0);
+      const afterCursor = currentValue.substring(selectionStart || 0);
+      const newValue = beforeCursor + key + afterCursor;
+
+      // Always allow empty string and single minus at start
+      if (newValue === '' || newValue === '-') return;
+
+      // Prevent invalid keypresses
+      if (
+        // Invalid characters
+        !key.match(/^[0-9.-]$/) ||
+        // Multiple decimal points
+        (key === '.' && currentValue.includes('.')) ||
+        // Minus sign not at start
+        (key === '-' && selectionStart !== 0) ||
+        // Invalid number
+        isNaN(Number(newValue)) ||
+        !isFinite(Number(newValue))
+      ) {
+        event.preventDefault();
+      }
+    },
+    [disableArrowKeys]
+  );
+
   const handleBlur = () => {
     if (isNil(value) || value === '') {
       setErrorMessage(null);
@@ -61,13 +102,6 @@ const NumberInput = ({
     }
   };
 
-  // Prevent form submission on Enter. Enter should toggle the state.
-  const onKeyDown: KeyboardEventHandler<HTMLInputElement> = useCallback((e) => {
-    if (e.key.match(/(ArrowDown|ArrowUp)/)) {
-      e.preventDefault();
-    }
-  }, []);
-
   const preventValueChangeOnScroll: WheelEventHandler<HTMLDivElement> =
     useCallback((e) => {
       // Prevent the input value change
@@ -88,10 +122,9 @@ const NumberInput = ({
       type='text'
       inputProps={{
         inputMode: 'numeric',
-        pattern: '[0-9]*',
         min,
         max,
-        onKeyDown: disableArrowKeys ? onKeyDown : undefined,
+        onKeyDown: handleKeyDown,
         'aria-labelledby': ariaLabelledBy,
         ...inputProps,
       }}

--- a/src/components/elements/input/NumberInput.tsx
+++ b/src/components/elements/input/NumberInput.tsx
@@ -35,6 +35,9 @@ const NumberInput = ({
 
   const handleKeyDown: KeyboardEventHandler<HTMLInputElement> = useCallback(
     (event) => {
+      // Allow copy/paste and undo operations
+      if (event.ctrlKey || event.metaKey) return;
+
       const currentValue = event.currentTarget.value || '';
       const selectionStart = event.currentTarget.selectionStart;
       const key = event.key;
@@ -72,6 +75,41 @@ const NumberInput = ({
       }
     },
     [disableArrowKeys]
+  );
+
+  const handlePaste = useCallback(
+    (event: React.ClipboardEvent<HTMLInputElement>) => {
+      event.preventDefault();
+      const pastedText = event.clipboardData.getData('text');
+      const currentValue = event.currentTarget.value || '';
+      const selectionStart = event.currentTarget.selectionStart || 0;
+      const selectionEnd = event.currentTarget.selectionEnd || 0;
+
+      // Build what the value would be after paste
+      const beforeSelection = currentValue.substring(0, selectionStart);
+      const afterSelection = currentValue.substring(selectionEnd);
+
+      // Clean pasted text - remove commas and whitespace
+      const cleanPastedText = pastedText.replace(/[,\s]/g, '');
+      const newValue = beforeSelection + cleanPastedText + afterSelection;
+
+      // Validate the resulting value
+      const isValidNumber = (str: string) => {
+        if (str === '' || str === '-') return true;
+        const num = Number(str);
+        return !isNaN(num) && isFinite(num);
+      };
+
+      // If valid, trigger change event with new value
+      if (isValidNumber(newValue)) {
+        const inputEvent = new InputEvent('input', { bubbles: true });
+        Object.defineProperty(inputEvent, 'data', { value: cleanPastedText });
+        Object.defineProperty(inputEvent, 'inputType', { value: 'insertText' });
+        event.currentTarget.value = newValue;
+        event.currentTarget.dispatchEvent(inputEvent);
+      }
+    },
+    []
   );
 
   const handleBlur = () => {
@@ -122,9 +160,11 @@ const NumberInput = ({
       type='text'
       inputProps={{
         inputMode: 'numeric',
+        pattern: '[0-9]*', // hint mobile keyboards
         min,
         max,
         onKeyDown: handleKeyDown,
+        onPaste: handlePaste,
         'aria-labelledby': ariaLabelledBy,
         ...inputProps,
       }}

--- a/src/components/elements/input/NumberInput.tsx
+++ b/src/components/elements/input/NumberInput.tsx
@@ -35,6 +35,8 @@ const NumberInput: React.FC<Props> = ({
   helperText,
   ariaLabelledBy,
   onChange,
+  defaultValue,
+  type,
   ...props
 }) => {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -110,7 +112,9 @@ const NumberInput: React.FC<Props> = ({
         ) : undefined,
         ...InputProps,
       }}
-      {...(props as any)}
+      defaultValue={(defaultValue || '') as string}
+      type={type as any}
+      {...props}
     />
   );
 };

--- a/src/components/elements/input/NumberInput.tsx
+++ b/src/components/elements/input/NumberInput.tsx
@@ -1,116 +1,42 @@
-import { Box } from '@mui/system';
+import { InputAdornment } from '@mui/material';
 import { isFinite, isNil } from 'lodash-es';
-import {
-  KeyboardEventHandler,
-  useCallback,
-  useState,
-  WheelEventHandler,
-} from 'react';
+import { ChangeEventHandler, useState } from 'react';
 
+import {
+  NumberFormatValues,
+  NumericFormat,
+  OnValueChange,
+} from 'react-number-format';
 import TextInput, { TextInputProps } from './TextInput';
 
-const NumberInput = ({
+// protect from integer overflows
+const withValueLimit = ({ floatValue }: NumberFormatValues) => {
+  if (floatValue) {
+    return floatValue > 1
+      ? floatValue < Number.MAX_SAFE_INTEGER
+      : floatValue > Number.MIN_SAFE_INTEGER;
+  }
+  return true;
+};
+
+interface Props extends TextInputProps {
+  onChange: ChangeEventHandler<HTMLInputElement | HTMLTextAreaElement>;
+  currency?: boolean;
+}
+
+const NumberInput: React.FC<Props> = ({
   inputProps,
   min = 0,
   max,
   InputProps,
   currency = false,
-  disableArrowKeys = false,
   value,
   error,
   ariaLabelledBy,
+  onChange,
   ...props
-}: TextInputProps & { currency?: boolean; disableArrowKeys?: boolean }) => {
+}) => {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
-
-  const currencyInputProps = currency
-    ? {
-        startAdornment: <Box sx={{ color: 'text.secondary', pr: 1 }}>$</Box>,
-        sx: {
-          pl: 1,
-          '.MuiInputBase-input': { textAlign: 'left' },
-        },
-      }
-    : {};
-
-  const handleKeyDown: KeyboardEventHandler<HTMLInputElement> = useCallback(
-    (event) => {
-      // Allow copy/paste and undo operations
-      if (event.ctrlKey || event.metaKey) return;
-
-      const currentValue = event.currentTarget.value || '';
-      const selectionStart = event.currentTarget.selectionStart;
-      const key = event.key;
-
-      // Handle arrow keys first
-      if (key.match(/(ArrowDown|ArrowUp)/)) {
-        if (disableArrowKeys) event.preventDefault();
-        return;
-      }
-
-      // Allow all other special keys (Tab, Delete, etc.)
-      if (key.length > 1) return;
-
-      // Build what the value would be if we allow this keypress
-      const beforeCursor = currentValue.substring(0, selectionStart || 0);
-      const afterCursor = currentValue.substring(selectionStart || 0);
-      const newValue = beforeCursor + key + afterCursor;
-
-      // Always allow empty string and single minus at start
-      if (newValue === '' || newValue === '-') return;
-
-      // Prevent invalid keypresses
-      if (
-        // Invalid characters
-        !key.match(/^[0-9.-]$/) ||
-        // Multiple decimal points
-        (key === '.' && currentValue.includes('.')) ||
-        // Minus sign not at start
-        (key === '-' && selectionStart !== 0) ||
-        // Invalid number
-        isNaN(Number(newValue)) ||
-        !isFinite(Number(newValue))
-      ) {
-        event.preventDefault();
-      }
-    },
-    [disableArrowKeys]
-  );
-
-  const handlePaste = useCallback(
-    (event: React.ClipboardEvent<HTMLInputElement>) => {
-      event.preventDefault();
-      const pastedText = event.clipboardData.getData('text');
-      const currentValue = event.currentTarget.value || '';
-      const selectionStart = event.currentTarget.selectionStart || 0;
-      const selectionEnd = event.currentTarget.selectionEnd || 0;
-
-      // Build what the value would be after paste
-      const beforeSelection = currentValue.substring(0, selectionStart);
-      const afterSelection = currentValue.substring(selectionEnd);
-
-      // Clean pasted text - remove commas and whitespace
-      const cleanPastedText = pastedText.replace(/[,\s]/g, '');
-      const newValue = beforeSelection + cleanPastedText + afterSelection;
-
-      // Validate the resulting value
-      const isValidNumber = (str: string) => {
-        if (str === '' || str === '-') return true;
-        const num = Number(str);
-        return !isNaN(num) && isFinite(num);
-      };
-
-      // If valid, trigger change event with new value
-      if (isValidNumber(newValue)) {
-        const inputEvent = new InputEvent('input', { bubbles: true });
-        Object.defineProperty(inputEvent, 'data', { value: cleanPastedText });
-        Object.defineProperty(inputEvent, 'inputType', { value: 'insertText' });
-        event.currentTarget.value = newValue;
-        event.currentTarget.dispatchEvent(inputEvent);
-      }
-    },
-    []
-  );
 
   const handleBlur = () => {
     if (isNil(value) || value === '') {
@@ -140,43 +66,51 @@ const NumberInput = ({
     }
   };
 
-  const preventValueChangeOnScroll: WheelEventHandler<HTMLDivElement> =
-    useCallback((e) => {
-      // Prevent the input value change
-      (e.target as HTMLInputElement).blur();
+  const decimalScale = currency ? 2 : 0;
+  const prefix = currency ? '$' : undefined;
 
-      // Prevent the page/container scrolling
-      e.stopPropagation();
+  const handleChange: OnValueChange = (v) => {
+    const syntheticEvent = {
+      target: {
+        value: v.value,
+        name: props.name, // If you have a name prop
+      },
+      // Add other event properties you might need
+      preventDefault: () => {},
+      stopPropagation: () => {},
+    } as React.ChangeEvent<HTMLInputElement>;
 
-      // Refocus immediately, on the next tick (after the current
-      // function is done)
-      setTimeout(() => {
-        (e.target as HTMLInputElement).focus();
-      }, 0);
-    }, []);
+    onChange(syntheticEvent);
+  };
 
   return (
-    <TextInput
-      type='text'
+    <NumericFormat
+      error={error}
+      customInput={TextInput}
+      onValueChange={handleChange}
+      onBlur={handleBlur}
+      value={(value || '') as string}
+      isAllowed={withValueLimit}
+      thousandSeparator
+      decimalScale={decimalScale}
       inputProps={{
-        inputMode: 'numeric',
         pattern: '[0-9]*', // hint mobile keyboards
+        inputMode: 'numeric',
         min,
         max,
-        onKeyDown: handleKeyDown,
-        onPaste: handlePaste,
         'aria-labelledby': ariaLabelledBy,
         ...inputProps,
       }}
-      onWheel={preventValueChangeOnScroll}
-      InputProps={{ ...currencyInputProps, ...InputProps }}
-      onBlur={handleBlur}
-      value={value}
       placeholder={currency ? '0' : undefined}
-      {...props}
-      error={error || !!errorMessage}
-      // If there is a server error, show that instead of the local message
-      helperText={error ? undefined : errorMessage || props.helperText}
+      InputProps={{
+        startAdornment: prefix ? (
+          <InputAdornment position='start'>{prefix}</InputAdornment>
+        ) : undefined,
+        error: error || !!errorMessage,
+        helperText: error ? undefined : errorMessage || props.helperText,
+        ...InputProps,
+      }}
+      {...(props as any)}
     />
   );
 };

--- a/src/modules/form/components/DynamicField.tsx
+++ b/src/modules/form/components/DynamicField.tsx
@@ -278,7 +278,6 @@ const DynamicField: React.FC<DynamicFieldProps> = ({
             onChange={onChangeEvent}
             horizontal={horizontal}
             currency={item.type === ItemType.Currency}
-            disableArrowKeys={item.type === ItemType.Currency}
             {...commonInputProps}
             inputWidth={120}
           />

--- a/yarn.lock
+++ b/yarn.lock
@@ -8483,6 +8483,11 @@ react-is@^18.3.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
   integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
 
+react-number-format@^5.4.2:
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/react-number-format/-/react-number-format-5.4.2.tgz#aec282241f36cee31da13dc5e0f364c0fc6902ab"
+  integrity sha512-cg//jVdS49PYDgmcYoBnMMHl4XNTMuV723ZnHD2aXYtWWWqbVF3hjQ8iB+UZEuXapLbeA8P8H+1o6ZB1lcw3vg==
+
 react-pdf@^8.0.2:
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/react-pdf/-/react-pdf-8.0.2.tgz#ff4a0e9260c47f1a261b878a2cc0408080eecc06"
@@ -9177,7 +9182,16 @@ string-env-interpolation@^1.0.1:
   resolved "https://registry.yarnpkg.com/string-env-interpolation/-/string-env-interpolation-1.0.1.tgz#ad4397ae4ac53fe6c91d1402ad6f6a52862c7152"
   integrity sha512-78lwMoCcn0nNu8LszbP1UA7g55OeE4v7rCeWnM5B453rnNr4aq+5it3FEYtZrSEiMvHZOZ9Jlqb0OD0M2VInqg==
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -9264,7 +9278,14 @@ string_decoder@^1.1.1:
   dependencies:
     safe-buffer "~5.2.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -10047,7 +10068,7 @@ wide-align@^1.1.2:
   dependencies:
     string-width "^1.0.2 || 2 || 3 || 4"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -10060,6 +10081,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
prevent non-numeric values

## Description

[GH Issue](https://github.com/open-path/Green-River/issues/7058)

[Related warehouse issue for backend validation](https://github.com/greenriver/hmis-warehouse/pull/4982)

Restrict numeric inputs to numeric characters. Adds `react-number-format` to avoid the complexities of scrubbing user input. Also supports commas

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [x] New feature (adds functionality)
- [ ] New dependency 

## Testing
should exercise the multitude of keyboard entries:
- integers (non-zero leading)
- decimals (non-zero leading)
- just 0
- 0.0x
- negative numbers
- copy & paste
- undo

See testing instructions [in the wh PR
](https://github.com/greenriver/hmis-warehouse/pull/4982)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
