### PR TITLE
Remove some old unused props, display HoH rel as "HoH"

### DIFF
--- a/src/modules/projects/components/tables/ProjectEnrollmentsTable.tsx
+++ b/src/modules/projects/components/tables/ProjectEnrollmentsTable.tsx
@@ -67,13 +67,11 @@ const ProjectEnrollmentsTable: React.FC<Props> = ({ projectId }) => {
             </Grid>
           }
           <Grid item flexGrow={1}>
-            {true ? (
-              <ClientSearchInput
-                value={search || ''}
-                onChange={setSearch}
-                helperText={null}
-              />
-            ) : undefined}
+            <ClientSearchInput
+              value={search || ''}
+              onChange={setSearch}
+              helperText={null}
+            />
           </Grid>
         </Grid>
       </Box>

--- a/src/modules/projects/components/tables/ProjectEnrollmentsTable.tsx
+++ b/src/modules/projects/components/tables/ProjectEnrollmentsTable.tsx
@@ -1,46 +1,31 @@
 import PersonIcon from '@mui/icons-material/Person';
 import { Box, Grid } from '@mui/material';
-import { useState } from 'react';
+import React, { useState } from 'react';
 
-import ProjectClientEnrollmentsTable, {
-  EnrollmentFields,
-} from './ProjectClientEnrollmentsTable';
+import ProjectClientEnrollmentsTable from './ProjectClientEnrollmentsTable';
 import ProjectHouseholdsTable from './ProjectHouseholdsTable';
 
 import CommonToggle from '@/components/elements/CommonToggle';
 import LabelWithContent from '@/components/elements/LabelWithContent';
 import { HouseholdIcon } from '@/components/elements/SemanticIcons';
-import { ColumnDef } from '@/components/elements/table/types';
 import useDebouncedState from '@/hooks/useDebouncedState';
 import ClientSearchInput from '@/modules/search/components/ClientTextSearchInput';
 
 type Mode = 'clients' | 'households';
 
