### PR TITLE
Safely parse location data for display - PIT submission display hotfix

### DIFF
--- a/src/modules/auth/api/storage.ts
+++ b/src/modules/auth/api/storage.ts
@@ -1,18 +1,11 @@
 import { HmisUser } from '@/modules/auth/api/sessions';
 import { HmisAppSettings } from '@/modules/hmisAppSettings/types';
+import { parseJson } from '@/utils/jsonUtil';
 
 export const SESSION_KEY = '_hmis_session_id';
 export const USER_STORAGE_KEY = '_hmis_user_info';
 export const SETTINGS_STORAGE_KEY = '_hmis_app_settings';
 export const SESSION_TRACKING_STORAGE_KEY = '_hmis_session_ts';
-
-const parseJson = <T>(value: string | undefined) => {
-  try {
-    return value ? (JSON.parse(value) as T) : undefined;
-  } catch {
-    return undefined;
-  }
-};
 
 // Stores user name and email. No sensitive information stored!
 export const setUser = (value: HmisUser) =>

--- a/src/modules/form/components/DynamicField.tsx
+++ b/src/modules/form/components/DynamicField.tsx
@@ -49,7 +49,9 @@ import useAuth from '@/modules/auth/hooks/useAuth';
 import MciClearance from '@/modules/external/mci/components/MciClearance';
 import SimpleAddressInput from '@/modules/form/components/client/addresses/SimpleAddressInput';
 import { INVALID_ENUM, parseHmisDateString } from '@/modules/hmis/hmisUtil';
+import { isLatLon, LatLon } from '@/types/geolocationTypes';
 import { Component, FormItem, InputSize, ItemType } from '@/types/gqlTypes';
