### PR TITLE
Fix mobile menu and make mobile table nav buttons into icons

### DIFF
--- a/src/components/elements/tableFilters/filters/FilterButton.tsx
+++ b/src/components/elements/tableFilters/filters/FilterButton.tsx
@@ -16,7 +16,7 @@ const TableFilterButton: React.FC<TableFilterButtonProps> = ({
   return isTiny ? (
     <IconButton
       sx={(theme) => ({
-        border: `1px solid ${theme.palette.grayscale[300]}`,
+        border: `1px solid ${theme.palette.borders.dark}`,
         borderRadius: 1,
         height: '32px',
         width: '32px',

--- a/src/components/elements/tableFilters/filters/FilterButton.tsx
+++ b/src/components/elements/tableFilters/filters/FilterButton.tsx
@@ -1,5 +1,6 @@
-import { Button, ButtonProps, alpha } from '@mui/material';
+import { alpha, Button, ButtonProps, IconButton } from '@mui/material';
 import React from 'react';
+import { useIsMobile } from '@/hooks/useIsMobile';
 
 export interface TableFilterButtonProps extends ButtonProps {
   active?: boolean;
@@ -7,12 +8,28 @@ export interface TableFilterButtonProps extends ButtonProps {
 
 const TableFilterButton: React.FC<TableFilterButtonProps> = ({
   active = false,
+  startIcon,
   ...props
 }) => {
-  return (
+  const isTiny = useIsMobile('sm');
+
+  return isTiny ? (
+    <IconButton
+      sx={(theme) => ({
+        border: `1px solid ${theme.palette.grayscale[300]}`,
+        borderRadius: 1,
+        height: '32px',
+        width: '32px',
+      })}
+      {...props}
+    >
+      {startIcon}
+    </IconButton>
+  ) : (
     <Button
       size='small'
       variant='text'
+      startIcon={startIcon}
       sx={(theme) => ({
         color: active ? theme.palette.links : theme.palette.text.primary,
         fontWeight: 600,

--- a/src/components/elements/tableFilters/filters/SortMenu.tsx
+++ b/src/components/elements/tableFilters/filters/SortMenu.tsx
@@ -30,6 +30,7 @@ const TableSortMenu = <S extends Record<string, string>>({
       <TableFilterButton
         startIcon={<ArrowDownwardIcon />}
         active={!isNil(sortOptionValue)}
+        aria-label={'Sort'}
         {...bindTrigger(popupState)}
       >
         Sort

--- a/src/components/elements/tableFilters/filters/TableControlPopover.tsx
+++ b/src/components/elements/tableFilters/filters/TableControlPopover.tsx
@@ -18,7 +18,7 @@ export interface TableControlPopoverProps {
   onReset: VoidFunction;
   onApply: VoidFunction;
   header: ReactNode;
-  label: ReactNode;
+  label: string;
   icon: ReactNode;
   applyLabel?: ReactNode;
 }
@@ -57,6 +57,7 @@ const TableControlPopover = (props: TableControlPopoverProps): JSX.Element => {
       <TableFilterButton
         startIcon={icon}
         active={filterCount > 0}
+        aria-label={label}
         {...bindTrigger(popupState)}
       >
         {label}

--- a/src/components/layout/nav/MobileMenu.tsx
+++ b/src/components/layout/nav/MobileMenu.tsx
@@ -103,22 +103,18 @@ const MobileMenu: React.FC<Props> = ({
         </Box>
       )}
 
-      {/* If we child nav items for a dashboard, render them in a scrollable area */}
       {children && (
-        <Box sx={{ flex: '1', overflowY: 'scroll' }}>
-          <Box
-            id='dashboard-nav-menu'
-            sx={({ palette }) => ({ background: palette.grey[100] })}
-          >
-            {children}
-          </Box>
+        <Box
+          id='dashboard-nav-menu'
+          sx={({ palette }) => ({ background: palette.grey[100] })}
+        >
+          {children}
         </Box>
       )}
 
       {/* Navigation for top-level items (Clients, Projects, Admin) */}
       <Box
         sx={({ palette }) => ({
-          flex: '1',
           borderTop: `1px solid ${palette.divider}`,
         })}
       >


### PR DESCRIPTION
## Description

Summary of changes:
- Make table buttons (Filter, Sort) icon-only on mobile, loosely following [Figma](https://www.figma.com/design/kqZiUPjXvqSvJVslJCnlTB/OP-HMIS-%2F-Tickets-%2F-Figma?node-id=8200-20140&t=7dg7OVG3rYhQkdST-0). This is to prevent the table toolbar from becoming scrollable on small screens.
- Fix mobile menu navigability on tiny screens. The scrollable area for dashboard nav (Project, Enrollment, etc.) was completely cut off for small screen heights.
  - I tested this using Chrome devtools mimicking an iPhone 4, so 320px by 480px, because I read online that many designers consider that the smallest screen size to sanely design for.
  - We should make more improvements here, but I held off since design has an open ticket: https://github.com/open-path/Green-River/issues/6475

## Type of change
[//]: # 'remove options that are not relevant'
Mobile improvements

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
