### PR TITLE
Fix a11y landmark issues

### DIFF
--- a/src/components/elements/CommonLabeledTextBlock.tsx
+++ b/src/components/elements/CommonLabeledTextBlock.tsx
@@ -8,6 +8,7 @@ interface Props {
   title: ReactNode;
   sx?: TypographyProps['sx'];
   variant?: TypographyProps['variant'];
+  component?: TypographyProps['component'];
   horizontal?: boolean;
 }
 
@@ -15,6 +16,7 @@ export const CommonLabeledTextBlock: React.FC<Props> = ({
   title,
   children,
   variant = 'body2',
+  component = 'div',
   sx,
   horizontal = false,
 }) => (
@@ -25,7 +27,7 @@ export const CommonLabeledTextBlock: React.FC<Props> = ({
       ...sx,
     }}
     variant={variant}
-    component='div'
+    component={component}
   >
     <Box sx={({ typography }) => ({ fontWeight: typography.fontWeightBold })}>
       {title}

--- a/src/components/layout/BasicBreadcrumbPageLayout.tsx
+++ b/src/components/layout/BasicBreadcrumbPageLayout.tsx
@@ -21,7 +21,7 @@ const BasicBreadcrumbPageLayout = ({
           <Breadcrumbs crumbs={crumbs} />
         </Container>
       </ContextHeaderAppBar>
-      <Container maxWidth={maxWidth} sx={{ pt: 2, pb: 6 }}>
+      <Container component='main' maxWidth={maxWidth} sx={{ pt: 2, pb: 6 }}>
         {children}
       </Container>
     </>

--- a/src/components/layout/PageContainer.tsx
+++ b/src/components/layout/PageContainer.tsx
@@ -14,7 +14,11 @@ const PageContainer = ({
 }) => {
   const isTiny = useIsMobile('sm');
   return (
-    <Container maxWidth='lg' sx={{ px: { xs: 1, sm: 3, lg: 4 }, pt: 4, pb: 6 }}>
+    <Container
+      component='main'
+      maxWidth='lg'
+      sx={{ px: { xs: 1, sm: 3, lg: 4 }, pt: 4, pb: 6 }}
+    >
       <Stack
         spacing={2}
         direction={isTiny ? 'column' : 'row'}

--- a/src/components/layout/dashboard/DashboardContentNav.tsx
+++ b/src/components/layout/dashboard/DashboardContentNav.tsx
@@ -109,7 +109,7 @@ const DashboardContentNav: React.FC<Props> = ({
           },
         })}
       >
-        <Box>
+        <Box component='nav' aria-label='sidebar-nav'>
           <CloseMenuRow onClose={handleCloseDesktopMenu} label={label} />
           <Box
             sx={{

--- a/src/components/layout/dashboard/contextHeader/ContextHeader.tsx
+++ b/src/components/layout/dashboard/contextHeader/ContextHeader.tsx
@@ -27,6 +27,8 @@ export const ContextHeaderAppBar: React.FC<{ children: ReactNode }> = ({
   children,
 }) => (
   <AppBar
+    component='nav'
+    aria-label='breadcrumbs-nav'
     position='sticky'
     color='default'
     elevation={0}

--- a/src/components/layout/nav/MobileMenu.tsx
+++ b/src/components/layout/nav/MobileMenu.tsx
@@ -66,6 +66,8 @@ const MobileMenu: React.FC<Props> = ({
       })}
     >
       <Stack
+        component='nav'
+        aria-label='sidebar-nav'
         direction='row'
         sx={({ zIndex }) => ({
           boxShadow: children ? 2 : undefined,

--- a/src/modules/admin/components/AdminDashboard.tsx
+++ b/src/modules/admin/components/AdminDashboard.tsx
@@ -23,6 +23,7 @@ import { RootPermissionsFragment } from '@/types/gqlTypes';
 const ProjectNavHeader: React.FC = () => {
   return (
     <Typography
+      component='p'
       variant='h5'
       sx={({ typography }) => ({ fontWeight: typography.fontWeightBold })}
     >

--- a/src/modules/assessments/components/AssessmentTitle.tsx
+++ b/src/modules/assessments/components/AssessmentTitle.tsx
@@ -1,4 +1,4 @@
-import { Typography } from '@mui/material';
+import { Stack, Typography } from '@mui/material';
 import { ReactNode } from 'react';
 import { CommonLabeledTextBlock } from '@/components/elements/CommonLabeledTextBlock';
 import RouterLink from '@/components/elements/RouterLink';
@@ -26,13 +26,16 @@ const AssessmentTitle = ({
   exitDate,
 }: AssessmentTitleProps) => {
   return (
-    <>
-      <Typography variant='h4'>{clientName}</Typography>
+    <Stack gap={1} component='h1' sx={{ m: 0 }}>
+      <Typography variant='h4' component='span'>
+        {clientName}
+      </Typography>
 
       <CommonLabeledTextBlock
         title={assessmentTitle + ':'}
         horizontal
         variant='body1'
+        component='span'
       >
         <RouterLink
           to={generateSafePath(Routes.ENROLLMENT_DASHBOARD, {
@@ -44,7 +47,7 @@ const AssessmentTitle = ({
           {projectName} ({parseAndFormatDateRange(entryDate, exitDate)})
         </RouterLink>
       </CommonLabeledTextBlock>
-    </>
+    </Stack>
   );
 };
 

--- a/src/modules/auth/components/Login.tsx
+++ b/src/modules/auth/components/Login.tsx
@@ -15,7 +15,12 @@ const Login: React.FC = () => {
     <Box sx={{ backgroundColor: 'background.default', height: '100vh' }}>
       <Container component='main' maxWidth='xs'>
         <Box sx={{ pt: { md: 4, xs: 2 } }}>
-          <Typography variant='h5' fontWeight={600} textAlign='center'>
+          <Typography
+            variant='h1'
+            component='h5'
+            fontWeight={600}
+            textAlign='center'
+          >
             OPEN PATH{' '}
             <Box display='inline' color='text.secondary' component='span'>
               HMIS

--- a/src/modules/caseNotes/components/EnrollmentCaseNotes.tsx
+++ b/src/modules/caseNotes/components/EnrollmentCaseNotes.tsx
@@ -124,6 +124,7 @@ const EnrollmentCaseNotes = () => {
       <TitleCard
         title='Case Notes'
         headerVariant='border'
+        headerComponent='h1'
         actions={
           canEdit &&
           !caseNotesFeature.legacy && (

--- a/src/modules/client/components/ClientCardMini.tsx
+++ b/src/modules/client/components/ClientCardMini.tsx
@@ -16,7 +16,9 @@ const ClientCardMini = ({ client, hideImage = false }: Props) => {
   const clientPronouns = pronouns(client);
   return (
     <Stack gap={0.5}>
-      <Typography variant='h5'>{clientNameAllParts(client)}</Typography>
+      <Typography component='p' variant='h5'>
+        {clientNameAllParts(client)}
+      </Typography>
       <Stack direction='row' gap={1} sx={{ mt: 1 }}>
         {!hideImage && (
           <ClientImage clientId={client.id} width={80} height={80} />

--- a/src/modules/client/components/ClientProfileCard.tsx
+++ b/src/modules/client/components/ClientProfileCard.tsx
@@ -380,7 +380,9 @@ const ClientProfileCard: React.FC<Props> = ({ client }) => {
       >
         <Grid container spacing={2}>
           <Grid item xs={12}>
-            <Typography variant='h4'>{clientNameAllParts(client)}</Typography>
+            <Typography component='h1' variant='h4'>
+              {clientNameAllParts(client)}
+            </Typography>
           </Grid>
           <Grid item xs={12} sx={{ display: 'flex', gap: 2 }}>
             {canViewClientPhoto &&

--- a/src/modules/client/components/pages/CreateClientPage.tsx
+++ b/src/modules/client/components/pages/CreateClientPage.tsx
@@ -43,7 +43,7 @@ const CreateClientPage: React.FC = () => {
         localConstants={localConstants}
         title={
           <>
-            <Typography variant='h3' sx={{ mt: 2, mb: 3 }}>
+            <Typography component='h1' variant='h3' sx={{ mt: 2, mb: 3 }}>
               Add New Client
             </Typography>
           </>

--- a/src/modules/client/components/pages/EditClientPage.tsx
+++ b/src/modules/client/components/pages/EditClientPage.tsx
@@ -45,7 +45,12 @@ const EditClientPage = () => {
       top={STICKY_BAR_HEIGHT + CONTEXT_HEADER_HEIGHT}
       title={
         <Stack direction='row' justifyContent='space-between'>
-          <Typography variant='h3' sx={{ pt: 2, pb: 4 }} flexGrow={1}>
+          <Typography
+            component='h1'
+            variant='h3'
+            sx={{ pt: 2, pb: 4 }}
+            flexGrow={1}
+          >
             Update Client Details
           </Typography>
         </Stack>

--- a/src/modules/clientFiles/components/EditFilePage.tsx
+++ b/src/modules/clientFiles/components/EditFilePage.tsx
@@ -56,7 +56,7 @@ const EditFilePage = ({ create = false }: { create?: boolean }) => {
       pickListArgs={pickListArgs}
       title={
         <Stack direction={'row'} spacing={2}>
-          <Typography variant='h3' sx={{ pt: 0, mt: 0 }}>
+          <Typography component='h1' variant='h3' sx={{ pt: 0, mt: 0 }}>
             {title}
           </Typography>
         </Stack>

--- a/src/modules/enrollment/components/EnrollmentNavHeader.tsx
+++ b/src/modules/enrollment/components/EnrollmentNavHeader.tsx
@@ -23,7 +23,7 @@ const EnrollmentNavHeader = ({
   return (
     <Stack gap={1.5}>
       <Stack direction={'row'}>
-        <Typography variant='h5'>
+        <Typography component='p' variant='h5'>
           {clientBriefName(enrollment.client)}
         </Typography>
       </Stack>

--- a/src/modules/enrollment/components/pages/EnrollmentAssessmentsPage.tsx
+++ b/src/modules/enrollment/components/pages/EnrollmentAssessmentsPage.tsx
@@ -68,6 +68,7 @@ const AssessmentsTable = () => {
       }
       actions={actions}
       headerVariant='border'
+      headerComponent='h1'
       data-testid='enrollmentAssessmentsCard'
       mobileBreakpoint='md'
     >

--- a/src/modules/enrollment/components/pages/EnrollmentCeAssessmentsPage.tsx
+++ b/src/modules/enrollment/components/pages/EnrollmentCeAssessmentsPage.tsx
@@ -113,6 +113,7 @@ const EnrollmentCeAssessmentsPage = () => {
       <TitleCard
         title='Coordinated Entry Assessments'
         headerVariant='border'
+        headerComponent='h1'
         actions={
           canEditCeAssessments &&
           !ceAssessmentFeature.legacy && (

--- a/src/modules/enrollment/components/pages/EnrollmentCeEventsPage.tsx
+++ b/src/modules/enrollment/components/pages/EnrollmentCeEventsPage.tsx
@@ -89,6 +89,7 @@ const EnrollmentCeEventsPage = () => {
       <TitleCard
         title='Coordinated Entry Events'
         headerVariant='border'
+        headerComponent='h1'
         actions={
           canEditCeEvents &&
           !ceEventFeature.legacy && (

--- a/src/modules/enrollment/components/pages/EnrollmentCurrentLivingSituationsPage.tsx
+++ b/src/modules/enrollment/components/pages/EnrollmentCurrentLivingSituationsPage.tsx
@@ -112,6 +112,7 @@ const EnrollmentCurrentLivingSituationsPage = () => {
       <TitleCard
         title='Current Living Situations'
         headerVariant='border'
+        headerComponent='h1'
         actions={
           canEditCls ? (
             <Button

--- a/src/modules/enrollment/components/pages/HouseholdPage.tsx
+++ b/src/modules/enrollment/components/pages/HouseholdPage.tsx
@@ -19,6 +19,7 @@ const HouseholdPage = () => {
     <TitleCard
       title='Household'
       headerVariant='border'
+      headerComponent='h1'
       actions={
         <CommonLabeledTextBlock title='Household ID' horizontal>
           <ClickToCopyId value={enrollment.householdId} />

--- a/src/modules/errors/components/ErrorFallback.tsx
+++ b/src/modules/errors/components/ErrorFallback.tsx
@@ -20,6 +20,7 @@ export const FullPageError: React.FC<{
   text?: string;
 }> = ({ text = UNKNOWN_ERROR_HEADING }) => (
   <Box
+    component='main'
     display='flex'
     justifyContent='center'
     alignItems='center'
@@ -28,7 +29,9 @@ export const FullPageError: React.FC<{
     flexDirection='column'
     sx={{ p: 10 }}
   >
-    <Typography variant='h4'>{text}</Typography>
+    <Typography variant='h4' component='h1'>
+      {text}
+    </Typography>
   </Box>
 );
 

--- a/src/modules/projectAdministration/components/CreateOrganizationPage.tsx
+++ b/src/modules/projectAdministration/components/CreateOrganizationPage.tsx
@@ -43,7 +43,7 @@ const CreateOrganizationPage = () => {
         onCompleted={onCompleted}
         FormActionProps={{ submitButtonText: 'Create Organization' }}
         title={
-          <Typography variant='h3' sx={{ mt: 2, mb: 1 }}>
+          <Typography component='h1' variant='h3' sx={{ mt: 2, mb: 1 }}>
             Create a new organization
           </Typography>
         }

--- a/src/modules/projectAdministration/components/CreateProjectPage.tsx
+++ b/src/modules/projectAdministration/components/CreateProjectPage.tsx
@@ -42,7 +42,7 @@ const CreateProjectPage = () => {
         inputVariables={{ organizationId }}
         FormActionProps={{ submitButtonText: 'Create Project' }}
         title={
-          <Typography variant='h3' sx={{ mt: 1, mb: 3 }}>
+          <Typography component='h1' variant='h3' sx={{ mt: 1, mb: 3 }}>
             Add a new Project to {organizationName}
           </Typography>
         }

--- a/src/modules/projectAdministration/components/EditFunderPage.tsx
+++ b/src/modules/projectAdministration/components/EditFunderPage.tsx
@@ -1,4 +1,3 @@
-import { Typography } from '@mui/material';
 import { useCallback, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 
@@ -63,36 +62,6 @@ const EditFunderPage = ({ create = false }: { create?: boolean }) => {
       projectEndDate: parseHmisDateString(project.operatingEndDate),
     };
   }, [project]);
-
-  const titleComponent = useMemo(() => {
-    if (!create && funder) {
-      return (
-        <ProjectFormTitle
-          title={title}
-          project={project}
-          actions={
-            <DeleteMutationButton<
-              DeleteFunderMutation,
-              DeleteFunderMutationVariables
-            >
-              queryDocument={DeleteFunderDocument}
-              variables={{ input: { id: funder.id } }}
-              idPath={'deleteFunder.funder.id'}
-              recordName='Funder'
-              onSuccess={onSuccessfulDelete}
-            >
-              Delete Record
-            </DeleteMutationButton>
-          }
-        />
-      );
-    }
-    return (
-      <Typography component='h1' variant='h3'>
-        {title}
-      </Typography>
-    );
-  }, [create, funder, onSuccessfulDelete, project, title]);
 
   if (loading) return <Loading />;
   if (!create && !funder) return <NotFound />;

--- a/src/modules/projectAdministration/components/EditFunderPage.tsx
+++ b/src/modules/projectAdministration/components/EditFunderPage.tsx
@@ -108,7 +108,28 @@ const EditFunderPage = ({ create = false }: { create?: boolean }) => {
       formRole={RecordFormRole.Funder}
       inputVariables={{ projectId }}
       record={funder || undefined}
-      title={titleComponent}
+      title={
+        <ProjectFormTitle
+          title={title}
+          project={project}
+          actions={
+            funder && (
+              <DeleteMutationButton<
+                DeleteFunderMutation,
+                DeleteFunderMutationVariables
+              >
+                queryDocument={DeleteFunderDocument}
+                variables={{ input: { id: funder.id } }}
+                idPath={'deleteFunder.funder.id'}
+                recordName='Funder'
+                onSuccess={onSuccessfulDelete}
+              >
+                Delete Record
+              </DeleteMutationButton>
+            )
+          }
+        />
+      }
     />
   );
 };

--- a/src/modules/projectAdministration/components/EditFunderPage.tsx
+++ b/src/modules/projectAdministration/components/EditFunderPage.tsx
@@ -1,3 +1,4 @@
+import { Typography } from '@mui/material';
 import { useCallback, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 
@@ -63,6 +64,36 @@ const EditFunderPage = ({ create = false }: { create?: boolean }) => {
     };
   }, [project]);
 
+  const titleComponent = useMemo(() => {
+    if (!create && funder) {
+      return (
+        <ProjectFormTitle
+          title={title}
+          project={project}
+          actions={
+            <DeleteMutationButton<
+              DeleteFunderMutation,
+              DeleteFunderMutationVariables
+            >
+              queryDocument={DeleteFunderDocument}
+              variables={{ input: { id: funder.id } }}
+              idPath={'deleteFunder.funder.id'}
+              recordName='Funder'
+              onSuccess={onSuccessfulDelete}
+            >
+              Delete Record
+            </DeleteMutationButton>
+          }
+        />
+      );
+    }
+    return (
+      <Typography component='h1' variant='h3'>
+        {title}
+      </Typography>
+    );
+  }, [create, funder, onSuccessfulDelete, project, title]);
+
   if (loading) return <Loading />;
   if (!create && !funder) return <NotFound />;
   if (error) throw error;
@@ -77,29 +108,7 @@ const EditFunderPage = ({ create = false }: { create?: boolean }) => {
       formRole={RecordFormRole.Funder}
       inputVariables={{ projectId }}
       record={funder || undefined}
-      title={
-        !create &&
-        funder && (
-          <ProjectFormTitle
-            title={title}
-            project={project}
-            actions={
-              <DeleteMutationButton<
-                DeleteFunderMutation,
-                DeleteFunderMutationVariables
-              >
-                queryDocument={DeleteFunderDocument}
-                variables={{ input: { id: funder.id } }}
-                idPath={'deleteFunder.funder.id'}
-                recordName='Funder'
-                onSuccess={onSuccessfulDelete}
-              >
-                Delete Record
-              </DeleteMutationButton>
-            }
-          />
-        )
-      }
+      title={titleComponent}
     />
   );
 };

--- a/src/modules/projectAdministration/components/EditInventoryPage.tsx
+++ b/src/modules/projectAdministration/components/EditInventoryPage.tsx
@@ -1,3 +1,4 @@
+import { Typography } from '@mui/material';
 import { useCallback, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 
@@ -56,6 +57,17 @@ const EditInventoryPage = ({ create = false }: { create?: boolean }) => {
   const pickListArgs = useMemo(() => ({ projectId }), [projectId]);
   const inputVariables = useMemo(() => ({ projectId }), [projectId]);
 
+  const titleComponent = useMemo(() => {
+    if (!create && inventory) {
+      return <ProjectFormTitle title={title} project={project} />;
+    }
+    return (
+      <Typography component='h1' variant='h3'>
+        {title}
+      </Typography>
+    );
+  }, [create, inventory, project, title]);
+
   if (loading) return <Loading />;
   if (!create && !inventory) return <NotFound />;
   if (error) throw error;
@@ -71,10 +83,7 @@ const EditInventoryPage = ({ create = false }: { create?: boolean }) => {
       localConstants={localConstants}
       inputVariables={inputVariables}
       pickListArgs={pickListArgs}
-      title={
-        !create &&
-        inventory && <ProjectFormTitle title={title} project={project} />
-      }
+      title={titleComponent}
     />
   );
 };

--- a/src/modules/projectAdministration/components/EditOrganizationPage.tsx
+++ b/src/modules/projectAdministration/components/EditOrganizationPage.tsx
@@ -66,7 +66,7 @@ const EditOrganizationPage = () => {
               sx={{ my: 1 }}
             >
               <Stack direction={'row'} spacing={2}>
-                <Typography variant='h3' sx={{ pt: 0, mt: 0 }}>
+                <Typography component='h1' variant='h3' sx={{ pt: 0, mt: 0 }}>
                   Edit {organizationName}
                 </Typography>
               </Stack>

--- a/src/modules/projectAdministration/components/EditProjectCocPage.tsx
+++ b/src/modules/projectAdministration/components/EditProjectCocPage.tsx
@@ -1,4 +1,5 @@
-import { useCallback } from 'react';
+import { Typography } from '@mui/material';
+import { useCallback, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import Loading from '@/components/elements/Loading';
@@ -52,6 +53,37 @@ const EditProjectCocPage = ({ create = false }: { create?: boolean }) => {
     navigate(generateSafePath(ProjectDashboardRoutes.COCS, { projectId }));
   }, [projectId, navigate]);
 
+  const titleComponent = useMemo(() => {
+    if (!create && projectCoc) {
+      return (
+        <ProjectFormTitle
+          title={title}
+          project={project}
+          actions={
+            <DeleteMutationButton<
+              DeleteProjectCocMutation,
+              DeleteProjectCocMutationVariables
+            >
+              queryDocument={DeleteProjectCocDocument}
+              variables={{ input: { id: projectCoc.id } }}
+              idPath={'deleteProjectCoc.projectCoc.id'}
+              recordName='Project CoC record'
+              ConfirmationDialogProps={{ confirmText: 'Yes, delete' }}
+              onSuccess={onSuccessfulDelete}
+            >
+              Delete Record
+            </DeleteMutationButton>
+          }
+        />
+      );
+    }
+    return (
+      <Typography component='h1' variant='h3'>
+        {title}
+      </Typography>
+    );
+  }, [create, onSuccessfulDelete, project, projectCoc, title]);
+
   if (!project.access.canEditProjectDetails) return <NotFound />;
   if (loading) return <Loading />;
   if (error) throw error;
@@ -66,30 +98,7 @@ const EditProjectCocPage = ({ create = false }: { create?: boolean }) => {
         formRole={RecordFormRole.ProjectCoc}
         inputVariables={{ projectId }}
         record={projectCoc || undefined}
-        title={
-          !create &&
-          projectCoc && (
-            <ProjectFormTitle
-              title={title}
-              project={project}
-              actions={
-                <DeleteMutationButton<
-                  DeleteProjectCocMutation,
-                  DeleteProjectCocMutationVariables
-                >
-                  queryDocument={DeleteProjectCocDocument}
-                  variables={{ input: { id: projectCoc.id } }}
-                  idPath={'deleteProjectCoc.projectCoc.id'}
-                  recordName='Project CoC record'
-                  ConfirmationDialogProps={{ confirmText: 'Yes, delete' }}
-                  onSuccess={onSuccessfulDelete}
-                >
-                  Delete Record
-                </DeleteMutationButton>
-              }
-            />
-          )
-        }
+        title={titleComponent}
       />
     </>
   );

--- a/src/modules/projects/components/ProjectDashboard.tsx
+++ b/src/modules/projects/components/ProjectDashboard.tsx
@@ -32,7 +32,7 @@ const ProjectNavHeader = ({
 }) => {
   return (
     <>
-      <Typography variant='h4' sx={{ mb: 2 }}>
+      <Typography component='p' variant='h4' sx={{ mb: 2 }}>
         {project.projectName}
       </Typography>
       <Stack gap={2}>

--- a/src/modules/projects/components/ProjectOverviewPage.tsx
+++ b/src/modules/projects/components/ProjectOverviewPage.tsx
@@ -85,7 +85,7 @@ export const ProjectFormTitle = ({
     sx={{ my: 1 }}
   >
     <Stack direction={'row'} spacing={2}>
-      <Typography variant='h3' sx={{ pt: 0, mt: 0 }}>
+      <Typography component='h1' variant='h3' sx={{ pt: 0, mt: 0 }}>
         {title}
       </Typography>
       <InactiveChip project={project} />

--- a/src/modules/referrals/components/ProjectReferralPostingPage.tsx
+++ b/src/modules/referrals/components/ProjectReferralPostingPage.tsx
@@ -46,7 +46,7 @@ const ProjectReferralPostingPage: React.FC = () => {
     <>
       <PageTitle
         title={
-          <Typography variant='h3'>
+          <Typography component='h1' variant='h3'>
             {`Referral from `}
             <b>{referralPosting.referredBy}</b>
           </Typography>

--- a/src/modules/services/components/EnrollmentServicesPage.tsx
+++ b/src/modules/services/components/EnrollmentServicesPage.tsx
@@ -71,6 +71,7 @@ const EnrollmentServicesPage = () => {
           )
         }
         headerVariant='border'
+        headerComponent='h1'
       >
         <GenericTableWithData<
           GetEnrollmentServicesQuery,


### PR DESCRIPTION
## Description

GH issue: https://github.com/open-path/Green-River/issues/7002
Summary of changes:
- Remove heading markup from left-nav in dashboard contexts
- Ensure all pages contain a level one heading
- Add <nav> markup to the Breadcrumb nav, removing the default <header> markup that is applied by AppBar
- Add <nav> markup to the left-hand dashboard nav
- Add <main> markup on non-dashboard pages that lacked it

For QA instructions, see the issues mentioned in the linked tickets. The axe-devtools extension should no longer highlight those errors.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [x] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
