### PR TITLE
Fix assessment print bug, remove adjustValue

### DIFF
--- a/src/modules/assessments/components/AssessmentForm.tsx
+++ b/src/modules/assessments/components/AssessmentForm.tsx
@@ -243,7 +243,8 @@ const AssessmentForm: React.FC<Props> = ({
     [enrollment]
   );
 
-  // Manually preload picklists here so we can prevent printing until they're fetched
+  // Manually preload picklists here so we can prevent printing until they're fetched.
+  // usePreloadPicklists will be invoked again by DynamicViewEnrichmentLoader, but it will just hit the cache.
   const { loading: pickListsLoading } = usePreloadPicklists({
     definition: definition.definition,
     pickListArgs,

--- a/src/modules/form/components/DynamicFormField.tsx
+++ b/src/modules/form/components/DynamicFormField.tsx
@@ -94,8 +94,6 @@ const DynamicFormField: React.FC<Props> = ({
                 disabled={isDisabled}
                 horizontal={horizontal}
                 pickListArgs={pickListArgs}
-                // Needed because there are some enable/disabled and autofill dependencies that depend on PickListOption.labels that are fetched (PriorLivingSituation is an example)
-                adjustValue={itemChanged}
                 // Needed to support referencing local constants in expression evaluation (DynamicDisplay)
                 localConstants={localConstants}
                 {...fieldProps}

--- a/src/modules/form/components/viewable/DynamicView.tsx
+++ b/src/modules/form/components/viewable/DynamicView.tsx
@@ -13,7 +13,6 @@ import { FormDefinitionJson } from '@/types/gqlTypes';
 export interface DynamicViewProps {
   definition: FormDefinitionJson;
   horizontal?: boolean;
-  pickListArgs?: PickListArgs;
   visible?: boolean;
   GridProps?: GridProps;
   localConstants?: LocalConstants;
@@ -25,7 +24,6 @@ const DynamicView: React.FC<
   definition,
   horizontal = false,
   visible = true,
-  pickListArgs,
   localConstants = {},
   GridProps,
   defaultValues,
@@ -64,7 +62,6 @@ const DynamicView: React.FC<
         >
           <DynamicViewFields
             horizontal={horizontal}
-            pickListArgs={pickListArgs}
             visible={visible}
             handlers={handlers}
           />
@@ -75,7 +72,10 @@ const DynamicView: React.FC<
 };
 
 const DynamicViewEnrichmentLoader: React.FC<
-  DynamicViewProps & { values: Record<string, any> }
+  DynamicViewProps & {
+    values: Record<string, any>;
+    pickListArgs?: PickListArgs;
+  }
 > = (props): JSX.Element => {
   const { defaultValues, loading } = useEnrichedFormData({
     pickListArgs: props.pickListArgs,

--- a/src/modules/form/components/viewable/DynamicViewField.tsx
+++ b/src/modules/form/components/viewable/DynamicViewField.tsx
@@ -1,9 +1,8 @@
-import { Card, Divider, Skeleton, Stack, Typography } from '@mui/material';
+import { Card, Divider, Stack, Typography } from '@mui/material';
 import { formatDuration } from 'date-fns';
 import { isNil } from 'lodash-es';
 import React, { useMemo } from 'react';
 
-import { getValueFromPickListData, usePickList } from '../../hooks/usePickList';
 import { DynamicViewFieldProps } from '../../types';
 import { isDataNotCollected } from '../../util/formUtil';
 import DynamicDisplay from '../DynamicDisplay';
@@ -60,31 +59,12 @@ const DynamicViewField: React.FC<DynamicViewFieldProps> = ({
   item,
   value,
   horizontal = false,
-  pickListArgs,
   noLabel = false,
-  adjustValue = () => {},
   disabled = false,
   localConstants,
 }) => {
   const label = noLabel ? null : getLabel(item, horizontal);
 
-  const { loading: pickListLoading } = usePickList({
-    item,
-    ...pickListArgs,
-    fetchOptions: {
-      onCompleted: (data) => {
-        const newValue = getValueFromPickListData({
-          item,
-          value,
-          linkId: item.linkId,
-          data,
-          setInitial: false,
-        });
-        // If this is already cached this will call setState within a render, which is an error; So use timeout to push the setter call to the next render cycle
-        if (newValue) setTimeout(() => adjustValue(newValue));
-      },
-    },
-  });
   const commonProps = useMemo(
     () => ({
       label,
@@ -189,17 +169,13 @@ const DynamicViewField: React.FC<DynamicViewFieldProps> = ({
       return (
         <TextContent
           {...commonProps}
-          renderValue={(value) => {
-            if (pickListLoading) return <Skeleton width={200} />;
-
-            return (
-              <Typography variant='body2'>
-                {ensureArray(value)
-                  .map((val) => val.label || val.code)
-                  .join(', ')}
-              </Typography>
-            );
-          }}
+          renderValue={(value) => (
+            <Typography variant='body2'>
+              {ensureArray(value)
+                .map((val) => val.label || val.code)
+                .join(', ')}
+            </Typography>
+          )}
         />
       );
     case ItemType.Image:

--- a/src/modules/form/components/viewable/DynamicViewFields.tsx
+++ b/src/modules/form/components/viewable/DynamicViewFields.tsx
@@ -1,11 +1,9 @@
 import { Grid } from '@mui/material';
-import React, { ReactNode, useCallback } from 'react';
+import React, { ReactNode } from 'react';
 
 import { FormDefinitionHandlers } from '../../hooks/useFormDefinitionHandlers';
 import {
-  ChangeType,
   FormValues,
-  ItemChangedFn,
   LocalConstants,
   OverrideableDynamicFieldProps,
   PickListArgs,
@@ -19,7 +17,6 @@ import { FormItem, ItemType } from '@/types/gqlTypes';
 export interface Props {
   horizontal?: boolean;
   visible?: boolean;
-  pickListArgs?: PickListArgs;
   handlers: FormDefinitionHandlers;
   nestingLevel: number;
   item: FormItem;
@@ -27,12 +24,10 @@ export interface Props {
   renderFn?: (children: ReactNode) => ReactNode;
   localConstants?: LocalConstants;
   values: FormValues;
-  itemChanged: ItemChangedFn;
 }
 
 const DynamicViewFormField: React.FC<Props> = ({
   horizontal = false,
-  pickListArgs,
   handlers,
   item,
   nestingLevel,
@@ -40,7 +35,6 @@ const DynamicViewFormField: React.FC<Props> = ({
   renderFn,
   localConstants,
   values,
-  itemChanged,
   ...fieldsProps
 }) => {
   // Recursively render an item
@@ -60,7 +54,6 @@ const DynamicViewFormField: React.FC<Props> = ({
               props={props}
               renderFn={fn}
               values={values}
-              itemChanged={itemChanged}
             />
           )}
           values={values}
@@ -78,10 +71,7 @@ const DynamicViewFormField: React.FC<Props> = ({
               value={values[item.linkId]}
               disabled={isDisabled}
               horizontal={horizontal}
-              pickListArgs={pickListArgs}
               localConstants={localConstants}
-              // Needed because there are some enable/disabled and autofill dependencies that depend on PickListOption.labels that are fetched (PriorLivingSituation is an example)
-              adjustValue={itemChanged}
               {...fieldProps}
             />
           )}
@@ -113,21 +103,6 @@ const DynamicViewFields: React.FC<DynamicViewFieldsProps> = ({
   const definition = handlers.definition;
   const values = handlers.methods.getValues();
 
-  const itemChanged: ItemChangedFn = useCallback(
-    ({ linkId, value: baseValue, type }) => {
-      const item = handlers.itemMap[linkId];
-      let value = baseValue;
-      if (item) {
-        if (item.type === ItemType.Integer) value = parseInt(value) || 0;
-        if (item.type === ItemType.Currency) value = parseFloat(value) || 0;
-      }
-      handlers.methods.setValue(linkId, value, {
-        shouldDirty: type === ChangeType.User,
-      });
-    },
-    [handlers]
-  );
-
   return (
     <>
       {definition.item.map((item) => (
@@ -137,7 +112,6 @@ const DynamicViewFields: React.FC<DynamicViewFieldsProps> = ({
           nestingLevel={0}
           item={item}
           values={values}
-          itemChanged={itemChanged}
           {...props}
         />
       ))}

--- a/src/modules/form/types.ts
+++ b/src/modules/form/types.ts
@@ -65,9 +65,7 @@ export interface DynamicViewFieldProps {
   item: FormItem;
   value: any;
   horizontal?: boolean;
-  pickListArgs?: PickListArgs;
   noLabel?: boolean;
-  adjustValue?: ItemChangedFn;
   disabled?: boolean;
   localConstants?: LocalConstants;
 }


### PR DESCRIPTION
## Description

QA fix for issue https://github.com/open-path/Green-River/issues/6043 

Bug repro: try to print a HUD intake assessment. Fields with remote pick lists don't appear, because DynamicViewField is fetching them and displaying a loading indicator.

Changes:
* Now that we have `useEnrichedFormData`, the pick list data is all loaded upfront. So we can rip out the code from DynamicViewField that re-fetches them.
* Remove  `adjustValue` (yay!!!) as it was **only** used for setting enriched pick list values.


<img width="600" alt="Screenshot 2025-02-25 at 12 17 26 PM" src="https://github.com/user-attachments/assets/263f80c0-3da0-4a1f-818e-4d9407453953" />


Things tested:
- [x] all system tests pass
- [x] readonly autofill still works (inventory bed count example)

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
