### PR TITLE
Implement sticky columns in GenericTable

### DIFF
--- a/src/components/elements/CommonMenuButton.tsx
+++ b/src/components/elements/CommonMenuButton.tsx
@@ -102,6 +102,9 @@ const CommonMenuButton = ({
           vertical: 'top',
           horizontal: 'right',
         }}
+        // Bug: Opening the CommonMenu applies padding to the body, which can look weird on mobile.
+        // It's sort of fixable with disableScrollLock, but that seems to introduce other scroll problems.
+        // disableScrollLock={true}
         {...MenuProps}
       >
         {items.map(

--- a/src/components/elements/SemanticIcons.tsx
+++ b/src/components/elements/SemanticIcons.tsx
@@ -1,6 +1,7 @@
 import AccessTimeIcon from '@mui/icons-material/AccessTime';
 import AddIcon from '@mui/icons-material/Add';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import ArrowCircleRight from '@mui/icons-material/ArrowCircleRight';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import ArrowDropDownRoundedIcon from '@mui/icons-material/ArrowDropDownRounded';
 import ArrowDropUpRoundedIcon from '@mui/icons-material/ArrowDropUpRounded';
@@ -62,6 +63,7 @@ export {
   CloseIcon as CloseIcon,
   MoreVertRoundedIcon as MoreMenuIcon,
   MyLocationIcon as MyLocationIcon,
+  ArrowCircleRight as GoIcon,
 
   // Icons for Form Builder
   CheckBoxIcon as FormBooleanIcon,

--- a/src/components/elements/table/GenericTable.tsx
+++ b/src/components/elements/table/GenericTable.tsx
@@ -81,13 +81,17 @@ const clickableRowStyles = {
   '&:focus': { backgroundColor: 'rgba(0, 0, 0, 0.04)' },
   cursor: 'pointer',
 };
-
-export const getStickyCellStyles = (
-  sticky: 'left' | 'right' | undefined,
-  stickyBorder: boolean,
-  leftOffset: string | number = 0,
-  rightOffset: string | number = 0
-): SystemStyleObject<Theme> => {
+export const getStickyCellStyles = ({
+  sticky,
+  stickyBorder = true,
+  leftOffset = 0,
+  rightOffset = 0,
+}: {
+  sticky?: 'left' | 'right';
+  stickyBorder?: boolean;
+  leftOffset?: string | number;
+  rightOffset?: string | number;
+}): SystemStyleObject<Theme> => {
   if (!sticky) return {};
 
   const base = {
@@ -279,7 +283,7 @@ const GenericTable = <T extends { id: string }>({
           {selectable && (
             <HeaderCell
               padding='checkbox'
-              sx={getStickyCellStyles('left', false)}
+              sx={getStickyCellStyles({ sticky: 'left', stickyBorder: false })}
             >
               <Checkbox
                 color='primary'
@@ -303,12 +307,10 @@ const GenericTable = <T extends { id: string }>({
               <HeaderCell
                 key={key(def) || i}
                 sx={{
-                  ...getStickyCellStyles(
-                    def.sticky,
-                    true,
-                    selectable ? '46px' : 0,
-                    0
-                  ),
+                  ...getStickyCellStyles({
+                    sticky: def.sticky,
+                    leftOffset: selectable ? '46px' : 0,
+                  }),
                   textAlign: def.textAlign,
                   width: def.width,
                   // headerStyles has SxProps type so we can't spread it directly. https://mui.com/system/getting-started/the-sx-prop/#passing-the-sx-prop
@@ -437,7 +439,10 @@ const GenericTable = <T extends { id: string }>({
                       <TableCell
                         padding='checkbox'
                         key='selection'
-                        sx={getStickyCellStyles('left', false)}
+                        sx={getStickyCellStyles({
+                          sticky: 'left',
+                          stickyBorder: false,
+                        })}
                       >
                         <Checkbox
                           color='primary'
@@ -487,12 +492,10 @@ const GenericTable = <T extends { id: string }>({
                           key={key(def) || index}
                           {...tableCellProps}
                           sx={{
-                            ...getStickyCellStyles(
-                              def.sticky,
-                              true,
-                              selectable ? '46px' : 0,
-                              0
-                            ),
+                            ...getStickyCellStyles({
+                              sticky: def.sticky,
+                              leftOffset: selectable ? '46px' : 0,
+                            }),
                             width,
                             minWidth,
                             ...(isLinked ? { p: 0 } : undefined),

--- a/src/components/elements/table/GenericTable.tsx
+++ b/src/components/elements/table/GenericTable.tsx
@@ -17,6 +17,7 @@ import {
   TableRow,
   Theme,
 } from '@mui/material';
+import { SystemStyleObject } from '@mui/system';
 import { visuallyHidden } from '@mui/utils';
 import { compact, get, includes, isNil, without } from 'lodash-es';
 import {
@@ -83,8 +84,8 @@ const clickableRowStyles = {
 
 export const getStickyCellStyles = (
   sticky?: 'left' | 'right' | undefined
-): SxProps<Theme> => {
-  if (!sticky) return {} as SxProps<Theme>;
+): SystemStyleObject<Theme> => {
+  if (!sticky) return {};
 
   const base = {
     backgroundColor: 'background.paper', // Otherwise it's transparent and other cell content appears beneath it
@@ -113,7 +114,7 @@ export const getStickyCellStyles = (
         ...pseudo,
         left: 0,
       },
-    } as SxProps<Theme>;
+    };
 
   return {
     ...base,
@@ -122,7 +123,7 @@ export const getStickyCellStyles = (
       ...pseudo,
       right: 0,
     },
-  } as SxProps<Theme>;
+  };
 };
 
 const HeaderCell = ({ children, sx, ...rest }: TableCellProps) => (
@@ -288,21 +289,21 @@ const GenericTable = <T extends { id: string }>({
               />
             </HeaderCell>
           )}
-          {columns.map((def, i) => (
-            <HeaderCell
-              key={key(def) || i}
-              sx={
-                {
-                  ...getStickyCellStyles(def.sticky),
-                  ...(headerCellSx ? headerCellSx(def) : {}),
-                  textAlign: def.textAlign,
-                  width: def.width,
-                } as SxProps<Theme>
-              }
-            >
-              {renderHeaderCellContents(def)}
-            </HeaderCell>
-          ))}
+          {columns.map((def, i) => {
+            const headerStyles = headerCellSx ? headerCellSx(def) : {};
+            const sx: SxProps<Theme> = {
+              ...getStickyCellStyles(def.sticky),
+              textAlign: def.textAlign,
+              width: def.width,
+              // headerStyles has SxProps type so we can't spread it directly. https://mui.com/system/getting-started/the-sx-prop/#passing-the-sx-prop
+              ...(Array.isArray(headerStyles) ? headerStyles : [headerStyles]),
+            };
+            return (
+              <HeaderCell key={key(def) || i} sx={sx}>
+                {renderHeaderCellContents(def)}
+              </HeaderCell>
+            );
+          })}
         </TableRow>
       )}
       {loading && loadingVariant === 'linear' && (
@@ -459,22 +460,23 @@ const GenericTable = <T extends { id: string }>({
                               textDecorationColor: 'links',
                             }
                           : undefined;
+
+                      const sx: SxProps<Theme> = {
+                        ...getStickyCellStyles(def.sticky),
+                        width,
+                        minWidth,
+                        ...(isLinked ? { p: 0 } : undefined),
+                        textAlign,
+                        whiteSpace: 'initial',
+                        ...onClickLinkTreatment,
+                        ...tableCellProps?.sx,
+                      };
+
                       return (
                         <TableCell
                           key={key(def) || index}
                           {...tableCellProps}
-                          sx={
-                            {
-                              ...getStickyCellStyles(def.sticky),
-                              width,
-                              minWidth,
-                              ...(isLinked ? { p: 0 } : undefined),
-                              textAlign,
-                              whiteSpace: 'initial',
-                              ...onClickLinkTreatment,
-                              ...tableCellProps?.sx,
-                            } as SxProps<Theme>
-                          }
+                          sx={sx}
                         >
                           {isLinked ? (
                             <RouterLink

--- a/src/components/elements/table/GenericTable.tsx
+++ b/src/components/elements/table/GenericTable.tsx
@@ -80,6 +80,47 @@ const clickableRowStyles = {
   cursor: 'pointer',
 };
 
+export const getStickyCellStyles = (
+  sticky?: 'left' | 'right' | undefined
+): SxProps<Theme> => {
+  if (!sticky) return {} as SxProps<Theme>;
+
+  const base = {
+    backgroundColor: 'background.paper', // Otherwise it's transparent and other cell content appears beneath it
+    position: 'sticky',
+  };
+
+  // Pseudo-element to achieve a border on sticky cells. `position: sticky` doesn't work with regular border
+  const pseudo = {
+    content: '""',
+    position: 'absolute',
+    top: 0,
+    bottom: 0,
+    width: '1px',
+    backgroundColor: 'borders.light',
+    pointerEvents: 'none', // Don't interfere with interactions
+  };
+
+  if (sticky === 'right')
+    return {
+      ...base,
+      right: 0,
+      '&::before': {
+        ...pseudo,
+        left: 0,
+      },
+    } as SxProps<Theme>;
+
+  return {
+    ...base,
+    left: 0,
+    '&::after': {
+      ...pseudo,
+      right: 0,
+    },
+  } as SxProps<Theme>;
+};
+
 const HeaderCell = ({
   children,
   sx,
@@ -237,11 +278,14 @@ const GenericTable = <T extends { id: string }>({
           {columns.map((def, i) => (
             <HeaderCell
               key={key(def) || i}
-              sx={{
-                ...(headerCellSx ? headerCellSx(def) : undefined),
-                textAlign: def.textAlign,
-                width: def.width,
-              }}
+              sx={
+                {
+                  ...getStickyCellStyles(def.sticky),
+                  ...(headerCellSx ? headerCellSx(def) : {}),
+                  textAlign: def.textAlign,
+                  width: def.width,
+                } as SxProps<Theme>
+              }
             >
               {def.header ? (
                 <strong>{def.header}</strong>
@@ -411,15 +455,18 @@ const GenericTable = <T extends { id: string }>({
                         <TableCell
                           key={key(def) || index}
                           {...tableCellProps}
-                          sx={{
-                            width,
-                            minWidth,
-                            ...(isLinked ? { p: 0 } : undefined),
-                            textAlign,
-                            whiteSpace: 'initial',
-                            ...onClickLinkTreatment,
-                            ...tableCellProps?.sx,
-                          }}
+                          sx={
+                            {
+                              ...getStickyCellStyles(def.sticky),
+                              width,
+                              minWidth,
+                              ...(isLinked ? { p: 0 } : undefined),
+                              textAlign,
+                              whiteSpace: 'initial',
+                              ...onClickLinkTreatment,
+                              ...tableCellProps?.sx,
+                            } as SxProps<Theme>
+                          }
                         >
                           {isLinked ? (
                             <RouterLink

--- a/src/components/elements/table/GenericTable.tsx
+++ b/src/components/elements/table/GenericTable.tsx
@@ -88,6 +88,7 @@ export const getStickyCellStyles = (
   const base = {
     backgroundColor: 'background.paper', // Otherwise it's transparent and other cell content appears beneath it
     position: 'sticky',
+    zIndex: 1,
   };
 
   // Pseudo-element to achieve a border on sticky cells. `position: sticky` doesn't work with regular border

--- a/src/components/elements/table/GenericTable.tsx
+++ b/src/components/elements/table/GenericTable.tsx
@@ -83,7 +83,10 @@ const clickableRowStyles = {
 };
 
 export const getStickyCellStyles = (
-  sticky?: 'left' | 'right' | undefined
+  sticky: 'left' | 'right' | undefined,
+  stickyBorder: boolean,
+  leftOffset: string | number = 0,
+  rightOffset: string | number = 0
 ): SystemStyleObject<Theme> => {
   if (!sticky) return {};
 
@@ -96,20 +99,22 @@ export const getStickyCellStyles = (
   };
 
   // Pseudo-element to achieve a border on sticky cells. `position: sticky` doesn't work with regular border
-  const pseudo = {
-    content: '""',
-    position: 'absolute',
-    top: 0,
-    bottom: 0,
-    width: '1px',
-    backgroundColor: 'borders.light',
-    pointerEvents: 'none', // Don't interfere with interactions
-  };
+  const pseudo = stickyBorder
+    ? {
+        content: '""',
+        position: 'absolute',
+        top: 0,
+        bottom: 0,
+        width: '1px',
+        backgroundColor: 'borders.light',
+        pointerEvents: 'none', // Don't interfere with interactions
+      }
+    : {};
 
   if (sticky === 'right')
     return {
       ...base,
-      right: 0,
+      right: rightOffset,
       '&::before': {
         ...pseudo,
         left: 0,
@@ -118,7 +123,7 @@ export const getStickyCellStyles = (
 
   return {
     ...base,
-    left: 0,
+    left: leftOffset,
     '&::after': {
       ...pseudo,
       right: 0,
@@ -272,7 +277,10 @@ const GenericTable = <T extends { id: string }>({
       {hasHeaders && (
         <TableRow>
           {selectable && (
-            <HeaderCell padding='checkbox'>
+            <HeaderCell
+              padding='checkbox'
+              sx={getStickyCellStyles('left', false)}
+            >
               <Checkbox
                 color='primary'
                 indeterminate={
@@ -295,7 +303,12 @@ const GenericTable = <T extends { id: string }>({
               <HeaderCell
                 key={key(def) || i}
                 sx={{
-                  ...getStickyCellStyles(def.sticky),
+                  ...getStickyCellStyles(
+                    def.sticky,
+                    true,
+                    selectable ? '46px' : 0,
+                    0
+                  ),
                   textAlign: def.textAlign,
                   width: def.width,
                   // headerStyles has SxProps type so we can't spread it directly. https://mui.com/system/getting-started/the-sx-prop/#passing-the-sx-prop
@@ -421,7 +434,11 @@ const GenericTable = <T extends { id: string }>({
                     tabIndex={handleRowClick ? 0 : undefined}
                   >
                     {selectable && (
-                      <TableCell padding='checkbox' key='selection'>
+                      <TableCell
+                        padding='checkbox'
+                        key='selection'
+                        sx={getStickyCellStyles('left', false)}
+                      >
                         <Checkbox
                           color='primary'
                           disabled={!isSelectable}
@@ -470,7 +487,12 @@ const GenericTable = <T extends { id: string }>({
                           key={key(def) || index}
                           {...tableCellProps}
                           sx={{
-                            ...getStickyCellStyles(def.sticky),
+                            ...getStickyCellStyles(
+                              def.sticky,
+                              true,
+                              selectable ? '46px' : 0,
+                              0
+                            ),
                             width,
                             minWidth,
                             ...(isLinked ? { p: 0 } : undefined),

--- a/src/components/elements/table/GenericTable.tsx
+++ b/src/components/elements/table/GenericTable.tsx
@@ -291,15 +291,19 @@ const GenericTable = <T extends { id: string }>({
           )}
           {columns.map((def, i) => {
             const headerStyles = headerCellSx ? headerCellSx(def) : {};
-            const sx: SxProps<Theme> = {
-              ...getStickyCellStyles(def.sticky),
-              textAlign: def.textAlign,
-              width: def.width,
-              // headerStyles has SxProps type so we can't spread it directly. https://mui.com/system/getting-started/the-sx-prop/#passing-the-sx-prop
-              ...(Array.isArray(headerStyles) ? headerStyles : [headerStyles]),
-            };
             return (
-              <HeaderCell key={key(def) || i} sx={sx}>
+              <HeaderCell
+                key={key(def) || i}
+                sx={{
+                  ...getStickyCellStyles(def.sticky),
+                  textAlign: def.textAlign,
+                  width: def.width,
+                  // headerStyles has SxProps type so we can't spread it directly. https://mui.com/system/getting-started/the-sx-prop/#passing-the-sx-prop
+                  ...(Array.isArray(headerStyles)
+                    ? headerStyles
+                    : [headerStyles]),
+                }}
+              >
                 {renderHeaderCellContents(def)}
               </HeaderCell>
             );
@@ -461,22 +465,20 @@ const GenericTable = <T extends { id: string }>({
                             }
                           : undefined;
 
-                      const sx: SxProps<Theme> = {
-                        ...getStickyCellStyles(def.sticky),
-                        width,
-                        minWidth,
-                        ...(isLinked ? { p: 0 } : undefined),
-                        textAlign,
-                        whiteSpace: 'initial',
-                        ...onClickLinkTreatment,
-                        ...tableCellProps?.sx,
-                      };
-
                       return (
                         <TableCell
                           key={key(def) || index}
                           {...tableCellProps}
-                          sx={sx}
+                          sx={{
+                            ...getStickyCellStyles(def.sticky),
+                            width,
+                            minWidth,
+                            ...(isLinked ? { p: 0 } : undefined),
+                            textAlign,
+                            whiteSpace: 'initial',
+                            ...onClickLinkTreatment,
+                            ...tableCellProps?.sx,
+                          }}
                         >
                           {isLinked ? (
                             <RouterLink

--- a/src/components/elements/table/GenericTable.tsx
+++ b/src/components/elements/table/GenericTable.tsx
@@ -89,6 +89,8 @@ export const getStickyCellStyles = (
     backgroundColor: 'background.paper', // Otherwise it's transparent and other cell content appears beneath it
     position: 'sticky',
     zIndex: 1,
+    maxWidth: '200px', // Mitigates the risk that the column may be so wide as to obscure any scrollable columns
+    overflow: 'clip',
   };
 
   // Pseudo-element to achieve a border on sticky cells. `position: sticky` doesn't work with regular border

--- a/src/components/elements/table/TableRowActions.tsx
+++ b/src/components/elements/table/TableRowActions.tsx
@@ -86,7 +86,10 @@ const TableRowActions = <T extends { id: string }>({
         <CommonMenuButton
           iconButton
           title='Actions'
-          items={secondaryActionConfigs}
+          items={[
+            ...(primaryActionConfig ? [primaryActionConfig] : []),
+            ...secondaryActionConfigs,
+          ]}
           ButtonProps={{
             'aria-label': `Action menu for ${recordName || record.id}`,
           }}

--- a/src/components/elements/table/TableRowActions.tsx
+++ b/src/components/elements/table/TableRowActions.tsx
@@ -1,7 +1,11 @@
-import { Button, Stack } from '@mui/material';
+import { Button, ButtonProps, Stack } from '@mui/material';
 import { ReactNode } from 'react';
 import ButtonLink from '../ButtonLink';
 import CommonMenuButton, { CommonMenuItem } from '../CommonMenuButton';
+import ButtonTooltipContainer from '@/components/elements/ButtonTooltipContainer';
+import { GoIcon } from '@/components/elements/SemanticIcons';
+import { useIsMobile } from '@/hooks/useIsMobile';
+import IconButtonContainer from '@/modules/enrollment/components/IconButtonContainer';
 
 interface TableRowActionsProps<T> {
   record: T;
@@ -21,35 +25,62 @@ const TableRowActions = <T extends { id: string }>({
   primaryActionConfig,
   secondaryActionConfigs,
 }: TableRowActionsProps<T>) => {
+  const isTiny = useIsMobile('sm');
+
+  const primaryAria =
+    primaryActionConfig?.ariaLabel ||
+    `${primaryActionConfig?.title}, ${recordName}`;
+
+  const buttonProps: Pick<ButtonProps, 'size' | 'variant' | 'aria-label'> = {
+    size: 'small',
+    variant: 'outlined',
+    'aria-label': primaryAria,
+  };
+
   return (
-    <Stack direction='row' alignItems='center' justifyContent='end' gap={0.5}>
-      {!!primaryActionConfig && primaryActionConfig.to && (
-        <ButtonLink
-          to={primaryActionConfig.to || ''}
-          size='small'
-          variant='outlined'
-          aria-label={
-            primaryActionConfig.ariaLabel ||
-            `${primaryActionConfig.title}, ${recordName}`
-          }
-          state={primaryActionConfig.linkState}
-        >
-          {primaryActionConfig.title}
-        </ButtonLink>
-      )}
-      {!!primaryActionConfig && primaryActionConfig.onClick && (
-        <Button
-          onClick={primaryActionConfig.onClick}
-          size='small'
-          variant='outlined'
-          aria-label={
-            primaryActionConfig.ariaLabel ||
-            `${primaryActionConfig.title}, ${recordName}`
-          }
-        >
-          {primaryActionConfig.title}
-        </Button>
-      )}
+    <Stack
+      direction='row'
+      alignItems='center'
+      justifyContent='end'
+      gap={{ xs: 0, sm: 0.5 }}
+    >
+      {!!primaryActionConfig &&
+        primaryActionConfig.to &&
+        (isTiny ? (
+          <ButtonTooltipContainer title={primaryAria}>
+            <ButtonLink
+              to={primaryActionConfig.to || ''}
+              state={primaryActionConfig.linkState}
+              {...buttonProps}
+              variant='text'
+              sx={{ maxWidth: '20px', minWidth: 0 }}
+            >
+              <GoIcon />
+            </ButtonLink>
+          </ButtonTooltipContainer>
+        ) : (
+          <ButtonLink
+            to={primaryActionConfig.to || ''}
+            state={primaryActionConfig.linkState}
+            {...buttonProps}
+          >
+            {primaryActionConfig.title}
+          </ButtonLink>
+        ))}
+      {!!primaryActionConfig &&
+        primaryActionConfig.onClick &&
+        (isTiny ? (
+          <IconButtonContainer
+            Icon={GoIcon}
+            onClick={primaryActionConfig.onClick}
+            tooltip={primaryAria}
+            IconButtonProps={{ size: 'medium' }}
+          />
+        ) : (
+          <Button onClick={primaryActionConfig.onClick} {...buttonProps}>
+            {primaryActionConfig.title}
+          </Button>
+        ))}
       {primaryAction}
       {!!secondaryActionConfigs && secondaryActionConfigs.length > 0 && (
         <CommonMenuButton

--- a/src/components/elements/table/tableRowActionUtil.tsx
+++ b/src/components/elements/table/tableRowActionUtil.tsx
@@ -21,9 +21,10 @@ import { generateSafePath } from '@/utils/pathEncoding';
 
 export const BASE_ACTION_COLUMN_DEF: ColumnDef<any> = {
   key: 'Actions',
-  tableCellProps: { sx: { py: 0 } },
+  tableCellProps: { sx: { py: 0, px: { xs: 1, sm: 2 } } },
   render: '', // gets overridden when used
   sticky: 'right',
+  width: '0px',
 };
 
 export const getViewClientMenuItem = (client: ClientNameFragment) => {

--- a/src/components/elements/table/tableRowActionUtil.tsx
+++ b/src/components/elements/table/tableRowActionUtil.tsx
@@ -23,6 +23,7 @@ export const BASE_ACTION_COLUMN_DEF: ColumnDef<any> = {
   key: 'Actions',
   tableCellProps: { sx: { py: 0 } },
   render: '', // gets overridden when used
+  sticky: 'right',
 };
 
 export const getViewClientMenuItem = (client: ClientNameFragment) => {

--- a/src/components/elements/table/types.tsx
+++ b/src/components/elements/table/types.tsx
@@ -19,6 +19,7 @@ type BaseColumnDef<T> = {
   tableCellProps?: TableCellProps;
   optional?: boolean;
   defaultHidden?: boolean;
+  sticky?: 'left' | 'right';
 };
 
 export type ColumnDef<T> =

--- a/src/modules/assessments/components/pages/ClientAssessmentsPage.tsx
+++ b/src/modules/assessments/components/pages/ClientAssessmentsPage.tsx
@@ -30,7 +30,7 @@ const ClientAssessmentsPage = () => {
 
   const columns: ColumnDef<ClientAssessmentType>[] = useMemo(
     () => [
-      ASSESSMENT_COLUMNS.date,
+      { ...ASSESSMENT_COLUMNS.date, sticky: 'left' },
       {
         header: 'Project Name',
         render: (row: ClientAssessmentType) => row.enrollment.projectName,

--- a/src/modules/assessments/util.tsx
+++ b/src/modules/assessments/util.tsx
@@ -99,5 +99,6 @@ export const ASSESSMENT_CLIENT_NAME_COL: ColumnDef<
   ProjectAssessmentType | HhmAssessmentType
 > = {
   header: 'Client Name',
+  sticky: 'left',
   render: (a) => clientBriefName(a.enrollment.client),
 };

--- a/src/modules/bulkServices/components/BulkServicesTable.tsx
+++ b/src/modules/bulkServices/components/BulkServicesTable.tsx
@@ -74,7 +74,7 @@ const BulkServicesTable: React.FC<Props> = ({
         </NotCollectedText>
       );
       return [
-        CLIENT_COLUMNS.name,
+        { ...CLIENT_COLUMNS.name, sticky: 'left' },
         ...(canViewDob ? [CLIENT_COLUMNS.dobAge] : []),
         {
           header: 'Entry Date',

--- a/src/modules/caseNotes/components/EnrollmentCaseNotes.tsx
+++ b/src/modules/caseNotes/components/EnrollmentCaseNotes.tsx
@@ -7,6 +7,7 @@ import { useViewEditRecordDialogs } from '../../form/hooks/useViewEditRecordDial
 import RelativeDateDisplay from '@/components/elements/RelativeDateDisplay';
 import TableRowActions from '@/components/elements/table/TableRowActions';
 import { BASE_ACTION_COLUMN_DEF } from '@/components/elements/table/tableRowActionUtil';
+import { ColumnDef } from '@/components/elements/table/types';
 import TitleCard from '@/components/elements/TitleCard';
 import NotFound from '@/components/pages/NotFound';
 import GenericTableWithData from '@/modules/dataFetching/components/GenericTableWithData';
@@ -26,12 +27,16 @@ import {
   RecordFormRole,
 } from '@/types/gqlTypes';
 
-export const CASE_NOTE_COLUMNS = {
+export const CASE_NOTE_COLUMNS: Record<
+  string,
+  ColumnDef<CustomCaseNoteFieldsFragment>
+> = {
   InformationDate: {
     header: 'Information Date',
     width: '150px',
     render: ({ informationDate }: CustomCaseNoteFieldsFragment) =>
       parseAndFormatDate(informationDate),
+    sticky: 'left',
   },
   NoteContent: {
     header: 'Note Content',
@@ -52,7 +57,6 @@ export const CASE_NOTE_COLUMNS = {
   NoteContentPreview: {
     key: 'content-preview',
     header: 'Note Content Preview',
-    maxWidth: '450px',
     render: ({ content }: CustomCaseNoteFieldsFragment) => (
       <Box
         sx={{

--- a/src/modules/clientFiles/components/ClientFilesPage.tsx
+++ b/src/modules/clientFiles/components/ClientFilesPage.tsx
@@ -79,6 +79,7 @@ const ClientFilesPage = () => {
         render: (file) => (
           <Typography variant='inherit'>{file.name}</Typography>
         ),
+        sticky: 'left',
       },
       {
         header: 'File Tags',

--- a/src/modules/enrollment/components/EnrollmentAssessmentsTable.tsx
+++ b/src/modules/enrollment/components/EnrollmentAssessmentsTable.tsx
@@ -5,6 +5,7 @@ import {
   BASE_ACTION_COLUMN_DEF,
   getViewAssessmentMenuItem,
 } from '@/components/elements/table/tableRowActionUtil';
+import { ColumnDef } from '@/components/elements/table/types';
 import { ASSESSMENT_COLUMNS } from '@/modules/assessments/util';
 import GenericTableWithData from '@/modules/dataFetching/components/GenericTableWithData';
 import { useFilters } from '@/modules/hmis/filterUtil';
@@ -27,9 +28,9 @@ const EnrollmentAssessmentsTable: React.FC<Props> = ({
   enrollmentId,
   projectId,
 }) => {
-  const columns = useMemo(
+  const columns: ColumnDef<AssessmentFieldsFragment>[] = useMemo(
     () => [
-      ASSESSMENT_COLUMNS.date,
+      { ...ASSESSMENT_COLUMNS.date, sticky: 'left' },
       ASSESSMENT_COLUMNS.type,
       ASSESSMENT_COLUMNS.lastUpdated,
       {

--- a/src/modules/enrollment/components/pages/ClientEnrollmentsPage.tsx
+++ b/src/modules/enrollment/components/pages/ClientEnrollmentsPage.tsx
@@ -49,6 +49,7 @@ const CLIENT_ENROLLMENT_COLUMNS: {
   projectName: {
     header: 'Project Name',
     render: 'projectName',
+    sticky: 'left',
   },
   organizationName: {
     header: 'Organization Name',

--- a/src/modules/enrollment/components/pages/EnrollmentCeAssessmentsPage.tsx
+++ b/src/modules/enrollment/components/pages/EnrollmentCeAssessmentsPage.tsx
@@ -71,6 +71,7 @@ const EnrollmentCeAssessmentsPage = () => {
         header: 'Assessment Date',
         render: (a: CeAssessmentFieldsFragment) =>
           parseAndFormatDate(a.assessmentDate),
+        sticky: 'left',
       },
       {
         header: 'Assessment Level',

--- a/src/modules/enrollment/components/pages/EnrollmentCeEventsPage.tsx
+++ b/src/modules/enrollment/components/pages/EnrollmentCeEventsPage.tsx
@@ -4,6 +4,7 @@ import { useCallback, useMemo } from 'react';
 
 import TableRowActions from '@/components/elements/table/TableRowActions';
 import { BASE_ACTION_COLUMN_DEF } from '@/components/elements/table/tableRowActionUtil';
+import { ColumnDef } from '@/components/elements/table/types';
 import TitleCard from '@/components/elements/TitleCard';
 import NotFound from '@/components/pages/NotFound';
 import GenericTableWithData from '@/modules/dataFetching/components/GenericTableWithData';
@@ -66,13 +67,14 @@ const EnrollmentCeEventsPage = () => {
     DataCollectionFeatureRole.CeEvent
   );
 
-  const columns = useMemo(
+  const columns: ColumnDef<EventFieldsFragment>[] = useMemo(
     () => [
       {
         header: 'Event Type',
         render: (e: EventFieldsFragment) => (
           <HmisEnum value={e.event} enumMap={HmisEnums.EventType} />
         ),
+        sticky: 'left',
       },
       {
         header: 'Event Date',

--- a/src/modules/enrollment/components/pages/EnrollmentCurrentLivingSituationsPage.tsx
+++ b/src/modules/enrollment/components/pages/EnrollmentCurrentLivingSituationsPage.tsx
@@ -3,6 +3,7 @@ import { Button } from '@mui/material';
 import { useCallback, useMemo } from 'react';
 import TableRowActions from '@/components/elements/table/TableRowActions';
 import { BASE_ACTION_COLUMN_DEF } from '@/components/elements/table/tableRowActionUtil';
+import { ColumnDef } from '@/components/elements/table/types';
 import TitleCard from '@/components/elements/TitleCard';
 import NotFound from '@/components/pages/NotFound';
 import GenericTableWithData from '@/modules/dataFetching/components/GenericTableWithData';
@@ -93,10 +94,12 @@ const EnrollmentCurrentLivingSituationsPage = () => {
     });
 
   const getColumnDefs = useCallback(
-    (rows: CurrentLivingSituationFieldsFragment[]) => {
+    (
+      rows: CurrentLivingSituationFieldsFragment[]
+    ): ColumnDef<CurrentLivingSituationFieldsFragment>[] => {
       const customColumns = getCustomDataElementColumns(rows);
       return [
-        CLS_COLUMNS.informationDate,
+        { ...CLS_COLUMNS.informationDate, sticky: 'left' },
         CLS_COLUMNS.livingSituation,
         CLS_COLUMNS.locationDetails,
         ...customColumns,

--- a/src/modules/projectAdministration/components/AllProjectsPage.tsx
+++ b/src/modules/projectAdministration/components/AllProjectsPage.tsx
@@ -40,6 +40,7 @@ const PROJECT_COLUMNS: ColumnDef<ProjectAllFieldsFragment>[] = [
   {
     header: 'Project Name',
     render: 'projectName',
+    sticky: 'left',
   },
   {
     header: 'Organization Name',
@@ -81,6 +82,7 @@ const ORGANIZATION_COLUMNS: ColumnDef<OrganizationType>[] = [
   {
     header: 'Organization Name',
     render: 'organizationName',
+    sticky: 'left',
   },
   {
     header: 'Project Count',

--- a/src/modules/projects/components/ProjectCurrentLivingSituations.tsx
+++ b/src/modules/projects/components/ProjectCurrentLivingSituations.tsx
@@ -24,6 +24,7 @@ import { generateSafePath } from '@/utils/pathEncoding';
 const COLUMNS: ColumnDef<ProjectCurrentLivingSituationFieldsFragment>[] = [
   {
     header: 'Client Name',
+    sticky: 'left',
     render: (cls: ProjectCurrentLivingSituationFieldsFragment) => (
       <ClientName client={cls.client} />
     ),

--- a/src/modules/projects/components/tables/ProjectClientEnrollmentsTable.tsx
+++ b/src/modules/projects/components/tables/ProjectClientEnrollmentsTable.tsx
@@ -200,7 +200,7 @@ const ProjectClientEnrollmentsTable = ({
   const defaultColumns: ColumnDef<ProjectEnrollmentQueryEnrollmentFieldsFragment>[] =
     useMemo(() => {
       return [
-        CLIENT_COLUMNS.name,
+        { ...CLIENT_COLUMNS.name, sticky: 'left' },
         CLIENT_COLUMNS.age,
         ENROLLMENT_COLUMNS.entryDate,
         ENROLLMENT_COLUMNS.exitDate,

--- a/src/modules/projects/components/tables/ProjectHouseholdsTable.tsx
+++ b/src/modules/projects/components/tables/ProjectHouseholdsTable.tsx
@@ -1,6 +1,9 @@
 import { TableBody, TableCell, TableRow } from '@mui/material';
-import React, { useMemo } from 'react';
-import { renderCellContents } from '@/components/elements/table/GenericTable';
+import React, { useCallback, useMemo } from 'react';
+import {
+  getStickyCellStyles,
+  renderCellContents,
+} from '@/components/elements/table/GenericTable';
 import TableRowActions from '@/components/elements/table/TableRowActions';
 import {
   BASE_ACTION_COLUMN_DEF,
@@ -39,7 +42,7 @@ export type HouseholdFields = NonNullable<
 
 type OneHouseholdClient = HouseholdFields['householdClients'][number];
 const BASE_COLUMNS: ColumnDef<OneHouseholdClient>[] = [
-  CLIENT_COLUMNS.name,
+  { ...CLIENT_COLUMNS.name, sticky: 'left' },
   CLIENT_COLUMNS.age,
   {
     header: 'Relationship',
@@ -84,24 +87,30 @@ const ProjectHouseholdsClientRow: React.FC<ProjectHouseholdsClientRowProps> = ({
   lastInGroup = false,
   showAssignedStaff = false,
 }) => {
-  const cellSx = useMemo(
-    () => (lastInGroup ? { borderBottom: 0, py: 0.5 } : { py: 0.5 }),
+  const cellSx = useCallback(
+    (col?: ColumnDef<ProjectEnrollmentsHouseholdClientFieldsFragment>) => {
+      return {
+        py: 0.5,
+        ...(lastInGroup ? { borderBottom: 0 } : {}),
+        ...getStickyCellStyles(col?.sticky),
+      };
+    },
     [lastInGroup]
   );
 
   return (
     <TableRow key={household.id + householdClient.id}>
       {BASE_COLUMNS.map((col, i) => (
-        <TableCell role={i === 0 ? 'rowheader' : undefined} sx={cellSx}>
+        <TableCell role={i === 0 ? 'rowheader' : undefined} sx={cellSx(col)}>
           {renderCellContents(householdClient, col.render)}
         </TableCell>
       ))}
       {showAssignedStaff && (
-        <TableCell sx={cellSx}>
+        <TableCell sx={cellSx()}>
           {renderCellContents(household, ASSIGNED_STAFF_COL.render)}
         </TableCell>
       )}
-      <TableCell sx={cellSx}>
+      <TableCell sx={cellSx(ACTION_COL)}>
         {renderCellContents(householdClient, ACTION_COL.render)}
       </TableCell>
     </TableRow>
@@ -148,13 +157,12 @@ const ProjectHouseholdsTable = ({
   const defaultColumns: ColumnDef<HouseholdFields>[] = useMemo(() => {
     return [
       ...BASE_COLUMNS,
-      ...(staffAssignmentsEnabled ? [ASSIGNED_STAFF_COL] : []),
+      ...(staffAssignmentsEnabled
+        ? [{ ...ASSIGNED_STAFF_COL, ariaLabel: undefined }]
+        : []), // typescript appeasement
       ACTION_COL,
-    ].map(({ header, key, optional, defaultHidden }) => ({
-      header,
-      key,
-      optional,
-      defaultHidden,
+    ].map(({ render, ariaLabel, ...rest }) => ({
+      ...rest,
       render: () => null,
     }));
   }, [staffAssignmentsEnabled]);

--- a/src/modules/projects/components/tables/ProjectHouseholdsTable.tsx
+++ b/src/modules/projects/components/tables/ProjectHouseholdsTable.tsx
@@ -92,7 +92,7 @@ const ProjectHouseholdsClientRow: React.FC<ProjectHouseholdsClientRowProps> = ({
       return {
         py: 0.5,
         ...(lastInGroup ? { borderBottom: 0 } : {}),
-        ...getStickyCellStyles(col?.sticky),
+        ...getStickyCellStyles({ sticky: col?.sticky }),
       };
     },
     [lastInGroup]

--- a/src/modules/services/components/ClientServicesPage.tsx
+++ b/src/modules/services/components/ClientServicesPage.tsx
@@ -42,7 +42,7 @@ const ClientServicesPage: React.FC<{
     () =>
       (
         [
-          SERVICE_BASIC_COLUMNS.serviceDate,
+          { ...SERVICE_BASIC_COLUMNS.serviceDate, sticky: 'left' },
           SERVICE_BASIC_COLUMNS.serviceType,
           {
             key: 'project',

--- a/src/modules/services/components/EnrollmentServicesPage.tsx
+++ b/src/modules/services/components/EnrollmentServicesPage.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from 'react';
 
 import TableRowActions from '@/components/elements/table/TableRowActions';
 import { BASE_ACTION_COLUMN_DEF } from '@/components/elements/table/tableRowActionUtil';
+import { ColumnDef } from '@/components/elements/table/types';
 import TitleCard from '@/components/elements/TitleCard';
 import NotFound from '@/components/pages/NotFound';
 import GenericTableWithData from '@/modules/dataFetching/components/GenericTableWithData';
@@ -49,9 +50,9 @@ const EnrollmentServicesPage = () => {
 
   const canEditServices = enrollment?.access.canEditEnrollments;
 
-  const columns = useMemo(() => {
+  const columns: ColumnDef<ServiceFieldsFragment>[] = useMemo(() => {
     return [
-      SERVICE_BASIC_COLUMNS.serviceDate,
+      { ...SERVICE_BASIC_COLUMNS.serviceDate, sticky: 'left' },
       SERVICE_BASIC_COLUMNS.serviceType,
       SERVICE_COLUMNS.serviceDetails,
       ...(canEditServices

--- a/src/modules/services/components/ProjectServicesTable.tsx
+++ b/src/modules/services/components/ProjectServicesTable.tsx
@@ -40,6 +40,7 @@ const ProjectServicesTable = ({
     return [
       {
         header: 'Client Name',
+        sticky: 'left',
         render: (s: ServiceFields) => (
           <ClientName client={s.enrollment.client} />
         ),


### PR DESCRIPTION
## Description

GH issue: https://github.com/open-path/Green-River/issues/6761

This PR is a follow-up from [this comment thread](https://greenriver.slack.com/archives/C033YNSN0Q1/p1736540407532099?thread_ts=1736448766.234739&cid=C033YNSN0Q1) in Slack. Summary of changes:
- Add ability in GenericTable to define columns as "sticky" on the left or right
- Implement "sticky" columns on all the in-scope tables for 6761
- Update to TableRowActions so that on mobile (smallest screen size), the primary action button appears as an icon. (It sounds like this may become true across the board, even on wider screens pending design decision)

I should note that, while I've once-overed every individual table that's using this new pattern, I haven't tested this PR extremely thoroughly, since the ticket is over estimate. For efficiency, I'm proposing to do more thorough QA in the QA environment once this is merged to the deploy branch.

## Type of change
[//]: # 'remove options that are not relevant'
- [ ] Bug fix
- [x] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
