### PR TITLE
Fix color bug on disabled ButtonLink

### DIFF
--- a/src/components/elements/Button.stories.tsx
+++ b/src/components/elements/Button.stories.tsx
@@ -71,3 +71,11 @@ export const AllVariants: Story = {
   },
   render: (props) => <ButtonMatrix {...props} />,
 };
+
+export const AllVariantsDisabled: Story = {
+  args: {
+    children: 'Action',
+    startIcon: <CheckIcon />,
+  },
+  render: (props) => <ButtonMatrix disabled {...props} />,
+};

--- a/src/components/elements/ButtonLink.stories.tsx
+++ b/src/components/elements/ButtonLink.stories.tsx
@@ -1,5 +1,6 @@
+import { Stack } from '@mui/material';
 import { Meta, StoryObj } from '@storybook/react';
-import ButtonLink from './ButtonLink';
+import ButtonLink, { ButtonLinkProps } from './ButtonLink';
 
 export default {
   component: ButtonLink,
@@ -7,9 +8,54 @@ export default {
 
 type Story = StoryObj<typeof ButtonLink>;
 
+const ButtonLinkMatrix: React.FC<ButtonLinkProps> = (props) => (
+  <Stack gap={2} direction='row'>
+    {(
+      [
+        'grayscale',
+        'primary',
+        'error',
+        'warning',
+        // Note: secondary, info, and success button colors exist in MUI but are not part of HMIS design language.
+      ] as ButtonLinkProps['color'][]
+    ).map((color, idx) => (
+      <Stack gap={2} alignItems='center' key={color}>
+        <Stack direction='row' gap={1}>
+          {idx === 0 && <span style={{ width: '100px' }}></span>}
+          <span style={{ width: '100px' }}>{color}</span>
+        </Stack>
+        {(
+          ['contained', 'outlined', 'text'] as ButtonLinkProps['variant'][]
+        ).map((variant) => (
+          <Stack direction='row' gap={1} key={variant}>
+            {idx === 0 && <span style={{ width: '100px' }}>{variant}</span>}
+            <ButtonLink {...props} color={color} variant={variant} />
+          </Stack>
+        ))}
+      </Stack>
+    ))}
+  </Stack>
+);
+
 export const Default: Story = {
   args: {
     to: '/',
-    children: 'This is a button link',
+    children: 'Link Text',
   },
+};
+
+export const AllVariants: Story = {
+  args: {
+    to: '/',
+    children: 'Link Text',
+  },
+  render: (props) => <ButtonLinkMatrix {...props} />,
+};
+
+export const AllVariantsDisabled: Story = {
+  args: {
+    to: '/',
+    children: 'Link Text',
+  },
+  render: (props) => <ButtonLinkMatrix disabled {...props} />,
 };

--- a/src/components/elements/ButtonLink.tsx
+++ b/src/components/elements/ButtonLink.tsx
@@ -3,13 +3,19 @@ import { Button, ButtonProps } from '@mui/material';
 import { forwardRef, Ref } from 'react';
 import { Link, LinkProps } from 'react-router-dom';
 
-export type ButtonLinkProps = Omit<ButtonProps, 'href' | `on${string}`> &
+export type ButtonLinkProps = Omit<
+  ButtonProps,
+  'href' | `on${string}` | 'component' | 'role' | 'ref'
+> &
   LinkProps & {
     leftAlign?: boolean;
     Icon?: SvgIconComponent;
     openInNew?: boolean;
   };
 
+/**
+ * A `ButtonLink` is a React-Router link that looks like a button. The underlying interactive element is an `a` tag.
+ */
 const ButtonLink = forwardRef<HTMLAnchorElement, ButtonLinkProps>(
   function ButtonLink(
     { sx, leftAlign, Icon, openInNew, ...props },

--- a/src/config/theme.ts
+++ b/src/config/theme.ts
@@ -525,7 +525,7 @@ const createThemeOptions = (theme: Theme) => ({
           props: { color: 'grayscale' },
           style: theme.unstable_sx({
             color: 'text.primary',
-            '&:not(:disabled) .MuiButton-icon': {
+            '&:not(:disabled, .Mui-disabled) .MuiButton-icon': {
               color: 'grayscale.main',
             },
             '&.MuiButton-contained': {
@@ -550,18 +550,21 @@ const createThemeOptions = (theme: Theme) => ({
             backgroundColor: 'grayscale.200',
           },
           // Contained Warning and Primary use 'light' for bg instead of usual 'main'
-          '&.MuiButton-contained.MuiButton-colorWarning:not(:disabled)': {
-            backgroundColor: 'warning.light',
-            '&:hover': { backgroundColor: 'warning.main' },
-          },
-          '&.MuiButton-contained.MuiButton-colorError:not(:disabled)': {
-            backgroundColor: 'error.light',
-            '&:hover': { backgroundColor: 'error.main' },
-          },
-          '&.MuiButton-contained.MuiButton-colorSuccess:not(:disabled)': {
-            backgroundColor: 'success.light',
-            '&:hover': { backgroundColor: 'success.main' },
-          },
+          '&.MuiButton-contained.MuiButton-colorWarning:not(:disabled, .Mui-disabled)':
+            {
+              backgroundColor: 'warning.light',
+              '&:hover': { backgroundColor: 'warning.main' },
+            },
+          '&.MuiButton-contained.MuiButton-colorError:not(:disabled, .Mui-disabled)':
+            {
+              backgroundColor: 'error.light',
+              '&:hover': { backgroundColor: 'error.main' },
+            },
+          '&.MuiButton-contained.MuiButton-colorSuccess:not(:disabled, .Mui-disabled)':
+            {
+              backgroundColor: 'success.light',
+              '&:hover': { backgroundColor: 'success.main' },
+            },
           // Overrides to make all `text buttons use 12% opacity instead of 4%
           '&.MuiButton-text.MuiButton-colorPrimary:hover': {
             backgroundColor: 'primary.200',
@@ -579,31 +582,39 @@ const createThemeOptions = (theme: Theme) => ({
             backgroundColor: 'success.200',
           },
           // Overrides to make all `outlined` buttons use dark text
-          '&.MuiButton-outlined.MuiButton-colorPrimary:not(:disabled)': {
-            color: 'primary.dark',
-          },
-          '&.MuiButton-outlined.MuiButton-colorWarning:not(:disabled)': {
-            color: 'warning.dark',
-          },
-          '&.MuiButton-outlined.MuiButton-colorError:not(:disabled)': {
-            color: 'error.dark',
-          },
-          '&.MuiButton-outlined.MuiButton-colorSuccess:not(:disabled)': {
-            color: 'success.dark',
-          },
+          '&.MuiButton-outlined.MuiButton-colorPrimary:not(:disabled, .Mui-disabled)':
+            {
+              color: 'primary.dark',
+            },
+          '&.MuiButton-outlined.MuiButton-colorWarning:not(:disabled, .Mui-disabled)':
+            {
+              color: 'warning.dark',
+            },
+          '&.MuiButton-outlined.MuiButton-colorError:not(:disabled, .Mui-disabled)':
+            {
+              color: 'error.dark',
+            },
+          '&.MuiButton-outlined.MuiButton-colorSuccess:not(:disabled, .Mui-disabled)':
+            {
+              color: 'success.dark',
+            },
           // Overrides to make all `text` buttons use dark text
-          '&.MuiButton-text.MuiButton-colorPrimary:not(:disabled)': {
-            color: 'primary.dark',
-          },
-          '&.MuiButton-text.MuiButton-colorWarning:not(:disabled)': {
-            color: 'warning.dark',
-          },
-          '&.MuiButton-text.MuiButton-colorError:not(:disabled)': {
-            color: 'error.dark',
-          },
-          '&.MuiButton-text.MuiButton-colorSuccess:not(:disabled)': {
-            color: 'success.dark',
-          },
+          '&.MuiButton-text.MuiButton-colorPrimary:not(:disabled, .Mui-disabled)':
+            {
+              color: 'primary.dark',
+            },
+          '&.MuiButton-text.MuiButton-colorWarning:not(:disabled, .Mui-disabled)':
+            {
+              color: 'warning.dark',
+            },
+          '&.MuiButton-text.MuiButton-colorError:not(:disabled, .Mui-disabled)':
+            {
+              color: 'error.dark',
+            },
+          '&.MuiButton-text.MuiButton-colorSuccess:not(:disabled, .Mui-disabled)':
+            {
+              color: 'success.dark',
+            },
           // Overrides to make all `outlined` buttons use 12% opacity instead of 4%
           '&.MuiButton-outlined.MuiButton-colorPrimary:hover': {
             backgroundColor: 'primary.200',


### PR DESCRIPTION
## Description

- Fix but where disabled `ButtonLink` element would show colored text. Fix was changing selectors `:not(:disabled)` to `:not(:disabled, .Mui-disabled)`
- Add `ButtonLink` stories including button matrix

follow-up to https://github.com/greenriver/hmis-frontend/pull/1007

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