+import { parseJson } from '@/utils/jsonUtil';
 
 export const getLabel = (
   item: FormItem,
@@ -439,11 +441,15 @@ const DynamicField: React.FC<DynamicFieldProps> = ({
         </InputContainer>
       );
     case ItemType.Geolocation:
+      // Coordinates may be stringified if collected from External Form,
+      // so try to parse value as JSON if it's not already in LatLon shape.
+      const coordinates = isLatLon(value) ? value : parseJson<LatLon>(value);
+
       return (
         <InputContainer {...commonContainerProps}>
           <GeolocationInput
             label={label}
-            value={value}
+            value={coordinates}
             onChange={onChangeValue}
             helperText={commonInputProps.helperText}
             disabled={commonInputProps.disabled}

--- a/src/modules/form/components/DynamicField.tsx
+++ b/src/modules/form/components/DynamicField.tsx
@@ -49,9 +49,8 @@ import useAuth from '@/modules/auth/hooks/useAuth';
 import MciClearance from '@/modules/external/mci/components/MciClearance';
 import SimpleAddressInput from '@/modules/form/components/client/addresses/SimpleAddressInput';
 import { INVALID_ENUM, parseHmisDateString } from '@/modules/hmis/hmisUtil';
-import { isLatLon, LatLon } from '@/types/geolocationTypes';
+import { safeParseLatLon } from '@/types/geolocationTypes';
 import { Component, FormItem, InputSize, ItemType } from '@/types/gqlTypes';
-import { parseJson } from '@/utils/jsonUtil';
 
 export const getLabel = (
   item: FormItem,
@@ -441,10 +440,7 @@ const DynamicField: React.FC<DynamicFieldProps> = ({
         </InputContainer>
       );
     case ItemType.Geolocation:
-      // Coordinates may be stringified if collected from External Form,
-      // so try to parse value as JSON if it's not already in LatLon shape.
-      const coordinates = isLatLon(value) ? value : parseJson<LatLon>(value);
-
+      const coordinates = safeParseLatLon(value);
       return (
         <InputContainer {...commonContainerProps}>
           <GeolocationInput

--- a/src/modules/form/components/viewable/DynamicViewField.tsx
+++ b/src/modules/form/components/viewable/DynamicViewField.tsx
@@ -29,7 +29,7 @@ import {
   formatTimeOfDay,
   parseAndFormatDate,
 } from '@/modules/hmis/hmisUtil';
-import { isLatLon, LatLon } from '@/types/geolocationTypes';
+import { safeParseLatLon } from '@/types/geolocationTypes';
 import {
   ClientContactPointSystem,
   Component,
@@ -38,7 +38,6 @@ import {
   ItemType,
 } from '@/types/gqlTypes';
 import { ensureArray } from '@/utils/arrays';
-import { parseJson } from '@/utils/jsonUtil';
 
 const getLabel = (item: FormItem, horizontal?: boolean) => {
   const label = item.readonlyText || item.text;
@@ -276,12 +275,10 @@ const DynamicViewField: React.FC<DynamicViewFieldProps> = ({
           );
       }
     case ItemType.Geolocation:
-      // Coordinates may be stringified if collected from External Form,
-      // so try to parse value as JSON if it's not already in LatLon shape.
-      const coordinates = isLatLon(value) ? value : parseJson<LatLon>(value);
+      const coordinates = safeParseLatLon(value);
       return (
         <LabelWithContent {...commonProps}>
-          {coordinates && coordinates.latitude && coordinates.longitude ? (
+          {coordinates ? (
             <SingleGeolocationMap coordinates={coordinates} />
           ) : (
             <NotCollectedText variant='body2'>

--- a/src/modules/form/components/viewable/DynamicViewField.tsx
+++ b/src/modules/form/components/viewable/DynamicViewField.tsx
@@ -29,6 +29,7 @@ import {
   formatTimeOfDay,
   parseAndFormatDate,
 } from '@/modules/hmis/hmisUtil';
+import { isLatLon, LatLon } from '@/types/geolocationTypes';
 import {
   ClientContactPointSystem,
   Component,
@@ -37,6 +38,7 @@ import {
   ItemType,
 } from '@/types/gqlTypes';
 import { ensureArray } from '@/utils/arrays';
+import { parseJson } from '@/utils/jsonUtil';
 
 const getLabel = (item: FormItem, horizontal?: boolean) => {
   const label = item.readonlyText || item.text;
@@ -274,11 +276,12 @@ const DynamicViewField: React.FC<DynamicViewFieldProps> = ({
           );
       }
     case ItemType.Geolocation:
-      // coordinates may be stringified if collected from External Form
-      const coordinates = typeof value === 'string' ? JSON.parse(value) : value;
+      // Coordinates may be stringified if collected from External Form,
+      // so try to parse value as JSON if it's not already in LatLon shape.
+      const coordinates = isLatLon(value) ? value : parseJson<LatLon>(value);
       return (
         <LabelWithContent {...commonProps}>
-          {coordinates ? (
+          {coordinates && coordinates.latitude && coordinates.longitude ? (
             <SingleGeolocationMap coordinates={coordinates} />
           ) : (
             <NotCollectedText variant='body2'>

--- a/src/types/geolocationTypes.ts
+++ b/src/types/geolocationTypes.ts
@@ -1,1 +1,10 @@
 export type LatLon = Pick<GeolocationCoordinates, 'latitude' | 'longitude'>;
+
+export function isLatLon(value: unknown): value is LatLon {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'latitude' in value &&
+    'longitude' in value
+  );
+}

--- a/src/types/geolocationTypes.ts
+++ b/src/types/geolocationTypes.ts
@@ -7,7 +7,9 @@ export function isLatLon(value: unknown): value is LatLon {
     typeof value === 'object' &&
     value !== null &&
     'latitude' in value &&
-    'longitude' in value
+    'longitude' in value &&
+    typeof value.latitude === 'number' &&
+    typeof value.longitude === 'number'
   );
 }
 

--- a/src/types/geolocationTypes.ts
+++ b/src/types/geolocationTypes.ts
@@ -1,3 +1,5 @@
+import { parseJson } from '@/utils/jsonUtil';
+
 export type LatLon = Pick<GeolocationCoordinates, 'latitude' | 'longitude'>;
 
 export function isLatLon(value: unknown): value is LatLon {
@@ -7,4 +9,17 @@ export function isLatLon(value: unknown): value is LatLon {
     'latitude' in value &&
     'longitude' in value
   );
+}
+
+export function safeParseLatLon(value: any): LatLon | undefined {
+  // Already in LatLon shape
+  if (isLatLon(value)) return value;
+
+  // Try to parse to LatLon shape from string.
+  // Coordinates may be stringified if collected from an External Form.
+  const parsed = parseJson<LatLon>(value);
+  // Use type guard again, to ensure that latitude and longitude are present
+  if (isLatLon(parsed)) return parsed;
+
+  return undefined;
 }

--- a/src/utils/jsonUtil.ts
+++ b/src/utils/jsonUtil.ts
@@ -1,0 +1,7 @@
+export const parseJson = <T>(value: string | undefined) => {
+  try {
+    return value ? (JSON.parse(value) as T) : undefined;
+  } catch {
+    return undefined;
+  }
+};


### PR DESCRIPTION
## Description

Bug fix from QA for issue https://github.com/open-path/Green-River/issues/5726

The PIT form submissions can have any of the following formats in `raw_data`:
* `"Geolocation.coordinates"=>"{\"notCollectedReason\":\"cleared\"}`
* `"Geolocation.coordinates"=>""`
* `"Geolocation.coordinates"=>"{\"latitude\":40.6,\"longitude\":-70.321}"`

The bug was that DynamicViewField was throwing an error when trying to render the`""` or `notCollectedReason` formats, when viewing an External Form submission in the HMIS.

This PR updates the component to safely parse the value. I added this safe parsing into the DynamicField component too, even though that's not getting hit currently (since you can't Edit forms that were submitted from external forms).

Sentry issues:
* https://green-river.sentry.io/issues/6186854163/?project=4504006381273088&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&statsPeriod=90d&stream_index=0
* https://green-river.sentry.io/issues/6186833610/?project=4504006381273088&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&statsPeriod=90d&stream_index=1

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
   - I tested by manually updating my `HmisExternalApis::ExternalForms::FormSubmission` values to match what I was seeing in staging environments (values in list above)