### PR TITLE
Fix minor markup accessibility issues

### DIFF
--- a/src/components/elements/ButtonTooltipContainer.tsx
+++ b/src/components/elements/ButtonTooltipContainer.tsx
@@ -8,7 +8,16 @@ const ButtonTooltipContainer = ({
   if (!title) return children;
 
   return (
-    <Tooltip title={title} placement='top' arrow {...props}>
+    <Tooltip
+      title={title}
+      placement='top'
+      // describeChild makes the tooltip text become the `title` of the direct child,
+      // which is a span in this case. Otherwise it would become the `aria-label` of
+      // the direct child, which is not valid for spans.
+      describeChild
+      arrow
+      {...props}
+    >
       <span>{children}</span>
     </Tooltip>
   );

--- a/src/components/elements/ButtonTooltipContainer.tsx
+++ b/src/components/elements/ButtonTooltipContainer.tsx
@@ -9,7 +9,7 @@ const ButtonTooltipContainer = ({
 
   return (
     <Tooltip title={title} placement='top' arrow {...props}>
-      <span>{children}</span>
+      {children}
     </Tooltip>
   );
 };

--- a/src/components/elements/ButtonTooltipContainer.tsx
+++ b/src/components/elements/ButtonTooltipContainer.tsx
@@ -9,7 +9,7 @@ const ButtonTooltipContainer = ({
 
   return (
     <Tooltip title={title} placement='top' arrow {...props}>
-      {children}
+      <span>{children}</span>
     </Tooltip>
   );
 };

--- a/src/modules/admin/components/projectConfig/ProjectConfigTable.tsx
+++ b/src/modules/admin/components/projectConfig/ProjectConfigTable.tsx
@@ -89,9 +89,7 @@ const ProjectConfigTable = ({
                   recordName='Project Config'
                   onSuccess={() => evictProjectConfigs()}
                   onlyIcon
-                >
-                  Delete
-                </DeleteMutationButton>
+                />
               </Box>
             ),
           },

--- a/src/modules/clientAlerts/components/ClientAlert.tsx
+++ b/src/modules/clientAlerts/components/ClientAlert.tsx
@@ -52,9 +52,7 @@ const ClientAlert: React.FC<ClientAlertProps> = ({ clientAlert }) => {
               });
             }}
             onlyIcon
-          >
-            Delete
-          </DeleteMutationButton>
+          />
         )}
       </AlertTitle>
       <Box className='MuiAlert-body'>

