### PR TITLE
Follow up on QA items for Table Actions deploy branch

### DIFF
--- a/src/components/elements/ButtonTooltipContainer.tsx
+++ b/src/components/elements/ButtonTooltipContainer.tsx
@@ -18,6 +18,8 @@ const ButtonTooltipContainer = ({
       arrow
       {...props}
     >
+      {/* This inner `span` allows Tooltips to appear on disabled Button elements.
+      We sometimes do this to explain why the button is disabled.*/}
       <span>{children}</span>
     </Tooltip>
   );

--- a/src/modules/bulkServices/components/AssignServiceButton.tsx
+++ b/src/modules/bulkServices/components/AssignServiceButton.tsx
@@ -3,7 +3,7 @@ import WarningAmberRoundedIcon from '@mui/icons-material/WarningAmberRounded';
 import { LoadingButton } from '@mui/lab';
 import { ButtonProps, DialogActions, DialogContent } from '@mui/material';
 import DialogTitle from '@mui/material/DialogTitle';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 
 import * as React from 'react';
 import { useBulkAssignMutations } from '../hooks/useBulkAssignMutations';
@@ -161,4 +161,4 @@ const AssignServiceButton: React.FC<Props> = ({
   );
 };
 
-export default AssignServiceButton;
+export default memo(AssignServiceButton);

--- a/src/modules/bulkServices/components/BulkServicesTable.tsx
+++ b/src/modules/bulkServices/components/BulkServicesTable.tsx
@@ -1,3 +1,4 @@
+import { Box } from '@mui/material';
 import { ReactNode, useCallback, useMemo, useState } from 'react';
 import { ServicePeriod } from '../bulkServicesTypes';
 import AssignServiceButton from './AssignServiceButton';
@@ -108,23 +109,26 @@ const BulkServicesTable: React.FC<Props> = ({
         },
         {
           ...BASE_ACTION_COLUMN_DEF,
+          width: '180px',
           render: (row: RowType) => (
             <TableRowActions
               record={row}
               recordName={clientBriefName(row)}
               primaryAction={
-                <AssignServiceButton
-                  client={row}
-                  queryVariables={mutationQueryVariables}
-                  tableLoading={loading}
-                  disabled={anyRowsSelected}
-                  disabledReason={
-                    anyRowsSelected
-                      ? 'Deselect checkboxes to assign clients individually.'
-                      : undefined
-                  }
-                  serviceTypeName={serviceTypeName}
-                />
+                <Box sx={{ width: '100%' }}>
+                  <AssignServiceButton
+                    client={row}
+                    queryVariables={mutationQueryVariables}
+                    tableLoading={loading}
+                    disabled={anyRowsSelected}
+                    disabledReason={
+                      anyRowsSelected
+                        ? 'Deselect checkboxes to assign clients individually.'
+                        : undefined
+                    }
+                    serviceTypeName={serviceTypeName}
+                  />
+                </Box>
               }
               secondaryActionConfigs={[
                 getViewClientMenuItem(row),

--- a/src/modules/projects/components/tables/ProjectHouseholdsTable.tsx
+++ b/src/modules/projects/components/tables/ProjectHouseholdsTable.tsx
@@ -1,5 +1,4 @@
-import { Box, TableBody, TableCell, TableRow } from '@mui/material';
-import { visuallyHidden } from '@mui/utils';
+import { TableBody, TableCell, TableRow } from '@mui/material';
 import React, { useMemo } from 'react';
 import { renderCellContents } from '@/components/elements/table/GenericTable';
 import TableRowActions from '@/components/elements/table/TableRowActions';
@@ -32,7 +31,6 @@ import {
   HouseholdFilterOptions,
   ProjectEnrollmentsHouseholdClientFieldsFragment,
   ProjectEnrollmentsHouseholdFieldsFragment,
-  RelationshipToHoH,
 } from '@/types/gqlTypes';
 
 export type HouseholdFields = NonNullable<
@@ -45,24 +43,14 @@ const BASE_COLUMNS: ColumnDef<OneHouseholdClient>[] = [
   CLIENT_COLUMNS.age,
   {
     header: 'Relationship',
-    render: (householdClient) => {
-      const relationship = (
-        <HmisEnum
-          key={householdClient.id}
-          value={householdClient.relationshipToHoH}
-          enumMap={HmisEnums.RelationshipToHoH}
-          whiteSpace='nowrap'
-        />
-      );
-
-      if (
-        householdClient.relationshipToHoH === RelationshipToHoH.DataNotCollected
-      ) {
-        return <Box sx={visuallyHidden}>{relationship}</Box>;
-      }
-
-      return relationship;
-    },
+    render: (householdClient) => (
+      <HmisEnum
+        key={householdClient.id}
+        value={householdClient.relationshipToHoH}
+        enumMap={HmisEnums.RelationshipToHoH}
+        whiteSpace='nowrap'
+      />
+    ),
   },
   WITH_ENROLLMENT_COLUMNS.entryDate,
   WITH_ENROLLMENT_COLUMNS.exitDate,

--- a/src/modules/projects/components/tables/ProjectHouseholdsTable.tsx
+++ b/src/modules/projects/components/tables/ProjectHouseholdsTable.tsx
@@ -1,4 +1,5 @@
-import { TableBody, TableCell, TableRow } from '@mui/material';
+import { Box, TableBody, TableCell, TableRow } from '@mui/material';
+import { visuallyHidden } from '@mui/utils';
 import React, { useMemo } from 'react';
 import { renderCellContents } from '@/components/elements/table/GenericTable';
 import TableRowActions from '@/components/elements/table/TableRowActions';
@@ -31,6 +32,7 @@ import {
   HouseholdFilterOptions,
   ProjectEnrollmentsHouseholdClientFieldsFragment,
   ProjectEnrollmentsHouseholdFieldsFragment,
+  RelationshipToHoH,
 } from '@/types/gqlTypes';
 
 export type HouseholdFields = NonNullable<
@@ -43,14 +45,24 @@ const BASE_COLUMNS: ColumnDef<OneHouseholdClient>[] = [
   CLIENT_COLUMNS.age,
   {
     header: 'Relationship',
-    render: (householdClient) => (
-      <HmisEnum
-        key={householdClient.id}
-        value={householdClient.relationshipToHoH}
-        enumMap={HmisEnums.RelationshipToHoH}
-        whiteSpace='nowrap'
-      />
-    ),
+    render: (householdClient) => {
+      const relationship = (
+        <HmisEnum
+          key={householdClient.id}
+          value={householdClient.relationshipToHoH}
+          enumMap={HmisEnums.RelationshipToHoH}
+          whiteSpace='nowrap'
+        />
+      );
+
+      if (
+        householdClient.relationshipToHoH === RelationshipToHoH.DataNotCollected
+      ) {
+        return <Box sx={visuallyHidden}>{relationship}</Box>;
+      }
+
+      return relationship;
+    },
   },
   WITH_ENROLLMENT_COLUMNS.entryDate,
   WITH_ENROLLMENT_COLUMNS.exitDate,

--- a/src/modules/search/components/ClientSearch.tsx
+++ b/src/modules/search/components/ClientSearch.tsx
@@ -73,7 +73,7 @@ export const CLIENT_COLUMNS: {
   >;
 } = {
   name: {
-    header: 'Name',
+    header: 'Client Name',
     key: 'name',
     render: (client) => <ClientName client={asClient(client)} />,
   },


### PR DESCRIPTION
## Description

GH issues: https://github.com/open-path/Green-River/issues/6761 and https://github.com/open-path/Green-River/issues/6825

Since the changes on the deploy branch (https://github.com/greenriver/hmis-frontend/pull/1020) have already been reviewed, I'll plan to open PRs against that branch for further changes.

Summary of changes:
- ~Restore blank cells for `DataNotCollected` relationship in the Project Households table. This is the current prod behavior, which my previous PR changed unintentionally. https://github.com/greenriver/hmis-frontend/pull/1014#discussion_r1911307027~ Edit: reverted this reversion, per inline comment thread
- Memoize `AssignServiceButton`. I was seeing "High memory usage" warnings from my tab locally when checking and unchecking the "select all" button on the Bulk Services page multiple times in a row. This seems to have improved it somewhat.
- Restore styles on the Assign Service action tab. The '180px' was removed unintentionally. The <Box> wrapper fixes a problem introduced by the TableRowActions's internal `<Stack>`. You can see the problem on QA if you go to Bulk Services and select/deselect; the button width jumps around.
- Rename Name column to Client Name -- I either missed this or it changed, but per our spreadsheet and mocks it should read "Client Name" always

## Type of change
[//]: # 'remove options that are not relevant'
QA followups
Bug fixes

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
