### PR TITLE
More followups on link color

### DIFF
--- a/src/components/elements/ExternalIdDisplay.tsx
+++ b/src/components/elements/ExternalIdDisplay.tsx
@@ -60,7 +60,7 @@ export const externalIdColumn = (
   ) => {
     const client = isHouseholdClient(record) ? record.client : record;
     return (
-      <Stack gap={0.8}>
+      <Stack gap={0.8} sx={{ width: 'fit-content' }}>
         {filter(client.externalIds, { type }).map((val) => (
           <ExternalIdDisplay key={val?.identifier} value={val} {...props} />
         ))}

--- a/src/components/elements/ExternalLink.tsx
+++ b/src/components/elements/ExternalLink.tsx
@@ -7,7 +7,12 @@ const ExternalLink: React.FC<LinkProps> = ({ children, ...props }) => {
     <Link target='_blank' {...props}>
       <Typography
         variant='inherit'
-        sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.75 }}
+        sx={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 0.75,
+          textDecoration: 'inherit',
+        }}
       >
         {children} <OpenInNewIcon fontSize='inherit' />
       </Typography>

--- a/src/config/theme.ts
+++ b/src/config/theme.ts
@@ -320,7 +320,6 @@ const createThemeOptions = (theme: Theme) => ({
       styleOverrides: {
         root: theme.unstable_sx({
           color: 'primary.dark',
-          textDecorationColor: 'primary.dark',
           textUnderlineOffset: '0.2rem',
           cursor: 'pointer',
           '&.Mui-focusVisible': {

--- a/src/modules/enrollment/components/EnrollmentReminders.tsx
+++ b/src/modules/enrollment/components/EnrollmentReminders.tsx
@@ -1,5 +1,5 @@
 import TaskAltIcon from '@mui/icons-material/TaskAlt';
-import { Box, Stack, Typography } from '@mui/material';
+import { Box, Link, Stack, Typography } from '@mui/material';
 import { isToday } from 'date-fns';
 import { lowerCase, sortBy } from 'lodash-es';
 import { useMemo } from 'react';
@@ -88,16 +88,8 @@ const generateColumns = (
     render: (reminder: ReminderFieldsFragment) => {
       return (
         <Stack gap={0.4}>
-          <Typography
-            variant='inherit'
-            sx={{
-              color: 'primary.dark',
-              textDecoration: 'underline',
-              textDecorationColor: 'primary.dark',
-            }}
-          >
-            {reminderTitle(reminder)}
-          </Typography>
+          {/* style reminder as a link, even though it's not (the row is clickable) */}
+          <Link component='span'>{reminderTitle(reminder)}</Link>
           <Typography color='text.secondary' variant='inherit'>
             {reminderDesciption(reminder, currentClientId)}
           </Typography>

--- a/src/modules/form/components/FormStepper.tsx
+++ b/src/modules/form/components/FormStepper.tsx
@@ -1,5 +1,5 @@
 import RadioButtonUncheckedIcon from '@mui/icons-material/RadioButtonUnchecked';
-import { Step, StepButton, StepLabel, Stepper } from '@mui/material';
+import { Link, Step, StepButton, StepLabel, Stepper } from '@mui/material';
 import { useCallback, useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
 
@@ -62,14 +62,10 @@ const FormStepper = ({ items, useUrlHash, scrollOffset }: Props) => {
                 sx={{
                   '.MuiStepLabel-root': { py: 0 },
                   '.MuiStepLabel-iconContainer': { display: 'none' },
-                  '.MuiStepLabel-label': {
-                    color: '#1976d2',
-                    textDecoration: 'underline',
-                    textDecorationColor: 'rgba(25, 118, 210, 0.4)',
-                  },
                 }}
               >
-                {step.label}
+                {/* style button as link */}
+                <Link component='span'>{step.label}</Link>
               </StepButton>
             )}
           </StepLabel>

--- a/src/modules/form/components/client/RepeatedInputContainer.tsx
+++ b/src/modules/form/components/client/RepeatedInputContainer.tsx
@@ -77,9 +77,7 @@ const RepeatedInputContainer = <T extends object>({
                     variant='text'
                     disabled={!removeAt(val, idx)}
                     sx={{
-                      color: 'error.dark',
                       width: 'fit-content',
-                      textDecoration: 'underline',
                       py: 0,
                       ml: -1,
                       fontSize: 'inherit',


### PR DESCRIPTION
## Description

a few more qa followups for https://github.com/open-path/Green-River/issues/7108:
* old link color was still used on form stepper, fix
* fix missing text decoration for external links (incl MCI ID)
* fix mismatched text decoration color on Enrollment Reminders and some other places

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
