### PR TITLE
Remove unneeded warning from Sentry on verifiedBy field

### DIFF
--- a/src/modules/form/util/formUtil.ts
+++ b/src/modules/form/util/formUtil.ts
@@ -1333,14 +1333,17 @@ const getMappedValue = (
     const value = get(record, keys); // lodash's `get` will return undefined if the field doesn't exist
 
     // Special cases where we DON'T want to alert Sentry if the field can't be resolved on the record.
-    // - imageBlobId and fileBlobId: we pass these fields when first saving a file, but they aren't persisted on the file or returned on a saved file record.
-    // - mciId: similarly, we pass this field to save an MCI ID or indicate that a new one would be created, but it's resolved on `externalIds` on the client record
-    // - resendReferralRequest: special case for the admin update referral posting, not saved on the referral posting record, but used by the custom mutation for this form.
     const specialCaseFieldNames = [
+      // imageBlobId and fileBlobId: we pass these fields when first saving a file, but they aren't persisted on the file or returned on a saved file record.
       'fileBlobId',
       'imageBlobId',
+      // mciId: similarly, we pass this field to save an MCI ID or indicate that a new one would be created, but it's resolved on `externalIds` on the client record
       'mciId',
+      // resendReferralRequest: special case for the admin update referral posting, not saved on the referral posting record, but used by the custom mutation for this form.
       'resendReferralRequest',
+      // verifiedBy: we may pass this field to the backend if this is a migrated-in CLS with no verifiedByProjectId, but we don't need to resolve it separately from verifiedByProjectId.
+      // See comments on the backend CLS schema object for more details
+      'verifiedBy',
     ];
     if (!specialCaseFieldNames.includes(mapping.fieldName)) {
       // In general, we do want to alert Sentry if the key is missing, to prevent silently swallowing developer errors.


### PR DESCRIPTION
## Description

We got a Sentry alert 'Field "verifiedBy" is missing in record CurrentLivingSituation:id'. 

It's intentional that we don't resolve` verifiedBy` separately from `verifiedByProjectId`. See comments here: https://github.com/greenriver/hmis-warehouse/blob/bed6c406257826d1ed2616af338b6cc2aa490326/drivers/hmis/app/graphql/types/hmis_schema/current_living_situation.rb#L50-L60

This PR proposes adding `verifiedBy` to the special cases that we ignore when generating these warnings.

## Type of change
Sentry noise reduction

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (eslint)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