--- a/src/modules/dataFetching/components/DeleteMutationButton.tsx
+++ b/src/modules/dataFetching/components/DeleteMutationButton.tsx
@@ -90,6 +90,7 @@ const DeleteMutationButton = <Mutation, MutationVariables>({
           onClick={onClick}
           size='small'
           className={className}
+          aria-label={`Delete ${recordName}`}
           {...ButtonProps}
         >
           <DeleteIcon fontSize='small' />

--- a/src/modules/enrollment/components/EntryExitDatesWithAssessmentLinks.tsx
+++ b/src/modules/enrollment/components/EntryExitDatesWithAssessmentLinks.tsx
@@ -55,10 +55,14 @@ const EntryExitDatesWithAssessmentLinks: React.FC<Props> = ({ enrollment }) => {
         {canLinkToIntake ? (
           <Stack direction='row' alignItems='center'>
             <span>{parseAndFormatDate(enrollment.entryDate)}</span>
-            <ButtonTooltipContainer title='Go to Intake Assessment'>
+            <ButtonTooltipContainer
+              describeChild
+              title='Go to Intake Assessment'
+            >
               <ButtonLink
                 to={intakePath}
                 variant='text'
+                aria-label='Go to Intake Assessment'
                 sx={{ minWidth: '30px', color: theme.palette.links }}
               >
                 <AssessmentIcon fontSize='small' />
@@ -73,10 +77,11 @@ const EntryExitDatesWithAssessmentLinks: React.FC<Props> = ({ enrollment }) => {
       <Box component='span'>
         <Stack direction='row' alignItems='center'>
           <span>{exitDateOrActive}</span>
-          <ButtonTooltipContainer title='Go to Exit Assessment'>
+          <ButtonTooltipContainer describeChild title='Go to Exit Assessment'>
             <ButtonLink
               to={exitPath}
               variant='text'
+              aria-label='Go to Exit Assessment'
               sx={{ minWidth: '30px', color: theme.palette.links }}
             >
               <AssessmentIcon fontSize='small' />

--- a/src/modules/enrollment/components/EntryExitDatesWithAssessmentLinks.tsx
+++ b/src/modules/enrollment/components/EntryExitDatesWithAssessmentLinks.tsx
@@ -55,10 +55,7 @@ const EntryExitDatesWithAssessmentLinks: React.FC<Props> = ({ enrollment }) => {
         {canLinkToIntake ? (
           <Stack direction='row' alignItems='center'>
             <span>{parseAndFormatDate(enrollment.entryDate)}</span>
-            <ButtonTooltipContainer
-              describeChild
-              title='Go to Intake Assessment'
-            >
+            <ButtonTooltipContainer title='Go to Intake Assessment'>
               <ButtonLink
                 to={intakePath}
                 variant='text'
@@ -77,7 +74,7 @@ const EntryExitDatesWithAssessmentLinks: React.FC<Props> = ({ enrollment }) => {
       <Box component='span'>
         <Stack direction='row' alignItems='center'>
           <span>{exitDateOrActive}</span>
-          <ButtonTooltipContainer describeChild title='Go to Exit Assessment'>
+          <ButtonTooltipContainer title='Go to Exit Assessment'>
             <ButtonLink
               to={exitPath}
               variant='text'

--- a/src/modules/formBuilder/components/FormBuilderHeader.tsx
+++ b/src/modules/formBuilder/components/FormBuilderHeader.tsx
@@ -134,7 +134,7 @@ const FormBuilderHeader: React.FC<FormEditorHeaderProps> = ({
               </Stack>
             }
             onlyIcon
-          ></DeleteMutationButton>
+          />
         </Stack>
       </Stack>
     </>

--- a/src/modules/hmis/components/AssessmentDateWithStatusIndicator.tsx
+++ b/src/modules/hmis/components/AssessmentDateWithStatusIndicator.tsx
@@ -18,8 +18,8 @@ const AssessmentDateWithStatusIndicator = ({
       <Typography variant='inherit' color='error'>
         {parseAndFormatDate(assessment.assessmentDate)}
       </Typography>
-      <Tooltip title='Assessment has not been submitted.' arrow describeChild>
-        <ErrorOutlineIcon color='error' fontSize='small' />
+      <Tooltip title='Assessment has not been submitted.' arrow>
+        <ErrorOutlineIcon aria-hidden={false} color='error' fontSize='small' />
       </Tooltip>
     </Stack>
   );


### PR DESCRIPTION
## Description

GH issue: https://github.com/open-path/Green-River/issues/7003
Summary of changes:
- Add an aria-label to the `DeleteMutationButton` when it is in icon-only mode. 
  - This was motivated by the Client Alert delete button; the other icon-only usages of this component weren't flagged in the audit because of being part of admin/config screens. 
  - By default the label is just "Delete {recordName}". It can be overridden as part of `ButtonProps` if need be to get more specific, but for AA wcag compliance, which requires that button text make sense in context, I think this is sufficient.
  - I also tidied up usages of this component to consistently end in `/>` if they don't have children
- ~Remove inner `span` from `ButtonTooltipContainer`. Tooltip applies its accessible text to its direct child, so when that's a span, as Bobby noted [here](https://github.com/open-path/hmis-accessibility/issues/42), it won't be correctly parsed by all screen readers.~ See inline comment. This change was reverted
  - Let's discuss, do you remember the reason for this `span` and/or do you see any risk to removing it? I checked the usages in code and confirmed that they are all 1-child only, so I think it should be ok, but I haven't checked every usage in-app to confirm no style regressions. I think it does make a significantly better screen reader experience though (no more ‘group’ to step into - see the Intake/Exit icons on Enrollment Dashboard and compare with QA).
- Remove `describeChild` from the `AssessmentDateWithStatusIndicator` to enable the tooltip to apply its accessible text
  - I found it completely unintuitive that _removing_ `describeChild` causes the accessibility behavior to improve, based on the confusing documentation here https://mui.com/material-ui/react-tooltip/#accessibility. I guess the key is “Note that you shouldn't use `describeChild` if the tooltip provides the only visual label. Otherwise, the child would have no accessible name”

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [x] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
