### PR TITLE
Revert to MUI's default behavior on Autocomplete

### DIFF
--- a/src/components/elements/input/GenericSelect.tsx
+++ b/src/components/elements/input/GenericSelect.tsx
@@ -52,11 +52,16 @@ const GenericSelect = <
       slotProps={{
         clearIndicator: {
           tabIndex: 0,
-          // In order to make the Clear Button focusable, have to disable the default MUI behavior of hiding it except on hover.
-          // However, it can only be activated using Space, and not Enter.
-          // See https://github.com/mui/material-ui/issues/44936
+          // In order to make the Clear Button focusable, disable the default MUI behavior of hiding it except on hover.
+          // However, it can only be activated using Space, and not Enter. https://github.com/mui/material-ui/issues/44936
           sx: {
             visibility: 'visible',
+          },
+          // Now that the Clear button is focusable, prevent the Down Arrow key from opening the dropdown (#7197)
+          onKeyDown: (event) => {
+            if (event.key === 'ArrowDown') {
+              event.stopPropagation();
+            }
           },
         },
       }}

--- a/src/components/elements/input/GenericSelect.tsx
+++ b/src/components/elements/input/GenericSelect.tsx
@@ -49,22 +49,6 @@ const GenericSelect = <
     <Autocomplete
       options={options}
       value={value}
-      slotProps={{
-        clearIndicator: {
-          tabIndex: 0,
-          // In order to make the Clear Button focusable, disable the default MUI behavior of hiding it except on hover.
-          // However, it can only be activated using Space, and not Enter. https://github.com/mui/material-ui/issues/44936
-          sx: {
-            visibility: 'visible',
-          },
-          // Now that the Clear button is focusable, prevent the Down Arrow key from opening the dropdown (#7197)
-          onKeyDown: (event) => {
-            if (event.key === 'ArrowDown') {
-              event.stopPropagation();
-            }
-          },
-        },
-      }}
       renderInput={(params) => (
         <TextInput
           {...params}


### PR DESCRIPTION
## Description

Arose from bug: https://github.com/open-path/Green-River/issues/7197
Original GH issue and decision to revert to MUI defaults: https://github.com/open-path/Green-River/issues/7004#issuecomment-2605513306

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
