### PR TITLE
6043 rhf dirty observer fix

### DIFF
--- a/src/modules/assessments/components/household/HouseholdAssessmentTabPanel.tsx
+++ b/src/modules/assessments/components/household/HouseholdAssessmentTabPanel.tsx
@@ -115,7 +115,7 @@ const HouseholdAssessmentTabPanel = memo(
 
     const onCompletedMutation = useCallback(
       (status: AssessmentResponseStatus) => {
-        // console.debug('Completed with status', status);
+        // console.info(`form for ${client.id} completed`, status);
         if (['saved', 'submitted'].includes(status)) {
           onFormStateChange?.(enrollmentId, 'saveCompleted');
         } else if (['warning', 'error'].includes(status)) {

--- a/src/modules/assessments/components/household/HouseholdAssessments.tsx
+++ b/src/modules/assessments/components/household/HouseholdAssessments.tsx
@@ -204,6 +204,7 @@ const HouseholdAssessments: React.FC<Props> = ({
     if (hasInflights) return;
     if (nextTab === currentTab) return;
 
+    // console.info(`navigated from tab ${currentTab} to ${nextTab}`)
     setCurrentTab(nextTab);
     setNextTab(undefined);
     window.scrollTo(0, 0);

--- a/src/modules/form/components/DirtyObserver.tsx
+++ b/src/modules/form/components/DirtyObserver.tsx
@@ -19,12 +19,17 @@ const DirtyObserver: React.FC<DirtyObserverProps> = ({
     methods: { control },
   },
 }) => {
-  const { isDirty } = useFormState({ control });
-  const prevDirty = usePrevious(isDirty);
+  const { dirtyFields } = useFormState({ control });
+  // detect dirty state using dirtyFields rather than isDirty. It seems that isDirty is not always reliable or 1:1 with dirtyFields
+  const anyDirtyFields = Object.values(dirtyFields).length > 0;
+  const prevDirty = usePrevious(anyDirtyFields);
 
   useEffect(() => {
-    if (isDirty !== prevDirty) onDirty(isDirty);
-  }, [isDirty, prevDirty, onDirty]);
+    if (anyDirtyFields !== prevDirty) {
+      //console.info(`form for client ${clientId} became`, anyDirtyFields ? 'dirty' : 'clean')
+      onDirty(anyDirtyFields);
+    }
+  }, [anyDirtyFields, prevDirty, onDirty]);
 
   return null;
 };


### PR DESCRIPTION

## Description
Use RHF dirtyFields instead of isDirty to avoid false-positives (dirty forms block tab nav in household assessment)

### Observed behavior

Current flow (as expected)
1. I make a change the form
2. the form is marked dirty in RHF
3. the nav form state is updated by dirty observer to also be dirty
4. I click 'next client'
5. the form saves since it's dirty
6. the form is marked clean by dirty observer 

Then after 6, this bug may occur (under some circumstances): The dirtyObserver fires again, marking the step as dirty. The dirty tab is the previous tab so I can't interact with it. At this point the buttons stop working because the useEffect in HouseholdAssessments does not update currentTab with the value of nextTab if there are outstanding dirty form states.

### About the Fix

It appears that under some circumstances RHF isDirty does not accurately reflect the dirty state, the form isDirty is true even though dirtyFields is empty. Not sure what causes this.


## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix


## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [ ] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
