### PR TITLE
Add target enrollment as wayfinding option post-referral

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -4781,6 +4781,18 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "targetHousehold",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Household",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -4783,12 +4783,12 @@
             "deprecationReason": null
           },
           {
-            "name": "targetHousehold",
+            "name": "targetEnrollment",
             "description": null,
             "args": [],
             "type": {
               "kind": "OBJECT",
-              "name": "Household",
+              "name": "Enrollment",
               "ofType": null
             },
             "isDeprecated": false,

--- a/src/api/operations/ce.fragments.graphql
+++ b/src/api/operations/ce.fragments.graphql
@@ -67,6 +67,12 @@ fragment CeReferralFields on CeReferral {
   opportunity {
     ...CeOpportunitySummaryFields
   }
+  targetHousehold {
+    id
+    householdClients {
+      ...HouseholdClientFields
+    }
+  }
 }
 
 fragment CeReferralStepSummaryFields on CeReferralStep {

--- a/src/api/operations/ce.fragments.graphql
+++ b/src/api/operations/ce.fragments.graphql
@@ -67,10 +67,10 @@ fragment CeReferralFields on CeReferral {
   opportunity {
     ...CeOpportunitySummaryFields
   }
-  targetHousehold {
+  targetEnrollment {
     id
-    householdClients {
-      ...HouseholdClientFields
+    client {
+      id
     }
   }
 }

--- a/src/api/operations/ce.operations.graphql
+++ b/src/api/operations/ce.operations.graphql
@@ -51,10 +51,10 @@ mutation SubmitCeReferralStep(
       opportunity {
         ...CeOpportunityFields
       }
-      targetHousehold {
+      targetEnrollment {
         id
-        householdClients {
-          ...HouseholdClientFields
+        client {
+          id
         }
       }
     }

--- a/src/api/operations/ce.operations.graphql
+++ b/src/api/operations/ce.operations.graphql
@@ -51,6 +51,12 @@ mutation SubmitCeReferralStep(
       opportunity {
         ...CeOpportunityFields
       }
+      targetHousehold {
+        id
+        householdClients {
+          ...HouseholdClientFields
+        }
+      }
     }
     errors {
       ...ValidationErrorFields

--- a/src/modules/ce/components/ReferralWayfinder.tsx
+++ b/src/modules/ce/components/ReferralWayfinder.tsx
@@ -1,10 +1,17 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import WayfindingDialog from '@/components/elements/navigation/WayfindingDialog';
 import { DeclinedIcon } from '@/components/elements/SemanticIcons';
 import useSafeParams from '@/hooks/useSafeParams';
 import { useReferralContext } from '@/modules/ce/components/ReferralPage';
-import { clientNameFromRecordWithOptionalClient } from '@/modules/hmis/hmisUtil';
-import { ProjectDashboardRoutes, Routes } from '@/routes/routes';
+import {
+  clientNameFromRecordWithOptionalClient,
+  findHohOrRep,
+} from '@/modules/hmis/hmisUtil';
+import {
+  EnrollmentDashboardRoutes,
+  ProjectDashboardRoutes,
+  Routes,
+} from '@/routes/routes';
 import { CeReferralStatus } from '@/types/gqlTypes';
 import { generateSafePath } from '@/utils/pathEncoding';
 
@@ -21,6 +28,13 @@ const ReferralWayfinder: React.FC<Props> = ({ open, onClose }) => {
 
   const { status, opportunity } = referral;
   const clientName = clientNameFromRecordWithOptionalClient(referral);
+
+  // if there is a target household on the referral, allow navigating to that HoH's enrollment
+  const target = useMemo(() => {
+    if (!referral.targetHousehold) return;
+
+    return findHohOrRep(referral.targetHousehold.householdClients);
+  }, [referral.targetHousehold]);
 
   switch (status) {
     case CeReferralStatus.Accepted:
@@ -40,6 +54,20 @@ const ReferralWayfinder: React.FC<Props> = ({ open, onClose }) => {
               title: 'Go to My Dashboard',
               to: generateSafePath(Routes.MY_DASHBOARD),
             },
+            ...(!!target
+              ? [
+                  {
+                    title: `Go to Enrollment`,
+                    to: generateSafePath(
+                      EnrollmentDashboardRoutes.ENROLLMENT_OVERVIEW,
+                      {
+                        clientId: target.client.id,
+                        enrollmentId: target.enrollment.id,
+                      }
+                    ),
+                  },
+                ]
+              : []),
           ]}
         />
       );

--- a/src/modules/ce/components/ReferralWayfinder.tsx
+++ b/src/modules/ce/components/ReferralWayfinder.tsx
@@ -29,7 +29,7 @@ const ReferralWayfinder: React.FC<Props> = ({ open, onClose }) => {
   const { status, opportunity } = referral;
   const clientName = clientNameFromRecordWithOptionalClient(referral);
 
-  // if there is a target household on the referral, allow navigating to that HoH's enrollment
+  // "target" household on the referral links to the household/enrollment that was created by this referral, if any
   const target = useMemo(() => {
     if (!referral.targetHousehold) return;
 

--- a/src/modules/ce/components/ReferralWayfinder.tsx
+++ b/src/modules/ce/components/ReferralWayfinder.tsx
@@ -1,12 +1,9 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import WayfindingDialog from '@/components/elements/navigation/WayfindingDialog';
 import { DeclinedIcon } from '@/components/elements/SemanticIcons';
 import useSafeParams from '@/hooks/useSafeParams';
 import { useReferralContext } from '@/modules/ce/components/ReferralPage';
-import {
-  clientNameFromRecordWithOptionalClient,
-  findHohOrRep,
-} from '@/modules/hmis/hmisUtil';
+import { clientNameFromRecordWithOptionalClient } from '@/modules/hmis/hmisUtil';
 import {
   EnrollmentDashboardRoutes,
   ProjectDashboardRoutes,
@@ -29,13 +26,6 @@ const ReferralWayfinder: React.FC<Props> = ({ open, onClose }) => {
   const { status, opportunity } = referral;
   const clientName = clientNameFromRecordWithOptionalClient(referral);
 
-  // "target" household on the referral links to the household/enrollment that was created by this referral, if any
-  const target = useMemo(() => {
-    if (!referral.targetHousehold) return;
-
-    return findHohOrRep(referral.targetHousehold.householdClients);
-  }, [referral.targetHousehold]);
-
   switch (status) {
     case CeReferralStatus.Accepted:
       return (
@@ -54,15 +44,15 @@ const ReferralWayfinder: React.FC<Props> = ({ open, onClose }) => {
               title: 'Go to My Dashboard',
               to: generateSafePath(Routes.MY_DASHBOARD),
             },
-            ...(!!target
+            ...(!!referral.targetEnrollment
               ? [
                   {
                     title: `Go to Enrollment`,
                     to: generateSafePath(
                       EnrollmentDashboardRoutes.ENROLLMENT_OVERVIEW,
                       {
-                        clientId: target.client.id,
-                        enrollmentId: target.enrollment.id,
+                        clientId: referral.targetEnrollment.client.id,
+                        enrollmentId: referral.targetEnrollment.id,
                       }
                     ),
                   },

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -657,6 +657,7 @@ export type CeReferral = {
   opportunity: CeOpportunity;
   status: CeReferralStatus;
   steps: Array<CeReferralStep>;
+  targetHousehold?: Maybe<Household>;
 };
 
 export type CeReferralFilterOptions = {
@@ -15970,6 +15971,87 @@ export type CeReferralFieldsFragment = {
     projectId: string;
     projectName: string;
   };
+  targetHousehold?: {
+    __typename?: 'Household';
+    id: string;
+    householdClients: Array<{
+      __typename?: 'HouseholdClient';
+      id: string;
+      relationshipToHoH: RelationshipToHoH;
+      client: {
+        __typename?: 'Client';
+        id: string;
+        lockVersion: number;
+        firstName?: string | null;
+        middleName?: string | null;
+        lastName?: string | null;
+        nameSuffix?: string | null;
+        dob?: string | null;
+        age?: number | null;
+        gender: Array<Gender>;
+        pronouns: Array<string>;
+        ssn?: string | null;
+        race: Array<Race>;
+        veteranStatus: NoYesReasonsForMissingData;
+        access: {
+          __typename?: 'ClientAccess';
+          id: string;
+          canEditClient: boolean;
+          canDeleteClient: boolean;
+          canViewDob: boolean;
+          canViewFullSsn: boolean;
+          canViewPartialSsn: boolean;
+          canViewClientName: boolean;
+          canViewClientPhoto: boolean;
+          canViewClientAlerts: boolean;
+          canManageClientAlerts: boolean;
+          canViewEnrollmentDetails: boolean;
+          canAuditClients: boolean;
+          canManageScanCards: boolean;
+          canMergeClients: boolean;
+          canViewAnyFiles: boolean;
+          canManageAnyClientFiles: boolean;
+          canManageOwnClientFiles: boolean;
+          canUploadClientFiles: boolean;
+        };
+        externalIds: Array<{
+          __typename?: 'ExternalIdentifier';
+          id: string;
+          identifier?: string | null;
+          url?: string | null;
+          label: string;
+          type: ExternalIdentifierType;
+        }>;
+        alerts: Array<{
+          __typename?: 'ClientAlert';
+          id: string;
+          note: string;
+          expirationDate?: string | null;
+          createdAt: string;
+          priority: ClientAlertPriorityLevel;
+          createdBy?: {
+            __typename: 'ApplicationUser';
+            id: string;
+            name: string;
+            firstName?: string | null;
+            lastName?: string | null;
+            email: string;
+          } | null;
+        }>;
+      };
+      enrollment: {
+        __typename?: 'Enrollment';
+        id: string;
+        lockVersion: number;
+        relationshipToHoH: RelationshipToHoH;
+        autoExited: boolean;
+        entryDate: string;
+        exitDate?: string | null;
+        inProgress: boolean;
+        currentUnit?: { __typename?: 'Unit'; id: string; name: string } | null;
+      };
+    }>;
+  } | null;
   client?: {
     __typename?: 'Client';
     id: string;
@@ -17677,6 +17759,91 @@ export type SubmitCeReferralStepMutation = {
           ownerType: string;
         } | null;
       };
+      targetHousehold?: {
+        __typename?: 'Household';
+        id: string;
+        householdClients: Array<{
+          __typename?: 'HouseholdClient';
+          id: string;
+          relationshipToHoH: RelationshipToHoH;
+          client: {
+            __typename?: 'Client';
+            id: string;
+            lockVersion: number;
+            firstName?: string | null;
+            middleName?: string | null;
+            lastName?: string | null;
+            nameSuffix?: string | null;
+            dob?: string | null;
+            age?: number | null;
+            gender: Array<Gender>;
+            pronouns: Array<string>;
+            ssn?: string | null;
+            race: Array<Race>;
+            veteranStatus: NoYesReasonsForMissingData;
+            access: {
+              __typename?: 'ClientAccess';
+              id: string;
+              canEditClient: boolean;
+              canDeleteClient: boolean;
+              canViewDob: boolean;
+              canViewFullSsn: boolean;
+              canViewPartialSsn: boolean;
+              canViewClientName: boolean;
+              canViewClientPhoto: boolean;
+              canViewClientAlerts: boolean;
+              canManageClientAlerts: boolean;
+              canViewEnrollmentDetails: boolean;
+              canAuditClients: boolean;
+              canManageScanCards: boolean;
+              canMergeClients: boolean;
+              canViewAnyFiles: boolean;
+              canManageAnyClientFiles: boolean;
+              canManageOwnClientFiles: boolean;
+              canUploadClientFiles: boolean;
+            };
+            externalIds: Array<{
+              __typename?: 'ExternalIdentifier';
+              id: string;
+              identifier?: string | null;
+              url?: string | null;
+              label: string;
+              type: ExternalIdentifierType;
+            }>;
+            alerts: Array<{
+              __typename?: 'ClientAlert';
+              id: string;
+              note: string;
+              expirationDate?: string | null;
+              createdAt: string;
+              priority: ClientAlertPriorityLevel;
+              createdBy?: {
+                __typename: 'ApplicationUser';
+                id: string;
+                name: string;
+                firstName?: string | null;
+                lastName?: string | null;
+                email: string;
+              } | null;
+            }>;
+          };
+          enrollment: {
+            __typename?: 'Enrollment';
+            id: string;
+            lockVersion: number;
+            relationshipToHoH: RelationshipToHoH;
+            autoExited: boolean;
+            entryDate: string;
+            exitDate?: string | null;
+            inProgress: boolean;
+            currentUnit?: {
+              __typename?: 'Unit';
+              id: string;
+              name: string;
+            } | null;
+          };
+        }>;
+      } | null;
     } | null;
     errors: Array<{
       __typename?: 'ValidationError';
@@ -17889,6 +18056,91 @@ export type GetCeReferralQuery = {
       projectId: string;
       projectName: string;
     };
+    targetHousehold?: {
+      __typename?: 'Household';
+      id: string;
+      householdClients: Array<{
+        __typename?: 'HouseholdClient';
+        id: string;
+        relationshipToHoH: RelationshipToHoH;
+        client: {
+          __typename?: 'Client';
+          id: string;
+          lockVersion: number;
+          firstName?: string | null;
+          middleName?: string | null;
+          lastName?: string | null;
+          nameSuffix?: string | null;
+          dob?: string | null;
+          age?: number | null;
+          gender: Array<Gender>;
+          pronouns: Array<string>;
+          ssn?: string | null;
+          race: Array<Race>;
+          veteranStatus: NoYesReasonsForMissingData;
+          access: {
+            __typename?: 'ClientAccess';
+            id: string;
+            canEditClient: boolean;
+            canDeleteClient: boolean;
+            canViewDob: boolean;
+            canViewFullSsn: boolean;
+            canViewPartialSsn: boolean;
+            canViewClientName: boolean;
+            canViewClientPhoto: boolean;
+            canViewClientAlerts: boolean;
+            canManageClientAlerts: boolean;
+            canViewEnrollmentDetails: boolean;
+            canAuditClients: boolean;
+            canManageScanCards: boolean;
+            canMergeClients: boolean;
+            canViewAnyFiles: boolean;
+            canManageAnyClientFiles: boolean;
+            canManageOwnClientFiles: boolean;
+            canUploadClientFiles: boolean;
+          };
+          externalIds: Array<{
+            __typename?: 'ExternalIdentifier';
+            id: string;
+            identifier?: string | null;
+            url?: string | null;
+            label: string;
+            type: ExternalIdentifierType;
+          }>;
+          alerts: Array<{
+            __typename?: 'ClientAlert';
+            id: string;
+            note: string;
+            expirationDate?: string | null;
+            createdAt: string;
+            priority: ClientAlertPriorityLevel;
+            createdBy?: {
+              __typename: 'ApplicationUser';
+              id: string;
+              name: string;
+              firstName?: string | null;
+              lastName?: string | null;
+              email: string;
+            } | null;
+          }>;
+        };
+        enrollment: {
+          __typename?: 'Enrollment';
+          id: string;
+          lockVersion: number;
+          relationshipToHoH: RelationshipToHoH;
+          autoExited: boolean;
+          entryDate: string;
+          exitDate?: string | null;
+          inProgress: boolean;
+          currentUnit?: {
+            __typename?: 'Unit';
+            id: string;
+            name: string;
+          } | null;
+        };
+      }>;
+    } | null;
     client?: {
       __typename?: 'Client';
       id: string;
@@ -44262,6 +44514,109 @@ export const CeReferralStepSummaryFieldsFragmentDoc = gql`
     swimlane
   }
 `;
+export const ClientIdentificationFieldsFragmentDoc = gql`
+  fragment ClientIdentificationFields on Client {
+    id
+    lockVersion
+    dob
+    age
+    gender
+    pronouns
+  }
+`;
+export const ClientNameDobVetFragmentDoc = gql`
+  fragment ClientNameDobVet on Client {
+    ...ClientName
+    dob
+    veteranStatus
+  }
+  ${ClientNameFragmentDoc}
+`;
+export const AssessedClientFieldsFragmentDoc = gql`
+  fragment AssessedClientFields on Client {
+    ...ClientNameDobVet
+    ssn
+    race
+  }
+  ${ClientNameDobVetFragmentDoc}
+`;
+export const ClientAccessFieldsFragmentDoc = gql`
+  fragment ClientAccessFields on ClientAccess {
+    id
+    canEditClient
+    canDeleteClient
+    canViewDob
+    canViewFullSsn
+    canViewPartialSsn
+    canViewClientName
+    canViewClientPhoto
+    canViewClientAlerts
+    canManageClientAlerts
+    canViewEnrollmentDetails
+    canAuditClients
+    canManageScanCards
+    canMergeClients
+    canViewAnyFiles
+    canManageAnyClientFiles
+    canManageOwnClientFiles
+    canUploadClientFiles
+  }
+`;
+export const ClientIdentifierFieldsFragmentDoc = gql`
+  fragment ClientIdentifierFields on ExternalIdentifier {
+    id
+    identifier
+    url
+    label
+    type
+  }
+`;
+export const EnrollmentRangeFieldsFragmentDoc = gql`
+  fragment EnrollmentRangeFields on Enrollment {
+    entryDate
+    exitDate
+    inProgress
+  }
+`;
+export const HouseholdClientFieldsFragmentDoc = gql`
+  fragment HouseholdClientFields on HouseholdClient {
+    id
+    relationshipToHoH
+    client {
+      id
+      ...ClientName
+      ...ClientIdentificationFields
+      ...AssessedClientFields
+      access {
+        ...ClientAccessFields
+      }
+      externalIds {
+        ...ClientIdentifierFields
+      }
+      alerts {
+        ...ClientAlertFields
+      }
+    }
+    enrollment {
+      id
+      lockVersion
+      relationshipToHoH
+      ...EnrollmentRangeFields
+      autoExited
+      currentUnit {
+        id
+        name
+      }
+    }
+  }
+  ${ClientNameFragmentDoc}
+  ${ClientIdentificationFieldsFragmentDoc}
+  ${AssessedClientFieldsFragmentDoc}
+  ${ClientAccessFieldsFragmentDoc}
+  ${ClientIdentifierFieldsFragmentDoc}
+  ${ClientAlertFieldsFragmentDoc}
+  ${EnrollmentRangeFieldsFragmentDoc}
+`;
 export const CeReferralFieldsFragmentDoc = gql`
   fragment CeReferralFields on CeReferral {
     ...CeReferralSummaryFields
@@ -44271,10 +44626,17 @@ export const CeReferralFieldsFragmentDoc = gql`
     opportunity {
       ...CeOpportunitySummaryFields
     }
+    targetHousehold {
+      id
+      householdClients {
+        ...HouseholdClientFields
+      }
+    }
   }
   ${CeReferralSummaryFieldsFragmentDoc}
   ${CeReferralStepSummaryFieldsFragmentDoc}
   ${CeOpportunitySummaryFieldsFragmentDoc}
+  ${HouseholdClientFieldsFragmentDoc}
 `;
 export const FormDefinitionMetadataFragmentDoc = gql`
   fragment FormDefinitionMetadata on FormDefinition {
@@ -44429,16 +44791,6 @@ export const CeReferralStepFieldsFragmentDoc = gql`
   ${CeReferralStepSummaryFieldsFragmentDoc}
   ${FormDefinitionFieldsFragmentDoc}
 `;
-export const ClientIdentificationFieldsFragmentDoc = gql`
-  fragment ClientIdentificationFields on Client {
-    id
-    lockVersion
-    dob
-    age
-    gender
-    pronouns
-  }
-`;
 export const ClientSsnFieldsFragmentDoc = gql`
   fragment ClientSsnFields on Client {
     id
@@ -44449,15 +44801,6 @@ export const ClientSsnFieldsFragmentDoc = gql`
       canViewFullSsn
       canViewPartialSsn
     }
-  }
-`;
-export const ClientIdentifierFieldsFragmentDoc = gql`
-  fragment ClientIdentifierFields on ExternalIdentifier {
-    id
-    identifier
-    url
-    label
-    type
   }
 `;
 export const ClientSearchResultFieldsFragmentDoc = gql`
@@ -44496,28 +44839,6 @@ export const ClientVeteranInfoFieldsFragmentDoc = gql`
     otherTheater
     militaryBranch
     dischargeStatus
-  }
-`;
-export const ClientAccessFieldsFragmentDoc = gql`
-  fragment ClientAccessFields on ClientAccess {
-    id
-    canEditClient
-    canDeleteClient
-    canViewDob
-    canViewFullSsn
-    canViewPartialSsn
-    canViewClientName
-    canViewClientPhoto
-    canViewClientAlerts
-    canManageClientAlerts
-    canViewEnrollmentDetails
-    canAuditClients
-    canManageScanCards
-    canMergeClients
-    canViewAnyFiles
-    canManageAnyClientFiles
-    canManageOwnClientFiles
-    canUploadClientFiles
   }
 `;
 export const ClientNameObjectFieldsFragmentDoc = gql`
@@ -44742,13 +45063,6 @@ export const ServiceTypeConfigFieldsFragmentDoc = gql`
   }
   ${ServiceTypeFieldsFragmentDoc}
 `;
-export const EnrollmentRangeFieldsFragmentDoc = gql`
-  fragment EnrollmentRangeFields on Enrollment {
-    entryDate
-    exitDate
-    inProgress
-  }
-`;
 export const CurrentLivingSituationFieldsFragmentDoc = gql`
   fragment CurrentLivingSituationFields on CurrentLivingSituation {
     id
@@ -44833,14 +45147,6 @@ export const ClientEnrollmentFieldsFragmentDoc = gql`
     }
   }
 `;
-export const ClientNameDobVetFragmentDoc = gql`
-  fragment ClientNameDobVet on Client {
-    ...ClientName
-    dob
-    veteranStatus
-  }
-  ${ClientNameFragmentDoc}
-`;
 export const EnrollmentAccessFieldsFragmentDoc = gql`
   fragment EnrollmentAccessFields on EnrollmentAccess {
     id
@@ -44904,14 +45210,6 @@ export const EnrollmentOccurrencePointFieldsFragmentDoc = gql`
     }
   }
   ${ClientAddressFieldsFragmentDoc}
-`;
-export const AssessedClientFieldsFragmentDoc = gql`
-  fragment AssessedClientFields on Client {
-    ...ClientNameDobVet
-    ssn
-    race
-  }
-  ${ClientNameDobVetFragmentDoc}
 `;
 export const EnrolledClientFieldsFragmentDoc = gql`
   fragment EnrolledClientFields on Client {
@@ -45029,45 +45327,6 @@ export const SubmittedEnrollmentResultFieldsFragmentDoc = gql`
   ${EnrollmentFieldsFragmentDoc}
   ${EnrollmentOccurrencePointFieldsFragmentDoc}
   ${CustomDataElementFieldsFragmentDoc}
-`;
-export const HouseholdClientFieldsFragmentDoc = gql`
-  fragment HouseholdClientFields on HouseholdClient {
-    id
-    relationshipToHoH
-    client {
-      id
-      ...ClientName
-      ...ClientIdentificationFields
-      ...AssessedClientFields
-      access {
-        ...ClientAccessFields
-      }
-      externalIds {
-        ...ClientIdentifierFields
-      }
-      alerts {
-        ...ClientAlertFields
-      }
-    }
-    enrollment {
-      id
-      lockVersion
-      relationshipToHoH
-      ...EnrollmentRangeFields
-      autoExited
-      currentUnit {
-        id
-        name
-      }
-    }
-  }
-  ${ClientNameFragmentDoc}
-  ${ClientIdentificationFieldsFragmentDoc}
-  ${AssessedClientFieldsFragmentDoc}
-  ${ClientAccessFieldsFragmentDoc}
-  ${ClientIdentifierFieldsFragmentDoc}
-  ${ClientAlertFieldsFragmentDoc}
-  ${EnrollmentRangeFieldsFragmentDoc}
 `;
 export const HouseholdFieldsFragmentDoc = gql`
   fragment HouseholdFields on Household {
@@ -47715,6 +47974,12 @@ export const SubmitCeReferralStepDocument = gql`
         opportunity {
           ...CeOpportunityFields
         }
+        targetHousehold {
+          id
+          householdClients {
+            ...HouseholdClientFields
+          }
+        }
       }
       errors {
         ...ValidationErrorFields
@@ -47723,6 +47988,7 @@ export const SubmitCeReferralStepDocument = gql`
   }
   ${CeReferralStepFieldsFragmentDoc}
   ${CeOpportunityFieldsFragmentDoc}
+  ${HouseholdClientFieldsFragmentDoc}
   ${ValidationErrorFieldsFragmentDoc}
 `;
 export type SubmitCeReferralStepMutationFn = Apollo.MutationFunction<

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -657,7 +657,7 @@ export type CeReferral = {
   opportunity: CeOpportunity;
   status: CeReferralStatus;
   steps: Array<CeReferralStep>;
-  targetHousehold?: Maybe<Household>;
+  targetEnrollment?: Maybe<Enrollment>;
 };
 
 export type CeReferralFilterOptions = {
@@ -15971,86 +15971,10 @@ export type CeReferralFieldsFragment = {
     projectId: string;
     projectName: string;
   };
-  targetHousehold?: {
-    __typename?: 'Household';
+  targetEnrollment?: {
+    __typename?: 'Enrollment';
     id: string;
-    householdClients: Array<{
-      __typename?: 'HouseholdClient';
-      id: string;
-      relationshipToHoH: RelationshipToHoH;
-      client: {
-        __typename?: 'Client';
-        id: string;
-        lockVersion: number;
-        firstName?: string | null;
-        middleName?: string | null;
-        lastName?: string | null;
-        nameSuffix?: string | null;
-        dob?: string | null;
-        age?: number | null;
-        gender: Array<Gender>;
-        pronouns: Array<string>;
-        ssn?: string | null;
-        race: Array<Race>;
-        veteranStatus: NoYesReasonsForMissingData;
-        access: {
-          __typename?: 'ClientAccess';
-          id: string;
-          canEditClient: boolean;
-          canDeleteClient: boolean;
-          canViewDob: boolean;
-          canViewFullSsn: boolean;
-          canViewPartialSsn: boolean;
-          canViewClientName: boolean;
-          canViewClientPhoto: boolean;
-          canViewClientAlerts: boolean;
-          canManageClientAlerts: boolean;
-          canViewEnrollmentDetails: boolean;
-          canAuditClients: boolean;
-          canManageScanCards: boolean;
-          canMergeClients: boolean;
-          canViewAnyFiles: boolean;
-          canManageAnyClientFiles: boolean;
-          canManageOwnClientFiles: boolean;
-          canUploadClientFiles: boolean;
-        };
-        externalIds: Array<{
-          __typename?: 'ExternalIdentifier';
-          id: string;
-          identifier?: string | null;
-          url?: string | null;
-          label: string;
-          type: ExternalIdentifierType;
-        }>;
-        alerts: Array<{
-          __typename?: 'ClientAlert';
-          id: string;
-          note: string;
-          expirationDate?: string | null;
-          createdAt: string;
-          priority: ClientAlertPriorityLevel;
-          createdBy?: {
-            __typename: 'ApplicationUser';
-            id: string;
-            name: string;
-            firstName?: string | null;
-            lastName?: string | null;
-            email: string;
-          } | null;
-        }>;
-      };
-      enrollment: {
-        __typename?: 'Enrollment';
-        id: string;
-        lockVersion: number;
-        relationshipToHoH: RelationshipToHoH;
-        autoExited: boolean;
-        entryDate: string;
-        exitDate?: string | null;
-        inProgress: boolean;
-        currentUnit?: { __typename?: 'Unit'; id: string; name: string } | null;
-      };
-    }>;
+    client: { __typename?: 'Client'; id: string };
   } | null;
   client?: {
     __typename?: 'Client';
@@ -17759,90 +17683,10 @@ export type SubmitCeReferralStepMutation = {
           ownerType: string;
         } | null;
       };
-      targetHousehold?: {
-        __typename?: 'Household';
+      targetEnrollment?: {
+        __typename?: 'Enrollment';
         id: string;
-        householdClients: Array<{
-          __typename?: 'HouseholdClient';
-          id: string;
-          relationshipToHoH: RelationshipToHoH;
-          client: {
-            __typename?: 'Client';
-            id: string;
-            lockVersion: number;
-            firstName?: string | null;
-            middleName?: string | null;
-            lastName?: string | null;
-            nameSuffix?: string | null;
-            dob?: string | null;
-            age?: number | null;
-            gender: Array<Gender>;
-            pronouns: Array<string>;
-            ssn?: string | null;
-            race: Array<Race>;
-            veteranStatus: NoYesReasonsForMissingData;
-            access: {
-              __typename?: 'ClientAccess';
-              id: string;
-              canEditClient: boolean;
-              canDeleteClient: boolean;
-              canViewDob: boolean;
-              canViewFullSsn: boolean;
-              canViewPartialSsn: boolean;
-              canViewClientName: boolean;
-              canViewClientPhoto: boolean;
-              canViewClientAlerts: boolean;
-              canManageClientAlerts: boolean;
-              canViewEnrollmentDetails: boolean;
-              canAuditClients: boolean;
-              canManageScanCards: boolean;
-              canMergeClients: boolean;
-              canViewAnyFiles: boolean;
-              canManageAnyClientFiles: boolean;
-              canManageOwnClientFiles: boolean;
-              canUploadClientFiles: boolean;
-            };
-            externalIds: Array<{
-              __typename?: 'ExternalIdentifier';
-              id: string;
-              identifier?: string | null;
-              url?: string | null;
-              label: string;
-              type: ExternalIdentifierType;
-            }>;
-            alerts: Array<{
-              __typename?: 'ClientAlert';
-              id: string;
-              note: string;
-              expirationDate?: string | null;
-              createdAt: string;
-              priority: ClientAlertPriorityLevel;
-              createdBy?: {
-                __typename: 'ApplicationUser';
-                id: string;
-                name: string;
-                firstName?: string | null;
-                lastName?: string | null;
-                email: string;
-              } | null;
-            }>;
-          };
-          enrollment: {
-            __typename?: 'Enrollment';
-            id: string;
-            lockVersion: number;
-            relationshipToHoH: RelationshipToHoH;
-            autoExited: boolean;
-            entryDate: string;
-            exitDate?: string | null;
-            inProgress: boolean;
-            currentUnit?: {
-              __typename?: 'Unit';
-              id: string;
-              name: string;
-            } | null;
-          };
-        }>;
+        client: { __typename?: 'Client'; id: string };
       } | null;
     } | null;
     errors: Array<{
@@ -18056,90 +17900,10 @@ export type GetCeReferralQuery = {
       projectId: string;
       projectName: string;
     };
-    targetHousehold?: {
-      __typename?: 'Household';
+    targetEnrollment?: {
+      __typename?: 'Enrollment';
       id: string;
-      householdClients: Array<{
-        __typename?: 'HouseholdClient';
-        id: string;
-        relationshipToHoH: RelationshipToHoH;
-        client: {
-          __typename?: 'Client';
-          id: string;
-          lockVersion: number;
-          firstName?: string | null;
-          middleName?: string | null;
-          lastName?: string | null;
-          nameSuffix?: string | null;
-          dob?: string | null;
-          age?: number | null;
-          gender: Array<Gender>;
-          pronouns: Array<string>;
-          ssn?: string | null;
-          race: Array<Race>;
-          veteranStatus: NoYesReasonsForMissingData;
-          access: {
-            __typename?: 'ClientAccess';
-            id: string;
-            canEditClient: boolean;
-            canDeleteClient: boolean;
-            canViewDob: boolean;
-            canViewFullSsn: boolean;
-            canViewPartialSsn: boolean;
-            canViewClientName: boolean;
-            canViewClientPhoto: boolean;
-            canViewClientAlerts: boolean;
-            canManageClientAlerts: boolean;
-            canViewEnrollmentDetails: boolean;
-            canAuditClients: boolean;
-            canManageScanCards: boolean;
-            canMergeClients: boolean;
-            canViewAnyFiles: boolean;
-            canManageAnyClientFiles: boolean;
-            canManageOwnClientFiles: boolean;
-            canUploadClientFiles: boolean;
-          };
-          externalIds: Array<{
-            __typename?: 'ExternalIdentifier';
-            id: string;
-            identifier?: string | null;
-            url?: string | null;
-            label: string;
-            type: ExternalIdentifierType;
-          }>;
-          alerts: Array<{
-            __typename?: 'ClientAlert';
-            id: string;
-            note: string;
-            expirationDate?: string | null;
-            createdAt: string;
-            priority: ClientAlertPriorityLevel;
-            createdBy?: {
-              __typename: 'ApplicationUser';
-              id: string;
-              name: string;
-              firstName?: string | null;
-              lastName?: string | null;
-              email: string;
-            } | null;
-          }>;
-        };
-        enrollment: {
-          __typename?: 'Enrollment';
-          id: string;
-          lockVersion: number;
-          relationshipToHoH: RelationshipToHoH;
-          autoExited: boolean;
-          entryDate: string;
-          exitDate?: string | null;
-          inProgress: boolean;
-          currentUnit?: {
-            __typename?: 'Unit';
-            id: string;
-            name: string;
-          } | null;
-        };
-      }>;
+      client: { __typename?: 'Client'; id: string };
     } | null;
     client?: {
       __typename?: 'Client';
@@ -44514,109 +44278,6 @@ export const CeReferralStepSummaryFieldsFragmentDoc = gql`
     swimlane
   }
 `;
-export const ClientIdentificationFieldsFragmentDoc = gql`
-  fragment ClientIdentificationFields on Client {
-    id
-    lockVersion
-    dob
-    age
-    gender
-    pronouns
-  }
-`;
-export const ClientNameDobVetFragmentDoc = gql`
-  fragment ClientNameDobVet on Client {
-    ...ClientName
-    dob
-    veteranStatus
-  }
-  ${ClientNameFragmentDoc}
-`;
-export const AssessedClientFieldsFragmentDoc = gql`
-  fragment AssessedClientFields on Client {
-    ...ClientNameDobVet
-    ssn
-    race
-  }
-  ${ClientNameDobVetFragmentDoc}
-`;
-export const ClientAccessFieldsFragmentDoc = gql`
-  fragment ClientAccessFields on ClientAccess {
-    id
-    canEditClient
-    canDeleteClient
-    canViewDob
-    canViewFullSsn
-    canViewPartialSsn
-    canViewClientName
-    canViewClientPhoto
-    canViewClientAlerts
-    canManageClientAlerts
-    canViewEnrollmentDetails
-    canAuditClients
-    canManageScanCards
-    canMergeClients
-    canViewAnyFiles
-    canManageAnyClientFiles
-    canManageOwnClientFiles
-    canUploadClientFiles
-  }
-`;
-export const ClientIdentifierFieldsFragmentDoc = gql`
-  fragment ClientIdentifierFields on ExternalIdentifier {
-    id
-    identifier
-    url
-    label
-    type
-  }
-`;
-export const EnrollmentRangeFieldsFragmentDoc = gql`
-  fragment EnrollmentRangeFields on Enrollment {
-    entryDate
-    exitDate
-    inProgress
-  }
-`;
-export const HouseholdClientFieldsFragmentDoc = gql`
-  fragment HouseholdClientFields on HouseholdClient {
-    id
-    relationshipToHoH
-    client {
-      id
-      ...ClientName
-      ...ClientIdentificationFields
-      ...AssessedClientFields
-      access {
-        ...ClientAccessFields
-      }
-      externalIds {
-        ...ClientIdentifierFields
-      }
-      alerts {
-        ...ClientAlertFields
-      }
-    }
-    enrollment {
-      id
-      lockVersion
-      relationshipToHoH
-      ...EnrollmentRangeFields
-      autoExited
-      currentUnit {
-        id
-        name
-      }
-    }
-  }
-  ${ClientNameFragmentDoc}
-  ${ClientIdentificationFieldsFragmentDoc}
-  ${AssessedClientFieldsFragmentDoc}
-  ${ClientAccessFieldsFragmentDoc}
-  ${ClientIdentifierFieldsFragmentDoc}
-  ${ClientAlertFieldsFragmentDoc}
-  ${EnrollmentRangeFieldsFragmentDoc}
-`;
 export const CeReferralFieldsFragmentDoc = gql`
   fragment CeReferralFields on CeReferral {
     ...CeReferralSummaryFields
@@ -44626,17 +44287,16 @@ export const CeReferralFieldsFragmentDoc = gql`
     opportunity {
       ...CeOpportunitySummaryFields
     }
-    targetHousehold {
+    targetEnrollment {
       id
-      householdClients {
-        ...HouseholdClientFields
+      client {
+        id
       }
     }
   }
   ${CeReferralSummaryFieldsFragmentDoc}
   ${CeReferralStepSummaryFieldsFragmentDoc}
   ${CeOpportunitySummaryFieldsFragmentDoc}
-  ${HouseholdClientFieldsFragmentDoc}
 `;
 export const FormDefinitionMetadataFragmentDoc = gql`
   fragment FormDefinitionMetadata on FormDefinition {
@@ -44791,6 +44451,16 @@ export const CeReferralStepFieldsFragmentDoc = gql`
   ${CeReferralStepSummaryFieldsFragmentDoc}
   ${FormDefinitionFieldsFragmentDoc}
 `;
+export const ClientIdentificationFieldsFragmentDoc = gql`
+  fragment ClientIdentificationFields on Client {
+    id
+    lockVersion
+    dob
+    age
+    gender
+    pronouns
+  }
+`;
 export const ClientSsnFieldsFragmentDoc = gql`
   fragment ClientSsnFields on Client {
     id
@@ -44801,6 +44471,15 @@ export const ClientSsnFieldsFragmentDoc = gql`
       canViewFullSsn
       canViewPartialSsn
     }
+  }
+`;
+export const ClientIdentifierFieldsFragmentDoc = gql`
+  fragment ClientIdentifierFields on ExternalIdentifier {
+    id
+    identifier
+    url
+    label
+    type
   }
 `;
 export const ClientSearchResultFieldsFragmentDoc = gql`
@@ -44839,6 +44518,28 @@ export const ClientVeteranInfoFieldsFragmentDoc = gql`
     otherTheater
     militaryBranch
     dischargeStatus
+  }
+`;
+export const ClientAccessFieldsFragmentDoc = gql`
+  fragment ClientAccessFields on ClientAccess {
+    id
+    canEditClient
+    canDeleteClient
+    canViewDob
+    canViewFullSsn
+    canViewPartialSsn
+    canViewClientName
+    canViewClientPhoto
+    canViewClientAlerts
+    canManageClientAlerts
+    canViewEnrollmentDetails
+    canAuditClients
+    canManageScanCards
+    canMergeClients
+    canViewAnyFiles
+    canManageAnyClientFiles
+    canManageOwnClientFiles
+    canUploadClientFiles
   }
 `;
 export const ClientNameObjectFieldsFragmentDoc = gql`
@@ -45063,6 +44764,13 @@ export const ServiceTypeConfigFieldsFragmentDoc = gql`
   }
   ${ServiceTypeFieldsFragmentDoc}
 `;
+export const EnrollmentRangeFieldsFragmentDoc = gql`
+  fragment EnrollmentRangeFields on Enrollment {
+    entryDate
+    exitDate
+    inProgress
+  }
+`;
 export const CurrentLivingSituationFieldsFragmentDoc = gql`
   fragment CurrentLivingSituationFields on CurrentLivingSituation {
     id
@@ -45147,6 +44855,14 @@ export const ClientEnrollmentFieldsFragmentDoc = gql`
     }
   }
 `;
+export const ClientNameDobVetFragmentDoc = gql`
+  fragment ClientNameDobVet on Client {
+    ...ClientName
+    dob
+    veteranStatus
+  }
+  ${ClientNameFragmentDoc}
+`;
 export const EnrollmentAccessFieldsFragmentDoc = gql`
   fragment EnrollmentAccessFields on EnrollmentAccess {
     id
@@ -45210,6 +44926,14 @@ export const EnrollmentOccurrencePointFieldsFragmentDoc = gql`
     }
   }
   ${ClientAddressFieldsFragmentDoc}
+`;
+export const AssessedClientFieldsFragmentDoc = gql`
+  fragment AssessedClientFields on Client {
+    ...ClientNameDobVet
+    ssn
+    race
+  }
+  ${ClientNameDobVetFragmentDoc}
 `;
 export const EnrolledClientFieldsFragmentDoc = gql`
   fragment EnrolledClientFields on Client {
@@ -45327,6 +45051,45 @@ export const SubmittedEnrollmentResultFieldsFragmentDoc = gql`
   ${EnrollmentFieldsFragmentDoc}
   ${EnrollmentOccurrencePointFieldsFragmentDoc}
   ${CustomDataElementFieldsFragmentDoc}
+`;
+export const HouseholdClientFieldsFragmentDoc = gql`
+  fragment HouseholdClientFields on HouseholdClient {
+    id
+    relationshipToHoH
+    client {
+      id
+      ...ClientName
+      ...ClientIdentificationFields
+      ...AssessedClientFields
+      access {
+        ...ClientAccessFields
+      }
+      externalIds {
+        ...ClientIdentifierFields
+      }
+      alerts {
+        ...ClientAlertFields
+      }
+    }
+    enrollment {
+      id
+      lockVersion
+      relationshipToHoH
+      ...EnrollmentRangeFields
+      autoExited
+      currentUnit {
+        id
+        name
+      }
+    }
+  }
+  ${ClientNameFragmentDoc}
+  ${ClientIdentificationFieldsFragmentDoc}
+  ${AssessedClientFieldsFragmentDoc}
+  ${ClientAccessFieldsFragmentDoc}
+  ${ClientIdentifierFieldsFragmentDoc}
+  ${ClientAlertFieldsFragmentDoc}
+  ${EnrollmentRangeFieldsFragmentDoc}
 `;
 export const HouseholdFieldsFragmentDoc = gql`
   fragment HouseholdFields on Household {
@@ -47974,10 +47737,10 @@ export const SubmitCeReferralStepDocument = gql`
         opportunity {
           ...CeOpportunityFields
         }
-        targetHousehold {
+        targetEnrollment {
           id
-          householdClients {
-            ...HouseholdClientFields
+          client {
+            id
           }
         }
       }
@@ -47988,7 +47751,6 @@ export const SubmitCeReferralStepDocument = gql`
   }
   ${CeReferralStepFieldsFragmentDoc}
   ${CeOpportunityFieldsFragmentDoc}
-  ${HouseholdClientFieldsFragmentDoc}
   ${ValidationErrorFieldsFragmentDoc}
 `;
 export type SubmitCeReferralStepMutationFn = Apollo.MutationFunction<


### PR DESCRIPTION
## Description

GH issue: https://github.com/open-path/Green-River/issues/7400
Depends on hmis-warehouse PR: https://github.com/greenriver/hmis-warehouse/pull/5244

This PR adds "Go to Enrollment" as a wayfinding step after a referral is accepted. It wasn't strictly part of the spec for 7400, but I thought of it as closing the loop in a helpful way. We can revert it if it's not part of the final designs.

## Type of change
[//]: # 'remove options that are not relevant'
- [ ] Bug fix
- [x] New feature (adds functionality)
- [ ] Code clean-up / housekeeping
- [ ] Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
