### PR TITLE
Patch render bug in ProjectReferralPostingForm

### DIFF
--- a/src/modules/form/components/DynamicForm.tsx
+++ b/src/modules/form/components/DynamicForm.tsx
@@ -159,6 +159,7 @@ const DynamicFormWithHandlers = forwardRef<
 const DynamicFormEnrichedDataLoader = forwardRef<
   DynamicFormRef,
   DynamicFormProps & {
+    // Initial values to be used for the form. NOTE: this prop shouldn't change after the initial render. defaultValues are only calculated once.
     initialValues?: InitialValues;
     // Loading element to render while the form is initially loading (due to PickLists being fetched). Named "initial" to distinguish from existing `loading` prop which typically is used to indicate that the form is submitting.
     initialLoadingElement?: ReactNode;

--- a/src/modules/referrals/components/ProjectReferralPostingForm.tsx
+++ b/src/modules/referrals/components/ProjectReferralPostingForm.tsx
@@ -97,6 +97,10 @@ export const ProjectReferralPostingForm: React.FC<Props> = ({
 
   return (
     <DynamicForm
+      // Use the key to force a re-render when the referral posting changes.
+      // Note: the change to initialValues won't not trigger a form re-render,
+      // because useEnrichedFormData doesn't recalculate defaultValues.
+      key={JSON.stringify(referralPosting)}
       definition={definition}
       FormActionProps={{
         submitButtonText: 'Update Referral',

--- a/src/modules/referrals/components/ProjectReferralPostingForm.tsx
+++ b/src/modules/referrals/components/ProjectReferralPostingForm.tsx
@@ -98,7 +98,7 @@ export const ProjectReferralPostingForm: React.FC<Props> = ({
   return (
     <DynamicForm
       // Use the key to force a re-render when the referral posting changes.
-      // Note: the change to initialValues won't not trigger a form re-render,
+      // Note: the change to initialValues won't trigger a form re-render,
       // because useEnrichedFormData doesn't recalculate defaultValues.
       key={JSON.stringify(referralPosting)}
       definition={definition}


### PR DESCRIPTION
## Description

Patch for bug that was introduced in 153. The way `initialValues` are treated changed with the RHF refactor. I also audited the codebases for other locations where we may have been expecting a change to initialValues; I couldn't find any.

Issue: https://github.com/open-path/Green-River/issues/7415

How to reproduce:
* open any "incoming" assigned referral
* update the note and hit save
* the value saves, but the form appears empty. refreshing the page makes the updated note appear.

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
