### PR TITLE
Remove relationship col from client table

### DIFF
--- a/src/modules/projects/components/tables/ProjectClientEnrollmentsTable.tsx
+++ b/src/modules/projects/components/tables/ProjectClientEnrollmentsTable.tsx
@@ -8,7 +8,6 @@ import {
 import { ColumnDef } from '@/components/elements/table/types';
 import GenericTableWithData from '@/modules/dataFetching/components/GenericTableWithData';
 import EnrollmentStatus from '@/modules/hmis/components/EnrollmentStatus';
-import HmisEnum from '@/modules/hmis/components/HmisEnum';
 import { useFilters } from '@/modules/hmis/filterUtil';
 import {
   clientBriefName,
@@ -18,7 +17,6 @@ import {
 } from '@/modules/hmis/hmisUtil';
 import { useProjectDashboardContext } from '@/modules/projects/components/ProjectDashboard';
 import { CLIENT_COLUMNS } from '@/modules/search/components/ClientSearch';
-import { HmisEnums } from '@/types/gqlEnums';
 import {
   ClientEnrollmentFieldsFragment,
   EnrollmentFieldsFragment,
@@ -70,22 +68,6 @@ export const ENROLLMENT_COLUMNS: {
     header: 'Status',
     render: (e) => <EnrollmentStatus enrollment={e} />,
   },
-};
-
-export const ENROLLMENT_RELATIONSHIP_COL = {
-  header: 'Relationship',
-  render: (e: Pick<EnrollmentFields, 'id' | 'relationshipToHoH'>) => (
-    <HmisEnum
-      key={e.id}
-      value={e.relationshipToHoH}
-      enumMap={{
-        ...HmisEnums.RelationshipToHoH,
-        // Display "HoH", instead of "Self (HoH)"
-        SELF_HEAD_OF_HOUSEHOLD: 'HoH',
-      }}
-      whiteSpace='nowrap'
-    />
-  ),
 };
 
 export const ASSIGNED_STAFF_COL = {
@@ -217,7 +199,6 @@ const ProjectClientEnrollmentsTable = ({
       return [
         { ...CLIENT_COLUMNS.name, sticky: 'left' },
         CLIENT_COLUMNS.age,
-        ENROLLMENT_RELATIONSHIP_COL,
         ENROLLMENT_COLUMNS.entryDate,
         ENROLLMENT_COLUMNS.exitDate,
         ENROLLMENT_COLUMNS.enrollmentStatus,

--- a/src/modules/projects/components/tables/ProjectEnrollmentsTable.tsx
+++ b/src/modules/projects/components/tables/ProjectEnrollmentsTable.tsx
@@ -51,14 +51,14 @@ const ProjectEnrollmentsTable: React.FC<Props> = ({ projectId }) => {
                     }}
                     items={[
                       {
-                        value: 'clients',
-                        label: 'Clients',
-                        Icon: PersonIcon,
-                      },
-                      {
                         value: 'households',
                         label: 'Households',
                         Icon: HouseholdIcon,
+                      },
+                      {
+                        value: 'clients',
+                        label: 'Clients',
+                        Icon: PersonIcon,
                       },
                     ]}
                   />

--- a/src/modules/projects/components/tables/ProjectHouseholdsTable.tsx
+++ b/src/modules/projects/components/tables/ProjectHouseholdsTable.tsx
@@ -15,15 +15,17 @@ import {
 } from '@/components/elements/table/tableRowActionUtil';
 import { ColumnDef } from '@/components/elements/table/types';
 import GenericTableWithData from '@/modules/dataFetching/components/GenericTableWithData';
+import HmisEnum from '@/modules/hmis/components/HmisEnum';
 import { useFilters } from '@/modules/hmis/filterUtil';
 import { clientBriefName, sortHouseholdMembers } from '@/modules/hmis/hmisUtil';
 import { useProjectDashboardContext } from '@/modules/projects/components/ProjectDashboard';
 import {
   ASSIGNED_STAFF_COL,
-  ENROLLMENT_RELATIONSHIP_COL,
+  EnrollmentFields,
   WITH_ENROLLMENT_COLUMNS,
 } from '@/modules/projects/components/tables/ProjectClientEnrollmentsTable';
 import { CLIENT_COLUMNS } from '@/modules/search/components/ClientSearch';
+import { HmisEnums } from '@/types/gqlEnums';
 import {
   GetProjectHouseholdsDocument,
   GetProjectHouseholdsQuery,
@@ -36,6 +38,22 @@ import {
 export type HouseholdFields = NonNullable<
   GetProjectHouseholdsQuery['project']
 >['households']['nodes'][number];
+
+export const ENROLLMENT_RELATIONSHIP_COL = {
+  header: 'Relationship',
+  render: (e: Pick<EnrollmentFields, 'id' | 'relationshipToHoH'>) => (
+    <HmisEnum
+      key={e.id}
+      value={e.relationshipToHoH}
+      enumMap={{
+        ...HmisEnums.RelationshipToHoH,
+        // Display "HoH", instead of "Self (HoH)"
+        SELF_HEAD_OF_HOUSEHOLD: 'HoH',
+      }}
+      whiteSpace='nowrap'
+    />
+  ),
+};
 
 type OneHouseholdClient = HouseholdFields['householdClients'][number];
 const BASE_COLUMNS: ColumnDef<OneHouseholdClient>[] = [


### PR DESCRIPTION
## Description

Revert 2 changes since we're moving back to households as default view:
* move household back to first position in toggle
* remove newly added relationship col from client table

## Type of change
- [x] New feature (adds functionality)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
