### PR TITLE
Follow up on QA items from Join/Split

### DIFF
--- a/src/components/elements/CommonMenuButton.tsx
+++ b/src/components/elements/CommonMenuButton.tsx
@@ -133,7 +133,6 @@ const CommonMenuButton = ({
             if (divider) return <Divider key={key} />;
 
             const props = {
-              key,
               'aria-label': ariaLabel,
               disabled,
             };
@@ -166,6 +165,7 @@ const CommonMenuButton = ({
             if (to) {
               return (
                 <MenuItem
+                  key={key}
                   {...props}
                   component={RouterLink}
                   to={to}
@@ -179,6 +179,7 @@ const CommonMenuButton = ({
 
             return (
               <MenuItem
+                key={key}
                 {...props}
                 onClick={() => {
                   if (onClick) {

--- a/src/components/elements/table/hooks/useTableSelection.tsx
+++ b/src/components/elements/table/hooks/useTableSelection.tsx
@@ -18,8 +18,9 @@ export function useTableSelection<T extends { id: string }>({
   const [selectedState, setSelectedState] = useState<string[]>();
 
   // Table row selection can be either controlled or uncontrolled:
-  // - controlled: `selectedCtrl` and `onChangeSelectedCtrl` props passed from parent
-  // - uncontrolled: managed internally in `selectedState`
+  // - controlled: `selectedControlled` and `onChangeSelected` props passed from parent
+  // - uncontrolled: managed internally in `selectedState`,
+  // (but we still call `onChangeSelected` so the caller can "listen in" on what rows are selected)
   const isSelectControlled = selectedControlled !== undefined;
 
   const selected = useMemo(
@@ -62,6 +63,13 @@ export function useTableSelection<T extends { id: string }>({
 
   // Clear selection when data changes
   useEffect(() => setSelectedState([]), [rows]);
+
+  // Call onChangeSelected callback if selection changes.
+  // (Usually we call onChangeSelected directly when changing the value, but
+  // it doesn't work for the useEffect above, so we still need this effect too)
+  useEffect(() => {
+    if (selected) onChangeSelected?.(selected);
+  }, [selected, onChangeSelected]);
 
   return {
     selected,

--- a/src/components/elements/table/hooks/useTableSelection.tsx
+++ b/src/components/elements/table/hooks/useTableSelection.tsx
@@ -62,14 +62,10 @@ export function useTableSelection<T extends { id: string }>({
   );
 
   // Clear selection when data changes
-  useEffect(() => setSelectedState([]), [rows]);
-
-  // Call onChangeSelected callback if selection changes.
-  // (Usually we call onChangeSelected directly when changing the value, but
-  // it doesn't work for the useEffect above, so we still need this effect too)
   useEffect(() => {
-    if (selected) onChangeSelected?.(selected);
-  }, [selected, onChangeSelected]);
+    setSelectedState([]);
+    onChangeSelected?.([]);
+  }, [onChangeSelected, rows]);
 
   return {
     selected,

--- a/src/modules/bulkServices/components/BulkServicesPage.tsx
+++ b/src/modules/bulkServices/components/BulkServicesPage.tsx
@@ -150,9 +150,13 @@ const BulkServicesPage: React.FC<Props> = ({
                 <ServiceTypeSelect
                   projectId={project.id}
                   value={serviceTypeId ? { code: serviceTypeId } : null}
-                  onChange={(option) =>
-                    setFilterParams({ serviceTypeId: option?.code })
-                  }
+                  onChange={(option) => {
+                    // ServiceTypeSelect's internal effect causes `onChange` to be called even when option value is not changing.
+                    // To avoid unneeded rerenders, only setFilterParams if the value is changing
+                    if (option?.code !== serviceTypeId) {
+                      setFilterParams({ serviceTypeId: option?.code });
+                    }
+                  }}
                   label='Service Type'
                   bulk
                 />

--- a/src/modules/bulkServices/components/BulkServicesTable.tsx
+++ b/src/modules/bulkServices/components/BulkServicesTable.tsx
@@ -173,6 +173,11 @@ const BulkServicesTable: React.FC<Props> = ({
     };
   }, [projectId, servicePeriod, serviceTypeId]);
 
+  const handleSelectedRowsChange = useCallback(
+    (rows: readonly string[]) => setAnyRowsSelected(rows.length > 0),
+    []
+  );
+
   return (
     <SsnDobShowContextProvider>
       <GenericTableWithData<
@@ -190,7 +195,7 @@ const BulkServicesTable: React.FC<Props> = ({
         }}
         loadingVariant='linear'
         selectable='checkbox'
-        onChangeSelectedRowIds={(rows) => setAnyRowsSelected(rows.length > 0)}
+        onChangeSelectedRowIds={handleSelectedRowsChange}
         queryDocument={BulkServicesClientSearchDocument}
         pagePath='clientSearch'
         getColumnDefs={getColumnDefs}

--- a/src/modules/household/components/householdActions/ConflictingEnrollmentAlert.tsx
+++ b/src/modules/household/components/householdActions/ConflictingEnrollmentAlert.tsx
@@ -59,8 +59,7 @@ const ConflictingEnrollmentAlert = ({
               You have two options:
               <List sx={{ listStyle: 'decimal', pl: 4 }} component='ol'>
                 <ListItem sx={{ display: 'list-item' }}>
-                  The conflicting enrollment can be joined with {hohName}’s
-                  household.
+                  Join the conflicting enrollment with {hohName}’s household.
                 </ListItem>
                 <ListItem sx={{ display: 'list-item' }}>
                   To retain the conflicting enrollment, update the entry and/or

--- a/src/modules/household/components/householdActions/JoinHouseholdDialog.tsx
+++ b/src/modules/household/components/householdActions/JoinHouseholdDialog.tsx
@@ -172,7 +172,7 @@ const JoinHouseholdDialog = ({
           >
             <Typography variant='body1'>
               Update joining clients’ relationships{' '}
-              {receivingHohName && <>to {receivingHohName}</>}
+              {receivingHohName && <>to {receivingHohName}</>}.
             </Typography>
           </AddRelationshipsStep>
         ),
@@ -205,7 +205,7 @@ const JoinHouseholdDialog = ({
         content: (
           <SuccessWayfindingStep
             title={'Successful Join'}
-            description={`${stringifyHousehold(joiningClients)} ${joiningClients.length > 1 ? 'have' : 'has'} been successfully joined to ${receivingHohName}’s Enrollment at ${project.projectName}`}
+            description={`${stringifyHousehold(joiningClients)} ${joiningClients.length > 1 ? 'have' : 'has'} been successfully joined to ${receivingHohName}’s Enrollment at ${project.projectName}.`}
             primaryClientName={receivingHohName}
             secondary={findHohOrRep(remainingHousehold?.householdClients || [])}
             project={project}

--- a/src/modules/household/components/householdActions/JoinHouseholdReview.tsx
+++ b/src/modules/household/components/householdActions/JoinHouseholdReview.tsx
@@ -61,14 +61,14 @@ const JoinHouseholdReview = ({
       reviewableHouseholds={[
         {
           title: 'Joining Household',
-          description: `The household that ${joining} will join`,
+          description: `The household that ${joining} will join.`,
           members: joinedHouseholdClients,
         },
         ...(remainingHouseholdClients
           ? [
               {
                 title: 'Remaining Household',
-                description: `The household that ${joining} will leave`,
+                description: `The household that ${joining} will leave.`,
                 members: remainingHouseholdClients,
               },
             ]
@@ -78,7 +78,7 @@ const JoinHouseholdReview = ({
       <Typography variant='body1'>
         Check that the joined{' '}
         {remainingHouseholdClients.length > 0 && 'and remaining '}household
-        members and details are correct
+        members and details are correct.
       </Typography>
     </ReviewHouseholdsStep>
   );

--- a/src/modules/household/components/householdActions/SplitHouseholdAddRelationships.tsx
+++ b/src/modules/household/components/householdActions/SplitHouseholdAddRelationships.tsx
@@ -48,7 +48,7 @@ const SplitHouseholdAddRelationships = ({
       updateRelationship={updateRelationship}
     >
       <Typography variant='body1'>
-        Select a new head of household and update all relationships
+        Select a new head of household and update all relationships.
       </Typography>
       {showHohAlert && (
         <Alert severity='warning'>

--- a/src/modules/household/components/householdActions/SplitHouseholdReview.tsx
+++ b/src/modules/household/components/householdActions/SplitHouseholdReview.tsx
@@ -50,19 +50,19 @@ const SplitHouseholdReview = ({
       reviewableHouseholds={[
         {
           title: 'Remaining Household',
-          description: `The household that ${splitSummary} will leave`,
+          description: `The household that ${splitSummary} will leave.`,
           members: remaining,
         },
         {
           title: 'Split Household',
-          description: `New household that ${splitSummary} will form`,
+          description: `New household that ${splitSummary} will form.`,
           members: splittingClients,
         },
       ]}
     >
       <Typography variant='body1'>
         Check that the remaining and split household members and details are
-        correct
+        correct.
       </Typography>
     </ReviewHouseholdsStep>
   );

--- a/src/modules/household/components/householdActions/SplitHouseholdSuccess.tsx
+++ b/src/modules/household/components/householdActions/SplitHouseholdSuccess.tsx
@@ -41,7 +41,7 @@ const SplitHouseholdSuccess = ({
   return (
     <SuccessWayfindingStep
       title={'Successful Split'}
-      description={`${stringifyHousehold(splitHousehold.householdClients)} ${splitHousehold.householdClients.length > 1 ? 'have' : 'has'} been successfully split from ${donorHohName}’s Enrollment at ${project.projectName}`}
+      description={`${stringifyHousehold(splitHousehold.householdClients)} ${splitHousehold.householdClients.length > 1 ? 'have' : 'has'} been successfully split from ${donorHohName}’s Enrollment at ${project.projectName}.`}
       primaryClientName={donorHohName}
       secondary={splitHoh}
       project={project}


### PR DESCRIPTION
## Description

Summary of changes:
- Move `key` out of spread `props` object to avoid console warning
- Fix bug with table selection refactor that impacted Bulk Services
- Avoid unneeded renders caused by `useEffect` in Bulk Services - this is unrelated to join/split, but something I found and fixed while debugging the above
- Lightly edit the language of the workflow instructions (active voice, full stops) per our new [guidelines](https://www.figma.com/design/bsw8CX4UOq6SIdXYorZDWV/OP-HMIS-%2F-Library-%2F-Design?node-id=2680-15812&p=f&t=ectRlT2RZjCxm4L9-0) ✨ 

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
