### PR TITLE
Fix a11y markup for inputs

### DIFF
--- a/src/components/elements/input/SsnInput.tsx
+++ b/src/components/elements/input/SsnInput.tsx
@@ -74,6 +74,10 @@ const SsnInput = ({
           inputProps: {
             ...baseInputProps,
             disabled: onlylast4 ? true : false,
+            inputProps: {
+              ...baseInputProps.inputProps,
+              'aria-label': ariaLabel + ' first 3 digits',
+            },
             placeholder: 'XXX',
             // Allow pasting into first box to fill the entire SSN
             onPaste: (event) => {
@@ -94,6 +98,10 @@ const SsnInput = ({
             ...baseInputProps,
             disabled: onlylast4 ? true : false,
             placeholder: 'XX',
+            inputProps: {
+              ...baseInputProps.inputProps,
+              'aria-label': ariaLabel + ' middle 2 digits',
+            },
           },
         },
         {
@@ -102,6 +110,10 @@ const SsnInput = ({
           inputProps: {
             ...baseInputProps,
             placeholder: 'XXXX',
+            inputProps: {
+              ...baseInputProps.inputProps,
+              'aria-label': ariaLabel + ' last 4 digits',
+            },
           },
         },
       ]}

--- a/src/components/elements/input/TextInput.tsx
+++ b/src/components/elements/input/TextInput.tsx
@@ -71,7 +71,7 @@ const TextInput = ({
       {...props}
       sx={{ maxWidth, ...sx }}
       inputProps={{
-        'aria-label': hiddenLabel ? ariaLabel || String(label) : undefined,
+        'aria-label': ariaLabel || String(label),
         'aria-labelledby': ariaLabelledBy,
         minLength: min,
         maxLength: max,

--- a/src/modules/form/components/group/Signature.tsx
+++ b/src/modules/form/components/group/Signature.tsx
@@ -57,7 +57,16 @@ const Signature = ({
             }}
           >
             {renderChildItem &&
-              item.item?.map((childItem) => renderChildItem(childItem))}
+              item.item?.map((childItem) =>
+                renderChildItem(childItem, {
+                  inputProps: {
+                    // Aria label special case for signatures: Pass in the parent item text _and_ child text.
+                    // E.g. if this is a Client Signature group with Client Name and Date Signed subfields,
+                    // then the aria labels should be "Client Signature - Client Name" and "Client Signature - Date Signed"
+                    ariaLabel: `${item.text} - ${childItem.text}`,
+                  },
+                })
+              )}
           </Grid>
           {!viewOnly && (
             <Typography variant='body2'>

--- a/src/modules/form/components/group/TableGroup.tsx
+++ b/src/modules/form/components/group/TableGroup.tsx
@@ -9,7 +9,7 @@ import {
   Typography,
 } from '@mui/material';
 
-import { useMemo } from 'react';
+import { useId, useMemo } from 'react';
 import { GroupItemComponentProps } from '../../types';
 import RequiredLabel from '../RequiredLabel';
 import { ItemType } from '@/types/gqlTypes';
@@ -19,6 +19,8 @@ import { ItemType } from '@/types/gqlTypes';
  *
  * The TableHeader labels and helper text will be pulled from the labels defined
  * on the items in the first "row group".
+ *
+ * Text and helperText are ignored for subsequent row items.
  *
  * {
  *   "type": "GROUP",
@@ -49,6 +51,7 @@ const TableGroup = ({
   viewOnly = false,
 }: GroupItemComponentProps) => {
   const label = viewOnly ? item.readonlyText || item.text : item.text;
+  const baseId = useId();
 
   // Determine header row details by looking at the first row of Items
   const tableHeaderInfo = useMemo(() => {
@@ -62,13 +65,13 @@ const TableGroup = ({
 
     return item.item[0].item.map(
       ({ linkId, text, helperText, readonlyText, required }) => ({
-        id: `${linkId}-id`,
+        id: baseId + linkId,
         label: viewOnly ? readonlyText || text : text,
         helperText,
         required,
       })
     );
-  }, [item, viewOnly]);
+  }, [item, viewOnly, baseId]);
 
   return (
     <Grid item xs>

--- a/src/modules/search/components/OmniSearch.tsx
+++ b/src/modules/search/components/OmniSearch.tsx
@@ -229,6 +229,7 @@ const OmniSearch: React.FC = () => {
         inputProps={{
           ...values.getInputProps(),
           value: value ? value : '',
+          title: 'Client and Project search',
         }}
         placeholder='Search'
         size='small'


### PR DESCRIPTION
## Description

GH issue: https://github.com/open-path/Green-River/issues/7005

Summary of changes:
- Apply descriptive aria-label to each mini-input within the SSN three-part input. (The nested `inputProps` here get a bit dizzying 😵 but I think the result is correct)
- Always apply aria label on `TextInput` component, regardless of the `hiddenLabel` prop. I think this api was misleading -- possibly it was a bug (`hiddenLabel` is false by default but the intended behavior was that, if `hiddenLabel` is true, then the label should be both hidden and not read by screenreader?). Anyway, my thinking was that we should err on the side of attaching the aria label if it's provided, regardless of whether the label should be visually hidden. Also, from what I could find searching in the code, this `hiddenLabel` prop is not used, so I think the change shouldn't have adverse consequences. This came up for the Signature input group -- see next bullet.
- For Signature input groups, apply a special-case aria label to the children of the group, so their accessible text reads the parent label as well as the child label. See inline comment for example
- For Table input groups, use the `useId` hooks to generate the IDs that are referred to by aria-labelledby. This fixes the nav issue described [here](https://github.com/open-path/hmis-accessibility/issues/14), achieving similar accessible behavior to the Disability table
- Add a title to omni search

No action taken on the following two tickets, pending conversation on those tickets:
- [x] https://github.com/open-path/hmis-accessibility/issues/11#issuecomment-2551467159 - confirmed no action needed
- [x] https://github.com/open-path/hmis-accessibility/issues/14#issuecomment-2551320311

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [x] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
