### PR TITLE
Fix broken input bg - theme QA fix

### DIFF
--- a/src/config/theme.ts
+++ b/src/config/theme.ts
@@ -312,7 +312,7 @@ const createThemeOptions = (theme: Theme) => ({
     MuiOutlinedInput: {
       styleOverrides: {
         root: {
-          backgroundColor: 'background.paper',
+          backgroundColor: theme.palette.background.paper,
         },
       },
     },


### PR DESCRIPTION
## Description

Revert syntax change from theme Pr that broke input bg color. The abbreviated syntax only works inside an `sx` block (or `theme.unstable_sx` in this case)

<img width="393" alt="Screenshot 2025-02-23 at 4 16 51 PM" src="https://github.com/user-attachments/assets/a2bbb4c8-66d3-4401-aa34-3acc4eb1c93b" />

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
