### PR TITLE
Revert overflow: scroll on table toolbar

### DIFF
--- a/src/components/elements/tableFilters/TableFilters.tsx
+++ b/src/components/elements/tableFilters/TableFilters.tsx
@@ -64,7 +64,7 @@ const TableFilters = <T, S extends Record<string, string>>({
   optionalColumns,
 }: TableFiltersProps<T, S>) => {
   return (
-    <Box sx={{ overflow: 'scroll' }} display='flex' alignItems='center' gap={1}>
+    <Box display='flex' alignItems='center' gap={1}>
       <Stack flexGrow={1} direction='row' gap={6} alignItems='center'>
         {loading ? (
           <Skeleton variant='text'>


### PR DESCRIPTION
## Description

Reverts [this change](https://github.com/greenriver/hmis-frontend/pull/1053/files#diff-8cd0a796588e47a533162d456703d9c29d2e06258360adf4c7d99fe5ba169beaR67) to prevent this visual bug:
![image](https://github.com/user-attachments/assets/7efd46e2-7845-4177-8503-df645e0d2f79)

This means https://github.com/open-path/Green-River/issues/7220 will now present on prod, which we have deemed an acceptable tradeoff until https://github.com/greenriver/hmis-frontend/pull/1054 is merged

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
