### PR TITLE
Bug fix for numeric year inputs

### DIFF
--- a/src/components/elements/input/NumberInput.stories.tsx
+++ b/src/components/elements/input/NumberInput.stories.tsx
@@ -16,5 +16,8 @@ export default {
 type Story = StoryObj<typeof NumberInput>;
 
 export const Labeled: Story = {
-  args: { label: 'Enter amount', min: 0, max: 10 },
+  args: { label: 'Enter amount', min: 0, max: 5000 },
+};
+export const Currency: Story = {
+  args: { label: 'Income', value: 500.6, currency: true },
 };

--- a/src/components/elements/input/NumberInput.tsx
+++ b/src/components/elements/input/NumberInput.tsx
@@ -95,7 +95,8 @@ const NumberInput: React.FC<Props> = ({
       onBlur={handleBlur}
       value={(value || '') as string}
       isAllowed={withValueLimit}
-      thousandSeparator
+      // only use thousand separator for currency, not other integer fields which may represent 'Year'
+      thousandSeparator={currency}
       decimalScale={decimalScale}
       inputProps={{
         pattern: '[0-9]*', // hint mobile keyboards

--- a/src/modules/form/components/viewable/DynamicViewField.tsx
+++ b/src/modules/form/components/viewable/DynamicViewField.tsx
@@ -5,10 +5,7 @@ import React, { useMemo } from 'react';
 
 import { getValueFromPickListData, usePickList } from '../../hooks/usePickList';
 import { DynamicViewFieldProps } from '../../types';
-import {
-  formatNumberWithTrailingZeroes,
-  isDataNotCollected,
-} from '../../util/formUtil';
+import { isDataNotCollected } from '../../util/formUtil';
 import DynamicDisplay from '../DynamicDisplay';
 
 import File from './item/File';
@@ -27,6 +24,7 @@ import ClientAddress from '@/modules/client/components/ClientAddress';
 import ClientContactPoint from '@/modules/client/components/ClientContactPoint';
 import ClientName from '@/modules/client/components/ClientName';
 import {
+  formatCurrency,
   formatDateForDisplay,
   formatTimeOfDay,
   parseAndFormatDate,
@@ -155,7 +153,7 @@ const DynamicViewField: React.FC<DynamicViewFieldProps> = ({
       return (
         <TextContent
           {...commonProps}
-          renderValue={(val) => `$${formatNumberWithTrailingZeroes(val)}`}
+          renderValue={(val) => formatCurrency(val)}
         />
       );
     case ItemType.Date:

--- a/src/modules/form/components/viewable/DynamicViewField.tsx
+++ b/src/modules/form/components/viewable/DynamicViewField.tsx
@@ -5,7 +5,10 @@ import React, { useMemo } from 'react';
 
 import { getValueFromPickListData, usePickList } from '../../hooks/usePickList';
 import { DynamicViewFieldProps } from '../../types';
-import { isDataNotCollected } from '../../util/formUtil';
+import {
+  formatNumberWithTrailingZeroes,
+  isDataNotCollected,
+} from '../../util/formUtil';
 import DynamicDisplay from '../DynamicDisplay';
 
 import File from './item/File';
@@ -149,7 +152,12 @@ const DynamicViewField: React.FC<DynamicViewFieldProps> = ({
       }
       return <TextContent {...commonProps} />;
     case ItemType.Currency:
-      return <TextContent {...commonProps} renderValue={(val) => `$${val}`} />;
+      return (
+        <TextContent
+          {...commonProps}
+          renderValue={(val) => `$${formatNumberWithTrailingZeroes(val)}`}
+        />
+      );
     case ItemType.Date:
       return (
         <TextContent

--- a/src/modules/form/util/formUtil.ts
+++ b/src/modules/form/util/formUtil.ts
@@ -1545,19 +1545,3 @@ export function findOptionLabel(
   }
   return option.code || '';
 }
-
-// 150    => "150"
-// 150.5  => "150.50"
-// 150.75 => "150.75"
-export const formatNumberWithTrailingZeroes = (value: any) => {
-  const num = parseFloat(value);
-
-  if (isNaN(num)) return value.toString();
-
-  // Check if the number has a decimal point
-  if (num % 1 !== 0) {
-    return num.toFixed(2);
-  }
-
-  return num.toString();
-};

--- a/src/modules/form/util/formUtil.ts
+++ b/src/modules/form/util/formUtil.ts
@@ -1545,3 +1545,23 @@ export function findOptionLabel(
   }
   return option.code || '';
 }
+
+// 150    => "150"
+// 150.5  => "150.50"
+// 150.75 => "150.75"
+export const formatNumberWithTrailingZeroes = (value: any) => {
+  // Convert the value to a number
+  const num = parseFloat(value);
+
+  // Check if the conversion was successful
+  if (isNaN(num)) {
+    return value.toString();
+  }
+  // Check if the number has a decimal point
+  if (num % 1 !== 0) {
+    // Format the number to two decimal places
+    return num.toFixed(2);
+  }
+  // Return the number as is if it doesn't have a decimal point
+  return num.toString();
+};

--- a/src/modules/form/util/formUtil.ts
+++ b/src/modules/form/util/formUtil.ts
@@ -1550,18 +1550,14 @@ export function findOptionLabel(
 // 150.5  => "150.50"
 // 150.75 => "150.75"
 export const formatNumberWithTrailingZeroes = (value: any) => {
-  // Convert the value to a number
   const num = parseFloat(value);
 
-  // Check if the conversion was successful
-  if (isNaN(num)) {
-    return value.toString();
-  }
+  if (isNaN(num)) return value.toString();
+
   // Check if the number has a decimal point
   if (num % 1 !== 0) {
-    // Format the number to two decimal places
     return num.toFixed(2);
   }
-  // Return the number as is if it doesn't have a decimal point
+
   return num.toString();
 };

--- a/src/modules/hmis/hmisUtil.ts
+++ b/src/modules/hmis/hmisUtil.ts
@@ -230,8 +230,11 @@ export const formatRelativeDate = (date: Date): string => {
   return formatRelativeDateTime(date);
 };
 
-export const formatCurrency = (number?: number | null) => {
-  if (isNil(number)) return number;
+export const formatCurrency = (value?: any) => {
+  if (isNil(value)) return value;
+  const number = parseFloat(value);
+  if (isNaN(number)) return value.toString();
+
   return currencyFormatter.format(number);
 };
 

--- a/src/test/utils/testUtils.ts
+++ b/src/test/utils/testUtils.ts
@@ -12,7 +12,7 @@ const mockValueForItem = (item: FormItem) => {
     case ItemType.Integer:
       return sample([0, 50, 100]);
     case ItemType.Currency:
-      return sample([0, 50.0, 100.25]);
+      return sample([0, 50.0, 100.5]);
     case ItemType.Date:
       return new Date();
     case ItemType.TimeOfDay:


### PR DESCRIPTION
## Description


1) Fix new issue where integer fields that represent "year" are displayed with separators. Adjust behavior so we only add separators for currency fields. Future improvement is to add specialized year input https://github.com/open-path/Green-River/issues/7096
<img width="138" alt="Screenshot 2024-12-13 at 7 34 23 AM" src="https://github.com/user-attachments/assets/bdac13da-5ca6-485b-921f-b9e05fdf8beb" />
=>
<img width="151" alt="Screenshot 2024-12-13 at 7 34 40 AM" src="https://github.com/user-attachments/assets/e156d79e-8b96-4f88-b8f9-2583fb8e5f11" />

2) Fix pre-existing issue where currencies are not displayed right in DynamicView `$150.5` instead of `$150.50`. This is because we store currencies as floats. The input field still has this issue, but that is a little trickier to resolve without using fixed decimals for all currency fields, which we may not want.
<img width="174" alt="Screenshot 2024-12-13 at 7 56 39 AM" src="https://github.com/user-attachments/assets/44ddfa91-c710-42f2-b857-35bb23f4ca17" />
=>
<img width="175" alt="Screenshot 2024-12-13 at 8 03 33 AM" src="https://github.com/user-attachments/assets/8e720df7-d772-4aef-a158-804b95bfe26a" />


Issue: https://github.com/open-path/Green-River/issues/7095

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
