### PR TITLE
Implement basic Opportunity page

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -4204,8 +4204,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
+                "kind": "ENUM",
+                "name": "CeOpportunityStatus",
                 "ofType": null
               }
             },
@@ -4272,6 +4272,36 @@
         ],
         "interfaces": null,
         "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "CeOpportunityStatus",
+        "description": null,
+        "isOneOf": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "closed",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "locked",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "open",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
         "possibleTypes": null
       },
       {

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -3624,6 +3624,22 @@
             "deprecationReason": null
           },
           {
+            "name": "clientId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "id",
             "description": null,
             "args": [],
@@ -4627,11 +4643,23 @@
             "description": null,
             "args": [],
             "type": {
+              "kind": "OBJECT",
+              "name": "Client",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "clientId",
+            "description": null,
+            "args": [],
+            "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "OBJECT",
-                "name": "Client",
+                "kind": "SCALAR",
+                "name": "ID",
                 "ofType": null
               }
             },

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -3613,7 +3613,7 @@
         "fields": [
           {
             "name": "client",
-            "description": null,
+            "description": "Null if the user lacks permission to view the client",
             "args": [],
             "type": {
               "kind": "OBJECT",
@@ -4220,18 +4220,6 @@
                 "name": "CeOpportunityStatus",
                 "ofType": null
               }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "topCandidate",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "OBJECT",
-              "name": "CeCandidate",
-              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -3616,13 +3616,9 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "Client",
-                "ofType": null
-              }
+              "kind": "OBJECT",
+              "name": "Client",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -4113,6 +4113,26 @@
             "deprecationReason": null
           },
           {
+            "name": "eligibilityRequirements",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CeMatchRule",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "expiresAt",
             "description": null,
             "args": [],
@@ -4157,6 +4177,18 @@
             "deprecationReason": null
           },
           {
+            "name": "priorityScheme",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "CeMatchRule",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "projectId",
             "description": null,
             "args": [],
@@ -4183,26 +4215,6 @@
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "rules",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "CeMatchRule",
-                  "ofType": null
-                }
               }
             },
             "isDeprecated": false,

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -3799,6 +3799,106 @@
       },
       {
         "kind": "OBJECT",
+        "name": "CeMatchRule",
+        "description": null,
+        "isOneOf": null,
+        "fields": [
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ownerType",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "CeMatchRuleType",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "CeMatchRuleType",
+        "description": null,
+        "isOneOf": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "eligibility_requirement",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "priority_scheme",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "CeOpportunitiesPaginated",
         "description": null,
         "isOneOf": null,
@@ -4077,6 +4177,26 @@
             "deprecationReason": null
           },
           {
+            "name": "rules",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CeMatchRule",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "status",
             "description": null,
             "args": [],
@@ -4088,6 +4208,18 @@
                 "name": "String",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "topCandidate",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "CeCandidate",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/src/api/operations/ce.fragments.graphql
+++ b/src/api/operations/ce.fragments.graphql
@@ -18,9 +18,6 @@ fragment CeOpportunityFields on CeOpportunity {
   rules {
     ...CeMatchRuleFields
   }
-  topCandidate {
-    ...CeCandidateFields
-  }
 }
 
 fragment CeMatchRuleFields on CeMatchRule {

--- a/src/api/operations/ce.fragments.graphql
+++ b/src/api/operations/ce.fragments.graphql
@@ -10,18 +10,31 @@ fragment CeOpportunitySummaryFields on CeOpportunity {
 fragment CeOpportunityFields on CeOpportunity {
   ...CeOpportunitySummaryFields
   activeReferral {
-    id
+    ...CeReferralSummaryFields
   }
   acceptedReferral {
-    id
+    ...CeReferralSummaryFields
   }
+  rules {
+    ...CeMatchRuleFields
+  }
+  topCandidate {
+    ...CeCandidateFields
+  }
+}
+
+fragment CeMatchRuleFields on CeMatchRule {
+  id
+  name
+  type
+  ownerType
 }
 
 fragment CeCandidateFields on CeCandidate {
   id
   priorityScore
   client {
-    id
+    ...ClientName
   }
 }
 

--- a/src/api/operations/ce.fragments.graphql
+++ b/src/api/operations/ce.fragments.graphql
@@ -33,6 +33,7 @@ fragment CeMatchRuleFields on CeMatchRule {
 fragment CeCandidateFields on CeCandidate {
   id
   priorityScore
+  clientId
   client {
     ...ClientName
   }
@@ -41,6 +42,7 @@ fragment CeCandidateFields on CeCandidate {
 fragment CeReferralSummaryFields on CeReferral {
   id
   status
+  clientId
   client {
     id
     ...ClientName

--- a/src/api/operations/ce.fragments.graphql
+++ b/src/api/operations/ce.fragments.graphql
@@ -15,7 +15,10 @@ fragment CeOpportunityFields on CeOpportunity {
   acceptedReferral {
     ...CeReferralSummaryFields
   }
-  rules {
+  eligibilityRequirements {
+    ...CeMatchRuleFields
+  }
+  priorityScheme {
     ...CeMatchRuleFields
   }
 }

--- a/src/api/operations/ce.operations.graphql
+++ b/src/api/operations/ce.operations.graphql
@@ -48,6 +48,9 @@ mutation SubmitCeReferralStep(
     referral {
       id
       status
+      opportunity {
+        ...CeOpportunityFields
+      }
     }
     errors {
       ...ValidationErrorFields

--- a/src/components/elements/CommonTabs.stories.tsx
+++ b/src/components/elements/CommonTabs.stories.tsx
@@ -1,0 +1,33 @@
+import { Button } from '@mui/material';
+import { Meta, StoryObj } from '@storybook/react';
+import CommonTabs from '@/components/elements/CommonTabs';
+
+export default {
+  component: CommonTabs,
+} as Meta<typeof CommonTabs>;
+
+type Story = StoryObj<typeof CommonTabs>;
+export const Default: Story = {
+  args: {
+    tabDefinitions: [
+      {
+        title: 'First tab',
+        contents: (
+          <>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+            eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
+            ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+            aliquip ex ea commodo consequat. Duis aute irure dolor in
+            reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+            pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+            culpa qui officia deserunt mollit anim id est laborum.
+          </>
+        ),
+      },
+      {
+        title: 'Second Tab',
+        contents: <Button>Click here</Button>,
+      },
+    ],
+  },
+};

--- a/src/components/elements/CommonTabs.tsx
+++ b/src/components/elements/CommonTabs.tsx
@@ -15,7 +15,7 @@ interface CommonTabsProps {
 }
 
 // CommonTabs wraps the MUI Tabs component. It can be controlled or uncontrolled,
-// so callers can choose whether to delegate of which tab is selected.
+// so callers can choose whether to delegate controlling the state of which tab is selected.
 // This is a rare case where ariaLabel is a required prop, otherwise the tabs won't be accessible.
 const CommonTabs: React.FC<CommonTabsProps> = ({
   sx,

--- a/src/components/elements/CommonTabs.tsx
+++ b/src/components/elements/CommonTabs.tsx
@@ -1,0 +1,74 @@
+import { Box, SxProps, Tab, Tabs } from '@mui/material';
+import React, { ReactNode, useState } from 'react';
+
+export type TabDefinition = {
+  title: string;
+  contents: ReactNode;
+};
+
+interface CommonTabsProps {
+  tabDefinitions: TabDefinition[];
+  ariaLabel: string;
+  sx?: SxProps;
+  currentTab?: number;
+  onChangeTab?: (tab: number) => void;
+}
+
+// CommonTabs wraps the MUI Tabs component, which requires a lot of boilerplate,
+// allowing the caller to provide a TabDefinition and abstracting away handling
+// of which tab value is currently selected.
+// This is a rare case where ariaLabel is a required prop, otherwise the tabs won't be accessible.
+const CommonTabs: React.FC<CommonTabsProps> = ({
+  sx,
+  ariaLabel,
+  tabDefinitions,
+  currentTab,
+  onChangeTab,
+}) => {
+  const [internalValue, setInternalValue] = useState(0);
+
+  // Use external value if provided; otherwise, use internal state
+  const currentValue = currentTab ?? internalValue;
+
+  const handleChange = (_event: React.SyntheticEvent, newValue: number) => {
+    if (onChangeTab) {
+      onChangeTab(newValue); // Controlled mode: notify parent
+    } else {
+      setInternalValue(newValue); // Uncontrolled mode: manage internally
+    }
+  };
+
+  return (
+    <Box sx={{ width: '100%', ...sx }}>
+      <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+        <Tabs
+          value={currentValue}
+          onChange={handleChange}
+          aria-label={ariaLabel}
+        >
+          {tabDefinitions.map((t, i) => (
+            <Tab
+              key={t.title}
+              label={<strong>{t.title}</strong>}
+              id={`tab-${i}`}
+              aria-controls={`tabpanel-${i}`}
+            />
+          ))}
+        </Tabs>
+      </Box>
+      {tabDefinitions.map((t, i) => (
+        <div
+          key={t.title}
+          role='tabpanel'
+          hidden={currentValue !== i}
+          id={`tabpanel-${i}`}
+          aria-labelledby={`tab-${i}`}
+        >
+          {currentValue === i && <Box mt={3}>{t.contents}</Box>}
+        </div>
+      ))}
+    </Box>
+  );
+};
+
+export default CommonTabs;

--- a/src/components/elements/CommonTabs.tsx
+++ b/src/components/elements/CommonTabs.tsx
@@ -14,9 +14,8 @@ interface CommonTabsProps {
   onChangeTab?: (tab: number) => void;
 }
 
-// CommonTabs wraps the MUI Tabs component, which requires a lot of boilerplate,
-// allowing the caller to provide a TabDefinition and abstracting away handling
-// of which tab value is currently selected.
+// CommonTabs wraps the MUI Tabs component. It can be controlled or uncontrolled,
+// so callers can choose whether to delegate of which tab is selected.
 // This is a rare case where ariaLabel is a required prop, otherwise the tabs won't be accessible.
 const CommonTabs: React.FC<CommonTabsProps> = ({
   sx,
@@ -26,8 +25,6 @@ const CommonTabs: React.FC<CommonTabsProps> = ({
   onChangeTab,
 }) => {
   const [internalValue, setInternalValue] = useState(0);
-
-  // Use external value if provided; otherwise, use internal state
   const currentValue = currentTab ?? internalValue;
 
   const handleChange = (_event: React.SyntheticEvent, newValue: number) => {

--- a/src/components/elements/SemanticIcons.tsx
+++ b/src/components/elements/SemanticIcons.tsx
@@ -1,3 +1,4 @@
+import { TimelapseRounded } from '@mui/icons-material';
 import AccessTimeIcon from '@mui/icons-material/AccessTime';
 import AddIcon from '@mui/icons-material/Add';
 import AddchartRoundedIcon from '@mui/icons-material/AddchartRounded';
@@ -120,4 +121,5 @@ export {
   ListRounded as TasksIcon,
   CheckCircleRounded as CompletedIcon,
   CancelIcon as DeclinedIcon,
+  TimelapseRounded as InProgressIcon,
 };

--- a/src/modules/ce/components/BeginReferralButton.tsx
+++ b/src/modules/ce/components/BeginReferralButton.tsx
@@ -2,7 +2,7 @@ import { LoadingButton } from '@mui/lab';
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { LoadingButtonProps } from '@/components/elements/LoadingButton';
-import { clientBriefName } from '@/modules/hmis/hmisUtil';
+import { clientNameFromRecordOptionalClient } from '@/modules/hmis/hmisUtil';
 import { cache } from '@/providers/apolloClient';
 import { ProjectDashboardRoutes } from '@/routes/routes';
 import {
@@ -28,7 +28,7 @@ const BeginReferralButton: React.FC<Props> = ({
   const [createReferral, { loading, error }] = useCreateCeReferralMutation({
     variables: {
       opportunityId,
-      clientId: candidate.client?.id || '',
+      clientId: candidate.clientId,
       input: {
         participants: [], // TODO(#7351) - assign participants
       },
@@ -58,14 +58,13 @@ const BeginReferralButton: React.FC<Props> = ({
   });
 
   if (error) throw error;
-  if (!candidate.client) return;
 
   return (
     <LoadingButton
       onClick={() => createReferral()}
       loading={loading}
       color='grayscale'
-      aria-label={`Begin Referral for ${clientBriefName(candidate.client)}`}
+      aria-label={`Begin Referral for ${clientNameFromRecordOptionalClient(candidate)}`}
       {...rest}
     >
       Begin Referral

--- a/src/modules/ce/components/BeginReferralButton.tsx
+++ b/src/modules/ce/components/BeginReferralButton.tsx
@@ -1,26 +1,29 @@
 import { LoadingButton } from '@mui/lab';
 import React from 'react';
+import { LoadingButtonProps } from '@/components/elements/LoadingButton';
+import { clientBriefName } from '@/modules/hmis/hmisUtil';
 import { cache } from '@/providers/apolloClient';
 import {
   CeCandidateFieldsFragment,
   useCreateCeReferralMutation,
 } from '@/types/gqlTypes';
 
-interface Props {
+type Props = {
   opportunityId: string;
   candidate: CeCandidateFieldsFragment;
-}
+} & LoadingButtonProps;
 
-const ActivateReferralButton: React.FC<Props> = ({
+const BeginReferralButton: React.FC<Props> = ({
   opportunityId,
   candidate,
+  ...rest
 }) => {
   const [createReferral, { loading, error }] = useCreateCeReferralMutation({
     variables: {
       opportunityId,
       clientId: candidate.client.id,
       input: {
-        participants: [], // hard-coded for now
+        participants: [], // TODO(#7351) - assign participants
       },
     },
     onCompleted: (data) => {
@@ -44,10 +47,12 @@ const ActivateReferralButton: React.FC<Props> = ({
       onClick={() => createReferral()}
       loading={loading}
       color='grayscale'
+      aria-label={`Begin Referral for ${clientBriefName(candidate.client)}`}
+      {...rest}
     >
-      Activate referral
+      Begin Referral
     </LoadingButton>
   );
 };
 
-export default ActivateReferralButton;
+export default BeginReferralButton;

--- a/src/modules/ce/components/BeginReferralButton.tsx
+++ b/src/modules/ce/components/BeginReferralButton.tsx
@@ -2,7 +2,7 @@ import { LoadingButton } from '@mui/lab';
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { LoadingButtonProps } from '@/components/elements/LoadingButton';
-import { clientNameFromRecordOptionalClient } from '@/modules/hmis/hmisUtil';
+import { clientNameFromRecordWithOptionalClient } from '@/modules/hmis/hmisUtil';
 import { cache } from '@/providers/apolloClient';
 import { ProjectDashboardRoutes } from '@/routes/routes';
 import {
@@ -64,7 +64,7 @@ const BeginReferralButton: React.FC<Props> = ({
       onClick={() => createReferral()}
       loading={loading}
       color='grayscale'
-      aria-label={`Begin Referral for ${clientNameFromRecordOptionalClient(candidate)}`}
+      aria-label={`Begin Referral for ${clientNameFromRecordWithOptionalClient(candidate)}`}
       {...rest}
     >
       Begin Referral

--- a/src/modules/ce/components/BeginReferralButton.tsx
+++ b/src/modules/ce/components/BeginReferralButton.tsx
@@ -1,23 +1,30 @@
 import { LoadingButton } from '@mui/lab';
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 import { LoadingButtonProps } from '@/components/elements/LoadingButton';
 import { clientBriefName } from '@/modules/hmis/hmisUtil';
 import { cache } from '@/providers/apolloClient';
+import { ProjectDashboardRoutes } from '@/routes/routes';
 import {
   CeCandidateFieldsFragment,
   useCreateCeReferralMutation,
 } from '@/types/gqlTypes';
+import { generateSafePath } from '@/utils/pathEncoding';
 
 type Props = {
   opportunityId: string;
+  projectId: string;
   candidate: CeCandidateFieldsFragment;
 } & LoadingButtonProps;
 
 const BeginReferralButton: React.FC<Props> = ({
   opportunityId,
+  projectId,
   candidate,
   ...rest
 }) => {
+  const navigate = useNavigate();
+
   const [createReferral, { loading, error }] = useCreateCeReferralMutation({
     variables: {
       opportunityId,
@@ -28,14 +35,24 @@ const BeginReferralButton: React.FC<Props> = ({
     },
     onCompleted: (data) => {
       if (data.createCeReferral?.referral) {
+        const referral = data.createCeReferral.referral;
+
         cache.modify({
           id: `CeOpportunity:${opportunityId}`,
           fields: {
             activeReferral() {
-              return data.createCeReferral?.referral;
+              return referral;
             },
           },
         });
+
+        navigate(
+          generateSafePath(ProjectDashboardRoutes.REFERRAL_DETAILS, {
+            projectId: projectId,
+            opportunityId: opportunityId,
+            referralId: referral.id,
+          })
+        );
       }
     },
   });

--- a/src/modules/ce/components/BeginReferralButton.tsx
+++ b/src/modules/ce/components/BeginReferralButton.tsx
@@ -28,7 +28,7 @@ const BeginReferralButton: React.FC<Props> = ({
   const [createReferral, { loading, error }] = useCreateCeReferralMutation({
     variables: {
       opportunityId,
-      clientId: candidate.client.id,
+      clientId: candidate.client?.id || '',
       input: {
         participants: [], // TODO(#7351) - assign participants
       },
@@ -58,6 +58,7 @@ const BeginReferralButton: React.FC<Props> = ({
   });
 
   if (error) throw error;
+  if (!candidate.client) return;
 
   return (
     <LoadingButton

--- a/src/modules/ce/components/CreateOpportunityButton.tsx
+++ b/src/modules/ce/components/CreateOpportunityButton.tsx
@@ -20,8 +20,8 @@ interface Props {
 }
 const CreateOpportunityButton: React.FC<Props> = ({ projectId }) => {
   const [open, setOpen] = useState(false);
-  const [name, setName] = useState<string | undefined>(undefined);
-  const [templateId, setTemplateId] = useState<string | undefined>(undefined);
+  const [name, setName] = useState<string | null>(null);
+  const [templateId, setTemplateId] = useState<string | null>(null);
 
   const [createOpportunity, { loading, error }] =
     useCreateCeOpportunityMutation({

--- a/src/modules/ce/components/MatchRuleGrid.tsx
+++ b/src/modules/ce/components/MatchRuleGrid.tsx
@@ -1,0 +1,33 @@
+import { Divider, Typography } from '@mui/material';
+import React from 'react';
+import {
+  CommonDetailGridContainer,
+  CommonDetailGridItem,
+} from '@/components/elements/CommonDetailGrid';
+import { CeMatchRule } from '@/types/gqlTypes';
+
+interface Props {
+  title: string;
+  rules: CeMatchRule[];
+}
+const MatchRuleGrid: React.FC<Props> = ({ title, rules }) => {
+  return (
+    <>
+      <Typography variant='h5' component='h3' mb={2}>
+        {title}
+      </Typography>
+      <CommonDetailGridContainer>
+        {rules.map((rule) => (
+          <CommonDetailGridItem key={rule.id} label={rule.name}>
+            {rule.ownerType === 'Opportunity'
+              ? 'Applies to this Opportunity'
+              : `Inherited from ${rule.ownerType}`}
+          </CommonDetailGridItem>
+        ))}
+      </CommonDetailGridContainer>
+      <Divider />
+    </>
+  );
+};
+
+export default MatchRuleGrid;

--- a/src/modules/ce/components/Opportunity.tsx
+++ b/src/modules/ce/components/Opportunity.tsx
@@ -1,5 +1,5 @@
 import { Grid, Paper, Typography } from '@mui/material';
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import MatchRuleGrid from './MatchRuleGrid';
 import CommonTabs from '@/components/elements/CommonTabs';
 import Loading from '@/components/elements/Loading';
@@ -9,7 +9,11 @@ import useSafeParams from '@/hooks/useSafeParams';
 import OpportunityBanner from '@/modules/ce/components/OpportunityBanner';
 import PrioritizedClientsTable from '@/modules/ce/components/PrioritizedClientsTable';
 import { useProjectDashboardContext } from '@/modules/projects/components/ProjectDashboard';
-import { CeMatchRuleType, useGetCeOpportunityQuery } from '@/types/gqlTypes';
+import {
+  CeMatchRuleType,
+  useGetCeOpportunityCandidatesQuery,
+  useGetCeOpportunityQuery,
+} from '@/types/gqlTypes';
 
 interface Props {}
 const Opportunity: React.FC<Props> = ({}) => {
@@ -32,6 +36,25 @@ const Opportunity: React.FC<Props> = ({}) => {
     },
   });
 
+  // query for the opportunity's top candidate here, rather than inside the OpportunityBanner,
+  // so we can batch it with the above query for the Opportunity
+  const {
+    data: {
+      ceOpportunity: { candidates: { nodes: candidates = [] } = {} } = {},
+    } = {},
+    loading: topCandidateLoading,
+    error: topCandidateError,
+  } = useGetCeOpportunityCandidatesQuery({
+    variables: {
+      opportunityId: opportunityId,
+      limit: 1,
+    },
+  });
+
+  const topCandidate = useMemo(() => {
+    return candidates[0];
+  }, [candidates]);
+
   const eligibilityRequirements = (opportunity?.rules || []).filter(
     (r) => r.type === CeMatchRuleType.EligibilityRequirement
   );
@@ -39,8 +62,9 @@ const Opportunity: React.FC<Props> = ({}) => {
     (r) => r.type === CeMatchRuleType.PriorityScheme
   );
 
-  if (loading) return <Loading />;
+  if (loading || topCandidateLoading) return <Loading />;
   if (error) throw error;
+  if (topCandidateError) throw topCandidateError;
   if (!opportunity) return <NotFound />;
 
   if (opportunity.projectId !== projectId) {
@@ -64,6 +88,7 @@ const Opportunity: React.FC<Props> = ({}) => {
               <Grid container columnSpacing={2} rowSpacing={4}>
                 <Grid item xs={12}>
                   <OpportunityBanner
+                    topCandidate={topCandidate}
                     opportunity={opportunity}
                     viewAllEligibleClients={() => setCurrentTab(1)}
                   />

--- a/src/modules/ce/components/Opportunity.tsx
+++ b/src/modules/ce/components/Opportunity.tsx
@@ -88,7 +88,10 @@ const Opportunity: React.FC<Props> = ({}) => {
             contents: (
               <Paper>
                 {/*todo @martha - discuss showing current referral and status here */}
-                <PrioritizedClientsTable opportunityId={opportunityId} />
+                <PrioritizedClientsTable
+                  opportunityId={opportunityId}
+                  status={opportunity.status}
+                />
               </Paper>
             ),
           },

--- a/src/modules/ce/components/Opportunity.tsx
+++ b/src/modules/ce/components/Opportunity.tsx
@@ -90,6 +90,7 @@ const Opportunity: React.FC<Props> = ({}) => {
                 {/*todo @martha - discuss showing current referral and status here */}
                 <PrioritizedClientsTable
                   opportunityId={opportunityId}
+                  projectId={projectId}
                   status={opportunity.status}
                 />
               </Paper>

--- a/src/modules/ce/components/Opportunity.tsx
+++ b/src/modules/ce/components/Opportunity.tsx
@@ -10,7 +10,6 @@ import OpportunityBanner from '@/modules/ce/components/OpportunityBanner';
 import PrioritizedClientsTable from '@/modules/ce/components/PrioritizedClientsTable';
 import { useProjectDashboardContext } from '@/modules/projects/components/ProjectDashboard';
 import {
-  CeMatchRuleType,
   useGetCeOpportunityCandidatesQuery,
   useGetCeOpportunityQuery,
 } from '@/types/gqlTypes';
@@ -55,13 +54,6 @@ const Opportunity: React.FC<Props> = ({}) => {
     return candidates[0];
   }, [candidates]);
 
-  const eligibilityRequirements = (opportunity?.rules || []).filter(
-    (r) => r.type === CeMatchRuleType.EligibilityRequirement
-  );
-  const prioritySchemes = (opportunity?.rules || []).filter(
-    (r) => r.type === CeMatchRuleType.PriorityScheme
-  );
-
   if (loading || topCandidateLoading) return <Loading />;
   if (error) throw error;
   if (topCandidateError) throw topCandidateError;
@@ -93,18 +85,22 @@ const Opportunity: React.FC<Props> = ({}) => {
                     viewAllEligibleClients={() => setCurrentTab(1)}
                   />
                 </Grid>
-                <Grid item xs={12} md={6}>
-                  <MatchRuleGrid
-                    title='Requirements'
-                    rules={eligibilityRequirements}
-                  />
-                </Grid>
-                <Grid item xs={12} md={6}>
-                  <MatchRuleGrid
-                    title='Prioritization'
-                    rules={prioritySchemes}
-                  />
-                </Grid>
+                {opportunity.eligibilityRequirements && (
+                  <Grid item xs={12} md={6}>
+                    <MatchRuleGrid
+                      title='Requirements'
+                      rules={opportunity.eligibilityRequirements}
+                    />
+                  </Grid>
+                )}
+                {opportunity.priorityScheme && (
+                  <Grid item xs={12} md={6}>
+                    <MatchRuleGrid
+                      title='Prioritization'
+                      rules={[opportunity.priorityScheme]}
+                    />
+                  </Grid>
+                )}
               </Grid>
             ),
           },

--- a/src/modules/ce/components/Opportunity.tsx
+++ b/src/modules/ce/components/Opportunity.tsx
@@ -1,37 +1,15 @@
-import { Paper, Stack, Typography } from '@mui/material';
-import React, { useMemo } from 'react';
-import ButtonLink from '@/components/elements/ButtonLink';
+import { Grid, Paper, Typography } from '@mui/material';
+import React, { useState } from 'react';
+import MatchRuleGrid from './MatchRuleGrid';
+import CommonTabs from '@/components/elements/CommonTabs';
 import Loading from '@/components/elements/Loading';
-import TableRowActions from '@/components/elements/table/TableRowActions';
-import { BASE_ACTION_COLUMN_DEF } from '@/components/elements/table/tableRowActionUtil';
-import { ColumnDef } from '@/components/elements/table/types';
 import PageTitle from '@/components/layout/PageTitle';
 import NotFound from '@/components/pages/NotFound';
 import useSafeParams from '@/hooks/useSafeParams';
-import ActivateReferralButton from '@/modules/ce/components/ActivateReferralButton';
-import GenericTableWithData from '@/modules/dataFetching/components/GenericTableWithData';
-import { ClientDashboardRoutes, ProjectDashboardRoutes } from '@/routes/routes';
-import {
-  CeCandidateFieldsFragment,
-  GetCeOpportunityCandidatesDocument,
-  GetCeOpportunityCandidatesQuery,
-  GetCeOpportunityCandidatesQueryVariables,
-  useGetCeOpportunityQuery,
-} from '@/types/gqlTypes';
-import { generateSafePath } from '@/utils/pathEncoding';
-
-const COLUMNS: ColumnDef<CeCandidateFieldsFragment>[] = [
-  {
-    header: 'ID',
-    render: 'id',
-    key: 'id',
-  },
-  {
-    header: 'Client ID',
-    render: (candidate) => candidate.client.id,
-    key: 'clientId',
-  },
-];
+import OpportunityBanner from '@/modules/ce/components/OpportunityBanner';
+import PrioritizedClientsTable from '@/modules/ce/components/PrioritizedClientsTable';
+import { useProjectDashboardContext } from '@/modules/projects/components/ProjectDashboard';
+import { CeMatchRuleType, useGetCeOpportunityQuery } from '@/types/gqlTypes';
 
 interface Props {}
 const Opportunity: React.FC<Props> = ({}) => {
@@ -39,6 +17,10 @@ const Opportunity: React.FC<Props> = ({}) => {
     opportunityId: string;
     projectId: string;
   };
+
+  const { project } = useProjectDashboardContext();
+
+  const [currentTab, setCurrentTab] = useState(0);
 
   const {
     data: { ceOpportunity: opportunity } = {},
@@ -50,81 +32,68 @@ const Opportunity: React.FC<Props> = ({}) => {
     },
   });
 
-  const columns = useMemo(() => {
-    return [
-      ...COLUMNS,
-      {
-        ...BASE_ACTION_COLUMN_DEF,
-        render: (row: CeCandidateFieldsFragment) => (
-          <TableRowActions
-            record={row}
-            recordName={`ID ${row.id}`}
-            primaryAction={
-              <ActivateReferralButton
-                opportunityId={opportunityId}
-                candidate={row}
-              />
-            }
-            menuActionConfigs={[
-              {
-                title: 'View Client',
-                key: 'client',
-                ariaLabel: `View Client, ${row.client.id}`,
-                to: generateSafePath(ClientDashboardRoutes.PROFILE, {
-                  clientId: row.client.id,
-                }),
-              },
-            ]}
-          />
-        ),
-      },
-    ];
-  }, [opportunityId]);
+  const eligibilityRequirements = (opportunity?.rules || []).filter(
+    (r) => r.type === CeMatchRuleType.EligibilityRequirement
+  );
+  const prioritySchemes = (opportunity?.rules || []).filter(
+    (r) => r.type === CeMatchRuleType.PriorityScheme
+  );
 
   if (loading) return <Loading />;
-  if (!opportunity) return <NotFound />;
   if (error) throw error;
+  if (!opportunity) return <NotFound />;
 
   if (opportunity.projectId !== projectId) {
     return <NotFound />;
   }
 
-  const { activeReferral, acceptedReferral, name } = opportunity;
-
   return (
     <>
-      <PageTitle title={`Opportunity ${name}`} />
-      {!!(activeReferral || acceptedReferral) && (
-        <ButtonLink
-          to={generateSafePath(ProjectDashboardRoutes.REFERRAL_DETAILS, {
-            projectId: projectId,
-            opportunityId: opportunityId,
-            referralId: activeReferral?.id || acceptedReferral?.id || '',
-          })}
-        >
-          View Referral
-        </ButtonLink>
-      )}
-      {!activeReferral && !acceptedReferral && (
-        <Stack gap={2}>
-          <Typography variant='h4' component='h2'>
-            Candidates
-          </Typography>
-          <Paper>
-            <GenericTableWithData<
-              GetCeOpportunityCandidatesQuery,
-              GetCeOpportunityCandidatesQueryVariables,
-              CeCandidateFieldsFragment
-            >
-              columns={columns}
-              queryVariables={{ opportunityId: opportunityId }}
-              queryDocument={GetCeOpportunityCandidatesDocument}
-              pagePath='ceOpportunity.candidates'
-              paginationItemName='candidates'
-            />
-          </Paper>
-        </Stack>
-      )}
+      <PageTitle title={opportunity.name} />
+      <Typography variant='body2' mb={2}>
+        {project.projectName} Opportunity
+      </Typography>
+      <CommonTabs
+        currentTab={currentTab}
+        onChangeTab={(tab) => setCurrentTab(tab)}
+        ariaLabel={'Eligible Clients and Details tabs'}
+        tabDefinitions={[
+          {
+            title: 'Overview',
+            contents: (
+              <Grid container columnSpacing={2} rowSpacing={4}>
+                <Grid item xs={12}>
+                  <OpportunityBanner
+                    opportunity={opportunity}
+                    viewAllEligibleClients={() => setCurrentTab(1)}
+                  />
+                </Grid>
+                <Grid item xs={12} md={6}>
+                  <MatchRuleGrid
+                    title='Requirements'
+                    rules={eligibilityRequirements}
+                  />
+                </Grid>
+                <Grid item xs={12} md={6}>
+                  <MatchRuleGrid
+                    title='Prioritization'
+                    rules={prioritySchemes}
+                  />
+                </Grid>
+              </Grid>
+            ),
+          },
+          {
+            title: 'Eligible Clients',
+            contents: (
+              <Paper>
+                {/*todo @martha - discuss showing current referral and status here */}
+                <PrioritizedClientsTable opportunityId={opportunityId} />
+              </Paper>
+            ),
+          },
+        ]}
+      />
     </>
   );
 };

--- a/src/modules/ce/components/OpportunityBanner.tsx
+++ b/src/modules/ce/components/OpportunityBanner.tsx
@@ -6,7 +6,7 @@ import { CommonLabeledTextBlock } from '@/components/elements/CommonLabeledTextB
 import { useIsMobile } from '@/hooks/useIsMobile';
 import BeginReferralButton from '@/modules/ce/components/BeginReferralButton';
 import ReferralStatusChip from '@/modules/ce/components/ReferralStatusChip';
-import { clientNameFromRecordOptionalClient } from '@/modules/hmis/hmisUtil';
+import { clientNameFromRecordWithOptionalClient } from '@/modules/hmis/hmisUtil';
 import { ProjectDashboardRoutes } from '@/routes/routes';
 import { CeOpportunityFieldsFragment } from '@/types/gqlTypes';
 import { generateSafePath } from '@/utils/pathEncoding';
@@ -30,8 +30,9 @@ const OpportunityBanner: React.FC<Props> = ({
   }, [acceptedReferral, activeReferral, topCandidate]);
 
   const clientName = useMemo(() => {
-    if (referral) return clientNameFromRecordOptionalClient(referral);
-    if (topCandidate) return clientNameFromRecordOptionalClient(topCandidate);
+    if (referral) return clientNameFromRecordWithOptionalClient(referral);
+    if (topCandidate)
+      return clientNameFromRecordWithOptionalClient(topCandidate);
   }, [referral, topCandidate]);
 
   const action = useMemo(() => {

--- a/src/modules/ce/components/OpportunityBanner.tsx
+++ b/src/modules/ce/components/OpportunityBanner.tsx
@@ -61,6 +61,7 @@ const OpportunityBanner: React.FC<Props> = ({
       return (
         <BeginReferralButton
           opportunityId={opportunity.id}
+          projectId={opportunity.projectId}
           candidate={topCandidate}
           color='primary'
         />

--- a/src/modules/ce/components/OpportunityBanner.tsx
+++ b/src/modules/ce/components/OpportunityBanner.tsx
@@ -8,19 +8,24 @@ import BeginReferralButton from '@/modules/ce/components/BeginReferralButton';
 import ReferralStatusChip from '@/modules/ce/components/ReferralStatusChip';
 import { clientNameFromRecordWithOptionalClient } from '@/modules/hmis/hmisUtil';
 import { ProjectDashboardRoutes } from '@/routes/routes';
-import { CeOpportunityFieldsFragment } from '@/types/gqlTypes';
+import {
+  CeCandidateFieldsFragment,
+  CeOpportunityFieldsFragment,
+} from '@/types/gqlTypes';
 import { generateSafePath } from '@/utils/pathEncoding';
 
 interface Props {
   opportunity: CeOpportunityFieldsFragment;
+  topCandidate?: CeCandidateFieldsFragment;
   viewAllEligibleClients: VoidFunction;
 }
 const OpportunityBanner: React.FC<Props> = ({
   opportunity,
+  topCandidate,
   viewAllEligibleClients,
 }) => {
   const isTiny = useIsMobile('sm');
-  const { activeReferral, acceptedReferral, topCandidate } = opportunity;
+  const { activeReferral, acceptedReferral } = opportunity;
   const referral = acceptedReferral || activeReferral;
 
   const header = useMemo(() => {

--- a/src/modules/ce/components/OpportunityBanner.tsx
+++ b/src/modules/ce/components/OpportunityBanner.tsx
@@ -1,12 +1,12 @@
 import PeopleIcon from '@mui/icons-material/People';
-import { Button, Chip, Paper, Stack, Typography } from '@mui/material';
+import { Button, Paper, Stack, Typography } from '@mui/material';
 import React, { useMemo } from 'react';
 import ButtonLink from '@/components/elements/ButtonLink';
 import { CommonLabeledTextBlock } from '@/components/elements/CommonLabeledTextBlock';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import BeginReferralButton from '@/modules/ce/components/BeginReferralButton';
 import ReferralStatusChip from '@/modules/ce/components/ReferralStatusChip';
-import { clientBriefName } from '@/modules/hmis/hmisUtil';
+import { clientNameFromRecordOptionalClient } from '@/modules/hmis/hmisUtil';
 import { ProjectDashboardRoutes } from '@/routes/routes';
 import { CeOpportunityFieldsFragment } from '@/types/gqlTypes';
 import { generateSafePath } from '@/utils/pathEncoding';
@@ -30,13 +30,8 @@ const OpportunityBanner: React.FC<Props> = ({
   }, [acceptedReferral, activeReferral, topCandidate]);
 
   const clientName = useMemo(() => {
-    if (referral) return clientBriefName(referral.client);
-    if (topCandidate)
-      return topCandidate.client ? (
-        clientBriefName(topCandidate.client)
-      ) : (
-        <Chip label={topCandidate.id} />
-      );
+    if (referral) return clientNameFromRecordOptionalClient(referral);
+    if (topCandidate) return clientNameFromRecordOptionalClient(topCandidate);
   }, [referral, topCandidate]);
 
   const action = useMemo(() => {
@@ -62,7 +57,7 @@ const OpportunityBanner: React.FC<Props> = ({
       );
     }
 
-    if (topCandidate && topCandidate.client) {
+    if (topCandidate) {
       return (
         <BeginReferralButton
           opportunityId={opportunity.id}

--- a/src/modules/ce/components/OpportunityBanner.tsx
+++ b/src/modules/ce/components/OpportunityBanner.tsx
@@ -1,0 +1,127 @@
+import PeopleIcon from '@mui/icons-material/People';
+import { Button, Paper, Stack, Typography } from '@mui/material';
+import React, { useMemo } from 'react';
+import ButtonLink from '@/components/elements/ButtonLink';
+import { CommonLabeledTextBlock } from '@/components/elements/CommonLabeledTextBlock';
+import { useIsMobile } from '@/hooks/useIsMobile';
+import BeginReferralButton from '@/modules/ce/components/BeginReferralButton';
+import ReferralStatusChip from '@/modules/ce/components/ReferralStatusChip';
+import { clientBriefName } from '@/modules/hmis/hmisUtil';
+import { ProjectDashboardRoutes } from '@/routes/routes';
+import { CeOpportunityFieldsFragment } from '@/types/gqlTypes';
+import { generateSafePath } from '@/utils/pathEncoding';
+
+interface Props {
+  opportunity: CeOpportunityFieldsFragment;
+  viewAllEligibleClients: VoidFunction;
+}
+const OpportunityBanner: React.FC<Props> = ({
+  opportunity,
+  viewAllEligibleClients,
+}) => {
+  const isTiny = useIsMobile('sm');
+  const { activeReferral, acceptedReferral, topCandidate } = opportunity;
+  const referral = acceptedReferral || activeReferral;
+
+  const header = useMemo(() => {
+    if (acceptedReferral) return 'Filled By';
+    if (activeReferral) return 'In-Progress Referral';
+    if (topCandidate) return 'Top Prioritization';
+  }, [acceptedReferral, activeReferral, topCandidate]);
+
+  const clientName = useMemo(() => {
+    if (referral) return clientBriefName(referral.client);
+    if (topCandidate) return clientBriefName(topCandidate.client);
+  }, [referral, topCandidate]);
+
+  const action = useMemo(() => {
+    if (referral) {
+      const to = generateSafePath(ProjectDashboardRoutes.REFERRAL_DETAILS, {
+        projectId: opportunity.projectId,
+        opportunityId: opportunity.id,
+        referralId: referral.id,
+      });
+
+      if (acceptedReferral) {
+        return (
+          <ButtonLink color='grayscale' variant='contained' to={to}>
+            View
+          </ButtonLink>
+        );
+      }
+
+      return (
+        <ButtonLink to={to} color='primary' variant='contained'>
+          Continue
+        </ButtonLink>
+      );
+    }
+
+    if (topCandidate)
+      return (
+        <BeginReferralButton
+          opportunityId={opportunity.id}
+          candidate={topCandidate}
+          color='primary'
+        />
+      );
+  }, [
+    acceptedReferral,
+    opportunity.id,
+    opportunity.projectId,
+    referral,
+    topCandidate,
+  ]);
+
+  return (
+    <>
+      <Stack
+        mb={2}
+        alignItems='center'
+        justifyContent='space-between'
+        gap={2}
+        direction='row'
+      >
+        <Typography variant='h5' component='h3'>
+          {header}
+        </Typography>
+        {!isTiny && (
+          <Button
+            onClick={viewAllEligibleClients}
+            startIcon={<PeopleIcon />}
+            variant='text'
+          >
+            View All Eligible Clients
+          </Button>
+        )}
+      </Stack>
+      <Paper
+        sx={{
+          backgroundColor: acceptedReferral ? undefined : 'primary.surface',
+          p: 2,
+        }}
+      >
+        <Stack direction='row' justifyContent='space-between'>
+          <Stack gap={4} direction={isTiny ? 'column' : 'row'}>
+            <CommonLabeledTextBlock title='Client'>
+              {clientName}
+            </CommonLabeledTextBlock>
+            {referral && (
+              <CommonLabeledTextBlock title='Status'>
+                <ReferralStatusChip status={referral.status} />
+              </CommonLabeledTextBlock>
+            )}
+            {!referral && topCandidate && (
+              <CommonLabeledTextBlock title='Prioritization Score'>
+                {topCandidate.priorityScore}
+              </CommonLabeledTextBlock>
+            )}
+          </Stack>
+          {action}
+        </Stack>
+      </Paper>
+    </>
+  );
+};
+
+export default OpportunityBanner;

--- a/src/modules/ce/components/OpportunityBanner.tsx
+++ b/src/modules/ce/components/OpportunityBanner.tsx
@@ -73,6 +73,8 @@ const OpportunityBanner: React.FC<Props> = ({
     topCandidate,
   ]);
 
+  if (!referral && !topCandidate) return;
+
   return (
     <>
       <Stack

--- a/src/modules/ce/components/OpportunityBanner.tsx
+++ b/src/modules/ce/components/OpportunityBanner.tsx
@@ -1,5 +1,5 @@
 import PeopleIcon from '@mui/icons-material/People';
-import { Button, Paper, Stack, Typography } from '@mui/material';
+import { Button, Chip, Paper, Stack, Typography } from '@mui/material';
 import React, { useMemo } from 'react';
 import ButtonLink from '@/components/elements/ButtonLink';
 import { CommonLabeledTextBlock } from '@/components/elements/CommonLabeledTextBlock';
@@ -31,7 +31,12 @@ const OpportunityBanner: React.FC<Props> = ({
 
   const clientName = useMemo(() => {
     if (referral) return clientBriefName(referral.client);
-    if (topCandidate) return clientBriefName(topCandidate.client);
+    if (topCandidate)
+      return topCandidate.client ? (
+        clientBriefName(topCandidate.client)
+      ) : (
+        <Chip label={topCandidate.id} />
+      );
   }, [referral, topCandidate]);
 
   const action = useMemo(() => {
@@ -57,7 +62,7 @@ const OpportunityBanner: React.FC<Props> = ({
       );
     }
 
-    if (topCandidate)
+    if (topCandidate && topCandidate.client) {
       return (
         <BeginReferralButton
           opportunityId={opportunity.id}
@@ -66,6 +71,7 @@ const OpportunityBanner: React.FC<Props> = ({
           color='primary'
         />
       );
+    }
   }, [
     acceptedReferral,
     opportunity.id,

--- a/src/modules/ce/components/PrioritizedClientsTable.tsx
+++ b/src/modules/ce/components/PrioritizedClientsTable.tsx
@@ -1,11 +1,13 @@
-import { Chip } from '@mui/material';
 import React, { useMemo } from 'react';
 import TableRowActions from '@/components/elements/table/TableRowActions';
 import { BASE_ACTION_COLUMN_DEF } from '@/components/elements/table/tableRowActionUtil';
 import { ColumnDef } from '@/components/elements/table/types';
 import BeginReferralButton from '@/modules/ce/components/BeginReferralButton';
 import GenericTableWithData from '@/modules/dataFetching/components/GenericTableWithData';
-import { clientBriefName } from '@/modules/hmis/hmisUtil';
+import {
+  clientBriefName,
+  clientNameFromRecordOptionalClient,
+} from '@/modules/hmis/hmisUtil';
 import { ClientDashboardRoutes } from '@/routes/routes';
 import {
   CeCandidateFieldsFragment,
@@ -21,12 +23,7 @@ const COLUMNS: ColumnDef<CeCandidateFieldsFragment>[] = [
     header: 'Client',
     key: 'client',
     sticky: 'left',
-    render: (candidate) =>
-      candidate.client ? (
-        clientBriefName(candidate.client)
-      ) : (
-        <Chip label={candidate.id} />
-      ),
+    render: (candidate) => clientNameFromRecordOptionalClient(candidate),
   },
   {
     header: 'Priority Score',
@@ -77,7 +74,7 @@ const PrioritizedClientsTable: React.FC<Props> = ({
                     },
                     // TODO(#7321) - add menu item for sending project here?
                   ]
-                : undefined
+                : []
             }
           />
         ),

--- a/src/modules/ce/components/PrioritizedClientsTable.tsx
+++ b/src/modules/ce/components/PrioritizedClientsTable.tsx
@@ -6,7 +6,7 @@ import BeginReferralButton from '@/modules/ce/components/BeginReferralButton';
 import GenericTableWithData from '@/modules/dataFetching/components/GenericTableWithData';
 import {
   clientBriefName,
-  clientNameFromRecordOptionalClient,
+  clientNameFromRecordWithOptionalClient,
 } from '@/modules/hmis/hmisUtil';
 import { ClientDashboardRoutes } from '@/routes/routes';
 import {
@@ -23,7 +23,7 @@ const COLUMNS: ColumnDef<CeCandidateFieldsFragment>[] = [
     header: 'Client',
     key: 'client',
     sticky: 'left',
-    render: (candidate) => clientNameFromRecordOptionalClient(candidate),
+    render: (candidate) => clientNameFromRecordWithOptionalClient(candidate),
   },
   {
     header: 'Priority Score',

--- a/src/modules/ce/components/PrioritizedClientsTable.tsx
+++ b/src/modules/ce/components/PrioritizedClientsTable.tsx
@@ -8,6 +8,7 @@ import { clientBriefName } from '@/modules/hmis/hmisUtil';
 import { ClientDashboardRoutes } from '@/routes/routes';
 import {
   CeCandidateFieldsFragment,
+  CeOpportunityStatus,
   GetCeOpportunityCandidatesDocument,
   GetCeOpportunityCandidatesQuery,
   GetCeOpportunityCandidatesQueryVariables,
@@ -30,8 +31,12 @@ const COLUMNS: ColumnDef<CeCandidateFieldsFragment>[] = [
 
 interface Props {
   opportunityId: string;
+  status: CeOpportunityStatus;
 }
-const PrioritizedClientsTable: React.FC<Props> = ({ opportunityId }) => {
+const PrioritizedClientsTable: React.FC<Props> = ({
+  opportunityId,
+  status,
+}) => {
   const columns = useMemo(() => {
     return [
       ...COLUMNS,
@@ -42,10 +47,12 @@ const PrioritizedClientsTable: React.FC<Props> = ({ opportunityId }) => {
             record={row}
             recordName={`ID ${row.id}`}
             primaryAction={
-              <BeginReferralButton
-                opportunityId={opportunityId}
-                candidate={row}
-              />
+              status === CeOpportunityStatus.Open && (
+                <BeginReferralButton
+                  opportunityId={opportunityId}
+                  candidate={row}
+                />
+              )
             }
             menuActionConfigs={[
               {
@@ -63,7 +70,7 @@ const PrioritizedClientsTable: React.FC<Props> = ({ opportunityId }) => {
         ),
       },
     ];
-  }, [opportunityId]);
+  }, [opportunityId, status]);
 
   return (
     <GenericTableWithData<
@@ -76,7 +83,6 @@ const PrioritizedClientsTable: React.FC<Props> = ({ opportunityId }) => {
       queryDocument={GetCeOpportunityCandidatesDocument}
       pagePath='ceOpportunity.candidates'
       paginationItemName='candidates'
-      //showTopToolbar={true}
     />
   );
 };

--- a/src/modules/ce/components/PrioritizedClientsTable.tsx
+++ b/src/modules/ce/components/PrioritizedClientsTable.tsx
@@ -1,0 +1,84 @@
+import React, { useMemo } from 'react';
+import TableRowActions from '@/components/elements/table/TableRowActions';
+import { BASE_ACTION_COLUMN_DEF } from '@/components/elements/table/tableRowActionUtil';
+import { ColumnDef } from '@/components/elements/table/types';
+import BeginReferralButton from '@/modules/ce/components/BeginReferralButton';
+import GenericTableWithData from '@/modules/dataFetching/components/GenericTableWithData';
+import { clientBriefName } from '@/modules/hmis/hmisUtil';
+import { ClientDashboardRoutes } from '@/routes/routes';
+import {
+  CeCandidateFieldsFragment,
+  GetCeOpportunityCandidatesDocument,
+  GetCeOpportunityCandidatesQuery,
+  GetCeOpportunityCandidatesQueryVariables,
+} from '@/types/gqlTypes';
+import { generateSafePath } from '@/utils/pathEncoding';
+
+const COLUMNS: ColumnDef<CeCandidateFieldsFragment>[] = [
+  {
+    header: 'Client',
+    key: 'client',
+    sticky: 'left',
+    render: (candidate) => clientBriefName(candidate.client),
+  },
+  {
+    header: 'Priority Score',
+    render: 'priorityScore',
+    key: 'priorityScore',
+  },
+];
+
+interface Props {
+  opportunityId: string;
+}
+const PrioritizedClientsTable: React.FC<Props> = ({ opportunityId }) => {
+  const columns = useMemo(() => {
+    return [
+      ...COLUMNS,
+      {
+        ...BASE_ACTION_COLUMN_DEF,
+        render: (row: CeCandidateFieldsFragment) => (
+          <TableRowActions
+            record={row}
+            recordName={`ID ${row.id}`}
+            primaryAction={
+              <BeginReferralButton
+                opportunityId={opportunityId}
+                candidate={row}
+              />
+            }
+            menuActionConfigs={[
+              {
+                title: 'View Client',
+                openInNew: true,
+                key: 'client',
+                ariaLabel: `View Client, ${clientBriefName(row.client)}`,
+                to: generateSafePath(ClientDashboardRoutes.PROFILE, {
+                  clientId: row.client.id,
+                }),
+              },
+              // TODO(#7321) - add menu item for sending project here?
+            ]}
+          />
+        ),
+      },
+    ];
+  }, [opportunityId]);
+
+  return (
+    <GenericTableWithData<
+      GetCeOpportunityCandidatesQuery,
+      GetCeOpportunityCandidatesQueryVariables,
+      CeCandidateFieldsFragment
+    >
+      columns={columns}
+      queryVariables={{ opportunityId: opportunityId }}
+      queryDocument={GetCeOpportunityCandidatesDocument}
+      pagePath='ceOpportunity.candidates'
+      paginationItemName='candidates'
+      //showTopToolbar={true}
+    />
+  );
+};
+
+export default PrioritizedClientsTable;

--- a/src/modules/ce/components/PrioritizedClientsTable.tsx
+++ b/src/modules/ce/components/PrioritizedClientsTable.tsx
@@ -1,3 +1,4 @@
+import { Chip } from '@mui/material';
 import React, { useMemo } from 'react';
 import TableRowActions from '@/components/elements/table/TableRowActions';
 import { BASE_ACTION_COLUMN_DEF } from '@/components/elements/table/tableRowActionUtil';
@@ -20,7 +21,12 @@ const COLUMNS: ColumnDef<CeCandidateFieldsFragment>[] = [
     header: 'Client',
     key: 'client',
     sticky: 'left',
-    render: (candidate) => clientBriefName(candidate.client),
+    render: (candidate) =>
+      candidate.client ? (
+        clientBriefName(candidate.client)
+      ) : (
+        <Chip label={candidate.id} />
+      ),
   },
   {
     header: 'Priority Score',
@@ -57,18 +63,22 @@ const PrioritizedClientsTable: React.FC<Props> = ({
                 />
               )
             }
-            menuActionConfigs={[
-              {
-                title: 'View Client',
-                openInNew: true,
-                key: 'client',
-                ariaLabel: `View Client, ${clientBriefName(row.client)}`,
-                to: generateSafePath(ClientDashboardRoutes.PROFILE, {
-                  clientId: row.client.id,
-                }),
-              },
-              // TODO(#7321) - add menu item for sending project here?
-            ]}
+            menuActionConfigs={
+              row.client
+                ? [
+                    {
+                      title: 'View Client',
+                      openInNew: true,
+                      key: 'client',
+                      ariaLabel: `View Client, ${clientBriefName(row.client)}`,
+                      to: generateSafePath(ClientDashboardRoutes.PROFILE, {
+                        clientId: row.client.id,
+                      }),
+                    },
+                    // TODO(#7321) - add menu item for sending project here?
+                  ]
+                : undefined
+            }
           />
         ),
       },

--- a/src/modules/ce/components/PrioritizedClientsTable.tsx
+++ b/src/modules/ce/components/PrioritizedClientsTable.tsx
@@ -31,10 +31,12 @@ const COLUMNS: ColumnDef<CeCandidateFieldsFragment>[] = [
 
 interface Props {
   opportunityId: string;
+  projectId: string;
   status: CeOpportunityStatus;
 }
 const PrioritizedClientsTable: React.FC<Props> = ({
   opportunityId,
+  projectId,
   status,
 }) => {
   const columns = useMemo(() => {
@@ -50,6 +52,7 @@ const PrioritizedClientsTable: React.FC<Props> = ({
               status === CeOpportunityStatus.Open && (
                 <BeginReferralButton
                   opportunityId={opportunityId}
+                  projectId={projectId}
                   candidate={row}
                 />
               )
@@ -70,7 +73,7 @@ const PrioritizedClientsTable: React.FC<Props> = ({
         ),
       },
     ];
-  }, [opportunityId, status]);
+  }, [opportunityId, projectId, status]);
 
   return (
     <GenericTableWithData<

--- a/src/modules/ce/components/ReferralPage.tsx
+++ b/src/modules/ce/components/ReferralPage.tsx
@@ -16,7 +16,7 @@ import NotFound from '@/components/pages/NotFound';
 import useCurrentPath from '@/hooks/useCurrentPath';
 import useSafeParams from '@/hooks/useSafeParams';
 import ReferralStatusChip from '@/modules/ce/components/ReferralStatusChip';
-import { clientNameFromRecordOptionalClient } from '@/modules/hmis/hmisUtil';
+import { clientNameFromRecordWithOptionalClient } from '@/modules/hmis/hmisUtil';
 import { ProjectDashboardRoutes } from '@/routes/routes';
 import {
   CeReferralFieldsFragment,
@@ -80,7 +80,7 @@ const ReferralPage: React.FC<Props> = ({}) => {
             <Stack direction='row' alignItems='center' gap={0.5}>
               <Person sx={{ color: 'grayscale.main' }} />
               <Typography variant='body1'>
-                {clientNameFromRecordOptionalClient(referral)}
+                {clientNameFromRecordWithOptionalClient(referral)}
               </Typography>
             </Stack>
             <Typography variant='body1'>

--- a/src/modules/ce/components/ReferralPage.tsx
+++ b/src/modules/ce/components/ReferralPage.tsx
@@ -16,7 +16,7 @@ import NotFound from '@/components/pages/NotFound';
 import useCurrentPath from '@/hooks/useCurrentPath';
 import useSafeParams from '@/hooks/useSafeParams';
 import ReferralStatusChip from '@/modules/ce/components/ReferralStatusChip';
-import { clientBriefName } from '@/modules/hmis/hmisUtil';
+import { clientNameFromRecordOptionalClient } from '@/modules/hmis/hmisUtil';
 import { ProjectDashboardRoutes } from '@/routes/routes';
 import {
   CeReferralFieldsFragment,
@@ -80,7 +80,7 @@ const ReferralPage: React.FC<Props> = ({}) => {
             <Stack direction='row' alignItems='center' gap={0.5}>
               <Person sx={{ color: 'grayscale.main' }} />
               <Typography variant='body1'>
-                {clientBriefName(referral.client)}
+                {clientNameFromRecordOptionalClient(referral)}
               </Typography>
             </Stack>
             <Typography variant='body1'>

--- a/src/modules/ce/components/ReferralStatusChip.tsx
+++ b/src/modules/ce/components/ReferralStatusChip.tsx
@@ -1,20 +1,42 @@
+import { Chip, ChipProps, SxProps } from '@mui/material';
 import React from 'react';
+import { InProgressIcon } from '@/components/elements/SemanticIcons';
 import { CeReferralStatus } from '@/types/gqlTypes';
 
 interface Props {
   status: CeReferralStatus;
 }
 const ReferralStatusChip: React.FC<Props> = ({ status }) => {
+  const baseChipSx: SxProps = {
+    borderWeight: '1px',
+    borderColor: 'borders.main',
+    borderStyle: 'solid',
+    fontWeight: 600,
+  };
+
+  const baseChipProps: ChipProps = {
+    size: 'small',
+    variant: 'outlined',
+    sx: baseChipSx,
+  };
+
   // TODO(7393) - add styles and colors, and make sure all statuses are mapped correctly
   switch (status) {
     case CeReferralStatus.Initialized:
-      return 'Eligible';
+      return <Chip label='Eligible' {...baseChipProps} />;
     case CeReferralStatus.InProgress:
-      return 'In Progress';
+      return (
+        <Chip
+          label='In Process'
+          {...baseChipProps}
+          color='primary'
+          icon={<InProgressIcon />}
+        />
+      );
     case CeReferralStatus.Accepted:
-      return 'Approved';
+      return <Chip label='Approved' {...baseChipProps} />;
     case CeReferralStatus.Rejected:
-      return 'Declined';
+      return <Chip label='Declined' {...baseChipProps} />;
     default:
       return '';
   }

--- a/src/modules/ce/components/ReferralStepCard.tsx
+++ b/src/modules/ce/components/ReferralStepCard.tsx
@@ -43,7 +43,8 @@ const ReferralStepCard: React.FC<Props> = ({ step }) => {
 
           // The step returned from the mutation is now auto added to the Apollo cache.
           // Here we are writing it to the cache specifically for the GetCeReferralStepDocument query,
-          // so that when we navigate to the Step page, we don't do a double-fetch for the data we already have.
+          // because the step is queried by `stepId` (the db ID) but cached by `id` (a composite ID).
+          // We might have to return to these IDs in the future if there are issues
           cache.writeQuery({
             query: GetCeReferralStepDocument,
             data: {

--- a/src/modules/ce/components/ReferralWayfinder.tsx
+++ b/src/modules/ce/components/ReferralWayfinder.tsx
@@ -3,7 +3,7 @@ import WayfindingDialog from '@/components/elements/navigation/WayfindingDialog'
 import { DeclinedIcon } from '@/components/elements/SemanticIcons';
 import useSafeParams from '@/hooks/useSafeParams';
 import { useReferralContext } from '@/modules/ce/components/ReferralPage';
-import { clientNameFromRecordOptionalClient } from '@/modules/hmis/hmisUtil';
+import { clientNameFromRecordWithOptionalClient } from '@/modules/hmis/hmisUtil';
 import { ProjectDashboardRoutes, Routes } from '@/routes/routes';
 import { CeReferralStatus } from '@/types/gqlTypes';
 import { generateSafePath } from '@/utils/pathEncoding';
@@ -20,7 +20,7 @@ const ReferralWayfinder: React.FC<Props> = ({ open, onClose }) => {
   };
 
   const { status, opportunity } = referral;
-  const clientName = clientNameFromRecordOptionalClient(referral);
+  const clientName = clientNameFromRecordWithOptionalClient(referral);
 
   switch (status) {
     case CeReferralStatus.Accepted:

--- a/src/modules/ce/components/ReferralWayfinder.tsx
+++ b/src/modules/ce/components/ReferralWayfinder.tsx
@@ -3,7 +3,7 @@ import WayfindingDialog from '@/components/elements/navigation/WayfindingDialog'
 import { DeclinedIcon } from '@/components/elements/SemanticIcons';
 import useSafeParams from '@/hooks/useSafeParams';
 import { useReferralContext } from '@/modules/ce/components/ReferralPage';
-import { clientBriefName } from '@/modules/hmis/hmisUtil';
+import { clientNameFromRecordOptionalClient } from '@/modules/hmis/hmisUtil';
 import { ProjectDashboardRoutes, Routes } from '@/routes/routes';
 import { CeReferralStatus } from '@/types/gqlTypes';
 import { generateSafePath } from '@/utils/pathEncoding';
@@ -19,7 +19,8 @@ const ReferralWayfinder: React.FC<Props> = ({ open, onClose }) => {
     opportunityId: string;
   };
 
-  const { status, client, opportunity } = referral;
+  const { status, opportunity } = referral;
+  const clientName = clientNameFromRecordOptionalClient(referral);
 
   switch (status) {
     case CeReferralStatus.Accepted:
@@ -29,7 +30,7 @@ const ReferralWayfinder: React.FC<Props> = ({ open, onClose }) => {
           onClose={onClose}
           title='Referral Complete'
           alertTitle='Referral Completed'
-          alertText={`${clientBriefName(client)} has been accepted to ${opportunity.name}`}
+          alertText={`${clientName} has been accepted to ${opportunity.name}`}
           items={[
             {
               title: 'Return to Opportunity Overview',
@@ -51,7 +52,7 @@ const ReferralWayfinder: React.FC<Props> = ({ open, onClose }) => {
           onClose={onClose}
           title='Referral Complete'
           alertTitle='Referral Declined'
-          alertText={`${clientBriefName(client)} has been declined from ${opportunity.name}`}
+          alertText={`${clientName} has been declined from ${opportunity.name}`}
           AlertProps={{
             icon: <DeclinedIcon />,
             severity: 'info',

--- a/src/modules/dataFetching/components/GenericTableWithData.tsx
+++ b/src/modules/dataFetching/components/GenericTableWithData.tsx
@@ -324,6 +324,12 @@ const GenericTableWithData = <
           tablePaginationProps={
             nonTablePagination ? undefined : tablePaginationProps
           }
+          tableContainerProps={{
+            sx: {
+              // makes sure border radius corners aren't cut off when top toolbar isn't shown
+              borderRadius: 1,
+            },
+          }}
           columns={showColumnDefs}
           noData={loading ? 'Loading...' : noDataValue}
           vertical={vertical}

--- a/src/modules/hmis/hmisUtil.ts
+++ b/src/modules/hmis/hmisUtil.ts
@@ -42,6 +42,7 @@ import {
   EnrollmentOccurrencePointFieldsFragment,
   EventFieldsFragment,
   HouseholdClientFieldsFragment,
+  Maybe,
   NoYes,
   NoYesMissing,
   NoYesReasonsForMissingData,
@@ -254,6 +255,17 @@ export const clientBriefName = (
 ) =>
   [client.firstName, client.lastName].filter(Boolean).join(' ') ||
   anonymousClientName(client);
+
+type WithClient = {
+  client?: Maybe<ClientNameFragment>;
+  clientId: string;
+};
+export const clientNameFromRecordOptionalClient = ({
+  client,
+  clientId,
+}: WithClient) => {
+  return client ? clientBriefName(client) : `Client ${clientId}`;
+};
 
 export const clientInitials = (client: ClientNameFragment) =>
   [client.firstName, client.lastName]

--- a/src/modules/hmis/hmisUtil.ts
+++ b/src/modules/hmis/hmisUtil.ts
@@ -260,7 +260,7 @@ type WithClient = {
   client?: Maybe<ClientNameFragment>;
   clientId: string;
 };
-export const clientNameFromRecordOptionalClient = ({
+export const clientNameFromRecordWithOptionalClient = ({
   client,
   clientId,
 }: WithClient) => {

--- a/src/types/gqlEnums.ts
+++ b/src/types/gqlEnums.ts
@@ -75,6 +75,10 @@ export const HmisEnums = {
     OTHER: 'Other',
   },
   BoundType: { MAX: 'MAX', MIN: 'MIN' },
+  CeMatchRuleType: {
+    eligibility_requirement: 'eligibility_requirement',
+    priority_scheme: 'priority_scheme',
+  },
   CeReferralStatus: {
     accepted: 'accepted',
     in_progress: 'in_progress',

--- a/src/types/gqlEnums.ts
+++ b/src/types/gqlEnums.ts
@@ -79,6 +79,7 @@ export const HmisEnums = {
     eligibility_requirement: 'eligibility_requirement',
     priority_scheme: 'priority_scheme',
   },
+  CeOpportunityStatus: { closed: 'closed', locked: 'locked', open: 'open' },
   CeReferralStatus: {
     accepted: 'accepted',
     in_progress: 'in_progress',

--- a/src/types/gqlObjects.ts
+++ b/src/types/gqlObjects.ts
@@ -498,6 +498,43 @@ export const HmisObjectSchemas: GqlSchema[] = [
     ],
   },
   {
+    name: 'CeMatchRule',
+    fields: [
+      {
+        name: 'id',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'ID', ofType: null },
+        },
+      },
+      {
+        name: 'name',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'String', ofType: null },
+        },
+      },
+      {
+        name: 'ownerType',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'String', ofType: null },
+        },
+      },
+      {
+        name: 'type',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'ENUM', name: 'CeMatchRuleType', ofType: null },
+        },
+      },
+    ],
+  },
+  {
     name: 'CeOpportunity',
     fields: [
       {

--- a/src/types/gqlObjects.ts
+++ b/src/types/gqlObjects.ts
@@ -578,7 +578,7 @@ export const HmisObjectSchemas: GqlSchema[] = [
         type: {
           kind: 'NON_NULL',
           name: null,
-          ofType: { kind: 'SCALAR', name: 'String', ofType: null },
+          ofType: { kind: 'ENUM', name: 'CeOpportunityStatus', ofType: null },
         },
       },
     ],

--- a/src/types/gqlObjects.ts
+++ b/src/types/gqlObjects.ts
@@ -480,6 +480,14 @@ export const HmisObjectSchemas: GqlSchema[] = [
     name: 'CeCandidate',
     fields: [
       {
+        name: 'clientId',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'ID', ofType: null },
+        },
+      },
+      {
         name: 'id',
         type: {
           kind: 'NON_NULL',
@@ -643,6 +651,14 @@ export const HmisObjectSchemas: GqlSchema[] = [
   {
     name: 'CeReferral',
     fields: [
+      {
+        name: 'clientId',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'ID', ofType: null },
+        },
+      },
       {
         name: 'id',
         type: {

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -546,6 +546,7 @@ export type CeAssessmentsPaginated = {
 
 export type CeCandidate = {
   __typename?: 'CeCandidate';
+  /** Null if the user lacks permission to view the client */
   client?: Maybe<Client>;
   clientId: Scalars['ID']['output'];
   id: Scalars['ID']['output'];
@@ -599,7 +600,6 @@ export type CeOpportunity = {
   projectName: Scalars['String']['output'];
   rules?: Maybe<Array<CeMatchRule>>;
   status: CeOpportunityStatus;
-  topCandidate?: Maybe<CeCandidate>;
 };
 
 export type CeOpportunityCandidatesArgs = {
@@ -15855,21 +15855,6 @@ export type CeOpportunityFieldsFragment = {
     type: CeMatchRuleType;
     ownerType: string;
   }> | null;
-  topCandidate?: {
-    __typename?: 'CeCandidate';
-    id: string;
-    priorityScore: number;
-    clientId: string;
-    client?: {
-      __typename?: 'Client';
-      id: string;
-      lockVersion: number;
-      firstName?: string | null;
-      middleName?: string | null;
-      lastName?: string | null;
-      nameSuffix?: string | null;
-    } | null;
-  } | null;
 };
 
 export type CeMatchRuleFieldsFragment = {
@@ -17633,21 +17618,6 @@ export type SubmitCeReferralStepMutation = {
           type: CeMatchRuleType;
           ownerType: string;
         }> | null;
-        topCandidate?: {
-          __typename?: 'CeCandidate';
-          id: string;
-          priorityScore: number;
-          clientId: string;
-          client?: {
-            __typename?: 'Client';
-            id: string;
-            lockVersion: number;
-            firstName?: string | null;
-            middleName?: string | null;
-            lastName?: string | null;
-            nameSuffix?: string | null;
-          } | null;
-        } | null;
       };
     } | null;
     errors: Array<{
@@ -17747,21 +17717,6 @@ export type GetCeOpportunityQuery = {
       type: CeMatchRuleType;
       ownerType: string;
     }> | null;
-    topCandidate?: {
-      __typename?: 'CeCandidate';
-      id: string;
-      priorityScore: number;
-      clientId: string;
-      client?: {
-        __typename?: 'Client';
-        id: string;
-        lockVersion: number;
-        firstName?: string | null;
-        middleName?: string | null;
-        lastName?: string | null;
-        nameSuffix?: string | null;
-      } | null;
-    } | null;
   };
 };
 
@@ -44149,17 +44104,6 @@ export const CeMatchRuleFieldsFragmentDoc = gql`
     ownerType
   }
 `;
-export const CeCandidateFieldsFragmentDoc = gql`
-  fragment CeCandidateFields on CeCandidate {
-    id
-    priorityScore
-    clientId
-    client {
-      ...ClientName
-    }
-  }
-  ${ClientNameFragmentDoc}
-`;
 export const CeOpportunityFieldsFragmentDoc = gql`
   fragment CeOpportunityFields on CeOpportunity {
     ...CeOpportunitySummaryFields
@@ -44172,14 +44116,21 @@ export const CeOpportunityFieldsFragmentDoc = gql`
     rules {
       ...CeMatchRuleFields
     }
-    topCandidate {
-      ...CeCandidateFields
-    }
   }
   ${CeOpportunitySummaryFieldsFragmentDoc}
   ${CeReferralSummaryFieldsFragmentDoc}
   ${CeMatchRuleFieldsFragmentDoc}
-  ${CeCandidateFieldsFragmentDoc}
+`;
+export const CeCandidateFieldsFragmentDoc = gql`
+  fragment CeCandidateFields on CeCandidate {
+    id
+    priorityScore
+    clientId
+    client {
+      ...ClientName
+    }
+  }
+  ${ClientNameFragmentDoc}
 `;
 export const CeReferralStepSummaryFieldsFragmentDoc = gql`
   fragment CeReferralStepSummaryFields on CeReferralStep {

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -547,6 +547,7 @@ export type CeAssessmentsPaginated = {
 export type CeCandidate = {
   __typename?: 'CeCandidate';
   client?: Maybe<Client>;
+  clientId: Scalars['ID']['output'];
   id: Scalars['ID']['output'];
   priorityScore: Scalars['Int']['output'];
 };
@@ -648,7 +649,8 @@ export type CeParticipationsPaginated = {
 
 export type CeReferral = {
   __typename?: 'CeReferral';
-  client: Client;
+  client?: Maybe<Client>;
+  clientId: Scalars['ID']['output'];
   id: Scalars['ID']['output'];
   opportunity: CeOpportunity;
   status: CeReferralStatus;
@@ -15820,7 +15822,8 @@ export type CeOpportunityFieldsFragment = {
     __typename?: 'CeReferral';
     id: string;
     status: CeReferralStatus;
-    client: {
+    clientId: string;
+    client?: {
       __typename?: 'Client';
       id: string;
       lockVersion: number;
@@ -15828,13 +15831,14 @@ export type CeOpportunityFieldsFragment = {
       middleName?: string | null;
       lastName?: string | null;
       nameSuffix?: string | null;
-    };
+    } | null;
   } | null;
   acceptedReferral?: {
     __typename?: 'CeReferral';
     id: string;
     status: CeReferralStatus;
-    client: {
+    clientId: string;
+    client?: {
       __typename?: 'Client';
       id: string;
       lockVersion: number;
@@ -15842,7 +15846,7 @@ export type CeOpportunityFieldsFragment = {
       middleName?: string | null;
       lastName?: string | null;
       nameSuffix?: string | null;
-    };
+    } | null;
   } | null;
   rules?: Array<{
     __typename?: 'CeMatchRule';
@@ -15855,6 +15859,7 @@ export type CeOpportunityFieldsFragment = {
     __typename?: 'CeCandidate';
     id: string;
     priorityScore: number;
+    clientId: string;
     client?: {
       __typename?: 'Client';
       id: string;
@@ -15879,6 +15884,7 @@ export type CeCandidateFieldsFragment = {
   __typename?: 'CeCandidate';
   id: string;
   priorityScore: number;
+  clientId: string;
   client?: {
     __typename?: 'Client';
     id: string;
@@ -15894,7 +15900,8 @@ export type CeReferralSummaryFieldsFragment = {
   __typename?: 'CeReferral';
   id: string;
   status: CeReferralStatus;
-  client: {
+  clientId: string;
+  client?: {
     __typename?: 'Client';
     id: string;
     lockVersion: number;
@@ -15902,13 +15909,14 @@ export type CeReferralSummaryFieldsFragment = {
     middleName?: string | null;
     lastName?: string | null;
     nameSuffix?: string | null;
-  };
+  } | null;
 };
 
 export type CeReferralFieldsFragment = {
   __typename?: 'CeReferral';
   id: string;
   status: CeReferralStatus;
+  clientId: string;
   steps: Array<{
     __typename?: 'CeReferralStep';
     id: string;
@@ -15926,7 +15934,7 @@ export type CeReferralFieldsFragment = {
     projectId: string;
     projectName: string;
   };
-  client: {
+  client?: {
     __typename?: 'Client';
     id: string;
     lockVersion: number;
@@ -15934,7 +15942,7 @@ export type CeReferralFieldsFragment = {
     middleName?: string | null;
     lastName?: string | null;
     nameSuffix?: string | null;
-  };
+  } | null;
 };
 
 export type CeReferralStepSummaryFieldsFragment = {
@@ -16501,7 +16509,8 @@ export type CreateCeReferralMutation = {
       __typename?: 'CeReferral';
       id: string;
       status: CeReferralStatus;
-      client: {
+      clientId: string;
+      client?: {
         __typename?: 'Client';
         id: string;
         lockVersion: number;
@@ -16509,7 +16518,7 @@ export type CreateCeReferralMutation = {
         middleName?: string | null;
         lastName?: string | null;
         nameSuffix?: string | null;
-      };
+      } | null;
     };
   } | null;
 };
@@ -17591,7 +17600,8 @@ export type SubmitCeReferralStepMutation = {
           __typename?: 'CeReferral';
           id: string;
           status: CeReferralStatus;
-          client: {
+          clientId: string;
+          client?: {
             __typename?: 'Client';
             id: string;
             lockVersion: number;
@@ -17599,13 +17609,14 @@ export type SubmitCeReferralStepMutation = {
             middleName?: string | null;
             lastName?: string | null;
             nameSuffix?: string | null;
-          };
+          } | null;
         } | null;
         acceptedReferral?: {
           __typename?: 'CeReferral';
           id: string;
           status: CeReferralStatus;
-          client: {
+          clientId: string;
+          client?: {
             __typename?: 'Client';
             id: string;
             lockVersion: number;
@@ -17613,7 +17624,7 @@ export type SubmitCeReferralStepMutation = {
             middleName?: string | null;
             lastName?: string | null;
             nameSuffix?: string | null;
-          };
+          } | null;
         } | null;
         rules?: Array<{
           __typename?: 'CeMatchRule';
@@ -17626,6 +17637,7 @@ export type SubmitCeReferralStepMutation = {
           __typename?: 'CeCandidate';
           id: string;
           priorityScore: number;
+          clientId: string;
           client?: {
             __typename?: 'Client';
             id: string;
@@ -17702,7 +17714,8 @@ export type GetCeOpportunityQuery = {
       __typename?: 'CeReferral';
       id: string;
       status: CeReferralStatus;
-      client: {
+      clientId: string;
+      client?: {
         __typename?: 'Client';
         id: string;
         lockVersion: number;
@@ -17710,13 +17723,14 @@ export type GetCeOpportunityQuery = {
         middleName?: string | null;
         lastName?: string | null;
         nameSuffix?: string | null;
-      };
+      } | null;
     } | null;
     acceptedReferral?: {
       __typename?: 'CeReferral';
       id: string;
       status: CeReferralStatus;
-      client: {
+      clientId: string;
+      client?: {
         __typename?: 'Client';
         id: string;
         lockVersion: number;
@@ -17724,7 +17738,7 @@ export type GetCeOpportunityQuery = {
         middleName?: string | null;
         lastName?: string | null;
         nameSuffix?: string | null;
-      };
+      } | null;
     } | null;
     rules?: Array<{
       __typename?: 'CeMatchRule';
@@ -17737,6 +17751,7 @@ export type GetCeOpportunityQuery = {
       __typename?: 'CeCandidate';
       id: string;
       priorityScore: number;
+      clientId: string;
       client?: {
         __typename?: 'Client';
         id: string;
@@ -17770,6 +17785,7 @@ export type GetCeOpportunityCandidatesQuery = {
         __typename?: 'CeCandidate';
         id: string;
         priorityScore: number;
+        clientId: string;
         client?: {
           __typename?: 'Client';
           id: string;
@@ -17794,6 +17810,7 @@ export type GetCeReferralQuery = {
     __typename?: 'CeReferral';
     id: string;
     status: CeReferralStatus;
+    clientId: string;
     steps: Array<{
       __typename?: 'CeReferralStep';
       id: string;
@@ -17811,7 +17828,7 @@ export type GetCeReferralQuery = {
       projectId: string;
       projectName: string;
     };
-    client: {
+    client?: {
       __typename?: 'Client';
       id: string;
       lockVersion: number;
@@ -17819,7 +17836,7 @@ export type GetCeReferralQuery = {
       middleName?: string | null;
       lastName?: string | null;
       nameSuffix?: string | null;
-    };
+    } | null;
   };
 };
 
@@ -44116,6 +44133,7 @@ export const CeReferralSummaryFieldsFragmentDoc = gql`
   fragment CeReferralSummaryFields on CeReferral {
     id
     status
+    clientId
     client {
       id
       ...ClientName
@@ -44135,6 +44153,7 @@ export const CeCandidateFieldsFragmentDoc = gql`
   fragment CeCandidateFields on CeCandidate {
     id
     priorityScore
+    clientId
     client {
       ...ClientName
     }

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -593,12 +593,13 @@ export type CeOpportunity = {
   acceptedReferral?: Maybe<CeReferral>;
   activeReferral?: Maybe<CeReferral>;
   candidates: CeCandidatesPaginated;
+  eligibilityRequirements?: Maybe<Array<CeMatchRule>>;
   expiresAt?: Maybe<Scalars['ISO8601DateTime']['output']>;
   id: Scalars['ID']['output'];
   name: Scalars['String']['output'];
+  priorityScheme?: Maybe<CeMatchRule>;
   projectId: Scalars['ID']['output'];
   projectName: Scalars['String']['output'];
-  rules?: Maybe<Array<CeMatchRule>>;
   status: CeOpportunityStatus;
 };
 
@@ -15848,13 +15849,20 @@ export type CeOpportunityFieldsFragment = {
       nameSuffix?: string | null;
     } | null;
   } | null;
-  rules?: Array<{
+  eligibilityRequirements?: Array<{
     __typename?: 'CeMatchRule';
     id: string;
     name: string;
     type: CeMatchRuleType;
     ownerType: string;
   }> | null;
+  priorityScheme?: {
+    __typename?: 'CeMatchRule';
+    id: string;
+    name: string;
+    type: CeMatchRuleType;
+    ownerType: string;
+  } | null;
 };
 
 export type CeMatchRuleFieldsFragment = {
@@ -17611,13 +17619,20 @@ export type SubmitCeReferralStepMutation = {
             nameSuffix?: string | null;
           } | null;
         } | null;
-        rules?: Array<{
+        eligibilityRequirements?: Array<{
           __typename?: 'CeMatchRule';
           id: string;
           name: string;
           type: CeMatchRuleType;
           ownerType: string;
         }> | null;
+        priorityScheme?: {
+          __typename?: 'CeMatchRule';
+          id: string;
+          name: string;
+          type: CeMatchRuleType;
+          ownerType: string;
+        } | null;
       };
     } | null;
     errors: Array<{
@@ -17710,13 +17725,20 @@ export type GetCeOpportunityQuery = {
         nameSuffix?: string | null;
       } | null;
     } | null;
-    rules?: Array<{
+    eligibilityRequirements?: Array<{
       __typename?: 'CeMatchRule';
       id: string;
       name: string;
       type: CeMatchRuleType;
       ownerType: string;
     }> | null;
+    priorityScheme?: {
+      __typename?: 'CeMatchRule';
+      id: string;
+      name: string;
+      type: CeMatchRuleType;
+      ownerType: string;
+    } | null;
   };
 };
 
@@ -44113,7 +44135,10 @@ export const CeOpportunityFieldsFragmentDoc = gql`
     acceptedReferral {
       ...CeReferralSummaryFields
     }
-    rules {
+    eligibilityRequirements {
+      ...CeMatchRuleFields
+    }
+    priorityScheme {
       ...CeMatchRuleFields
     }
   }

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -562,6 +562,19 @@ export type CeCandidatesPaginated = {
   pagesCount: Scalars['Int']['output'];
 };
 
+export type CeMatchRule = {
+  __typename?: 'CeMatchRule';
+  id: Scalars['ID']['output'];
+  name: Scalars['String']['output'];
+  ownerType: Scalars['String']['output'];
+  type: CeMatchRuleType;
+};
+
+export enum CeMatchRuleType {
+  EligibilityRequirement = 'eligibility_requirement',
+  PriorityScheme = 'priority_scheme',
+}
+
 export type CeOpportunitiesPaginated = {
   __typename?: 'CeOpportunitiesPaginated';
   hasMoreAfter: Scalars['Boolean']['output'];
@@ -583,7 +596,9 @@ export type CeOpportunity = {
   name: Scalars['String']['output'];
   projectId: Scalars['ID']['output'];
   projectName: Scalars['String']['output'];
+  rules?: Maybe<Array<CeMatchRule>>;
   status: Scalars['String']['output'];
+  topCandidate?: Maybe<CeCandidate>;
 };
 
 export type CeOpportunityCandidatesArgs = {
@@ -15795,15 +15810,78 @@ export type CeOpportunityFieldsFragment = {
   expiresAt?: string | null;
   projectId: string;
   projectName: string;
-  activeReferral?: { __typename?: 'CeReferral'; id: string } | null;
-  acceptedReferral?: { __typename?: 'CeReferral'; id: string } | null;
+  activeReferral?: {
+    __typename?: 'CeReferral';
+    id: string;
+    status: CeReferralStatus;
+    client: {
+      __typename?: 'Client';
+      id: string;
+      lockVersion: number;
+      firstName?: string | null;
+      middleName?: string | null;
+      lastName?: string | null;
+      nameSuffix?: string | null;
+    };
+  } | null;
+  acceptedReferral?: {
+    __typename?: 'CeReferral';
+    id: string;
+    status: CeReferralStatus;
+    client: {
+      __typename?: 'Client';
+      id: string;
+      lockVersion: number;
+      firstName?: string | null;
+      middleName?: string | null;
+      lastName?: string | null;
+      nameSuffix?: string | null;
+    };
+  } | null;
+  rules?: Array<{
+    __typename?: 'CeMatchRule';
+    id: string;
+    name: string;
+    type: CeMatchRuleType;
+    ownerType: string;
+  }> | null;
+  topCandidate?: {
+    __typename?: 'CeCandidate';
+    id: string;
+    priorityScore: number;
+    client: {
+      __typename?: 'Client';
+      id: string;
+      lockVersion: number;
+      firstName?: string | null;
+      middleName?: string | null;
+      lastName?: string | null;
+      nameSuffix?: string | null;
+    };
+  } | null;
+};
+
+export type CeMatchRuleFieldsFragment = {
+  __typename?: 'CeMatchRule';
+  id: string;
+  name: string;
+  type: CeMatchRuleType;
+  ownerType: string;
 };
 
 export type CeCandidateFieldsFragment = {
   __typename?: 'CeCandidate';
   id: string;
   priorityScore: number;
-  client: { __typename?: 'Client'; id: string };
+  client: {
+    __typename?: 'Client';
+    id: string;
+    lockVersion: number;
+    firstName?: string | null;
+    middleName?: string | null;
+    lastName?: string | null;
+    nameSuffix?: string | null;
+  };
 };
 
 export type CeReferralSummaryFieldsFragment = {
@@ -17556,8 +17634,55 @@ export type GetCeOpportunityQuery = {
     expiresAt?: string | null;
     projectId: string;
     projectName: string;
-    activeReferral?: { __typename?: 'CeReferral'; id: string } | null;
-    acceptedReferral?: { __typename?: 'CeReferral'; id: string } | null;
+    activeReferral?: {
+      __typename?: 'CeReferral';
+      id: string;
+      status: CeReferralStatus;
+      client: {
+        __typename?: 'Client';
+        id: string;
+        lockVersion: number;
+        firstName?: string | null;
+        middleName?: string | null;
+        lastName?: string | null;
+        nameSuffix?: string | null;
+      };
+    } | null;
+    acceptedReferral?: {
+      __typename?: 'CeReferral';
+      id: string;
+      status: CeReferralStatus;
+      client: {
+        __typename?: 'Client';
+        id: string;
+        lockVersion: number;
+        firstName?: string | null;
+        middleName?: string | null;
+        lastName?: string | null;
+        nameSuffix?: string | null;
+      };
+    } | null;
+    rules?: Array<{
+      __typename?: 'CeMatchRule';
+      id: string;
+      name: string;
+      type: CeMatchRuleType;
+      ownerType: string;
+    }> | null;
+    topCandidate?: {
+      __typename?: 'CeCandidate';
+      id: string;
+      priorityScore: number;
+      client: {
+        __typename?: 'Client';
+        id: string;
+        lockVersion: number;
+        firstName?: string | null;
+        middleName?: string | null;
+        lastName?: string | null;
+        nameSuffix?: string | null;
+      };
+    } | null;
   };
 };
 
@@ -17581,7 +17706,15 @@ export type GetCeOpportunityCandidatesQuery = {
         __typename?: 'CeCandidate';
         id: string;
         priorityScore: number;
-        client: { __typename?: 'Client'; id: string };
+        client: {
+          __typename?: 'Client';
+          id: string;
+          lockVersion: number;
+          firstName?: string | null;
+          middleName?: string | null;
+          lastName?: string | null;
+          nameSuffix?: string | null;
+        };
       }>;
     };
   };
@@ -43915,27 +44048,6 @@ export const CeOpportunitySummaryFieldsFragmentDoc = gql`
     projectName
   }
 `;
-export const CeOpportunityFieldsFragmentDoc = gql`
-  fragment CeOpportunityFields on CeOpportunity {
-    ...CeOpportunitySummaryFields
-    activeReferral {
-      id
-    }
-    acceptedReferral {
-      id
-    }
-  }
-  ${CeOpportunitySummaryFieldsFragmentDoc}
-`;
-export const CeCandidateFieldsFragmentDoc = gql`
-  fragment CeCandidateFields on CeCandidate {
-    id
-    priorityScore
-    client {
-      id
-    }
-  }
-`;
 export const CeReferralSummaryFieldsFragmentDoc = gql`
   fragment CeReferralSummaryFields on CeReferral {
     id
@@ -43946,6 +44058,45 @@ export const CeReferralSummaryFieldsFragmentDoc = gql`
     }
   }
   ${ClientNameFragmentDoc}
+`;
+export const CeMatchRuleFieldsFragmentDoc = gql`
+  fragment CeMatchRuleFields on CeMatchRule {
+    id
+    name
+    type
+    ownerType
+  }
+`;
+export const CeCandidateFieldsFragmentDoc = gql`
+  fragment CeCandidateFields on CeCandidate {
+    id
+    priorityScore
+    client {
+      ...ClientName
+    }
+  }
+  ${ClientNameFragmentDoc}
+`;
+export const CeOpportunityFieldsFragmentDoc = gql`
+  fragment CeOpportunityFields on CeOpportunity {
+    ...CeOpportunitySummaryFields
+    activeReferral {
+      ...CeReferralSummaryFields
+    }
+    acceptedReferral {
+      ...CeReferralSummaryFields
+    }
+    rules {
+      ...CeMatchRuleFields
+    }
+    topCandidate {
+      ...CeCandidateFields
+    }
+  }
+  ${CeOpportunitySummaryFieldsFragmentDoc}
+  ${CeReferralSummaryFieldsFragmentDoc}
+  ${CeMatchRuleFieldsFragmentDoc}
+  ${CeCandidateFieldsFragmentDoc}
 `;
 export const CeReferralStepSummaryFieldsFragmentDoc = gql`
   fragment CeReferralStepSummaryFields on CeReferralStep {

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -597,7 +597,7 @@ export type CeOpportunity = {
   projectId: Scalars['ID']['output'];
   projectName: Scalars['String']['output'];
   rules?: Maybe<Array<CeMatchRule>>;
-  status: Scalars['String']['output'];
+  status: CeOpportunityStatus;
   topCandidate?: Maybe<CeCandidate>;
 };
 
@@ -610,6 +610,12 @@ export type CeOpportunityInput = {
   name: Scalars['String']['input'];
   templateId: Scalars['ID']['input'];
 };
+
+export enum CeOpportunityStatus {
+  Closed = 'closed',
+  Locked = 'locked',
+  Open = 'open',
+}
 
 export type CeParticipation = {
   __typename?: 'CeParticipation';
@@ -15796,7 +15802,7 @@ export type CeOpportunitySummaryFieldsFragment = {
   __typename?: 'CeOpportunity';
   id: string;
   name: string;
-  status: string;
+  status: CeOpportunityStatus;
   expiresAt?: string | null;
   projectId: string;
   projectName: string;
@@ -15806,7 +15812,7 @@ export type CeOpportunityFieldsFragment = {
   __typename?: 'CeOpportunity';
   id: string;
   name: string;
-  status: string;
+  status: CeOpportunityStatus;
   expiresAt?: string | null;
   projectId: string;
   projectName: string;
@@ -15915,7 +15921,7 @@ export type CeReferralFieldsFragment = {
     __typename?: 'CeOpportunity';
     id: string;
     name: string;
-    status: string;
+    status: CeOpportunityStatus;
     expiresAt?: string | null;
     projectId: string;
     projectName: string;
@@ -16473,7 +16479,7 @@ export type CreateCeOpportunityMutation = {
       __typename?: 'CeOpportunity';
       id: string;
       name: string;
-      status: string;
+      status: CeOpportunityStatus;
       expiresAt?: string | null;
       projectId: string;
       projectName: string;
@@ -17611,7 +17617,7 @@ export type GetProjectCeOpportunitiesQuery = {
         __typename?: 'CeOpportunity';
         id: string;
         name: string;
-        status: string;
+        status: CeOpportunityStatus;
         expiresAt?: string | null;
         projectId: string;
         projectName: string;
@@ -17630,7 +17636,7 @@ export type GetCeOpportunityQuery = {
     __typename?: 'CeOpportunity';
     id: string;
     name: string;
-    status: string;
+    status: CeOpportunityStatus;
     expiresAt?: string | null;
     projectId: string;
     projectName: string;
@@ -17742,7 +17748,7 @@ export type GetCeReferralQuery = {
       __typename?: 'CeOpportunity';
       id: string;
       name: string;
-      status: string;
+      status: CeOpportunityStatus;
       expiresAt?: string | null;
       projectId: string;
       projectName: string;

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -546,7 +546,7 @@ export type CeAssessmentsPaginated = {
 
 export type CeCandidate = {
   __typename?: 'CeCandidate';
-  client: Client;
+  client?: Maybe<Client>;
   id: Scalars['ID']['output'];
   priorityScore: Scalars['Int']['output'];
 };
@@ -15855,7 +15855,7 @@ export type CeOpportunityFieldsFragment = {
     __typename?: 'CeCandidate';
     id: string;
     priorityScore: number;
-    client: {
+    client?: {
       __typename?: 'Client';
       id: string;
       lockVersion: number;
@@ -15863,7 +15863,7 @@ export type CeOpportunityFieldsFragment = {
       middleName?: string | null;
       lastName?: string | null;
       nameSuffix?: string | null;
-    };
+    } | null;
   } | null;
 };
 
@@ -15879,7 +15879,7 @@ export type CeCandidateFieldsFragment = {
   __typename?: 'CeCandidate';
   id: string;
   priorityScore: number;
-  client: {
+  client?: {
     __typename?: 'Client';
     id: string;
     lockVersion: number;
@@ -15887,7 +15887,7 @@ export type CeCandidateFieldsFragment = {
     middleName?: string | null;
     lastName?: string | null;
     nameSuffix?: string | null;
-  };
+  } | null;
 };
 
 export type CeReferralSummaryFieldsFragment = {
@@ -17626,7 +17626,7 @@ export type SubmitCeReferralStepMutation = {
           __typename?: 'CeCandidate';
           id: string;
           priorityScore: number;
-          client: {
+          client?: {
             __typename?: 'Client';
             id: string;
             lockVersion: number;
@@ -17634,7 +17634,7 @@ export type SubmitCeReferralStepMutation = {
             middleName?: string | null;
             lastName?: string | null;
             nameSuffix?: string | null;
-          };
+          } | null;
         } | null;
       };
     } | null;
@@ -17737,7 +17737,7 @@ export type GetCeOpportunityQuery = {
       __typename?: 'CeCandidate';
       id: string;
       priorityScore: number;
-      client: {
+      client?: {
         __typename?: 'Client';
         id: string;
         lockVersion: number;
@@ -17745,7 +17745,7 @@ export type GetCeOpportunityQuery = {
         middleName?: string | null;
         lastName?: string | null;
         nameSuffix?: string | null;
-      };
+      } | null;
     } | null;
   };
 };
@@ -17770,7 +17770,7 @@ export type GetCeOpportunityCandidatesQuery = {
         __typename?: 'CeCandidate';
         id: string;
         priorityScore: number;
-        client: {
+        client?: {
           __typename?: 'Client';
           id: string;
           lockVersion: number;
@@ -17778,7 +17778,7 @@ export type GetCeOpportunityCandidatesQuery = {
           middleName?: string | null;
           lastName?: string | null;
           nameSuffix?: string | null;
-        };
+        } | null;
       }>;
     };
   };

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -17579,6 +17579,64 @@ export type SubmitCeReferralStepMutation = {
       __typename?: 'CeReferral';
       id: string;
       status: CeReferralStatus;
+      opportunity: {
+        __typename?: 'CeOpportunity';
+        id: string;
+        name: string;
+        status: CeOpportunityStatus;
+        expiresAt?: string | null;
+        projectId: string;
+        projectName: string;
+        activeReferral?: {
+          __typename?: 'CeReferral';
+          id: string;
+          status: CeReferralStatus;
+          client: {
+            __typename?: 'Client';
+            id: string;
+            lockVersion: number;
+            firstName?: string | null;
+            middleName?: string | null;
+            lastName?: string | null;
+            nameSuffix?: string | null;
+          };
+        } | null;
+        acceptedReferral?: {
+          __typename?: 'CeReferral';
+          id: string;
+          status: CeReferralStatus;
+          client: {
+            __typename?: 'Client';
+            id: string;
+            lockVersion: number;
+            firstName?: string | null;
+            middleName?: string | null;
+            lastName?: string | null;
+            nameSuffix?: string | null;
+          };
+        } | null;
+        rules?: Array<{
+          __typename?: 'CeMatchRule';
+          id: string;
+          name: string;
+          type: CeMatchRuleType;
+          ownerType: string;
+        }> | null;
+        topCandidate?: {
+          __typename?: 'CeCandidate';
+          id: string;
+          priorityScore: number;
+          client: {
+            __typename?: 'Client';
+            id: string;
+            lockVersion: number;
+            firstName?: string | null;
+            middleName?: string | null;
+            lastName?: string | null;
+            nameSuffix?: string | null;
+          };
+        } | null;
+      };
     } | null;
     errors: Array<{
       __typename?: 'ValidationError';
@@ -47563,6 +47621,9 @@ export const SubmitCeReferralStepDocument = gql`
       referral {
         id
         status
+        opportunity {
+          ...CeOpportunityFields
+        }
       }
       errors {
         ...ValidationErrorFields
@@ -47570,6 +47631,7 @@ export const SubmitCeReferralStepDocument = gql`
     }
   }
   ${CeReferralStepFieldsFragmentDoc}
+  ${CeOpportunityFieldsFragmentDoc}
   ${ValidationErrorFieldsFragmentDoc}
 `;
 export type SubmitCeReferralStepMutationFn = Apollo.MutationFunction<


### PR DESCRIPTION
## Description

GH issue: https://github.com/open-path/Green-River/issues/7322
Depends on hmis-warehouse PR: https://github.com/greenriver/hmis-warehouse/pull/5218

Summary of changes:
- Add a new `CommonTabs` component that wraps the MUI Tabs
- Make some improvements to the `BeginReferralButton` (but see outstanding [thread](https://www.figma.com/board/axGI9vwmuBRC4uZ11ZJ3RP?node-id=2697-73498#1173994790))
- Add details to the Opportunity page about which match rules apply
- Refactor `PrioritizedClientsTable` out of `Opportunity` for clarity
- Add `OpportunityBanner`, meant to encapsulate some of the styles [here](https://www.figma.com/design/znYqGn21VZO5zF2LjpnUiL/OP-HMIS-%2F-Coordinated-Entry-%2F-Figma?node-id=3558-27348&t=9w7vL66doIA4FGJ4-0), although it is not pixel perfect yet. I'm open to feedback/thoughts about taking the time to more thoroughly match the mocks at this point!
- Make some also-not-pixel-perfect updates to `ReferralStatusChip`, 

How to test: 
- Run the "starter pack" locally, and see [this caveat](https://github.com/open-path/Green-River/issues/7396#issuecomment-2734633474) if you run into issues
- In the ui, go to the CE test project, and create some Opportunities
- Run the starter pack again to create candidate pools
- Check out the Opportunity page. Step the Opportunity through various statuses to see how it looks in different states

## Type of change
[//]: # 'remove options that are not relevant'
- [ ] Bug fix
- [x] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
