### PR TITLE
Reduce noise from missing field Sentry warnings

### DIFF
--- a/src/modules/form/hooks/useDynamicFormHandlersForRecord.tsx
+++ b/src/modules/form/hooks/useDynamicFormHandlersForRecord.tsx
@@ -42,6 +42,7 @@ export interface DynamicFormHandlerArgs<T> {
   localConstants?: LocalConstants;
   inputVariables?: SubmitFormInputVariables;
   errorRef?: RefObject<HTMLDivElement>;
+  handleMissingField?: (message: string) => void;
 }
 
 export function useDynamicFormHandlersForRecord<
@@ -53,6 +54,7 @@ export function useDynamicFormHandlersForRecord<
   inputVariables,
   localConstants,
   errorRef,
+  handleMissingField,
 }: DynamicFormHandlerArgs<T>) {
   const [errors, setErrors] = useState<ErrorState>(emptyErrorState);
 
@@ -90,6 +92,7 @@ export function useDynamicFormHandlersForRecord<
     itemMap,
     definition: formDefinition?.definition,
     localConstants,
+    handleMissingField,
   });
 
   const onSubmit: DynamicFormOnSubmit = useCallback(

--- a/src/modules/form/hooks/useInitialFormValues.tsx
+++ b/src/modules/form/hooks/useInitialFormValues.tsx
@@ -15,6 +15,7 @@ interface Args {
   itemMap?: ItemMap;
   definition?: FormDefinitionJsonFieldsFragment;
   localConstants?: LocalConstants;
+  handleMissingField?: (message: string) => void;
 }
 
 const useInitialFormValues = ({
@@ -22,6 +23,7 @@ const useInitialFormValues = ({
   itemMap: itemMapArg,
   definition,
   localConstants,
+  handleMissingField,
 }: Args) => {
   const itemMap = useMemo(() => {
     if (!definition) return;
@@ -39,6 +41,7 @@ const useInitialFormValues = ({
     const initialValuesFromRecord = createInitialValuesFromRecord({
       itemMap,
       record,
+      handleMissingField,
     });
     const values = {
       ...initialValuesFromDefinition,
@@ -46,7 +49,7 @@ const useInitialFormValues = ({
     };
     // console.debug('Initial form values:', values, 'from', record);
     return values;
-  }, [record, definition, itemMap, localConstants]);
+  }, [definition, itemMap, localConstants, record, handleMissingField]);
 
   return initialValues;
 };

--- a/src/modules/form/util/formUtil.ts
+++ b/src/modules/form/util/formUtil.ts
@@ -13,7 +13,6 @@ import {
   cloneDeep,
   compact,
   get,
-  has,
   isArray,
   isNil,
   isObject,
@@ -1269,6 +1268,45 @@ export const transformSubmitValues = ({
   return result;
 };
 
+/**
+ * Checks if path is missing in object. Similar to lodash's `has` helper,
+ * with the following key difference:
+ * - ONLY "leaf node" keys are considered missing.
+ * - If a parent key is null, that is allowed; we don't consider the leaf missing.
+ *
+ * Examples:
+ *
+ * object = { disabilityGroup: { viralLoadSource: 1 }}
+ * path = ['disabilityGroup', 'viralLoadSource']
+ * isMissingField(object, path) = false  // Path exists in the object
+ *
+ * object = { disabilityGroup: { viralLoadSource: 1 }}
+ * path = ['disabilityGroup', 'viralLoadCount']
+ * isMissingField(object, path) = true  // Path is missing in the object
+ *
+ * object = { disabilityGroup: null}
+ * path = ['disabilityGroup', 'viralLoadCount']
+ * isMissingField(object, path) = false  // Not considered missing, because the parent record is null
+ *
+ * @param object the object to query, such as an Assessment
+ * @param path a list of strings representing the path to query
+ */
+function isMissingField(object: any, path: string[]) {
+  let current = object;
+  for (const key of path) {
+    if (current === null) {
+      // If parent is null, we don't consider the leaf missing.
+      return false;
+    }
+    if (typeof current !== 'object' || !(key in current)) {
+      return true; // If current is not an object or the key doesn't exist, it's missing.
+    }
+    current = current[key]; // Move deeper in the object.
+  }
+  // If we complete the loop without returning, the field exists.
+  return false;
+}
+
 // record could be an Assessment
 const getMappedValue = (
   record: any,
@@ -1299,11 +1337,9 @@ const getMappedValue = (
     // - mciId: similarly, we pass this field to save an MCI ID or indicate that a new one would be created, but it's resolved on `externalIds` on the client record
     const specialCaseFieldNames = ['imageBlobId', 'mciId'];
     if (!specialCaseFieldNames.includes(mapping.fieldName)) {
-      const isMissingField = !has(record, keys); // logic to determine if attribute is not present
-
       // In general, we do want to alert Sentry if the key is missing, to prevent silently swallowing developer errors.
       // This would indicate we're not resolving a field that we should be resolving.
-      if (isMissingField) {
+      if (isMissingField(record, keys)) {
         handleMissingField(
           `Field "${keys.join('.')}" is missing in record ${record.__typename}:${record.id}`
         );

--- a/src/modules/referrals/components/ProjectOutgoingReferralDetailsSubForm.tsx
+++ b/src/modules/referrals/components/ProjectOutgoingReferralDetailsSubForm.tsx
@@ -49,6 +49,8 @@ const ProjectOutgoingReferralDetailsSubForm: React.FC<Props> = ({
         enrollmentId,
       },
       onCompleted: () => onSuccess(),
+      // Don't alert Sentry for missing properties, since record is empty
+      handleMissingField: () => {},
     };
   }, [formDefinition, destinationProjectId, enrollmentId, onSuccess]);
 


### PR DESCRIPTION
## Description

This PR aims to reduce Sentry noise introduced in https://github.com/greenriver/hmis-frontend/pull/1102. It targets **release-158**.

Examples of noise on QA:
- An assessment's related record is null, like `employment_education`
  - **Example**: https://green-river.sentry.io/issues/6505375313/?referrer=slack&notification_uuid=93170c43-606d-4f7c-bf6d-d64da33e6f6d&environment=staging&alert_rule_id=14743218&alert_type=issue
  - **Cause**: I _think_ this is happening because the form definition itself changed. The [assessment](https://qa-hmis.openpath.host/client/==RHBHYzd6RzRqcDRNNUkzNk80alRzdz09/enrollments/==NXJ6SllLK04xbGtNNUkzNk80alRzdz09/intake) was first filled out before this [enable_everything QA patch](https://github.com/greenriver/hmis-warehouse/blob/24aac3afd301147eaa8617d358ad7b2e59c5458b/drivers/hmis/lib/form_data/qa_hmis/fragments/patches/enable_everything_patch.json#L4) was introduced. I reproduced this locally and found that reopening and resubmitting the assessment (without touching the missing `employment_education` data in the form) caused creation of an empty `EmploymentEducation` record for this assessment, so on subsequent reloads, no errors are raised.
  - **Proposed changes**: It seems valid to me that the whole related record be nil. What [the new code that's triggering this warning](https://github.com/greenriver/hmis-frontend/pull/1119/files#diff-7d33d3e9a02ac3ebc1f517b289868d09de568774095409317f30b95d4c1d1341R1302) really wants to confirm is that we aren't forgetting to resolve a field _on_ a related record. Therefore, this PR introduces logic to _not_ consider fields "missing" if the parent related record is null.
- New referral form fields are missing
  - **Example**: https://green-river.sentry.io/issues/6506156446/?referrer=slack&notification_uuid=3f1c65f4-3e8a-425b-872c-bd1657b928cb&environment=staging&alert_rule_id=14743218&alert_type=issue
  - **Cause**: In the project Outgoing Referrals form, we use `useDynamicFormHandlersForRecord` with a [record of `{}`](https://github.com/greenriver/hmis-frontend/pull/1123/files#diff-9c914c598537ebdc0ba351424f0e318dbcf545706d77a45cb16bf2d155241ef0R46). I think this case is a bit similar to [`AssessmentForm`](https://github.com/greenriver/hmis-frontend/blob/release-158/src/modules/assessments/components/AssessmentForm.tsx#L212-L218) so I've added a similar override. 

## Type of change
Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
