### PR TITLE
Revert `SERVER_HTTPS` change

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -6,7 +6,7 @@ import react from '@vitejs/plugin-react';
 import { visualizer } from 'rollup-plugin-visualizer';
 import { defineConfig, loadEnv } from 'vite';
 
-// import mkcert from 'vite-plugin-mkcert';
+import mkcert from 'vite-plugin-mkcert';
 
 dns.setDefaultResultOrder('ipv4first');
 
@@ -49,7 +49,7 @@ export default defineConfig(({ command, mode }) => {
     },
     plugins: [
       react(),
-      // mkcert(),
+      mkcert(),
       sourcemapExclude({ excludeNodeModules: true }),
       // Note: even though sourcemaps are public, we upload them to get additional Sentry tooling around releases
       ...(env.SENTRY_ORG && env.SENTRY_PROJECT && env.SENTRY_AUTH_TOKEN
@@ -124,6 +124,8 @@ export default defineConfig(({ command, mode }) => {
         port: 5173,
         open: true,
         host: env.HMIS_HOST || 'hmis.dev.test',
+        https:
+          env.SERVER_HTTPS === undefined ? true : env.SERVER_HTTPS === 'true',
         proxy: {
           '/hmis': warehouseProxyServer,
           '/dev-assets/theme': warehouseProxyServer,

--- a/vite.config.js
+++ b/vite.config.js
@@ -6,7 +6,7 @@ import react from '@vitejs/plugin-react';
 import { visualizer } from 'rollup-plugin-visualizer';
 import { defineConfig, loadEnv } from 'vite';
 
-import mkcert from 'vite-plugin-mkcert';
+// import mkcert from 'vite-plugin-mkcert';
 
 dns.setDefaultResultOrder('ipv4first');
 
@@ -49,7 +49,7 @@ export default defineConfig(({ command, mode }) => {
     },
     plugins: [
       react(),
-      mkcert(),
+      // mkcert(),
       sourcemapExclude({ excludeNodeModules: true }),
       // Note: even though sourcemaps are public, we upload them to get additional Sentry tooling around releases
       ...(env.SENTRY_ORG && env.SENTRY_PROJECT && env.SENTRY_AUTH_TOKEN


### PR DESCRIPTION
## Description

Revert mistaken change from https://github.com/greenriver/hmis-frontend/pull/1090 that is causing CI system tests to fail because they can no longer disable https.


Successful CI run: https://github.com/greenriver/hmis-warehouse/actions/runs/14265515797/job/39986351898 (https://github.com/greenriver/hmis-warehouse/pull/5272)

## Type of change
- [x] Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
