### PR TITLE
Fix app color contrast issues

### DIFF
--- a/.storybook/test-runner.ts
+++ b/.storybook/test-runner.ts
@@ -14,11 +14,6 @@ const config: TestRunnerConfig = {
       // Skip some rules for now as we work on addressing them
       rules: [
         {
-          // TODO(#7108), https://github.com/open-path/hmis-accessibility/issues/162
-          id: 'color-contrast',
-          enabled: false,
-        },
-        {
           // TODO https://github.com/open-path/hmis-accessibility/issues/1
           id: 'autocomplete-valid',
           enabled: false,

--- a/src/components/elements/Button.stories.tsx
+++ b/src/components/elements/Button.stories.tsx
@@ -1,5 +1,5 @@
 import CheckIcon from '@mui/icons-material/Check';
-import { Button, ButtonProps, Stack } from '@mui/material';
+import { Button, ButtonProps, Paper, Stack } from '@mui/material';
 import { Meta, StoryObj } from '@storybook/react';
 
 export default {
@@ -34,32 +34,36 @@ export const Default: Story = {
 const ButtonMatrix: React.FC<ButtonProps> = (props) => {
   return (
     <>
-      <Stack gap={2} direction='row'>
-        {(
-          [
-            'grayscale',
-            'primary',
-            'error',
-            'warning',
-            // Note: secondary, info, and success button colors exist in MUI but are not part of HMIS design language.
-          ] as ButtonProps['color'][]
-        ).map((color, idx) => (
-          <Stack gap={2} alignItems='center' key={color}>
-            <Stack direction='row' gap={1}>
-              {idx === 0 && <span style={{ width: '100px' }}></span>}
-              <span style={{ width: '100px' }}>{color}</span>
-            </Stack>
-            {(
-              ['contained', 'outlined', 'text'] as ButtonProps['variant'][]
-            ).map((variant) => (
-              <Stack direction='row' gap={1} key={variant}>
-                {idx === 0 && <span style={{ width: '100px' }}>{variant}</span>}
-                <Button {...props} color={color} variant={variant} />
+      <Paper sx={{ p: 2 }}>
+        <Stack gap={2} direction='row'>
+          {(
+            [
+              'grayscale',
+              'primary',
+              'error',
+              'warning',
+              // Note: secondary, info, and success button colors exist in MUI but are not part of HMIS design language.
+            ] as ButtonProps['color'][]
+          ).map((color, idx) => (
+            <Stack gap={2} alignItems='center' key={color}>
+              <Stack direction='row' gap={1}>
+                {idx === 0 && <span style={{ width: '100px' }}></span>}
+                <span style={{ width: '100px' }}>{color}</span>
               </Stack>
-            ))}
-          </Stack>
-        ))}
-      </Stack>
+              {(
+                ['contained', 'outlined', 'text'] as ButtonProps['variant'][]
+              ).map((variant) => (
+                <Stack direction='row' gap={1} key={variant}>
+                  {idx === 0 && (
+                    <span style={{ width: '100px' }}>{variant}</span>
+                  )}
+                  <Button {...props} color={color} variant={variant} />
+                </Stack>
+              ))}
+            </Stack>
+          ))}
+        </Stack>
+      </Paper>
     </>
   );
 };

--- a/src/components/elements/ButtonLink.stories.tsx
+++ b/src/components/elements/ButtonLink.stories.tsx
@@ -1,4 +1,4 @@
-import { Stack } from '@mui/material';
+import { Paper, Stack } from '@mui/material';
 import { Meta, StoryObj } from '@storybook/react';
 import ButtonLink, { ButtonLinkProps } from './ButtonLink';
 
@@ -9,32 +9,34 @@ export default {
 type Story = StoryObj<typeof ButtonLink>;
 
 const ButtonLinkMatrix: React.FC<ButtonLinkProps> = (props) => (
-  <Stack gap={2} direction='row'>
-    {(
-      [
-        'grayscale',
-        'primary',
-        'error',
-        'warning',
-        // Note: secondary, info, and success button colors exist in MUI but are not part of HMIS design language.
-      ] as ButtonLinkProps['color'][]
-    ).map((color, idx) => (
-      <Stack gap={2} alignItems='center' key={color}>
-        <Stack direction='row' gap={1}>
-          {idx === 0 && <span style={{ width: '100px' }}></span>}
-          <span style={{ width: '100px' }}>{color}</span>
-        </Stack>
-        {(
-          ['contained', 'outlined', 'text'] as ButtonLinkProps['variant'][]
-        ).map((variant) => (
-          <Stack direction='row' gap={1} key={variant}>
-            {idx === 0 && <span style={{ width: '100px' }}>{variant}</span>}
-            <ButtonLink {...props} color={color} variant={variant} />
+  <Paper sx={{ p: 2 }}>
+    <Stack gap={2} direction='row'>
+      {(
+        [
+          'grayscale',
+          'primary',
+          'error',
+          'warning',
+          // Note: secondary, info, and success button colors exist in MUI but are not part of HMIS design language.
+        ] as ButtonLinkProps['color'][]
+      ).map((color, idx) => (
+        <Stack gap={2} alignItems='center' key={color}>
+          <Stack direction='row' gap={1}>
+            {idx === 0 && <span style={{ width: '100px' }}></span>}
+            <span style={{ width: '100px' }}>{color}</span>
           </Stack>
-        ))}
-      </Stack>
-    ))}
-  </Stack>
+          {(
+            ['contained', 'outlined', 'text'] as ButtonLinkProps['variant'][]
+          ).map((variant) => (
+            <Stack direction='row' gap={1} key={variant}>
+              {idx === 0 && <span style={{ width: '100px' }}>{variant}</span>}
+              <ButtonLink {...props} color={color} variant={variant} />
+            </Stack>
+          ))}
+        </Stack>
+      ))}
+    </Stack>
+  </Paper>
 );
 
 export const Default: Story = {

--- a/src/components/elements/Loading.tsx
+++ b/src/components/elements/Loading.tsx
@@ -1,15 +1,16 @@
-import { Box, CircularProgress } from '@mui/material';
+import { Box, BoxProps, CircularProgress } from '@mui/material';
 
-const Loading = () => (
+const Loading = ({ sx, ...rest }: BoxProps) => (
   <Box
     display='flex'
     justifyContent='center'
     alignItems='center'
     height='100%'
     data-testid='loading'
-    sx={{ p: 10 }}
+    sx={{ p: 10, ...sx }}
     aria-live='polite'
     aria-busy='true'
+    {...rest}
   >
     <CircularProgress aria-label='Loading' size={50} />
   </Box>

--- a/src/components/elements/NotCollectedText.tsx
+++ b/src/components/elements/NotCollectedText.tsx
@@ -11,7 +11,7 @@ const NotCollectedText = ({
 }: NotCollectedTextProps): JSX.Element => {
   return (
     <Typography
-      color='text.disabled'
+      color='grayscale.main'
       variant='inherit'
       className='HmisForm-notCollectedText'
       {...props}

--- a/src/components/elements/input/CheckboxGroupInput.tsx
+++ b/src/components/elements/input/CheckboxGroupInput.tsx
@@ -56,6 +56,8 @@ const CheckboxGroupInput: React.FC<CheckboxGroupInputProps> = ({
         component='fieldset'
         variant='standard'
         sx={{ maxWidth, ...sx }}
+        // this marks up the fieldset DOM element as `disabled`. MUI FormControl doesn't pass down the `disabled` prop
+        ref={(el) => el && disabled && el.setAttribute('disabled', 'true')}
       >
         {label && (
           <FormLabel

--- a/src/components/elements/input/GenericSelect.tsx
+++ b/src/components/elements/input/GenericSelect.tsx
@@ -86,6 +86,7 @@ const GenericSelect = <
               size='small'
               label={ownerState.getOptionLabel(option)}
               aria-label={`Option: ${ownerState.getOptionLabel(option)}. Press backspace or delete to remove.`}
+              aria-disabled={rest.disabled ? 'true' : undefined}
               {...rest}
             />
           );

--- a/src/components/elements/input/RadioGroupInput.tsx
+++ b/src/components/elements/input/RadioGroupInput.tsx
@@ -91,7 +91,12 @@ const RadioGroupInput = ({
   const ControlComponent = checkbox ? Checkbox : Radio;
 
   return (
-    <FormControl component='fieldset' sx={{ maxWidth, ...sx }}>
+    <FormControl
+      component='fieldset'
+      sx={{ maxWidth, ...sx }}
+      // this marks up the fieldset DOM element as `disabled`. MUI FormControl doesn't pass down the `disabled` prop
+      ref={(el) => el && props.disabled && el.setAttribute('disabled', 'true')}
+    >
       <FormLabel
         error={error}
         disabled={props.disabled}

--- a/src/components/elements/input/RadioGroupInputOption.tsx
+++ b/src/components/elements/input/RadioGroupInputOption.tsx
@@ -75,7 +75,9 @@ const RadioGroupInputOption: React.FC<Props> = ({
             variant: 'body2',
             mr: 0.5,
             color:
-              variant === 'checkbox' && value && !checked ? 'gray' : undefined,
+              variant === 'checkbox' && value && !checked
+                ? 'grayscale.main'
+                : undefined,
           },
         }}
       />

--- a/src/components/elements/input/SsnInput.tsx
+++ b/src/components/elements/input/SsnInput.tsx
@@ -1,7 +1,7 @@
 import { TextField, TextFieldProps } from '@mui/material';
 import { Box } from '@mui/system';
 import { isNil, padEnd, padStart } from 'lodash-es';
-import { useMemo } from 'react';
+import { useId, useMemo } from 'react';
 
 import LabelWithContent from '../LabelWithContent';
 import MultiFieldInput from './MultiFieldInput';
@@ -64,6 +64,8 @@ const SsnInput = ({
       third,
     };
   }, [value, onlylast4]);
+
+  const id = useId();
 
   return (
     <MultiFieldInput<TextFieldProps>
@@ -135,14 +137,24 @@ const SsnInput = ({
           sx={{ maxWidth, ...sx }}
           label={label}
           helperText={helperText}
-          LabelProps={{ disabled: baseInputProps.disabled }}
+          id={id}
+          LabelProps={{
+            disabled: baseInputProps.disabled,
+          }}
         >
           <Box
+            aria-labelledby={id}
+            component='fieldset'
             sx={{
               display: 'inline-flex',
               alignItems: 'center',
               justifyContent: 'flex-start',
+              // remove border, padding, and margin from fieldset
+              border: 'none',
+              padding: 0,
+              margin: 0,
             }}
+            disabled={baseInputProps.disabled}
           >
             {inputs.first.node}&#160;-&#160;{inputs.second.node}&#160;-&#160;
             {inputs.third.node}

--- a/src/components/elements/upload/Uploader.stories.tsx
+++ b/src/components/elements/upload/Uploader.stories.tsx
@@ -42,9 +42,7 @@ export default {
         id='result'
         sx={{ p: 2, borderRadius: 4, backgroundColor: 'grey.100' }}
       >
-        <Typography sx={({ palette }) => ({ color: palette.text.disabled })}>
-          Results will show here
-        </Typography>
+        <Typography>Results will show here</Typography>
       </Box>
     </>
   ),

--- a/src/components/elements/upload/Uploader.tsx
+++ b/src/components/elements/upload/Uploader.tsx
@@ -353,7 +353,11 @@ const Uploader = <Multiple extends boolean>({
                     </Link>{' '}
                     or drag and drop
                   </Typography>
-                  <Typography variant='body2' color='GrayText' sx={{ mt: 1 }}>
+                  <Typography
+                    variant='body2'
+                    color='grayscale.main'
+                    sx={{ mt: 1 }}
+                  >
                     {accept ? getFileTypesFromAccept(accept) : 'Any file type'}{' '}
                     (max. {getReadableSize(maxSize)})
                   </Typography>

--- a/src/components/elements/upload/fileSummary/FileSummary.tsx
+++ b/src/components/elements/upload/fileSummary/FileSummary.tsx
@@ -104,7 +104,7 @@ const FileSummary: React.FC<FileSummaryProps> = ({
                   onRemove();
                 }}
                 variant='body2'
-                color='GrayText'
+                color='grayscale.main'
                 sx={{
                   display: 'inline-flex',
                   alignItems: 'center',

--- a/src/config/theme.ts
+++ b/src/config/theme.ts
@@ -190,7 +190,7 @@ export const baseThemeOptions = {
     },
     activeStatus: '#75559F',
     grayscale: {
-      main: '#6E6E6E',
+      main: '#6E6E6E', // MUI's default text.disabled doesn't meet contrast requirements and should never be used for non-disabled text elements. Use grayscale.main instead
       dark: '#4D4D4D',
       light: '#8b8b8b',
       contrastText: '#fff',
@@ -361,6 +361,9 @@ const createThemeOptions = (theme: Theme) => ({
         root: theme.unstable_sx({
           typography: 'body2',
           fontWeight: 600,
+          '&.Mui-error': {
+            color: 'error.dark',
+          },
         }),
       },
     },
@@ -648,6 +651,14 @@ const createThemeOptions = (theme: Theme) => ({
       styleOverrides: {
         root: {
           marginLeft: 0,
+          '&.Mui-disabled': theme.unstable_sx({
+            opacity: 1,
+            color: 'grayscale.main',
+          }),
+          '&.Mui-error': theme.unstable_sx({
+            opacity: 1,
+            color: 'error.dark',
+          }),
         },
       },
     },

--- a/src/modules/assessments/components/household/HouseholdAssessments.tsx
+++ b/src/modules/assessments/components/household/HouseholdAssessments.tsx
@@ -325,7 +325,7 @@ const HouseholdAssessments: React.FC<Props> = ({
               alignItems: 'flex-end',
               // Dont show icon color for not-currently-active tabs
               '.MuiTab-root[aria-selected="false"] svg': {
-                color: 'text.disabled',
+                color: 'grayscale.main',
               },
             }}
           >

--- a/src/modules/audit/components/AuditObjectChangesSummary.tsx
+++ b/src/modules/audit/components/AuditObjectChangesSummary.tsx
@@ -27,7 +27,7 @@ interface Props {
 }
 
 const nullText = (
-  <Typography component='span' variant='inherit' color='text.disabled'>
+  <Typography component='span' variant='inherit' color='grayscale.main'>
     Empty
   </Typography>
 );

--- a/src/modules/bulkServices/components/BulkServicesTable.tsx
+++ b/src/modules/bulkServices/components/BulkServicesTable.tsx
@@ -73,7 +73,7 @@ const BulkServicesTable: React.FC<Props> = ({
   const getColumnDefs = useCallback(
     (_rows: RowType[], loading?: boolean) => {
       const notEnrolledText = (
-        <NotCollectedText variant='inherit' color='text.disabled'>
+        <NotCollectedText variant='inherit' color='grayscale.main'>
           Not enrolled on {formatDateForDisplay(serviceDate, 'M/d')}
         </NotCollectedText>
       );
@@ -94,7 +94,7 @@ const BulkServicesTable: React.FC<Props> = ({
             if (!row.activeEnrollment) return notEnrolledText;
 
             const noService = (
-              <NotCollectedText variant='inherit' color='text.disabled'>
+              <NotCollectedText variant='inherit' color='grayscale.main'>
                 No Previous {serviceTypeName}
               </NotCollectedText>
             );

--- a/src/modules/client/components/ClientCardImageElement.tsx
+++ b/src/modules/client/components/ClientCardImageElement.tsx
@@ -42,7 +42,7 @@ const ClientCardImageElement: React.FC<Props> = ({
       {src ? undefined : (
         <Typography
           sx={{
-            color: (theme) => theme.palette.text.disabled,
+            color: 'grayscale.main',
             borderBottom: 0,
             display: 'flex',
             flexGrow: 1,

--- a/src/modules/client/components/ClientEnrollmentCard.tsx
+++ b/src/modules/client/components/ClientEnrollmentCard.tsx
@@ -1,6 +1,7 @@
-import { Box, CircularProgress, Typography } from '@mui/material';
-import { useMemo } from 'react';
+import { Typography } from '@mui/material';
+import React, { useMemo } from 'react';
 
+import Loading from '@/components/elements/Loading';
 import GenericTable from '@/components/elements/table/GenericTable';
 import TitleCard from '@/components/elements/TitleCard';
 import EnrollmentDateRangeWithStatus from '@/modules/hmis/components/EnrollmentDateRangeWithStatus';
@@ -41,25 +42,13 @@ const RecentEnrollments = ({
 
   if (error) throw error;
   if (loading && !client) {
-    return (
-      <Box
-        sx={{
-          display: 'flex',
-          justifyContent: 'center',
-          alignItems: 'center',
-          color: (theme) => theme.palette.text.disabled,
-          p: 2,
-        }}
-      >
-        <CircularProgress aria-label='Loading' color='inherit' />
-      </Box>
-    );
+    return <Loading />;
   }
   if (!client) throw new Error('client not found');
 
   if (recentEnrollments && recentEnrollments.length === 0)
     return (
-      <Typography sx={{ p: 2 }} color='GrayText'>
+      <Typography sx={{ p: 2 }} color='grayscale.main'>
         No Recent Enrollments
       </Typography>
     );

--- a/src/modules/clientMerge/components/client/NewClientMerge.tsx
+++ b/src/modules/clientMerge/components/client/NewClientMerge.tsx
@@ -116,7 +116,7 @@ const NewClientMerge = () => {
           record.id === client.id ? (
             <Typography
               textAlign='center'
-              color='text.disabled'
+              color='grayscale.main'
               variant='body2'
             >
               Current Client

--- a/src/modules/form/components/InputContainer.tsx
+++ b/src/modules/form/components/InputContainer.tsx
@@ -30,7 +30,7 @@ const InputContainer = ({
         .map(({ message, fullMessage }) => (
           <Typography
             variant='body2'
-            color='error'
+            color='error.dark'
             key={fullMessage || message}
             sx={{ mt: 0.5, float: horizontal ? 'right' : undefined }}
           >

--- a/src/modules/form/components/client/useRenderLastUpdated.tsx
+++ b/src/modules/form/components/client/useRenderLastUpdated.tsx
@@ -25,7 +25,7 @@ export function useRenderLastUpdated(
           TypographyProps={{
             variant: 'body2',
             fontStyle: 'italic',
-            color: 'text.disabled',
+            color: 'grayscale.main',
             fontSize: 'inherit',
           }}
         />

--- a/src/modules/hmis/components/EnrollmentDateRangeWithStatus.tsx
+++ b/src/modules/hmis/components/EnrollmentDateRangeWithStatus.tsx
@@ -39,7 +39,7 @@ const EnrollmentDateRangeWithStatus = ({
     color = 'error.dark';
     endFormatted = 'Incomplete';
   } else if (!enrollment.exitDate) {
-    color = 'text.disabled';
+    color = 'grayscale.main';
   }
 
   return (

--- a/src/modules/hmis/components/HmisEnum.tsx
+++ b/src/modules/hmis/components/HmisEnum.tsx
@@ -8,11 +8,11 @@ const getLabelAndColor = (enumMap: Record<string, string>, value?: any) => {
   let color: TypographyProps['color'] = 'text.primary';
   const label = enumMap[value];
   if (!label) {
-    color = 'text.disabled';
+    color = 'grayscale.main';
   } else if (value === INVALID_ENUM) {
-    color = 'error';
+    color = 'error.dark';
   } else if (isDataNotCollected(value) || MISSING_DATA_KEYS.includes(value)) {
-    color = 'text.disabled';
+    color = 'grayscale.main';
   }
   return [label, color];
 };

--- a/src/modules/hmis/components/HohIndicator.tsx
+++ b/src/modules/hmis/components/HohIndicator.tsx
@@ -15,7 +15,7 @@ const HohIndicator = ({
     // <Tooltip title='Head of Household' arrow>
     <Typography
       variant='subtitle2'
-      color='text.disabled'
+      color='grayscale.main'
       {...{ component: 'div', ...props }}
       sx={{
         fontWeight: 600,

--- a/src/modules/hmis/components/IdDisplay.tsx
+++ b/src/modules/hmis/components/IdDisplay.tsx
@@ -35,7 +35,7 @@ const IdDisplay = ({
   return (
     <Typography
       variant='body2'
-      color='text.disabled'
+      color='grayscale.main'
       {...props}
       sx={{ ...centerAlignedSx, gap: 0.8, ...props.sx }}
     >

--- a/src/modules/search/components/CommonSearchInput.tsx
+++ b/src/modules/search/components/CommonSearchInput.tsx
@@ -12,7 +12,7 @@ const ClearSearchEndAdornmentButton: React.FC<
   <InputAdornment position='end'>
     <Button
       variant='text'
-      sx={{ color: 'text.disabled' }}
+      color='grayscale'
       startIcon={<ClearIcon />}
       onClick={onClick}
       {...props}

--- a/src/modules/search/components/OmniSearch.tsx
+++ b/src/modules/search/components/OmniSearch.tsx
@@ -18,6 +18,7 @@ import React, { useCallback, useMemo } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import TextInput from '@/components/elements/input/TextInput';
+import Loading from '@/components/elements/Loading';
 import useDebouncedState from '@/hooks/useDebouncedState';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import ClientName from '@/modules/client/components/ClientName';
@@ -255,17 +256,7 @@ const OmniSearch: React.FC = () => {
             }}
           >
             {loading ? (
-              <Box
-                sx={{
-                  display: 'flex',
-                  justifyContent: 'center',
-                  alignItems: 'center',
-                  py: 2,
-                  color: 'text.disabled',
-                }}
-              >
-                <CircularProgress color='inherit' />
-              </Box>
+              <Loading sx={{ py: 2 }} />
             ) : (
               <Grid
                 container
@@ -275,7 +266,7 @@ const OmniSearch: React.FC = () => {
               >
                 {isEmpty(options) ? (
                   <Grid item xs={12}>
-                    <Typography color='text.disabled'>
+                    <Typography color='grayscale.main'>
                       {value
                         ? 'No Results found'
                         : 'Search for clients or projects'}

--- a/src/modules/units/components/UnitManagementTable.tsx
+++ b/src/modules/units/components/UnitManagementTable.tsx
@@ -57,6 +57,7 @@ const UnitManagementTable = ({
               variant: 'text',
               color: 'info',
               disabled,
+              'aria-label': 'Delete unit',
             }}
             confirmationDialogContent={
               unitIds.length > 1 ? (

--- a/src/test/__mocks__/mockFormDefinition.json
+++ b/src/test/__mocks__/mockFormDefinition.json
@@ -470,7 +470,7 @@
                 {
                   "type": "DISPLAY",
                   "linkId": "4.06.2-info",
-                  "text": "<i style='color:gray;'>Not applicable.</i>"
+                  "text": "<i style='color:#6E6E6E;'>Not applicable.</i>"
                 }
               ]
             },


### PR DESCRIPTION
## Description

GH issue: https://github.com/open-path/hmis-accessibility/issues/162

Summary of changes:
- Update most usages of `text.disabled` and `GrayText` to `grayscale.main`
- Add a `Paper` backing to button stories, per https://github.com/open-path/hmis-accessibility/issues/162#issuecomment-2686139585
- Replace text uses of `error.main` with `error.dark`, particularly on MUI form labels and helper text
- Update accessible markup for SSN, Checkbox and Radio groups, and GenericSelect so that disabled elements "know" they are disabled. (This is peripherally relevant to color contrast because disabled elements are allowed to have insufficient contrast, which MUI's default disabled color does; but the axe test runner only excepts them from the rule if they are correctly marked up.)
- Consolidate `<Loading>` components - this isn't really relevant to color contrast, I just noticed it because I was searching for usages of `text.disabled`, and it was an easy cleanup.
- Remove the color contrast rule exception from our axe test CI ✨ 

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [ ] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
