### PR TITLE
Allow nav item to specify active paths

### DIFF
--- a/src/components/layout/dashboard/sideNav/types.ts
+++ b/src/components/layout/dashboard/sideNav/types.ts
@@ -4,8 +4,9 @@ export interface NavItem<T> {
   icon?: React.ReactElement;
   items?: NavItem<T>[];
   href?: string;
-  path?: string;
-  pathParams?: Record<string, string>;
+  path?: string; // path that this nav item links to
+  pathParams?: Record<string, string>; // params to use for linking to path
+  activePaths?: string[]; // additional paths that this nav item should be active for
   type?: 'topic' | 'category' | 'section';
   hide?: boolean;
   permissions?: (keyof Omit<T, 'id' | '__typename'>)[];

--- a/src/components/layout/dashboard/sideNav/useItemSelectionStatus.tsx
+++ b/src/components/layout/dashboard/sideNav/useItemSelectionStatus.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
 
 import { NavItem } from './types';
+import useCurrentPath from '@/hooks/useCurrentPath';
 
 export type Options<T> = {
   item: NavItem<T>;
@@ -10,13 +11,23 @@ export type Options<T> = {
 export const useItemSelectionStatus = <T extends object>({
   item,
 }: Options<T>) => {
-  const { pathname } = useLocation();
+  const { pathname: currentLocation } = useLocation(); // /projects/1/foo
+  const currentPath = useCurrentPath(); // /projects/:id/foo
 
   const isSelected = useMemo(() => {
-    if (!item.path) return false;
+    if (!item.path && !item.activePaths) return false;
+    // If current location starts with item path, then this nav item should be selected.
+    // (e.g. item path is /enrollments/1/services and current location is /enrollments/1/services/2)
+    if (item.path && currentLocation.startsWith(item.path)) {
+      return true;
+    }
 
-    return item.path && pathname.startsWith(item.path);
-  }, [pathname, item]);
+    // If current route is listed in this item's activePaths, then this nav item should be selected.
+    if (item.activePaths && item.activePaths.some((p) => p === currentPath)) {
+      return true;
+    }
+    return false;
+  }, [item.path, item.activePaths, currentLocation, currentPath]);
 
   const childItems = useMemo(() => {
     if (!item.items) return [];

--- a/src/modules/projects/hooks/useProjectDashboardNavItems.tsx
+++ b/src/modules/projects/hooks/useProjectDashboardNavItems.tsx
@@ -33,6 +33,7 @@ export const useProjectDashboardNavItems = (
             title: 'Enrollments',
             path: ProjectDashboardRoutes.PROJECT_ENROLLMENTS,
             hide: !project.access.canViewEnrollmentDetails,
+            activePaths: [ProjectDashboardRoutes.ADD_HOUSEHOLD],
           },
           {
             id: 'assessments',


### PR DESCRIPTION
## Description

Relates to https://github.com/open-path/Green-River/issues/7209 but this is a pre-existing bug.

Repro:
* Go to project
* Click add enrollment
* The "Enrollments" nav item becomes de-selected. It should remain selected, because you are still in that context (as reflected in the breadcrumbs)


This occurs because add-household path is not naturally nested under `projects/x/enrollments`, so added an `activePaths` arr to NavItem to specify which other sub-paths should be considered active.


## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
