### PR TITLE
Fix initialSelected option list behavior

### DIFF
--- a/src/modules/form/hooks/rhf/useEnrichedFormData.tsx
+++ b/src/modules/form/hooks/rhf/useEnrichedFormData.tsx
@@ -81,8 +81,6 @@ export const useEnrichedFormData = <T extends FieldValues>({
   >(undefined);
 
   useEffect(() => {
-    // Form has no remote picklists; nothing to enrich
-    if (!hasRemotePicklists) return;
     // Remote picklists are loading, wait
     if (loading) return;
     // Default values have already been enriched
@@ -118,7 +116,7 @@ export const useEnrichedFormData = <T extends FieldValues>({
   ]);
 
   return {
-    defaultValues: hasRemotePicklists ? enrichedDefaultValues : defaultValues,
+    defaultValues: enrichedDefaultValues,
     loading,
   };
 };

--- a/src/modules/form/hooks/rhf/useEnrichedFormData.tsx
+++ b/src/modules/form/hooks/rhf/useEnrichedFormData.tsx
@@ -3,20 +3,15 @@ import { cloneDeep } from 'lodash-es';
 import { useEffect, useMemo, useState } from 'react';
 import { DefaultValues, FieldValues } from 'react-hook-form';
 import usePreloadPicklists from '@/modules/form/hooks/usePreloadPicklists';
-import {
-  isPickListOption,
-  isPickListOptionArray,
-  LocalConstants,
-  PickListArgs,
-} from '@/modules/form/types';
+import { LocalConstants, PickListArgs } from '@/modules/form/types';
 import {
   autofillValues,
   formHasAnyRemotePicklists,
+  getEnrichedValueForChoiceItem,
   getInitialValues,
   getItemMap,
 } from '@/modules/form/util/formUtil';
-import { FormDefinitionJson, PickListType } from '@/types/gqlTypes';
-import { ensureArray } from '@/utils/arrays';
+import { FormDefinitionJson } from '@/types/gqlTypes';
 
 const handleError = (message: string) => {
   if (import.meta.env.MODE === 'development') {
@@ -33,7 +28,12 @@ interface Args<T extends FieldValues> {
   pickListArgs?: PickListArgs;
 }
 
-// we get incomplete form data and need to enrich it using local constants and pick lists before it can be displayed
+// We get incomplete form data and need to enrich it using local constants and pick lists before it can be displayed.
+//
+// This includes enriching incomplete values for "choice" items based on their pick lists, for example:
+//  - Converting code to PickListOption:  'yes' => { code: 'yes', label: 'Yes', groupLabel: 'Something' }
+//  - Filling in initialSelected option:   null => { code: 'foo', label: 'The Initial Value', initialSelected: true }
+//
 export const useEnrichedFormData = <T extends FieldValues>({
   definition,
   initialValues = {} as T,
@@ -89,53 +89,17 @@ export const useEnrichedFormData = <T extends FieldValues>({
     if (!!enrichedDefaultValues) return;
 
     const clonedValues = cloneDeep(defaultValues);
-    Object.values(itemMap || {}).forEach(({ pickListReference, linkId }) => {
-      let valueCode = clonedValues[linkId];
-      // Value may already be in Picklist shape with only the code, because of createInitialValuesFromRecord.
-      // in that case we still want to try to populate it with the full option, based on the code.
-      if (isPickListOption(valueCode)) {
-        valueCode = valueCode.code;
-      }
-      if (isPickListOptionArray(valueCode)) {
-        valueCode = valueCode.map((o) => o.code);
-      }
+    Object.values(itemMap || {}).forEach((item) => {
+      if (!item.pickListOptions && !item.pickListReference) return; // nothing to enrich if no pick list
 
-      // skip unless there's a value and a value code
-      if (!valueCode) return;
-      if (Array.isArray(valueCode) && valueCode.length === 0) return;
-      if (!pickListReference) return;
-      if (!Object.values<string>(PickListType).includes(pickListReference))
-        return;
+      const enrichedOptionValue = getEnrichedValueForChoiceItem({
+        item,
+        defaultValue: clonedValues[item.linkId],
+        remotePickListMap: picklistValues,
+        handleError,
+      });
 
-      const resolvedPicklist = picklistValues[pickListReference];
-      if (!resolvedPicklist) {
-        // this shouldn't occur
-        handleError(`Could not find pick list "${pickListReference}"`);
-        return;
-      }
-
-      // Map the value code(s) to the corresponding picklist option(s)
-      let found;
-      if (Array.isArray(valueCode)) {
-        found = valueCode
-          .map((value) =>
-            resolvedPicklist.find((option) => option.code === value)
-          )
-          .filter((option) => !!option);
-      } else {
-        found = resolvedPicklist.find((option) => option.code === valueCode);
-      }
-
-      if (
-        !found ||
-        ensureArray(found).length !== ensureArray(valueCode).length
-      ) {
-        handleError(
-          `Pick list "${pickListReference}" does not contain code "${valueCode}"`
-        );
-        return;
-      }
-      if (found) clonedValues[linkId] = found;
+      if (enrichedOptionValue) clonedValues[item.linkId] = enrichedOptionValue;
     });
     setEnrichedDefaultValues(clonedValues);
   }, [

--- a/src/modules/form/hooks/rhf/useEnrichedFormData.tsx
+++ b/src/modules/form/hooks/rhf/useEnrichedFormData.tsx
@@ -92,14 +92,19 @@ export const useEnrichedFormData = <T extends FieldValues>({
     Object.values(itemMap || {}).forEach((item) => {
       if (!item.pickListOptions && !item.pickListReference) return; // nothing to enrich if no pick list
 
-      const enrichedOptionValue = getEnrichedValueForChoiceItem({
-        item,
-        defaultValue: clonedValues[item.linkId],
-        remotePickListMap: picklistValues,
-        handleError,
-      });
+      const { enrichedValue, initialSelectedValue } =
+        getEnrichedValueForChoiceItem({
+          item,
+          defaultValue: clonedValues[item.linkId],
+          remotePickListMap: picklistValues,
+          handleError,
+        });
 
-      if (enrichedOptionValue) clonedValues[item.linkId] = enrichedOptionValue;
+      if (enrichedValue) {
+        clonedValues[item.linkId] = enrichedValue;
+      } else if (initialSelectedValue && !viewOnly) {
+        clonedValues[item.linkId] = initialSelectedValue;
+      }
     });
     setEnrichedDefaultValues(clonedValues);
   }, [
@@ -109,6 +114,7 @@ export const useEnrichedFormData = <T extends FieldValues>({
     picklistValues,
     hasRemotePicklists,
     enrichedDefaultValues,
+    viewOnly,
   ]);
 
   return {

--- a/src/modules/form/hooks/usePickList.tsx
+++ b/src/modules/form/hooks/usePickList.tsx
@@ -1,14 +1,8 @@
 import { QueryHookOptions } from '@apollo/client';
-import { intersectionBy } from 'lodash-es';
 import { useMemo } from 'react';
 
-import {
-  ChangeType,
-  isPickListOption,
-  isPickListOptionArray,
-  PickListArgs,
-} from '../types';
-import { hasMeaningfulValue, resolveOptionList } from '../util/formUtil';
+import { PickListArgs } from '../types';
+import { resolveOptionList } from '../util/formUtil';
 
 import {
   FormItem,
@@ -17,57 +11,6 @@ import {
   PickListType,
   useGetPickListQuery,
 } from '@/types/gqlTypes';
-
-export const getValueFromPickListData = ({
-  item,
-  linkId,
-  value,
-  data,
-  setInitial = true,
-}: {
-  item: FormItem;
-  linkId: string;
-  value: any;
-  data: GetPickListQuery;
-  setInitial?: boolean;
-}) => {
-  if (!data?.pickList) return;
-
-  // If there is no value, look for InitialSelected value and set it
-  if (!hasMeaningfulValue(value)) {
-    // ...Except if we tell it not to
-    if (!setInitial) return;
-
-    const initial = item.repeats
-      ? data.pickList.filter((o) => o.initialSelected)
-      : data.pickList.find((o) => o.initialSelected);
-    if (initial) {
-      return { linkId, value: initial, type: ChangeType.System };
-    }
-    return;
-  }
-
-  // Try to find the "full" option (including label) for this value from the pick list
-  let fullOption;
-  if (isPickListOption(value)) {
-    fullOption = data.pickList.find((o) => o.code === value.code);
-  } else if (isPickListOptionArray(value)) {
-    fullOption = intersectionBy(data.pickList, value, 'code');
-  }
-
-  if (fullOption) {
-    // Update the value so that it has the full option.
-    // This is ONLY NECESSARY BECAUSE some forms have conditional logic based on the "group_code"
-    // on the PickListOption, which would be null to start.
-    return { linkId, value: fullOption, type: ChangeType.System };
-  } else {
-    console.warn(
-      `Selected value '${JSON.stringify(
-        value
-      )}' is not present in option list '${item.pickListReference}'`
-    );
-  }
-};
 
 export function usePickList({
   item,

--- a/src/modules/form/util/formUtil.getEnrichedValueForChoiceItem.test.ts
+++ b/src/modules/form/util/formUtil.getEnrichedValueForChoiceItem.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest';
+import { getEnrichedValueForChoiceItem } from './formUtil';
+
+import { FormItem, ItemType, PickListType } from '@/types/gqlTypes';
+
+const remotePickListMap = {
+  [PickListType.Coc]: [
+    { code: 'ma', label: 'MA-100' },
+    { code: 'ca', label: 'CA-100' },
+  ],
+  [PickListType.AvailableUnitsForEnrollment]: [
+    { code: 'one', label: 'One (default)', initialSelected: true },
+    { code: 'two', label: 'Two' },
+  ],
+};
+const handleError = (message: string) => {
+  throw new Error(message);
+};
+
+const enrich = (item: FormItem, value: any) =>
+  getEnrichedValueForChoiceItem({
+    item,
+    remotePickListMap,
+    defaultValue: value,
+    handleError,
+  });
+
+describe('getEnrichedValueForChoiceItem', () => {
+  describe('single-select choice item', () => {
+    it('enriches value with local pick list reference', () => {
+      const item = {
+        linkId: 'foo',
+        type: ItemType.Choice,
+        pickListReference: 'NoYesMissing',
+      };
+
+      ['YES', { code: 'YES' }].forEach((defaultValue) => {
+        const result = enrich(item, defaultValue);
+        expect(result).toEqual({ code: 'YES', label: 'Yes' });
+      });
+      expect(enrich(item, undefined)).toEqual(undefined);
+    });
+
+    it('enriches value with remote pick list reference', () => {
+      const item = {
+        linkId: 'foo',
+        type: ItemType.Choice,
+        pickListReference: PickListType.Coc,
+      };
+
+      ['ma', { code: 'ma' }].forEach((defaultValue) => {
+        const result = enrich(item, defaultValue);
+        expect(result).toEqual({ code: 'ma', label: 'MA-100' });
+      });
+      expect(enrich(item, undefined)).toEqual(undefined);
+    });
+
+    it('enriches value with remote pick list reference and initialSelected option', () => {
+      const item = {
+        linkId: 'foo',
+        type: ItemType.Choice,
+        pickListReference: PickListType.AvailableUnitsForEnrollment,
+      };
+
+      // null value is enriched to initialSelected option
+      const initial = remotePickListMap[
+        PickListType.AvailableUnitsForEnrollment
+      ].find((o) => o.initialSelected);
+      expect(enrich(item, undefined)).toEqual(initial);
+      expect(enrich(item, null)).toEqual(initial);
+    });
+
+    it('enriches value with local pickListOptions', () => {
+      const opt = { code: 'opt', label: 'Label' };
+      const item = {
+        linkId: 'foo',
+        type: ItemType.Choice,
+        pickListOptions: [opt],
+      };
+
+      [opt.code, { code: 'opt' }].forEach((defaultValue) => {
+        const result = enrich(item, defaultValue);
+        expect(result).toEqual(opt);
+      });
+
+      expect(enrich(item, undefined)).toEqual(undefined);
+    });
+
+    it('enriches value with local pickListOptions and initialSelected option', () => {
+      const opt1 = { code: 'opt', label: 'Label' };
+      const opt2 = { code: 'opt2', label: 'Label', initialSelected: true };
+      const item = {
+        linkId: 'foo',
+        type: ItemType.Choice,
+        pickListOptions: [opt1, opt2],
+      };
+
+      // null value is enriched to initialSelected option
+      expect(enrich(item, undefined)).toEqual(opt2);
+      expect(enrich(item, null)).toEqual(opt2);
+
+      // default val is still enriched as expected
+      [opt1.code, { code: opt1.code }].forEach((defaultValue) => {
+        const result = enrich(item, defaultValue);
+        expect(result).toEqual(opt1);
+      });
+    });
+  });
+
+  describe('multi-select choice item', () => {
+    it('enriches value with local pick list reference', () => {
+      const item = {
+        linkId: 'foo',
+        type: ItemType.Choice,
+        pickListReference: 'NoYesMissing',
+        repeats: true,
+      };
+
+      expect(enrich(item, ['YES'])).toEqual([{ code: 'YES', label: 'Yes' }]);
+      expect(enrich(item, ['YES', 'NO'])).toEqual([
+        {
+          code: 'YES',
+          label: 'Yes',
+        },
+        {
+          code: 'NO',
+          label: 'No',
+        },
+      ]);
+    });
+
+    it('enriches value with local pickListOptions and multiple initialSelected options', () => {
+      const opt1 = { code: 'opt', label: 'Label' };
+      const opt2 = { code: 'opt2', label: 'Label', initialSelected: true };
+      const opt3 = { code: 'opt3', label: 'Label', initialSelected: true };
+      const item = {
+        linkId: 'foo',
+        type: ItemType.Choice,
+        pickListOptions: [opt1, opt2, opt3],
+        repeats: true,
+      };
+
+      // null value is enriched to initialSelected option
+      expect(enrich(item, undefined)).toEqual([opt2, opt3]);
+      expect(enrich(item, null)).toEqual([opt2, opt3]);
+      expect(enrich(item, [])).toEqual([opt2, opt3]);
+
+      // default val is still enriched as expected
+      expect(enrich(item, [opt1.code])).toEqual([opt1]);
+    });
+  });
+});

--- a/src/modules/form/util/formUtil.getEnrichedValueForChoiceItem.test.ts
+++ b/src/modules/form/util/formUtil.getEnrichedValueForChoiceItem.test.ts
@@ -17,13 +17,17 @@ const handleError = (message: string) => {
   throw new Error(message);
 };
 
-const enrich = (item: FormItem, value: any) =>
-  getEnrichedValueForChoiceItem({
-    item,
-    remotePickListMap,
-    defaultValue: value,
-    handleError,
-  });
+const enrich = (item: FormItem, value: any) => {
+  const { enrichedValue, initialSelectedValue } = getEnrichedValueForChoiceItem(
+    {
+      item,
+      remotePickListMap,
+      defaultValue: value,
+      handleError,
+    }
+  );
+  return enrichedValue || initialSelectedValue;
+};
 
 describe('getEnrichedValueForChoiceItem', () => {
   describe('single-select choice item', () => {

--- a/src/modules/form/util/formUtil.tsx
+++ b/src/modules/form/util/formUtil.tsx
@@ -74,6 +74,7 @@ import {
   Maybe,
   NoYesReasonsForMissingData,
   PickListOption,
+  PickListOptionFieldsFragment,
   PickListType,
   RelatedRecordType,
   RelationshipToHoH,
@@ -1543,3 +1544,77 @@ export function findOptionLabel(
   }
   return option.code || '';
 }
+
+// Given a CHOICE or OPEN_CHOICE item and an initial form value, "enrich" the value. Enriching the value means:
+// - Replacing the value with the full option object, e.g. 'yes' => { code: 'yes', label: 'Yes' }
+// - Replacing the value list with the full option objects, e.g. ['yes', 'no'] => [{ code: 'yes', label: 'Yes' }, { code: 'no', label: 'No' }] (for multi-select)
+// - Setting an initial value based on the `initialSelected` flag in the option list, if no options is present, e.g. null => { code: 'foo', label: 'The Initial Value', initialSelected: true }
+//
+// Returns undefined if the value does not need to be enriched
+export const getEnrichedValueForChoiceItem = ({
+  remotePickListMap,
+  item,
+  defaultValue,
+  handleError,
+}: {
+  remotePickListMap: Record<string, PickListOptionFieldsFragment[]>;
+  item: FormItem;
+  defaultValue: any;
+  handleError: (message: string) => void;
+}): PickListOption | PickListOption[] | undefined => {
+  const { pickListReference, pickListOptions } = item;
+  if (!pickListReference && !pickListOptions) return; // nothing to enrich
+
+  // Try to locally resolve the pick list (either pickListOptions or a "local" reference from codegen'd enums).
+  let resolvedPicklist = resolveOptionList(item);
+
+  // Try to resolve the list from the remotePickListMap
+  if (
+    !resolvedPicklist &&
+    pickListReference &&
+    Object.values<string>(PickListType).includes(pickListReference)
+  ) {
+    resolvedPicklist = remotePickListMap[pickListReference];
+  }
+
+  // Failed to resolve the pick list. Report to sentry.
+  if (!resolvedPicklist) {
+    handleError(`Could not resolve pick list "${pickListReference}"`);
+    return;
+  }
+
+  // Get the 'code' of the default value.
+  // Value may already be in Picklist shape with only the code, because of createInitialValuesFromRecord.
+  // in that case we still want to try to populate it with the full option, based on the code.
+  let valueCode = defaultValue;
+  if (isPickListOption(valueCode)) valueCode = valueCode.code;
+  if (isPickListOptionArray(valueCode))
+    valueCode = valueCode.map((o) => o.code);
+
+  // if there is no value, populate field with the default option (initialSelected) and return
+  if (!valueCode || (Array.isArray(valueCode) && valueCode.length === 0)) {
+    const initialSelected = resolvedPicklist.filter((o) => o.initialSelected);
+    if (initialSelected.length === 0) return; // nothing to enrich
+
+    // Return the initialSelected option(s) as the enriched value
+    return item.repeats ? initialSelected : initialSelected[0];
+  }
+
+  // Map the value code(s) to the corresponding picklist option(s)
+  let found;
+  if (Array.isArray(valueCode)) {
+    found = valueCode
+      .map((value) => resolvedPicklist.find((option) => option.code === value))
+      .filter((option) => !!option);
+  } else {
+    found = resolvedPicklist.find((option) => option.code === valueCode);
+  }
+
+  if (!found || ensureArray(found).length !== ensureArray(valueCode).length) {
+    handleError(
+      `Pick list "${pickListReference}" does not contain code "${valueCode}"`
+    );
+    return;
+  }
+  return found;
+};

--- a/src/modules/form/util/formUtil.tsx
+++ b/src/modules/form/util/formUtil.tsx
@@ -1545,12 +1545,13 @@ export function findOptionLabel(
   return option.code || '';
 }
 
-// Given a CHOICE or OPEN_CHOICE item and an initial form value, "enrich" the value. Enriching the value means:
-// - Replacing the value with the full option object, e.g. 'yes' => { code: 'yes', label: 'Yes' }
-// - Replacing the value list with the full option objects, e.g. ['yes', 'no'] => [{ code: 'yes', label: 'Yes' }, { code: 'no', label: 'No' }] (for multi-select)
-// - Setting an initial value based on the `initialSelected` flag in the option list, if no options is present, e.g. null => { code: 'foo', label: 'The Initial Value', initialSelected: true }
+// Given a CHOICE or OPEN_CHOICE item and an initial form value, provide an 'enriched' representation of the value.
 //
-// Returns undefined if the value does not need to be enriched
+// Returns an object with the following attributes:
+//  'enrichedValue' is the PickListOption representation, e.g. 'yes' => { code: 'yes', label: 'Yes', groupLabel: 'Something' }
+//  'initialSelectedValue' is the initialSelected option, if any (only present if the defaultValue was missing)
+//
+// Returns an empty object if the value does not need to be enriched
 export const getEnrichedValueForChoiceItem = ({
   remotePickListMap,
   item,
@@ -1560,10 +1561,14 @@ export const getEnrichedValueForChoiceItem = ({
   remotePickListMap: Record<string, PickListOptionFieldsFragment[]>;
   item: FormItem;
   defaultValue: any;
+  setInitialSelected?: boolean;
   handleError: (message: string) => void;
-}): PickListOption | PickListOption[] | undefined => {
+}): {
+  enrichedValue?: PickListOption | PickListOption[];
+  initialSelectedValue?: PickListOption | PickListOption[];
+} => {
   const { pickListReference, pickListOptions } = item;
-  if (!pickListReference && !pickListOptions) return; // nothing to enrich
+  if (!pickListReference && !pickListOptions) return {}; // nothing to enrich
 
   // Try to locally resolve the pick list (either pickListOptions or a "local" reference from codegen'd enums).
   let resolvedPicklist = resolveOptionList(item);
@@ -1580,7 +1585,7 @@ export const getEnrichedValueForChoiceItem = ({
   // Failed to resolve the pick list. Report to sentry.
   if (!resolvedPicklist) {
     handleError(`Could not resolve pick list "${pickListReference}"`);
-    return;
+    return {};
   }
 
   // Get the 'code' of the default value.
@@ -1594,10 +1599,13 @@ export const getEnrichedValueForChoiceItem = ({
   // if there is no value, populate field with the default option (initialSelected) and return
   if (!valueCode || (Array.isArray(valueCode) && valueCode.length === 0)) {
     const initialSelected = resolvedPicklist.filter((o) => o.initialSelected);
-    if (initialSelected.length === 0) return; // nothing to enrich
+    if (initialSelected.length === 0) return {}; // nothing to enrich
 
-    // Return the initialSelected option(s) as the enriched value
-    return item.repeats ? initialSelected : initialSelected[0];
+    // Return the initialSelected option(s)
+    const initialSelectedValue = item.repeats
+      ? initialSelected
+      : initialSelected[0];
+    return { initialSelectedValue };
   }
 
   // Map the value code(s) to the corresponding picklist option(s)
@@ -1614,7 +1622,7 @@ export const getEnrichedValueForChoiceItem = ({
     handleError(
       `Pick list "${pickListReference}" does not contain code "${valueCode}"`
     );
-    return;
+    return {};
   }
-  return found;
+  return { enrichedValue: found };
 };


### PR DESCRIPTION
## Description

Fix behavior for items where the pick list options have an option where `initialSelected: true`. When initial selected is true, the option should be initially selected by default. This fixes it for both remote picklists and local picklists, though it looks like previously this behavior only worked for remote pick lists.

I moved the logic to the formUtil file so I could add unit tests.


- [x] deployed and confirmed reported bug in training environment is fixed

## How to test:
1. Set up an item with `pickListOptions` where one option has `initialSelected: true`. It should be initially selected when you open the form. It should not be populated when opening the form as readonly.
2. Open an item with a remote pick list that sets `initial_selected`. I have been using AvailableUnitsForEnrollment. Setup is to seed the ac forms; go to project with units; enroll one client; enroll second client and their unit should be pre-populated. This has already been deployed and tested in the training environment where the bug was reported, so its probably not necessary for the reviewer to set it up locally too.

<img width="542" alt="Screenshot 2025-03-10 at 3 10 07 PM" src="https://github.com/user-attachments/assets/38b525ba-0d54-498e-bedf-543d7ce1dfa2" />


## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
