### PR TITLE
Augment accessible text for MUI Autocomplete

### DIFF
--- a/src/components/elements/input/GenericSelect.tsx
+++ b/src/components/elements/input/GenericSelect.tsx
@@ -1,6 +1,7 @@
 import {
   Autocomplete,
   AutocompleteProps,
+  Chip,
   CircularProgress,
   InputAdornment,
 } from '@mui/material';
@@ -83,6 +84,21 @@ const GenericSelect = <
           label={label}
         />
       )}
+      renderTags={(tagValue, getTagProps, ownerState) =>
+        // Augment the accessible text so that it's clear to screenreader users how they can remove options.
+        // TODO - do we want to open an issue in MUI repo?
+        // https://github.com/open-path/hmis-accessibility/issues/37
+        tagValue.map((option: T, index: number) => {
+          return (
+            <Chip
+              size='small'
+              label={ownerState.getOptionLabel(option)}
+              aria-label={`Option: ${ownerState.getOptionLabel(option)}. Press backspace or delete to remove.`}
+              {...getTagProps({ index })}
+            />
+          );
+        })
+      }
       {...rest}
     />
   );

--- a/src/components/elements/input/GenericSelect.tsx
+++ b/src/components/elements/input/GenericSelect.tsx
@@ -47,7 +47,6 @@ const GenericSelect = <
 
   return (
     <Autocomplete
-      disablePortal // https://mui.com/material-ui/react-autocomplete/#ios-voiceover
       options={options}
       value={value}
       slotProps={{

--- a/src/modules/form/components/FormSelect.tsx
+++ b/src/modules/form/components/FormSelect.tsx
@@ -1,5 +1,6 @@
 import { Box, Typography, createFilterOptions } from '@mui/material';
 
+import { visuallyHidden } from '@mui/utils';
 import { useCallback } from 'react';
 import { DynamicInputCommonProps } from '../types';
 import GenericSelect, {
@@ -28,6 +29,11 @@ const renderOption = (props: object, option: Option) => (
     data-testid={`option-${optionId(option)}`}
   >
     <Box sx={{ display: 'flex', justifyContent: 'space-between', width: 1 }}>
+      {/* Insert the group label or group code as a visually hidden element.
+          Temp fix for https://github.com/mui/material-ui/issues/42782 */}
+      {(option.groupLabel || option.groupCode) && (
+        <Box sx={visuallyHidden}>{option.groupLabel || option.groupCode}: </Box>
+      )}
       <Typography variant='body2'>{optionLabel(option)}</Typography>
       {option.secondaryLabel && (
         <Typography


### PR DESCRIPTION
## Description

GH issue: https://github.com/open-path/Green-River/issues/7004#issuecomment-2557230787
Summary of changes:
- In our `GenericSelect` wrapper around MUI's `Autocomplete`, add a custom `renderTags`. This allows us to inject additional accessible text into each chip on multiselect dropdowns. This is a partial/temp solution for https://github.com/open-path/hmis-accessibility/issues/37.
  - To discuss: Should we open an issue in MUI's repo?
- In our `FormSelect`, add a visually hidden element explaining the option's group label if it exists. This is a partial/temp solution for https://github.com/open-path/hmis-accessibility/issues/57.
  - This corresponds to an existing issue in the MUI repo, https://github.com/mui/material-ui/issues/42782, which has recent activity, so I think we can hope for a fix soon
  - The temp fix I've made here only helps `FormSelect`, not all places where we use `GenericSelect`.
- Remove `disablePortal` which was recently introduced, per thread here https://github.com/open-path/Green-River/issues/7004#issuecomment-2566690805

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix - a11y temporary solutions
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
