### PR TITLE
Stop sending unneeded messages to sentry

### DIFF
--- a/src/modules/form/util/formUtil.tsx
+++ b/src/modules/form/util/formUtil.tsx
@@ -1619,9 +1619,11 @@ export const getEnrichedValueForChoiceItem = ({
   }
 
   if (!found || ensureArray(found).length !== ensureArray(valueCode).length) {
-    handleError(
-      `Pick list "${pickListReference}" does not contain code "${valueCode}"`
-    );
+    // Resolved Pick List does not contain a code that matches this value. This can occur when
+    // migrated-in data had different values, or when picklist options have been removed from a form (and we are editing a form with old values).
+    // No need to send this to sentry in this case, just return empty to leave the values as-is. The value will still display in the form.
+
+    // console.debug(`Pick list "${pickListReference}" does not contain code "${valueCode}"`);
     return {};
   }
   return { enrichedValue: found };


### PR DESCRIPTION
## Description

Remove this Sentry error report that was added in release-153. We are encountering a lot of them and it's actually expected behavior. Mostly we're seeing it for migrated-in data, where the responses don't necessarily match up with the current form's option list, which is fine. This could also happen if the newer version of an assessment has removed some options from an option list, but historical assessments still contain those values. There is no need to report it to sentry.

## Type of change
- [x] Bug fix
- [x] Code clean-up / housekeeping

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
