### PR TITLE
Fix loading flicker on service form

### DIFF
--- a/src/modules/form/components/DynamicForm.tsx
+++ b/src/modules/form/components/DynamicForm.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useCallback, useImperativeHandle } from 'react';
+import { forwardRef, ReactNode, useCallback, useImperativeHandle } from 'react';
 
 import { DefaultValues, FormProvider } from 'react-hook-form';
 import useFormDefinitionHandlers, {
@@ -158,8 +158,12 @@ const DynamicFormWithHandlers = forwardRef<
 // load remote data (picklists) to augment form data (initialValues => defaultValues)
 const DynamicFormEnrichedDataLoader = forwardRef<
   DynamicFormRef,
-  DynamicFormProps & { initialValues?: InitialValues }
->(({ initialValues, ...props }, ref) => {
+  DynamicFormProps & {
+    initialValues?: InitialValues;
+    // Loading element to render while the form is initially loading (due to PickLists being fetched). Named "initial" to distinguish from existing `loading` prop which typically is used to indicate that the form is submitting.
+    initialLoadingElement?: ReactNode;
+  }
+>(({ initialValues, initialLoadingElement, ...props }, ref) => {
   const { defaultValues, loading } = useEnrichedFormData({
     pickListArgs: props.pickListArgs,
     definition: props.definition,
@@ -168,7 +172,7 @@ const DynamicFormEnrichedDataLoader = forwardRef<
     viewOnly: false,
   });
   if (loading || !defaultValues) {
-    return <Loading />;
+    return initialLoadingElement || <Loading />;
   }
   return (
     <DynamicFormWithHandlers

--- a/src/modules/form/hooks/rhf/useEnrichedFormData.tsx
+++ b/src/modules/form/hooks/rhf/useEnrichedFormData.tsx
@@ -6,6 +6,7 @@ import usePreloadPicklists from '@/modules/form/hooks/usePreloadPicklists';
 import { LocalConstants, PickListArgs } from '@/modules/form/types';
 import {
   autofillValues,
+  formHasAnyRemotePicklists,
   getInitialValues,
   getItemMap,
 } from '@/modules/form/util/formUtil';
@@ -35,9 +36,16 @@ export const useEnrichedFormData = <T extends FieldValues>({
   // we also calculate itemMap in useComputedData() which is redundant. Could optimize this by sharing the same state
   const itemMap = useMemo(() => getItemMap(definition), [definition]);
 
+  // If form doesn't have any remote picklists, we can skip the fetch
+  const hasRemotePicklists = useMemo(
+    () => formHasAnyRemotePicklists(itemMap),
+    [itemMap]
+  );
+
   const { data: picklistValues, loading } = usePreloadPicklists({
     definition: definition,
     pickListArgs,
+    skip: !hasRemotePicklists,
   });
 
   const [defaultValues] = useState<DefaultValues<T>>(() => {
@@ -60,9 +68,18 @@ export const useEnrichedFormData = <T extends FieldValues>({
   });
 
   // supplement with data from picklist
-  const [result, setResult] = useState<DefaultValues<T> | undefined>(undefined);
+  const [enrichedDefaultValues, setEnrichedDefaultValues] = useState<
+    DefaultValues<T> | undefined
+  >(undefined);
+
   useEffect(() => {
-    if (loading || result) return;
+    // Form has no remote picklists; nothing to enrich
+    if (!hasRemotePicklists) return;
+    // Remote picklists are loading, wait
+    if (loading) return;
+    // Default values have already been enriched
+    if (!!enrichedDefaultValues) return;
+
     const mutation = cloneDeep(defaultValues);
     Object.values(itemMap || {}).forEach(({ pickListReference, linkId }) => {
       const valueCode = mutation[linkId]?.code || mutation[linkId];
@@ -88,8 +105,18 @@ export const useEnrichedFormData = <T extends FieldValues>({
       }
       if (found) mutation[linkId] = found;
     });
-    setResult(mutation);
-  }, [loading, defaultValues, itemMap, picklistValues, result]);
+    setEnrichedDefaultValues(mutation);
+  }, [
+    loading,
+    defaultValues,
+    itemMap,
+    picklistValues,
+    hasRemotePicklists,
+    enrichedDefaultValues,
+  ]);
 
-  return { defaultValues: result, loading };
+  return {
+    defaultValues: hasRemotePicklists ? enrichedDefaultValues : defaultValues,
+    loading,
+  };
 };

--- a/src/modules/form/hooks/rhf/useEnrichedFormData.tsx
+++ b/src/modules/form/hooks/rhf/useEnrichedFormData.tsx
@@ -80,9 +80,9 @@ export const useEnrichedFormData = <T extends FieldValues>({
     // Default values have already been enriched
     if (!!enrichedDefaultValues) return;
 
-    const mutation = cloneDeep(defaultValues);
+    const clonedValues = cloneDeep(defaultValues);
     Object.values(itemMap || {}).forEach(({ pickListReference, linkId }) => {
-      const valueCode = mutation[linkId]?.code || mutation[linkId];
+      const valueCode = clonedValues[linkId]?.code || clonedValues[linkId];
       // skip unless there's a value and a value code
       if (!valueCode) return;
       if (!pickListReference) return;
@@ -103,9 +103,9 @@ export const useEnrichedFormData = <T extends FieldValues>({
         );
         return;
       }
-      if (found) mutation[linkId] = found;
+      if (found) clonedValues[linkId] = found;
     });
-    setEnrichedDefaultValues(mutation);
+    setEnrichedDefaultValues(clonedValues);
   }, [
     loading,
     defaultValues,

--- a/src/modules/form/hooks/usePreloadPicklists.tsx
+++ b/src/modules/form/hooks/usePreloadPicklists.tsx
@@ -1,15 +1,14 @@
 import { FetchPolicy, QueryOptions, useApolloClient } from '@apollo/client';
-import { compact, isEmpty } from 'lodash-es';
+import { isEmpty } from 'lodash-es';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { ItemMap, PickListArgs } from '../types';
-import { getItemMap } from '../util/formUtil';
+import { getItemMap, itemHasRemotePicklist } from '../util/formUtil';
 
 import {
   FormDefinitionJson,
   GetPickListDocument,
   PickListOptionFieldsFragment,
-  PickListType,
 } from '@/types/gqlTypes';
 
 interface Args {
@@ -37,19 +36,15 @@ const usePreloadPicklists = ({
     [definition]
   );
 
-  const pickListTypesToFetch = useMemo(
-    () =>
-      compact(
-        Object.values(itemMap || {})
-          .map((item) => item.pickListReference)
-          .filter(
-            (reference) =>
-              reference &&
-              Object.values<string>(PickListType).includes(reference)
-          )
-      ),
-    [itemMap]
-  );
+  // Get all `pickListReference` values from the Form Definition
+  const pickListTypesToFetch = useMemo(() => {
+    if (skip) return [];
+
+    const references = Object.values(itemMap)
+      .filter(itemHasRemotePicklist)
+      .map((item) => item.pickListReference);
+    return [...new Set(references)];
+  }, [itemMap, skip]);
 
   const fetch = useCallback(() => {
     if (skip || isEmpty(pickListTypesToFetch)) {
@@ -58,6 +53,7 @@ const usePreloadPicklists = ({
     }
 
     setLoading(true);
+    // Fetch all picklists
     Promise.all(
       pickListTypesToFetch.map((pickListType) =>
         client.query({
@@ -94,7 +90,10 @@ const usePreloadPicklists = ({
 
   return {
     fetch,
-    loading: loading && Object.keys(data).length === 0,
+    loading:
+      loading &&
+      pickListTypesToFetch.length > 0 && // always loading:false if there was no fetch
+      Object.keys(data).length === 0,
     data,
   };
 };

--- a/src/modules/form/util/formUtil.tsx
+++ b/src/modules/form/util/formUtil.tsx
@@ -74,6 +74,7 @@ import {
   Maybe,
   NoYesReasonsForMissingData,
   PickListOption,
+  PickListType,
   RelatedRecordType,
   RelationshipToHoH,
   ValueBound,
@@ -1489,6 +1490,13 @@ export const parseOccurrencePointFormDefinition = (
     isEditable,
   };
 };
+
+export const itemHasRemotePicklist = (item: FormItem): boolean =>
+  !!item.pickListReference &&
+  Object.values<string>(PickListType).includes(item.pickListReference);
+
+export const formHasAnyRemotePicklists = (itemMap: ItemMap): boolean =>
+  Object.values(itemMap).some(itemHasRemotePicklist);
 
 export const getFormStepperItems = (
   formDefinition: FormDefinitionFieldsFragment | undefined | null,

--- a/src/modules/services/hooks/useServiceDialog.tsx
+++ b/src/modules/services/hooks/useServiceDialog.tsx
@@ -184,6 +184,10 @@ export function useServiceDialog({
 
   const renderServiceDialog = (args?: RenderServiceDialogProps) => {
     const { dialogContent, ...props } = args || {};
+
+    const loadingSkeleton = (
+      <Skeleton variant='rectangular' sx={{ height: 60 }} />
+    );
     return (
       <CommonDialog open={!!dialogOpen} fullWidth onClose={closeDialog}>
         <DialogTitle>{service ? 'Update Service' : 'Add Service'}</DialogTitle>
@@ -202,9 +206,7 @@ export function useServiceDialog({
               />
             )}
           </Box>
-          {serviceTypeInfoLoading && (
-            <Skeleton variant='rectangular' sx={{ height: 60 }} />
-          )}
+          {serviceTypeInfoLoading && loadingSkeleton}
           {selectedService && formDefinition && serviceType && (
             <DynamicForm
               key={service?.id || selectedService.code}
@@ -218,6 +220,8 @@ export function useServiceDialog({
               localConstants={hookArgs?.localConstants}
               hideSubmit
               errorRef={errorRef}
+              // Render skeleton while initial picklists load, to prevent flicker to Loading spinner
+              initialLoadingElement={loadingSkeleton}
             />
           )}
         </DialogContent>


### PR DESCRIPTION
## Description

QA fix for issue https://github.com/open-path/Green-River/issues/6043 

Bug repro 1 (no remote pick lists):
- add a new service to an enrollment
- select a custom service that uses a basic form that doesn't have any remote pick lists
- **bug**: you'll see the dialog flicker to a loading spinner state before rendering the form. the spinner is being rendered by DynamicFormEnrichedDataLoader.
- **updated behavior**: loading state does not occur at all, because the form has no pick lists to fetch

Bug repro 2 (yes remote pick lists):
- add a new service to an enrollment
- select a HUD service. the default HUD service form has remote pick lists. (tbh we should remove them and hard-code them since they don't _need_ to be remote, but that's for another day).
- **bug**: you'll see the dialog flicker to a loading spinner state while the pick lists are fetched. the spinner is being rendered by DynamicFormEnrichedDataLoader.
- **updated behavior**: the service dialog passes a `Skeleton` to DynamicFormEnrichedDataLoader to avoid the loading spinner flickering while the pick lists load.


## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
