### PR TITLE
Fix bugs with Uploader found in QA

### DIFF
--- a/src/components/elements/CommonMenuButton.tsx
+++ b/src/components/elements/CommonMenuButton.tsx
@@ -22,6 +22,7 @@ export type CommonMenuItem = {
   divider?: boolean;
   disabled?: boolean;
   ariaLabel?: string;
+  openInNew?: boolean;
 };
 
 interface Props {
@@ -98,18 +99,29 @@ const CommonMenuButton = ({
         {...MenuProps}
       >
         {items.map(
-          ({ key, to, title, divider, onClick, disabled, ariaLabel }) =>
+          ({
+            key,
+            to,
+            title,
+            divider,
+            onClick,
+            disabled,
+            ariaLabel,
+            openInNew,
+          }) =>
             divider ? (
               <Divider key={key} />
             ) : to ? (
-              <MenuItem
-                key={key}
-                component={RouterLink}
-                to={to}
-                aria-label={ariaLabel}
-              >
-                {title}
-              </MenuItem>
+              <li key={key}>
+                <MenuItem
+                  component={RouterLink}
+                  to={to}
+                  aria-label={ariaLabel}
+                  openInNew={openInNew}
+                >
+                  {title}
+                </MenuItem>
+              </li>
             ) : (
               <MenuItem
                 key={key}

--- a/src/components/elements/input/ClientImageUploadDialog.tsx
+++ b/src/components/elements/input/ClientImageUploadDialog.tsx
@@ -163,6 +163,7 @@ const ClientImageUploadDialog: React.FC<ClientImageUploadDialogProps> = ({
               )}
               <Grid item xs={12}>
                 <Uploader
+                  image
                   id='clientImageUploader'
                   multiple={false}
                   onUpload={(upload?: DirectUpload, file?: File) => {

--- a/src/components/elements/upload/fileSummary/FileSummary.tsx
+++ b/src/components/elements/upload/fileSummary/FileSummary.tsx
@@ -69,6 +69,7 @@ const FileSummary: React.FC<FileSummaryProps> = ({
               title: 'Download',
               to: url,
               ariaLabel: `Download ${fileName}`,
+              openInNew: true,
             },
           ]
         : []),

--- a/src/modules/form/util/formUtil.ts
+++ b/src/modules/form/util/formUtil.ts
@@ -719,6 +719,7 @@ export const gqlValueToFormValue = (
       }
       return getOptionValue(value, item);
     case ItemType.File:
+    case ItemType.Image:
       // Use full File object in form to display metadata.
       // The metadata fields wont be submitted because of the `formValueToGqlValue`
       // logic which will transform the file object into an ID before submitting it back.


### PR DESCRIPTION
## Description
GH issue: https://github.com/open-path/Green-River/issues/6208
Depends on hmis-warehouse PR: n/a

Summary of changes:
- Fixes the issue where uploaded files aren't downloadable.
  - The fix is to open the file url in a new tab.
  - I wasn't able to repro this problem locally, but I'm almost confident in the fix, because in QA, if you try using command-click the "Download" menu item to open in a new tab, it works correctly, rather than leading to "Page not found."
  - This also adds a new-tab icon to the Download menu item, which I think is acceptable.
  - Unrelated to the fix, but while I was in here, I added a `<li>` enclosure to the MenuItem in order to correct the html, as I found recommended here: https://github.com/mui/material-ui/issues/204#issuecomment-545260260 
- Fixes the issue where previously uploaded images aren't shown when you reopen an assessment for editing.
  - The fix is to include `Image` types along with `File`s in the exception in `gqlValueToFormValue` that keeps the metadata attached to the type.
- Adds the `image` tag to the client profile image uploader?
  - This is not related to a QA bug, I just noticed it while I was working on the fixes above. I figured the client image uploader should only accept images. Currently in QA you are allowed to upload a PDF: https://qa-hmis.openpath.host/client/==TjEzWVNXbndEOFdhcm16aGxuaTNwZz09/profile

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
