### PR TITLE
Fix form builder bug when specifying numeric autofill value

### DIFF
--- a/src/modules/formBuilder/components/itemEditor/conditionals/AutofillValueCard.tsx
+++ b/src/modules/formBuilder/components/itemEditor/conditionals/AutofillValueCard.tsx
@@ -5,7 +5,6 @@ import { Controller, UseFormSetValue, useWatch } from 'react-hook-form';
 import { FormItemControl, FormItemState } from '../types';
 import ManageEnableWhen from './ManageEnableWhen';
 import LabeledCheckbox from '@/components/elements/input/LabeledCheckbox';
-import NumberInput from '@/components/elements/input/NumberInput';
 import YesNoRadio from '@/components/elements/input/YesNoRadio';
 import ControlledCheckbox from '@/modules/form/components/rhf/ControlledCheckbox';
 import ControlledTextInput from '@/modules/form/components/rhf/ControlledTextInput';
@@ -83,24 +82,12 @@ const AutofillValueCard: React.FC<AutofillValueCardProps> = ({
               />
             )}
             {fieldType === 'valueNumber' && (
-              <Controller
+              <ControlledTextInput
                 name={`autofillValues.${index}.valueNumber`}
                 control={control}
-                shouldUnregister
-                rules={{ required: 'This field is required' }}
-                render={({
-                  field: { ref, disabled, ...field },
-                  fieldState: { error },
-                }) => (
-                  <NumberInput
-                    sx={disabled ? { display: 'none' } : undefined}
-                    label='Value'
-                    inputRef={ref}
-                    error={!!error}
-                    helperText={error?.message}
-                    {...field}
-                  />
-                )}
+                label='Value (Numeric)'
+                type='number'
+                required
               />
             )}
           </>


### PR DESCRIPTION
## Description

Bug fix in form builder. Repro:
* Create a numeric item
* Add an Autofill rule
* Try to set the autofill value and submit. It will fail because it was a string


Self-qa done:
* can set to 0
* get validation error if left empty
* when toggling to "value", previous valueNumber gets cleared

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
