### PR TITLE
Remove invalid features from Feature-Policy

### DIFF
--- a/docker/templates/non_proxy_headers.conf.template
+++ b/docker/templates/non_proxy_headers.conf.template
@@ -7,5 +7,5 @@ add_header Strict-Transport-Security "max-age=63072000; includeSubdomains;" alwa
 add_header X-Frame-Options "SAMEORIGIN" always;
 add_header X-XSS-Protection "1; mode=block" always;
 add_header X-Content-Type-Options "nosniff" always;
-add_header Feature-Policy "geolocation 'self'; midi 'none'; push 'none'; sync-xhr 'none'; microphone 'none'; camera 'none'; magnetometer 'none'; gyroscope 'none'; fullscreen 'none'; payment 'none'; usb 'none';";
+add_header Feature-Policy "geolocation 'self'; midi 'none'; sync-xhr 'none'; microphone 'none'; camera 'none'; magnetometer 'none'; gyroscope 'none'; fullscreen 'none'; payment 'none'; usb 'none';";
 add_header Permissions-Policy "geolocation=(self)";

--- a/docker/templates/non_proxy_headers.conf.template
+++ b/docker/templates/non_proxy_headers.conf.template
@@ -7,5 +7,5 @@ add_header Strict-Transport-Security "max-age=63072000; includeSubdomains;" alwa
 add_header X-Frame-Options "SAMEORIGIN" always;
 add_header X-XSS-Protection "1; mode=block" always;
 add_header X-Content-Type-Options "nosniff" always;
-add_header Feature-Policy "geolocation 'self'; midi 'none'; notifications 'none'; push 'none'; sync-xhr 'none'; microphone 'none'; camera 'none'; magnetometer 'none'; gyroscope 'none'; speaker 'none'; vibrate 'none'; fullscreen 'none'; payment 'none'; usb 'none';";
+add_header Feature-Policy "geolocation 'self'; midi 'none'; push 'none'; sync-xhr 'none'; microphone 'none'; camera 'none'; magnetometer 'none'; gyroscope 'none'; fullscreen 'none'; payment 'none'; usb 'none';";
 add_header Permissions-Policy "geolocation=(self)";


### PR DESCRIPTION
## Description

There are a few features listed in the Feature-Policy that are not valid features, which causes warnings in production. (See [MDN reference](https://developer.mozilla.org/en-US/docs/Web/HTTP/Permissions_Policy)).

I only looked into the warnings recently when I was enabling geolocation in the `Permissions-Policy` and `Feature-Policy`. (https://github.com/greenriver/hmis-frontend/pull/992) 



<img width="516" alt="Screenshot 2024-12-24 at 9 44 11 AM" src="https://github.com/user-attachments/assets/92103f3f-3827-434c-8374-46949df01d70" />


## Type of change
- [x] Code clean-up / housekeeping

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