-const ProjectEnrollmentsTable = ({
-  projectId,
-  columns,
-  openOnDate,
-  searchable = true,
-  mode: modeProp,
-  initialMode: initialModeProp = 'clients',
-}: {
-  mode?: Mode;
-  initialMode?: Mode;
+interface Props {
   projectId: string;
-  columns?: ColumnDef<EnrollmentFields>[];
-  linkRowToEnrollment?: boolean;
-  openOnDate?: Date;
-  searchable?: boolean;
-}) => {
+}
+const ProjectEnrollmentsTable: React.FC<Props> = ({ projectId }) => {
   const [search, setSearch, debouncedSearch] = useDebouncedState<string>('');
 
-  const [mode, setMode] = useState<Mode>(modeProp || initialModeProp);
+  const [mode, setMode] = useState<Mode>('clients');
 
   return (
     <>
       <Box py={2} px={3} sx={{ borderBottom: 1, borderColor: 'divider' }}>
         <Grid container direction='row' rowSpacing={2} columnSpacing={4}>
-          {!modeProp && (
+          {
             <Grid item>
               <LabelWithContent
                 label='View enrollments by'
@@ -80,9 +65,9 @@ const ProjectEnrollmentsTable = ({
                 )}
               />
             </Grid>
-          )}
+          }
           <Grid item flexGrow={1}>
-            {searchable ? (
+            {true ? (
               <ClientSearchInput
                 value={search || ''}
                 onChange={setSearch}
@@ -94,17 +79,14 @@ const ProjectEnrollmentsTable = ({
       </Box>
       {mode === 'clients' && (
         <ProjectClientEnrollmentsTable
-          columns={columns}
           searchTerm={debouncedSearch || undefined}
           projectId={projectId}
-          openOnDate={openOnDate}
         />
       )}
       {mode === 'households' && (
         <ProjectHouseholdsTable
           searchTerm={debouncedSearch || undefined}
           projectId={projectId}
-          openOnDate={openOnDate}
         />
       )}
     </>

--- a/src/modules/projects/components/tables/ProjectHouseholdsTable.tsx
+++ b/src/modules/projects/components/tables/ProjectHouseholdsTable.tsx
@@ -17,12 +17,7 @@ import { ColumnDef } from '@/components/elements/table/types';
 import GenericTableWithData from '@/modules/dataFetching/components/GenericTableWithData';
 import HmisEnum from '@/modules/hmis/components/HmisEnum';
 import { useFilters } from '@/modules/hmis/filterUtil';
-import {
-  clientBriefName,
-  formatDateForDisplay,
-  formatDateForGql,
-  sortHouseholdMembers,
-} from '@/modules/hmis/hmisUtil';
+import { clientBriefName, sortHouseholdMembers } from '@/modules/hmis/hmisUtil';
 import { useProjectDashboardContext } from '@/modules/projects/components/ProjectDashboard';
 import {
   ASSIGNED_STAFF_COL,
@@ -53,7 +48,10 @@ const BASE_COLUMNS: ColumnDef<OneHouseholdClient>[] = [
       <HmisEnum
         key={householdClient.id}
         value={householdClient.relationshipToHoH}
-        enumMap={HmisEnums.RelationshipToHoH}
+        enumMap={{
+          ...HmisEnums.RelationshipToHoH,
+          SELF_HEAD_OF_HOUSEHOLD: 'HoH', // HoH, instead of "Self (HoH)"
+        }}
         whiteSpace='nowrap'
       />
     ),
@@ -155,28 +153,18 @@ const CustomDividerRow = ({ colSpan }: { colSpan: number }) => (
   </TableRow>
 );
 
-const ProjectHouseholdsTable = ({
-  projectId,
-  columns,
-  openOnDate,
-  searchTerm,
-}: {
+interface Props {
   projectId: string;
-  columns?: ColumnDef<HouseholdFields>[];
-  openOnDate?: Date;
   searchTerm?: string;
-}) => {
-  const openOnDateString = useMemo(
-    () => (openOnDate ? formatDateForGql(openOnDate) : undefined),
-    [openOnDate]
-  );
+}
 
+const ProjectHouseholdsTable: React.FC<Props> = ({ projectId, searchTerm }) => {
   const {
     project: { staffAssignmentsEnabled },
   } = useProjectDashboardContext();
 
   // dummy column defs for Household that are only used for the headers, not for rendering cells
-  const defaultColumns: ColumnDef<HouseholdFields>[] = useMemo(() => {
+  const columns: ColumnDef<HouseholdFields>[] = useMemo(() => {
     return [
       ...BASE_COLUMNS,
       ...(staffAssignmentsEnabled ? [{ ...ASSIGNED_STAFF_COL }] : []), // typescript appeasement
@@ -202,13 +190,11 @@ const ProjectHouseholdsTable = ({
     >
       queryVariables={{
         id: projectId,
-        filters: {
-          searchTerm,
-          openOnDate: openOnDateString,
-        },
+        // filter from parent component gets merged with any filters selected on the table
+        filters: { searchTerm },
       }}
       queryDocument={GetProjectHouseholdsDocument}
-      columns={columns || defaultColumns}
+      columns={columns}
       TableBodyComponent={React.Fragment}
       renderRow={(household, columnKeys) => {
         return (
@@ -217,7 +203,7 @@ const ProjectHouseholdsTable = ({
             key={household.id}
             role='rowgroup'
           >
-            <CustomDividerRow colSpan={(columns || defaultColumns).length} />
+            <CustomDividerRow colSpan={columns.length} />
             {sortHouseholdMembers(household.householdClients).map(
               (householdClient, index) => (
                 <ProjectHouseholdsClientRow
@@ -236,14 +222,10 @@ const ProjectHouseholdsTable = ({
       }}
       belowRowsContent={
         <TableBody>
-          <CustomDividerRow colSpan={(columns || defaultColumns).length} />
+          <CustomDividerRow colSpan={columns.length} />
         </TableBody>
       }
-      noData={
-        openOnDate
-          ? `No households open on ${formatDateForDisplay(openOnDate)}`
-          : 'No households'
-      }
+      noData='No households'
       pagePath='project.households'
       filters={filters}
       recordType='Household'


### PR DESCRIPTION
## Description

* delete old unused props
* `Relationship` col display `HoH` instead of `Self (HoH)`. I think it's clearer.

## Type of change
[//]: # 'remove options that are not relevant'
- [ ] Bug fix
- [ ] New feature (adds functionality)
- [x] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
