### PR TITLE
Fix bugs with reopening tasks

### DIFF
--- a/src/api/operations/ce.operations.graphql
+++ b/src/api/operations/ce.operations.graphql
@@ -46,8 +46,7 @@ mutation SubmitCeReferralStep(
       ...CeReferralStepFields
     }
     referral {
-      id
-      status
+      ...CeReferralFields
       opportunity {
         ...CeOpportunityFields
       }

--- a/src/modules/ce/components/ReferralStep.tsx
+++ b/src/modules/ce/components/ReferralStep.tsx
@@ -130,6 +130,7 @@ const ReferralStep: React.FC<Props> = ({}) => {
               submitButtonText: 'Submit',
               noDiscard: true,
             }}
+            initialValues={formState}
           />
         )}
         {status === CeReferralStepStatus.Completed && formState && (

--- a/src/modules/ce/components/ReferralStep.tsx
+++ b/src/modules/ce/components/ReferralStep.tsx
@@ -6,6 +6,7 @@ import Loading from '@/components/elements/Loading';
 import NotFound from '@/components/pages/NotFound';
 import useSafeParams from '@/hooks/useSafeParams';
 import ReferralStepAssignee from '@/modules/ce/components/ReferralStepAssignee';
+import StartCeReferralStepButton from '@/modules/ce/components/StartCeReferralStepButton';
 import {
   emptyErrorState,
   ErrorState,
@@ -100,6 +101,16 @@ const ReferralStep: React.FC<Props> = ({}) => {
       <Stack gap={2}>
         <ReferralStepAssignee step={step} />
         <Divider />
+        {status === CeReferralStepStatus.Available && (
+          <StartCeReferralStepButton
+            step={step}
+            opportunityId={opportunityId}
+            projectId={projectId}
+            referralId={referralId}
+          >
+            Start Step
+          </StartCeReferralStepButton>
+        )}
         {status === CeReferralStepStatus.InProgress && (
           <DynamicForm
             definition={formDefinition.definition}

--- a/src/modules/ce/components/ReferralStepCard.tsx
+++ b/src/modules/ce/components/ReferralStepCard.tsx
@@ -1,19 +1,15 @@
 import React, { useMemo } from 'react';
-import { useNavigate } from 'react-router-dom';
 import ReferralStepCardInner from './ReferralStepCardInner';
 import ButtonLink, { ButtonLinkProps } from '@/components/elements/ButtonLink';
-import LoadingButton from '@/components/elements/LoadingButton';
 import { GoToIcon } from '@/components/elements/SemanticIcons';
 import useSafeParams from '@/hooks/useSafeParams';
 import { useReferralContext } from '@/modules/ce/components/ReferralPage';
 import ReferralStepAssignee from '@/modules/ce/components/ReferralStepAssignee';
-import { cache } from '@/providers/apolloClient';
+import StartCeReferralStepButton from '@/modules/ce/components/StartCeReferralStepButton';
 import { ProjectDashboardRoutes } from '@/routes/routes';
 import {
   CeReferralStepStatus,
   CeReferralStepSummaryFieldsFragment,
-  GetCeReferralStepDocument,
-  useStartCeReferralStepMutation,
 } from '@/types/gqlTypes';
 import { generateSafePath } from '@/utils/pathEncoding';
 
@@ -27,57 +23,19 @@ const ReferralStepCard: React.FC<Props> = ({ step }) => {
     opportunityId: string;
   };
   const { referral } = useReferralContext();
-  const navigate = useNavigate();
-
   const { name, status } = step;
-
-  const [startStepMutation, { loading, error }] =
-    useStartCeReferralStepMutation({
-      variables: {
-        referralId: referral.id,
-        stepId: step.stepId || '',
-      },
-      onCompleted: (data) => {
-        if (data.startCeReferralStep?.step) {
-          const step = data.startCeReferralStep?.step;
-
-          // The step returned from the mutation is now auto added to the Apollo cache.
-          // Here we are writing it to the cache specifically for the GetCeReferralStepDocument query,
-          // because the step is queried by `stepId` (the db ID) but cached by `id` (a composite ID).
-          // We might have to return to these IDs in the future if there are issues
-          cache.writeQuery({
-            query: GetCeReferralStepDocument,
-            data: {
-              ceReferralStep: step,
-            },
-            variables: {
-              id: step.stepId,
-            },
-          });
-
-          navigate(
-            generateSafePath(ProjectDashboardRoutes.REFERRAL_STEP, {
-              projectId,
-              opportunityId,
-              referralId: referral.id,
-              stepId: step.stepId || '',
-            })
-          );
-        }
-      },
-    });
 
   const action = useMemo(() => {
     if (status === CeReferralStepStatus.Available) {
       return (
-        <LoadingButton
-          loading={loading}
-          variant='text'
-          endIcon={<GoToIcon />}
-          onClick={() => startStepMutation()}
+        <StartCeReferralStepButton
+          step={step}
+          referralId={referral.id}
+          opportunityId={opportunityId}
+          projectId={projectId}
         >
           Start
-        </LoadingButton>
+        </StartCeReferralStepButton>
       );
     }
 
@@ -103,17 +61,7 @@ const ReferralStepCard: React.FC<Props> = ({ step }) => {
         </ButtonLink>
       );
     }
-  }, [
-    loading,
-    opportunityId,
-    projectId,
-    referral.id,
-    startStepMutation,
-    status,
-    step.stepId,
-  ]);
-
-  if (error) throw error;
+  }, [opportunityId, projectId, referral.id, status, step]);
 
   return (
     <ReferralStepCardInner name={name} status={status} action={action}>

--- a/src/modules/ce/components/StartCeReferralStepButton.tsx
+++ b/src/modules/ce/components/StartCeReferralStepButton.tsx
@@ -1,0 +1,84 @@
+import React, { ReactNode } from 'react';
+import { useNavigate } from 'react-router-dom';
+import LoadingButton from '@/components/elements/LoadingButton';
+import { GoToIcon } from '@/components/elements/SemanticIcons';
+import { cache } from '@/providers/apolloClient';
+import { ProjectDashboardRoutes } from '@/routes/routes';
+import {
+  CeReferralStepStatus,
+  CeReferralStepSummaryFieldsFragment,
+  GetCeReferralStepDocument,
+  useStartCeReferralStepMutation,
+} from '@/types/gqlTypes';
+import { generateSafePath } from '@/utils/pathEncoding';
+
+interface Props {
+  step: CeReferralStepSummaryFieldsFragment;
+  referralId: string;
+  projectId: string;
+  opportunityId: string;
+  children: ReactNode;
+}
+
+const StartCeReferralStepButton: React.FC<Props> = ({
+  step,
+  referralId,
+  projectId,
+  opportunityId,
+  children,
+}) => {
+  const navigate = useNavigate();
+
+  const [startStepMutation, { loading, error }] =
+    useStartCeReferralStepMutation({
+      variables: {
+        referralId: referralId,
+        stepId: step.stepId || '',
+      },
+      onCompleted: (data) => {
+        if (data.startCeReferralStep?.step) {
+          const step = data.startCeReferralStep?.step;
+
+          // The step returned from the mutation is now auto added to the Apollo cache.
+          // Here we are writing it to the cache specifically for the GetCeReferralStepDocument query,
+          // because the step is queried by `stepId` (the db ID) but cached by `id` (a composite ID).
+          // We might have to return to these IDs in the future if there are issues
+          cache.writeQuery({
+            query: GetCeReferralStepDocument,
+            data: {
+              ceReferralStep: step,
+            },
+            variables: {
+              id: step.stepId,
+            },
+          });
+
+          navigate(
+            generateSafePath(ProjectDashboardRoutes.REFERRAL_STEP, {
+              projectId,
+              opportunityId,
+              referralId: referralId,
+              stepId: step.stepId || '',
+            })
+          );
+        }
+      },
+    });
+
+  if (error) throw error;
+
+  if (step.status !== CeReferralStepStatus.Available) return;
+
+  return (
+    <LoadingButton
+      loading={loading}
+      variant='text'
+      endIcon={<GoToIcon />}
+      onClick={() => startStepMutation()}
+    >
+      {children}
+    </LoadingButton>
+  );
+};
+
+export default StartCeReferralStepButton;

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -17625,6 +17625,7 @@ export type SubmitCeReferralStepMutation = {
       __typename?: 'CeReferral';
       id: string;
       status: CeReferralStatus;
+      clientId: string;
       opportunity: {
         __typename?: 'CeOpportunity';
         id: string;
@@ -17677,6 +17678,23 @@ export type SubmitCeReferralStepMutation = {
           ownerType: string;
         } | null;
       };
+      steps: Array<{
+        __typename?: 'CeReferralStep';
+        id: string;
+        stepId?: string | null;
+        name: string;
+        status: CeReferralStepStatus;
+        swimlane: string;
+      }>;
+      client?: {
+        __typename?: 'Client';
+        id: string;
+        lockVersion: number;
+        firstName?: string | null;
+        middleName?: string | null;
+        lastName?: string | null;
+        nameSuffix?: string | null;
+      } | null;
     } | null;
     errors: Array<{
       __typename?: 'ValidationError';
@@ -47710,8 +47728,7 @@ export const SubmitCeReferralStepDocument = gql`
         ...CeReferralStepFields
       }
       referral {
-        id
-        status
+        ...CeReferralFields
         opportunity {
           ...CeOpportunityFields
         }
@@ -47722,6 +47739,7 @@ export const SubmitCeReferralStepDocument = gql`
     }
   }
   ${CeReferralStepFieldsFragmentDoc}
+  ${CeReferralFieldsFragmentDoc}
   ${CeOpportunityFieldsFragmentDoc}
   ${ValidationErrorFieldsFragmentDoc}
 `;


### PR DESCRIPTION
## Description

GH issue: https://github.com/open-path/Green-River/issues/7396
Depends on https://github.com/greenriver/hmis-warehouse/pull/5247/files

Summary of changes: 
- Resolve whole `CeReferralFields` fragment on step submission mutation response so that page doesn't need to be refreshed to see available tasks
- Add a "Start Step" button to the task page, so that navigating among steps using the navigation buttons makes a bit more sense.
  - This is a design question that I started a thread about [here](https://www.figma.com/board/axGI9vwmuBRC4uZ11ZJ3RP?node-id=2453-45960#1192468671). The fix here is just a stopgap to help things make sense as we are building
- If a step has already been submitted, load the previous answers and show them in the form.

## Type of change
[//]: # 'remove options that are not relevant'
- [x] Bug fix
- [x] Feature build-out

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue - see ticket comments
