### PR TITLE
Determine nav item selection using regex

### DIFF
--- a/src/components/layout/dashboard/sideNav/navUtil.ts
+++ b/src/components/layout/dashboard/sideNav/navUtil.ts
@@ -72,3 +72,7 @@ export const applySafePaths = <T>(
 
   return config.map((child) => recur(child));
 };
+
+export const addTrailingSlash = (path: string) => {
+  return path.endsWith('/') ? path : path + '/';
+};

--- a/src/components/layout/dashboard/sideNav/useItemSelectionStatus.tsx
+++ b/src/components/layout/dashboard/sideNav/useItemSelectionStatus.tsx
@@ -1,8 +1,8 @@
-import { escapeRegExp } from 'lodash-es';
 import { useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
 
 import { NavItem } from './types';
+import { addTrailingSlash } from '@/components/layout/dashboard/sideNav/navUtil';
 import useCurrentPath from '@/hooks/useCurrentPath';
 
 export type Options<T> = {
@@ -16,20 +16,19 @@ export const useItemSelectionStatus = <T extends object>({
   const currentPath = useCurrentPath(); // /projects/:id/foo
 
   const isSelected = useMemo(() => {
-    if (!item.path && !item.activePaths) return false;
-    // If current location matches item path, then this nav item should be selected.
-    // (e.g. item path is /enrollments/1/services and current location is /enrollments/1/services/2)
-    // Use a regex to avoid false positives (e.g. item path is /projects/1/ce and current location is /projects/1/ce-participation)
-    const escapedPath = item.path ? escapeRegExp(item.path) : '';
-    const regex = new RegExp(`^${escapedPath}(?:[#/\?]|$)`);
-    if (item.path && regex.test(currentLocation)) {
-      return true;
+    if (item.path) {
+      const matchesPath =
+        currentLocation === item.path || // matches path exactly
+        currentLocation.startsWith(addTrailingSlash(item.path)); // starts with path
+
+      if (matchesPath) return true;
     }
 
     // If current route is listed in this item's activePaths, then this nav item should be selected.
-    if (item.activePaths && item.activePaths.some((p) => p === currentPath)) {
-      return true;
+    if (item.activePaths) {
+      return item.activePaths.some((p) => p === currentPath);
     }
+
     return false;
   }, [item.path, item.activePaths, currentLocation, currentPath]);
 

--- a/src/components/layout/dashboard/sideNav/useItemSelectionStatus.tsx
+++ b/src/components/layout/dashboard/sideNav/useItemSelectionStatus.tsx
@@ -1,3 +1,4 @@
+import { escapeRegExp } from 'lodash-es';
 import { useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
 
@@ -16,9 +17,12 @@ export const useItemSelectionStatus = <T extends object>({
 
   const isSelected = useMemo(() => {
     if (!item.path && !item.activePaths) return false;
-    // If current location starts with item path, then this nav item should be selected.
+    // If current location matches item path, then this nav item should be selected.
     // (e.g. item path is /enrollments/1/services and current location is /enrollments/1/services/2)
-    if (item.path && currentLocation.startsWith(item.path)) {
+    // Use a regex to avoid false positives (e.g. item path is /projects/1/ce and current location is /projects/1/ce-participation)
+    const escapedPath = item.path ? escapeRegExp(item.path) : '';
+    const regex = new RegExp(`^${escapedPath}(?:[#/\?]|$)`);
+    if (item.path && regex.test(currentLocation)) {
       return true;
     }
 


### PR DESCRIPTION
## Description

On QA, visit a project's CE Participations page. 
Bug: Both "Coordinated Entry" and "CE Participations" appear selected in the project nav.
![Screenshot 2025-04-11 at 9 47 44 AM](https://github.com/user-attachments/assets/86276802-4a92-493c-8ec3-76fd95fe350d)

I targeted release-159 with this PR, since it's fixing a bug, but I think it would be ok to go on release-160 instead since the bug is only on our QA environment (not affecting any clients).

## Type of change
[//]: # 'remove options that are not relevant'
Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
