### PR TITLE
Check editorUserIds when rendering occurrence point form

### DIFF
--- a/src/modules/client/components/ClientCustomDataElementsCard.tsx
+++ b/src/modules/client/components/ClientCustomDataElementsCard.tsx
@@ -4,6 +4,7 @@ import {
   CommonDetailGridItem,
 } from '@/components/elements/CommonDetailGrid';
 import TitleCard from '@/components/elements/TitleCard';
+import useAuth from '@/modules/auth/hooks/useAuth';
 import OccurrencePointForm from '@/modules/form/components/OccurrencePointForm';
 import { useClientDetailForms } from '@/modules/form/hooks/useClientDetailForms';
 import { parseOccurrencePointFormDefinition } from '@/modules/form/util/formUtil';
@@ -15,12 +16,14 @@ interface Props {
 
 const ClientCustomDataElementsCard: React.FC<Props> = ({ client }) => {
   const { forms, loading } = useClientDetailForms();
-
+  const { user } = useAuth();
   const rows = useMemo(
     () =>
       forms.map((form) => {
-        const { displayTitle, isEditable, readOnlyDefinition } =
-          parseOccurrencePointFormDefinition(form.definition);
+        // Determine whether this form has any fields that  are editable.
+        // Pass the user because there might be fields that are only editable by some users.
+        const { displayTitle, isEditable, definitionForDisplay } =
+          parseOccurrencePointFormDefinition(form.definition, user);
 
         return {
           id: form.id,
@@ -29,14 +32,14 @@ const ClientCustomDataElementsCard: React.FC<Props> = ({ client }) => {
             <OccurrencePointForm
               record={client}
               definition={form.definition}
-              readOnlyDefinition={readOnlyDefinition}
+              definitionForDisplay={definitionForDisplay}
               editable={isEditable && client.access.canEditClient}
               dialogTitle={displayTitle}
             />
           ),
         };
       }),
-    [client, forms]
+    [client, forms, user]
   );
 
   if (loading) return null;

--- a/src/modules/client/components/ClientCustomDataElementsCard.tsx
+++ b/src/modules/client/components/ClientCustomDataElementsCard.tsx
@@ -23,7 +23,7 @@ const ClientCustomDataElementsCard: React.FC<Props> = ({ client }) => {
         // Determine whether this form has any fields that  are editable.
         // Pass the user because there might be fields that are only editable by some users.
         const { displayTitle, isEditable, definitionForDisplay } =
-          parseOccurrencePointFormDefinition(form.definition, user);
+          parseOccurrencePointFormDefinition(form.definition, user!);
 
         return {
           id: form.id,

--- a/src/modules/enrollment/components/EnrollmentDetails.tsx
+++ b/src/modules/enrollment/components/EnrollmentDetails.tsx
@@ -69,7 +69,7 @@ const EnrollmentDetails = ({
       // Determine whether this form has any fields that  are editable.
       // Pass the user because there might be fields that are only editable by some users.
       const { displayTitle, isEditable, definitionForDisplay } =
-        parseOccurrencePointFormDefinition(definition, user);
+        parseOccurrencePointFormDefinition(definition, user!);
 
       content[displayTitle] = (
         <EnrollmentOccurrencePointForm

--- a/src/modules/enrollment/components/EnrollmentDetails.tsx
+++ b/src/modules/enrollment/components/EnrollmentDetails.tsx
@@ -12,6 +12,7 @@ import Loading from '@/components/elements/Loading';
 import NotCollectedText from '@/components/elements/NotCollectedText';
 
 import RouterLink from '@/components/elements/RouterLink';
+import useAuth from '@/modules/auth/hooks/useAuth';
 import { parseOccurrencePointFormDefinition } from '@/modules/form/util/formUtil';
 import EnrollmentStatus from '@/modules/hmis/components/EnrollmentStatus';
 import HmisEnum from '@/modules/hmis/components/HmisEnum';
@@ -27,6 +28,7 @@ const EnrollmentDetails = ({
 }: {
   enrollment: DashboardEnrollment;
 }) => {
+  const { user } = useAuth();
   const rows = useMemo(() => {
     const content: Record<string, ReactNode> = {};
     // If enrollment is incomplete, show that first
@@ -64,14 +66,16 @@ const EnrollmentDetails = ({
 
     // Occurrence point values (move in date, date of engagement, etc.)
     enrollment.occurrencePointForms.forEach(({ definition }) => {
-      const { displayTitle, isEditable, readOnlyDefinition } =
-        parseOccurrencePointFormDefinition(definition);
+      // Determine whether this form has any fields that  are editable.
+      // Pass the user because there might be fields that are only editable by some users.
+      const { displayTitle, isEditable, definitionForDisplay } =
+        parseOccurrencePointFormDefinition(definition, user);
 
       content[displayTitle] = (
         <EnrollmentOccurrencePointForm
           enrollment={enrollment}
           definition={definition}
-          readOnlyDefinition={readOnlyDefinition}
+          definitionForDisplay={definitionForDisplay}
           editable={isEditable && enrollment.access.canEditEnrollments}
           dialogTitle={displayTitle}
         />
@@ -136,7 +140,7 @@ const EnrollmentDetails = ({
       ),
       value,
     }));
-  }, [enrollment]);
+  }, [enrollment, user]);
 
   if (!enrollment || !rows) return <Loading />;
 

--- a/src/modules/form/components/DynamicFormFields.tsx
+++ b/src/modules/form/components/DynamicFormFields.tsx
@@ -20,7 +20,6 @@ import {
 import DynamicField from './DynamicField';
 import DynamicGroup from './DynamicGroup';
 
-import SentryErrorBoundary from '@/modules/errors/components/SentryErrorBoundary';
 import DynamicViewField from '@/modules/form/components/viewable/DynamicViewField';
 import {
   DisabledDisplay,
@@ -146,34 +145,33 @@ const DynamicFormFields: React.FC<Props> = ({
         />
       </Grid>
     ) : (
-      <SentryErrorBoundary key={item.linkId}>
-        <DynamicField
-          key={item.linkId}
-          item={item}
-          itemChanged={itemChanged}
-          value={
-            isDisabled &&
-            item.disabledDisplay !== DisabledDisplay.ProtectedWithValue
-              ? undefined
-              : values[item.linkId]
-          }
-          errors={getFieldErrors(item)}
-          horizontal={horizontal}
-          pickListArgs={pickListArgs}
-          warnIfEmpty={warnIfEmpty}
-          localConstants={localConstants}
-          {...props}
-          inputProps={{
-            ...props?.inputProps,
-            ...buildCommonInputProps({
-              item,
-              values,
-              localConstants: localConstants || {},
-            }),
-            disabled: isDisabled || locked || undefined,
-          }}
-        />
-      </SentryErrorBoundary>
+      <DynamicField
+        key={item.linkId}
+        item={item}
+        itemChanged={itemChanged}
+        value={
+          isDisabled &&
+          item.disabledDisplay !== DisabledDisplay.ProtectedWithValue
+            ? undefined
+            : values[item.linkId]
+        }
+        errors={getFieldErrors(item)}
+        horizontal={horizontal}
+        pickListArgs={pickListArgs}
+        warnIfEmpty={warnIfEmpty}
+        // Needed to support referencing local constants in expression evaluation (DynamicDisplay)
+        localConstants={localConstants}
+        {...props}
+        inputProps={{
+          ...props?.inputProps,
+          ...buildCommonInputProps({
+            item,
+            values,
+            localConstants: localConstants || {},
+          }),
+          disabled: isDisabled || locked || undefined,
+        }}
+      />
     );
     if (renderFn) {
       return renderFn(itemComponent);

--- a/src/modules/form/components/DynamicFormFields.tsx
+++ b/src/modules/form/components/DynamicFormFields.tsx
@@ -20,6 +20,7 @@ import {
 import DynamicField from './DynamicField';
 import DynamicGroup from './DynamicGroup';
 
+import SentryErrorBoundary from '@/modules/errors/components/SentryErrorBoundary';
 import DynamicViewField from '@/modules/form/components/viewable/DynamicViewField';
 import {
   DisabledDisplay,
@@ -145,33 +146,34 @@ const DynamicFormFields: React.FC<Props> = ({
         />
       </Grid>
     ) : (
-      <DynamicField
-        key={item.linkId}
-        item={item}
-        itemChanged={itemChanged}
-        value={
-          isDisabled &&
-          item.disabledDisplay !== DisabledDisplay.ProtectedWithValue
-            ? undefined
-            : values[item.linkId]
-        }
-        errors={getFieldErrors(item)}
-        horizontal={horizontal}
-        pickListArgs={pickListArgs}
-        warnIfEmpty={warnIfEmpty}
-        // Needed to support referencing local constants in expression evaluation (DynamicDisplay)
-        localConstants={localConstants}
-        {...props}
-        inputProps={{
-          ...props?.inputProps,
-          ...buildCommonInputProps({
-            item,
-            values,
-            localConstants: localConstants || {},
-          }),
-          disabled: isDisabled || locked || undefined,
-        }}
-      />
+      <SentryErrorBoundary key={item.linkId}>
+        <DynamicField
+          key={item.linkId}
+          item={item}
+          itemChanged={itemChanged}
+          value={
+            isDisabled &&
+            item.disabledDisplay !== DisabledDisplay.ProtectedWithValue
+              ? undefined
+              : values[item.linkId]
+          }
+          errors={getFieldErrors(item)}
+          horizontal={horizontal}
+          pickListArgs={pickListArgs}
+          warnIfEmpty={warnIfEmpty}
+          localConstants={localConstants}
+          {...props}
+          inputProps={{
+            ...props?.inputProps,
+            ...buildCommonInputProps({
+              item,
+              values,
+              localConstants: localConstants || {},
+            }),
+            disabled: isDisabled || locked || undefined,
+          }}
+        />
+      </SentryErrorBoundary>
     );
     if (renderFn) {
       return renderFn(itemComponent);

--- a/src/modules/form/components/OccurrencePointForm.tsx
+++ b/src/modules/form/components/OccurrencePointForm.tsx
@@ -29,9 +29,12 @@ import {
 
 export interface OccurrencePointFormProps {
   record: SubmitFormAllowedTypes;
-  definition: FormDefinitionFieldsFragment;
   submitFormInputVariables?: SubmitFormInputVariables;
-  readOnlyDefinition: FormDefinitionJson;
+  /** Definition to use for displaying the occurrence point as a DynamicView */
+  definitionForDisplay: FormDefinitionJson;
+  /** Definition to use for editing the Occurrence Point form values (if allowed) */
+  definition: FormDefinitionFieldsFragment;
+  /** Whether the Occurence Point form is editable. Some Occurrence Point forms are always read-only (like 'number of units assigned'), and some are only editable by certain users (via editor_user_ids). */
   editable?: boolean;
   dialogTitle?: string;
   localConstants?: LocalConstants;
@@ -52,7 +55,7 @@ const OccurrencePointForm: React.FC<OccurrencePointFormProps> = ({
   localConstants: localConstantsProp,
   definition,
   editable,
-  readOnlyDefinition,
+  definitionForDisplay,
   dialogTitle,
   pickListArgs,
   submitFormInputVariables,
@@ -114,7 +117,7 @@ const OccurrencePointForm: React.FC<OccurrencePointFormProps> = ({
     <DynamicView
       key={JSON.stringify(values)}
       values={values}
-      definition={readOnlyDefinition}
+      definition={definitionForDisplay}
       pickListArgs={pickListArgs}
     />
   ) : (

--- a/src/modules/form/util/formUtil.ts
+++ b/src/modules/form/util/formUtil.ts
@@ -1497,6 +1497,8 @@ export const parseOccurrencePointFormDefinition = (
   user?: HmisUser
 ) => {
   let displayTitle = definition.title;
+
+  // Whether this form as any fields that are editable to the current user
   let isEditable = false;
 
   function matchesTitle(item: FormItem, title: string) {
@@ -1505,7 +1507,7 @@ export const parseOccurrencePointFormDefinition = (
     );
   }
 
-  // Modify form definition into a "read only definition" by removing
+  // Created modified "definition for display" that will be used to render values in a DynamicView inside the Enrollment/Client details card
   const definitionForDisplay = modifyFormDefinition(
     definition.definition,
     (item) => {

--- a/src/modules/form/util/formUtil.ts
+++ b/src/modules/form/util/formUtil.ts
@@ -42,6 +42,7 @@ import {
   TypedObject,
 } from '../types';
 
+import { HmisUser } from '@/modules/auth/api/sessions';
 import { evaluateFormula } from '@/modules/form/util/expressions/formula';
 import { collectExpressionReferences } from '@/modules/form/util/expressions/references';
 import {
@@ -1492,7 +1493,8 @@ export const getFieldOnAssessment = (
 };
 
 export const parseOccurrencePointFormDefinition = (
-  definition: FormDefinitionFieldsFragment
+  definition: FormDefinitionFieldsFragment,
+  user?: HmisUser
 ) => {
   let displayTitle = definition.title;
   let isEditable = false;
@@ -1503,21 +1505,35 @@ export const parseOccurrencePointFormDefinition = (
     );
   }
 
-  const readOnlyDefinition = modifyFormDefinition(
+  // Modify form definition into a "read only definition" by removing
+  const definitionForDisplay = modifyFormDefinition(
     definition.definition,
     (item) => {
+      // Delete the 'text' from the item IF the text matches the title of the form.
+      // This is a hacky way to hide redundant labels for tiny Occurrence Point forms like Move-in Date.
       if (definition.title && matchesTitle(item, definition.title)) {
         displayTitle = item.readonlyText || item.text || displayTitle;
         delete item.text;
         delete item.readonlyText;
       }
       if (isQuestionItem(item) && !item.readOnly) {
-        isEditable = true;
+        if (item.editorUserIds && user) {
+          isEditable = item.editorUserIds.includes(user.id);
+        } else {
+          isEditable = true;
+        }
       }
     }
   );
 
-  return { displayTitle, isEditable, readOnlyDefinition };
+  return {
+    // Title to display in the left-hand column of the Enrollment/Client details card
+    displayTitle,
+    // Modified Form Definiton to use to display the form values as a DynamicView in the right-hand column of the Enrollment/Client details card
+    definitionForDisplay,
+    // Whether the form is editable by the current user
+    isEditable,
+  };
 };
 
 export const getFormStepperItems = (

--- a/src/modules/form/util/formUtil.ts
+++ b/src/modules/form/util/formUtil.ts
@@ -1494,7 +1494,7 @@ export const getFieldOnAssessment = (
 
 export const parseOccurrencePointFormDefinition = (
   definition: FormDefinitionFieldsFragment,
-  user?: HmisUser
+  user: HmisUser
 ) => {
   let displayTitle = definition.title;
 
@@ -1519,7 +1519,7 @@ export const parseOccurrencePointFormDefinition = (
         delete item.readonlyText;
       }
       if (isQuestionItem(item) && !item.readOnly) {
-        if (item.editorUserIds && user) {
+        if (item.editorUserIds) {
           isEditable = item.editorUserIds.includes(user.id);
         } else {
           isEditable = true;


### PR DESCRIPTION
## Description

Issue: https://github.com/open-path/Green-River/issues/7093

This PR makes it so that the newly added `editor_user_ids` field on Form Item is respected when rendering "occurrence point" details on the Enrollment Details card.


### How to Test
1. Create and Occurrence Point form with the following content:
    ```
    {
      "item": [
        {
          "text": "Favorite Color",
          "type": "STRING",
          "link_id": "name",
          "editor_user_ids": ["1"] #<=== put your application user id here. can only be found on the backend
        }
      ]
    }
    ```
2. Publish the form
3. Add a rule to enable the form for a project
4. Go to an enrollment at the project
5. "favorite color" should appear in the enrollment details card, and you can click the edit icon and edit the value.  
    <img width="578" alt="Screenshot 2024-12-29 at 11 58 25 AM" src="https://github.com/user-attachments/assets/c6b3f2a7-5107-4134-9bdd-ee1d565573b8" />
6. impersonate a different user who can also access this enrollment
7. that user should be able to view the favorite color, but not edit it. There should be no edit icon.
    <img width="723" alt="Screenshot 2024-12-29 at 11 59 00 AM" src="https://github.com/user-attachments/assets/baecdccc-8b75-4c4e-8281-c391604ba974" />


Note: if some `item`s are allowed to be edited, but others are not, then the form should still be editable. Screenshot shows an example where a second item is added to the form that doesn't have `editor_user_ids`:
<img width="625" alt="Screenshot 2024-12-29 at 11 54 29 AM" src="https://github.com/user-attachments/assets/4bc4755f-18da-4d6a-9447-2ea3b1564faa" />


## Type of change
- [x] New feature (adds functionality)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
