### PR TITLE
Fix bug with menu item links (partially revert #1013)

### DIFF
--- a/src/components/elements/CommonMenuButton.tsx
+++ b/src/components/elements/CommonMenuButton.tsx
@@ -116,16 +116,15 @@ const CommonMenuButton = ({
             divider ? (
               <Divider key={key} />
             ) : to ? (
-              <li key={key}>
-                <MenuItem
-                  component={RouterLink}
-                  to={to}
-                  aria-label={ariaLabel}
-                  openInNew={openInNew}
-                >
-                  {title}
-                </MenuItem>
-              </li>
+              <MenuItem
+                key={key}
+                component={RouterLink}
+                to={to}
+                aria-label={ariaLabel}
+                openInNew={openInNew}
+              >
+                {title}
+              </MenuItem>
             ) : (
               <MenuItem
                 key={key}


### PR DESCRIPTION
## Description

To reproduce:
- Visit a page with a menu button where the menu items include links. An example is the New Assessment button the Enrollment Assessments page. ([qa link](https://qa-hmis.openpath.host/client/==RERiYlo3bWpYOWk5UGpVaXNTSmNIQT09/enrollments/==UFU3YlVZbFZqSUpLK1pQVzdRNUJJQT09/assessments))
- Keyboard navigate using tab to the menu button, and press enter to open
- You should be able to navigate with up/down and select with enter. Instead, the interaction via keyboard is broken, you can only select using mouse.

This was introduced in release-145 with https://github.com/greenriver/hmis-frontend/pull/1013.
- The result of reverting that change is that the menu items are now no longer in <li> markup, which I think is acceptable
- I played with putting the `RouterLink` inside the `MenuItem`, but found this was also not keyboard accessible.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
