### PR TITLE
Fix bug with history

### DIFF
--- a/src/components/elements/CommonTabs.tsx
+++ b/src/components/elements/CommonTabs.tsx
@@ -1,6 +1,6 @@
 import { Box, SxProps, Tab, Tabs } from '@mui/material';
 import React, { ReactNode, useEffect, useMemo, useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 export type TabDefinition = {
   title: string;
@@ -27,7 +27,8 @@ const CommonTabs: React.FC<CommonTabsProps> = ({
   onChangeTab,
   updateUrlHash = true,
 }) => {
-  const { hash } = useLocation();
+  const { pathname, search, hash } = useLocation();
+  const navigate = useNavigate();
 
   // The prop for `currentTab` is a string (key), but internally MUI Tabs uses an number (index).
   // If a hash is already in the url, find the index for that tab and pass it in as the initial value to the useState call.
@@ -57,9 +58,9 @@ const CommonTabs: React.FC<CommonTabsProps> = ({
     if (!updateUrlHash) return;
     // If no hash is present on the path, set it to currentKey. (Should be `tabDefinitions[0].key` on pageload)
     if (!hash) {
-      window.location.assign(`#${currentKey}`);
+      navigate({ pathname, search, hash: currentKey }, { replace: true });
     }
-  }, [currentKey, updateUrlHash, hash]);
+  }, [currentKey, updateUrlHash, hash, pathname, search, navigate]);
 
   const handleChange = (_event: React.SyntheticEvent, newIndex: number) => {
     if (onChangeTab) {

--- a/src/hooks/useSearchParamState.ts
+++ b/src/hooks/useSearchParamState.ts
@@ -141,7 +141,7 @@ const useSearchParamsState = ({
     if (Object.keys(toUpdate).length) {
       // Spread currentParams to avoid overwriting search params set by other components
       const currentParams = getAllCurrentParams(searchParams);
-      setSearchParams({ ...currentParams, ...toUpdate });
+      setSearchParams({ ...currentParams, ...toUpdate }, { replace: true });
     }
 
     // Only run on mount, so the user can overwrite initial values.


### PR DESCRIPTION
## Description

Fix bug with back-navigation by ensuring that react-router-dom's "replace: true" option is used where appropriate.
- When updating the hash from within `CommonTabs`. (This isn't currently manifesting, since the only tabs we have other than on the CE feature branch are on the User Audit page, which don't update hash)
- When updating the search params from within `useSearchParamsState`. (This is the source of the bug that's described in the ticket.)

## Type of change
[//]: # 'remove options that are not relevant'
Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
