### PR TITLE
Implement frontend CE permissions

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -7937,6 +7937,22 @@
             "deprecationReason": null
           },
           {
+            "name": "canViewClientEligibleOpportunities",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "canViewClientName",
             "description": null,
             "args": [],
@@ -8017,7 +8033,39 @@
             "deprecationReason": null
           },
           {
+            "name": "canViewOwnReferrals",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "canViewPartialSsn",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "canViewReferrals",
             "description": null,
             "args": [],
             "type": {

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -5456,6 +5456,22 @@
         "isOneOf": null,
         "fields": [
           {
+            "name": "access",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "CeReferralStepAccess",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "assignees",
             "description": "User(s) currently assigned to this step",
             "args": [],
@@ -5474,22 +5490,6 @@
                     "ofType": null
                   }
                 }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "canCurrentUserPerform",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
               }
             },
             "isDeprecated": false,
@@ -5593,6 +5593,74 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "ISO8601DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedBy",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ApplicationUser",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "CeReferralStepAccess",
+        "description": null,
+        "isOneOf": null,
+        "fields": [
+          {
+            "name": "canPerformStep",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
                 "ofType": null
               }
             },

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -4206,6 +4206,22 @@
             "deprecationReason": null
           },
           {
+            "name": "dateAvailable",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ISO8601Date",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "eligibilityRequirements",
             "description": null,
             "args": [],
@@ -4255,6 +4271,22 @@
           },
           {
             "name": "name",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "organizationName",
             "description": null,
             "args": [],
             "type": {
@@ -4356,10 +4388,146 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "unit",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Unit",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "CeOpportunityFilterOptions",
+        "description": null,
+        "isOneOf": false,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "availableOnDate",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "ISO8601Date",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "organization",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "project",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectType",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "ProjectType",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "CeOpportunityStatus",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "workflowTemplate",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },
@@ -4405,6 +4573,30 @@
         ],
         "interfaces": null,
         "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "CeOpportunitySortOption",
+        "description": "Opportunity Sorting Options",
+        "isOneOf": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "DATE_AVAILABLE_EARLIEST_FIRST",
+            "description": "Date Available, earliest first",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "DATE_AVAILABLE_LATEST_FIRST",
+            "description": "Date Available, latest first",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
         "possibleTypes": null
       },
       {
@@ -4820,12 +5012,32 @@
             "deprecationReason": null
           },
           {
-            "name": "currentStepName",
+            "name": "currentSteps",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CeReferralStep",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "daysOnCurrentSteps",
             "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
-              "name": "String",
+              "name": "Int",
               "ofType": null
             },
             "isDeprecated": false,
@@ -4952,6 +5164,22 @@
             "deprecationReason": null
           },
           {
+            "name": "targetOrganizationName",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "targetProjectId",
             "description": null,
             "args": [],
@@ -4998,6 +5226,18 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "updatedBy",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ApplicationUser",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -5012,6 +5252,38 @@
         "isOneOf": false,
         "fields": null,
         "inputFields": [
+          {
+            "name": "onCurrentStepSince",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "ISO8601Date",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "organization",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "project",
             "description": null,
@@ -5064,6 +5336,26 @@
                 "ofType": {
                   "kind": "ENUM",
                   "name": "CeReferralStatus",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "workflowTemplate",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
                   "ofType": null
                 }
               }
@@ -5971,7 +6263,7 @@
                 "description": null,
                 "type": {
                   "kind": "INPUT_OBJECT",
-                  "name": "CeReferralFilterOptions",
+                  "name": "ClientCeReferralFilterOptions",
                   "ofType": null
                 },
                 "defaultValue": null,
@@ -6344,6 +6636,18 @@
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "sortOrder",
+                "description": null,
+                "type": {
+                  "kind": "ENUM",
+                  "name": "CeOpportunitySortOption",
                   "ofType": null
                 },
                 "defaultValue": null,
@@ -8807,6 +9111,98 @@
         "possibleTypes": null
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "ClientCeReferralFilterOptions",
+        "description": null,
+        "isOneOf": false,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "organization",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "project",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectType",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "ProjectType",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "CeReferralStatus",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "OBJECT",
         "name": "ClientContactPoint",
         "description": null,
@@ -9067,6 +9463,26 @@
         "isOneOf": false,
         "fields": null,
         "inputFields": [
+          {
+            "name": "organization",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "project",
             "description": null,
@@ -35197,6 +35613,12 @@
             "deprecationReason": null
           },
           {
+            "name": "CE_WORKFLOW_TEMPLATE_IDENTIFIERS_INCLUDING_RETIRED",
+            "description": "Templates for CE workflow definitions, including fully retired workflows",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "CLIENT_AUDIT_EVENT_RECORD_TYPES",
             "description": null,
             "isDeprecated": false,
@@ -37754,6 +38176,18 @@
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "sortOrder",
+                "description": null,
+                "type": {
+                  "kind": "ENUM",
+                  "name": "CeOpportunitySortOption",
                   "ofType": null
                 },
                 "defaultValue": null,
@@ -40876,6 +41310,71 @@
             "deprecationReason": null
           },
           {
+            "name": "ceOpportunities",
+            "description": null,
+            "args": [
+              {
+                "name": "filters",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "CeOpportunityFilterOptions",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "sortOrder",
+                "description": null,
+                "type": {
+                  "kind": "ENUM",
+                  "name": "CeOpportunitySortOption",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "CeOpportunitiesPaginated",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "ceOpportunity",
             "description": null,
             "args": [
@@ -40958,6 +41457,59 @@
               "kind": "OBJECT",
               "name": "CeReferralStep",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ceReferrals",
+            "description": null,
+            "args": [
+              {
+                "name": "filters",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "CeReferralFilterOptions",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "CeReferralsPaginated",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -35656,13 +35656,13 @@
           },
           {
             "name": "ELIGIBLE_REFERRAL_STEP_ASSIGNMENT_USERS",
-            "description": "Current users who can be assigned to referral steps in the specified project",
+            "description": "Users who can be assigned to referral steps in the specified project",
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "ELIGIBLE_STAFF_ASSIGNMENT_USERS",
-            "description": "Current users who are eligible for staff assignment",
+            "description": "Users who are eligible for staff assignment",
             "isDeprecated": false,
             "deprecationReason": null
           },
@@ -43218,6 +43218,22 @@
           },
           {
             "name": "canAdministrateConfig",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "canAdministrateCoordinatedEntry",
             "description": null,
             "args": [],
             "type": {

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -5188,6 +5188,22 @@
             "deprecationReason": null
           },
           {
+            "name": "canCurrentUserPerform",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "formDefinition",
             "description": null,
             "args": [],
@@ -35217,6 +35233,12 @@
             "deprecationReason": null
           },
           {
+            "name": "ELIGIBLE_REFERRAL_STEP_ASSIGNMENT_USERS",
+            "description": "Current users who can be assigned to referral steps in the specified project",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "ELIGIBLE_STAFF_ASSIGNMENT_USERS",
             "description": "Current users who are eligible for staff assignment",
             "isDeprecated": false,
@@ -38995,6 +39017,22 @@
         "isOneOf": null,
         "fields": [
           {
+            "name": "canAssignReferralTasks",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "canDeleteAssessments",
             "description": null,
             "args": [],
@@ -39171,7 +39209,55 @@
             "deprecationReason": null
           },
           {
+            "name": "canPerformAnyReferralTasks",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "canPerformOwnReferralTasks",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "canSplitHouseholds",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "canStartReferrals",
             "description": null,
             "args": [],
             "type": {
@@ -39235,7 +39321,55 @@
             "deprecationReason": null
           },
           {
+            "name": "canViewOwnReferrals",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "canViewPartialSsn",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "canViewPrioritizedClientLists",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "canViewReferrals",
             "description": null,
             "args": [],
             "type": {
@@ -42547,6 +42681,22 @@
             "deprecationReason": null
           },
           {
+            "name": "canAssignReferralTasks",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "canAuditClients",
             "description": null,
             "args": [],
@@ -42979,7 +43129,55 @@
             "deprecationReason": null
           },
           {
+            "name": "canPerformAnyReferralTasks",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "canPerformOwnReferralTasks",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "canSplitHouseholds",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "canStartReferrals",
             "description": null,
             "args": [],
             "type": {
@@ -43060,6 +43258,22 @@
           },
           {
             "name": "canViewClientContactInfo",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "canViewClientEligibleOpportunities",
             "description": null,
             "args": [],
             "type": {
@@ -43267,6 +43481,22 @@
             "deprecationReason": null
           },
           {
+            "name": "canViewOwnReferrals",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "canViewPartialSsn",
             "description": null,
             "args": [],
@@ -43283,7 +43513,39 @@
             "deprecationReason": null
           },
           {
+            "name": "canViewPrioritizedClientLists",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "canViewProject",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "canViewReferrals",
             "description": null,
             "args": [],
             "type": {

--- a/src/api/operations/access.fragments.graphql
+++ b/src/api/operations/access.fragments.graphql
@@ -29,6 +29,7 @@ fragment RootPermissions on QueryAccess {
   # Application permissions:
   canViewMyDashboard
   canViewCoordinatedEntry
+  canAdministrateCoordinatedEntry
 
   # Root Project permissions:
   canEditOrganization # globally, determines whether user can create organization

--- a/src/api/operations/access.fragments.graphql
+++ b/src/api/operations/access.fragments.graphql
@@ -22,6 +22,9 @@ fragment RootPermissions on QueryAccess {
   canEditClients # globally, determines whether user can add new clients
   canViewDob # globally, determines whether to show col header as "DOB" or "Age"
   canViewClientAlerts
+  canViewClientEligibleOpportunities
+  canViewReferrals
+  canViewOwnReferrals
 
   # Application permissions:
   canViewMyDashboard
@@ -88,6 +91,13 @@ fragment ProjectAccessFields on ProjectAccess {
   canManageOutgoingReferrals
   canManageExternalFormSubmissions
   canSplitHouseholds
+  canViewReferrals
+  canViewOwnReferrals
+  canViewPrioritizedClientLists
+  canStartReferrals
+  canPerformAnyReferralTasks
+  canPerformOwnReferralTasks
+  canAssignReferralTasks
 }
 
 fragment OrganizationAccessFields on OrganizationAccess {

--- a/src/api/operations/access.fragments.graphql
+++ b/src/api/operations/access.fragments.graphql
@@ -22,9 +22,6 @@ fragment RootPermissions on QueryAccess {
   canEditClients # globally, determines whether user can add new clients
   canViewDob # globally, determines whether to show col header as "DOB" or "Age"
   canViewClientAlerts
-  canViewClientEligibleOpportunities
-  canViewReferrals
-  canViewOwnReferrals
 
   # Application permissions:
   canViewMyDashboard
@@ -62,6 +59,11 @@ fragment ClientAccessFields on ClientAccess {
   canManageAnyClientFiles
   canManageOwnClientFiles
   canUploadClientFiles
+
+  # Referral-related root permissions, resolved on Client for convenience
+  canViewReferrals
+  canViewOwnReferrals
+  canViewClientEligibleOpportunities
 }
 
 fragment EnrollmentAccessFields on EnrollmentAccess {

--- a/src/api/operations/ce.fragments.graphql
+++ b/src/api/operations/ce.fragments.graphql
@@ -118,6 +118,7 @@ fragment CeReferralStepSummaryFields on CeReferralStep {
     id
     name
   }
+  canCurrentUserPerform
 }
 
 fragment CeReferralStepFields on CeReferralStep {

--- a/src/api/operations/ce.fragments.graphql
+++ b/src/api/operations/ce.fragments.graphql
@@ -61,7 +61,10 @@ fragment CeReferralTableFields on CeReferral {
     id
     name
   }
-  currentStepName
+  currentSteps {
+    id
+    name
+  }
   referredBy {
     id
     name

--- a/src/api/operations/ce.fragments.graphql
+++ b/src/api/operations/ce.fragments.graphql
@@ -163,7 +163,9 @@ fragment CeReferralStepSummaryFields on CeReferralStep {
     id
     name
   }
-  canCurrentUserPerform
+  access {
+    canPerformStep
+  }
 }
 
 fragment CeReferralStepFields on CeReferralStep {

--- a/src/api/operations/ce.operations.graphql
+++ b/src/api/operations/ce.operations.graphql
@@ -57,7 +57,10 @@ mutation SubmitCeReferralStep(
   }
 }
 
-mutation MarkUnitsAvailable($unitIds: [ID!]!, $ceEnabled: Boolean = true) {
+mutation MarkUnitsAvailable(
+  $unitIds: [ID!]!
+  $includeCeFields: Boolean = true
+) {
   markUnitsAvailable(unitIds: $unitIds) {
     units {
       ...UnitFields
@@ -65,7 +68,10 @@ mutation MarkUnitsAvailable($unitIds: [ID!]!, $ceEnabled: Boolean = true) {
   }
 }
 
-mutation MarkUnitsUnavailable($unitIds: [ID!]!, $ceEnabled: Boolean = true) {
+mutation MarkUnitsUnavailable(
+  $unitIds: [ID!]!
+  $includeCeFields: Boolean = true
+) {
   markUnitsUnavailable(unitIds: $unitIds) {
     units {
       ...UnitFields

--- a/src/api/operations/ce.queries.graphql
+++ b/src/api/operations/ce.queries.graphql
@@ -76,7 +76,7 @@ query GetClientCeReferrals(
   $id: ID!
   $limit: Int = 25
   $offset: Int = 0
-  $filters: CeReferralFilterOptions = null
+  $filters: ClientCeReferralFilterOptions = null
 ) {
   client(id: $id) {
     id

--- a/src/api/operations/units.fragments.graphql
+++ b/src/api/operations/units.fragments.graphql
@@ -28,7 +28,7 @@ fragment UnitFields on Unit {
       ...ClientName
     }
   }
-  ...UnitWithCeFields @include(if: $ceEnabled)
+  ...UnitWithCeFields @include(if: $includeCeFields)
 }
 
 fragment UnitWithCeFields on Unit {

--- a/src/api/operations/units.queries.graphql
+++ b/src/api/operations/units.queries.graphql
@@ -3,7 +3,7 @@ query GetUnits(
   $limit: Int = 10
   $offset: Int = 0
   $filters: UnitFilterOptions
-  $ceEnabled: Boolean = false
+  $includeCeFields: Boolean = false
 ) {
   project(id: $id) {
     id
@@ -27,7 +27,10 @@ query GetProjectUnitTypes($id: ID!) {
   }
 }
 
-mutation CreateUnits($input: CreateUnitsInput!, $ceEnabled: Boolean = false) {
+mutation CreateUnits(
+  $input: CreateUnitsInput!
+  $includeCeFields: Boolean = false
+) {
   createUnits(input: $input) {
     clientMutationId
     units {
@@ -49,7 +52,10 @@ mutation DeleteUnits($input: DeleteUnitsInput!) {
   }
 }
 
-mutation UpdateUnits($input: UpdateUnitsInput!, $ceEnabled: Boolean = false) {
+mutation UpdateUnits(
+  $input: UpdateUnitsInput!
+  $includeCeFields: Boolean = false
+) {
   updateUnits(input: $input) {
     clientMutationId
     units {

--- a/src/components/accessWrappers/ClientRoute.tsx
+++ b/src/components/accessWrappers/ClientRoute.tsx
@@ -13,11 +13,16 @@ import { generateSafePath } from '@/utils/pathEncoding';
 const ClientRoute: React.FC<
   React.PropsWithChildren<{
     permissions: ClientPermissions | ClientPermissions[];
+    permissionsMode?: 'any' | 'all';
     redirectRoute?: string;
   }>
-> = ({ permissions, redirectRoute, children }) => {
+> = ({ permissions, permissionsMode, redirectRoute, children }) => {
   const { client } = useClientDashboardContext();
-  const hasPermission = useHasPermissions(client?.access, permissions, 'all');
+  const hasPermission = useHasPermissions(
+    client?.access,
+    permissions,
+    permissionsMode || 'all'
+  );
   if (!hasPermission) {
     return redirectRoute ? (
       <Navigate

--- a/src/components/accessWrappers/ClientRoute.tsx
+++ b/src/components/accessWrappers/ClientRoute.tsx
@@ -13,15 +13,15 @@ import { generateSafePath } from '@/utils/pathEncoding';
 const ClientRoute: React.FC<
   React.PropsWithChildren<{
     permissions: ClientPermissions | ClientPermissions[];
-    permissionsMode?: 'any' | 'all';
+    permissionMode?: 'any' | 'all';
     redirectRoute?: string;
   }>
-> = ({ permissions, permissionsMode, redirectRoute, children }) => {
+> = ({ permissions, permissionMode, redirectRoute, children }) => {
   const { client } = useClientDashboardContext();
   const hasPermission = useHasPermissions(
     client?.access,
     permissions,
-    permissionsMode || 'all'
+    permissionMode || 'all'
   );
   if (!hasPermission) {
     return redirectRoute ? (

--- a/src/components/elements/CommonTabs.tsx
+++ b/src/components/elements/CommonTabs.tsx
@@ -1,5 +1,6 @@
 import { Box, SxProps, Tab, Tabs } from '@mui/material';
 import React, { ReactNode, useMemo } from 'react';
+import NotFound from '@/components/pages/NotFound';
 import useHashState from '@/hooks/useHashState.ts';
 
 export type TabDefinition = {
@@ -14,6 +15,7 @@ interface CommonTabsProps {
   sx?: SxProps;
   currentTab?: string;
   onChangeTab?: (tab: string) => void;
+  collapseSingleTab?: boolean; // If true (default), and there is only one tab definition, the tab interface is hidden, and the tab's content is shown with no wrapper
 }
 
 // CommonTabs wraps the MUI Tabs component. It can be controlled or uncontrolled.
@@ -26,6 +28,7 @@ const CommonTabs: React.FC<CommonTabsProps> = ({
   tabDefinitions,
   currentTab,
   onChangeTab,
+  collapseSingleTab = true,
 }) => {
   const [internalValue, setInternalValue] = useHashState({
     initial: tabDefinitions[0].key,
@@ -52,6 +55,12 @@ const CommonTabs: React.FC<CommonTabsProps> = ({
       setInternalValue(newKey); // Uncontrolled mode: manage internally
     }
   };
+
+  if (tabDefinitions.length === 0) return <NotFound />;
+
+  if (collapseSingleTab && tabDefinitions.length === 1) {
+    return tabDefinitions[0].contents;
+  }
 
   return (
     <Box sx={{ width: '100%', ...sx }}>

--- a/src/modules/admin/components/AdminDashboard.tsx
+++ b/src/modules/admin/components/AdminDashboard.tsx
@@ -46,7 +46,7 @@ const navItems: NavItem<RootPermissionsFragment>[] = [
         id: 'coordinated-entry',
         title: 'Coordinated Entry',
         path: AdminDashboardRoutes.COORDINATED_ENTRY,
-        permissions: ['canViewCoordinatedEntry'], // TODO (#7506) - update permission
+        permissions: ['canAdministrateCoordinatedEntry'],
       },
     ],
   },

--- a/src/modules/ce/components/AssignContactFormItem.tsx
+++ b/src/modules/ce/components/AssignContactFormItem.tsx
@@ -11,11 +11,13 @@ interface Props {
   swimlane: CeReferralSwimlaneFieldsFragment;
   users: PickListOption[];
   setUsers: (userIds: PickListOption[]) => void;
+  projectId: string;
 }
 const AssignContactFormItem: React.FC<Props> = ({
   swimlane,
   users,
   setUsers,
+  projectId,
 }) => {
   const {
     data: { pickList: staffPickList } = {},
@@ -23,9 +25,8 @@ const AssignContactFormItem: React.FC<Props> = ({
     error: staffPickListError,
   } = useGetPickListQuery({
     variables: {
-      // TODO(#7506) (or later), add a new pick list type ELIGIBLE_REFERRAL_PARTICIPANT_USERS
-      // and pass in the projectId to get users who are allowed to participate in this referral
-      pickListType: PickListType.Users,
+      pickListType: PickListType.EligibleReferralStepAssignmentUsers,
+      projectId: projectId,
     },
   });
 

--- a/src/modules/ce/components/AssignContactsButton.tsx
+++ b/src/modules/ce/components/AssignContactsButton.tsx
@@ -20,8 +20,12 @@ import {
 
 interface Props {
   referral: CeReferralFieldsFragment;
+  projectId: string;
 }
-const AssignContactsButton: React.FC<Props> = ({ referral }: Props) => {
+const AssignContactsButton: React.FC<Props> = ({
+  referral,
+  projectId,
+}: Props) => {
   const [open, setOpen] = useState(false);
 
   const initialValues = useMemo(() => {
@@ -109,6 +113,7 @@ const AssignContactsButton: React.FC<Props> = ({ referral }: Props) => {
                 setUsers={(userIds) => {
                   handleChangeValue(swimlane.id, userIds);
                 }}
+                projectId={projectId}
               />
             ))}
           </Stack>

--- a/src/modules/ce/components/Opportunity.tsx
+++ b/src/modules/ce/components/Opportunity.tsx
@@ -54,6 +54,70 @@ const Opportunity: React.FC<Props> = ({}) => {
     return ceOpportunity.candidates.nodes[0];
   }, [ceOpportunity]);
 
+  const tabDefinitions = useMemo(() => {
+    if (!opportunity) return [];
+    const defs = [];
+
+    if (project.access.canViewUnits) {
+      // just for symmetry; should already be the case if opportunity was returned
+      defs.push({
+        title: 'Overview',
+        key: 'overview',
+        contents: (
+          <Grid container columnSpacing={2} rowSpacing={4}>
+            <Grid item xs={12}>
+              <OpportunityBanner
+                topCandidate={topCandidate}
+                opportunity={opportunity}
+              />
+            </Grid>
+            {opportunity.eligibilityRequirements && (
+              <Grid item xs={12} md={6}>
+                <MatchRuleGrid
+                  title='Requirements'
+                  rules={opportunity.eligibilityRequirements}
+                />
+              </Grid>
+            )}
+            {opportunity.priorityScheme && (
+              <Grid item xs={12} md={6}>
+                <MatchRuleGrid
+                  title='Prioritization'
+                  rules={[opportunity.priorityScheme]}
+                />
+              </Grid>
+            )}
+          </Grid>
+        ),
+      });
+    }
+
+    if (project.access.canViewPrioritizedClientLists) {
+      defs.push({
+        title: 'Eligible Clients',
+        key: 'clients',
+        contents: (
+          <Paper>
+            <PrioritizedClientsTable
+              opportunityId={opportunityId}
+              projectId={projectId}
+              status={opportunity.status}
+            />
+          </Paper>
+        ),
+      });
+    }
+
+    return defs;
+  }, [
+    opportunity,
+    opportunityId,
+    project.access.canViewPrioritizedClientLists,
+    project.access.canViewUnits,
+    projectId,
+    topCandidate,
+  ]);
+
   if (loading || topCandidateLoading) return <Loading />;
   if (error) throw error;
   if (topCandidateError) throw topCandidateError;
@@ -71,51 +135,7 @@ const Opportunity: React.FC<Props> = ({}) => {
       </Typography>
       <CommonTabs
         ariaLabel={'Eligible Clients and Details tabs'}
-        tabDefinitions={[
-          {
-            title: 'Overview',
-            key: 'overview',
-            contents: (
-              <Grid container columnSpacing={2} rowSpacing={4}>
-                <Grid item xs={12}>
-                  <OpportunityBanner
-                    topCandidate={topCandidate}
-                    opportunity={opportunity}
-                  />
-                </Grid>
-                {opportunity.eligibilityRequirements && (
-                  <Grid item xs={12} md={6}>
-                    <MatchRuleGrid
-                      title='Requirements'
-                      rules={opportunity.eligibilityRequirements}
-                    />
-                  </Grid>
-                )}
-                {opportunity.priorityScheme && (
-                  <Grid item xs={12} md={6}>
-                    <MatchRuleGrid
-                      title='Prioritization'
-                      rules={[opportunity.priorityScheme]}
-                    />
-                  </Grid>
-                )}
-              </Grid>
-            ),
-          },
-          {
-            title: 'Eligible Clients',
-            key: 'clients',
-            contents: (
-              <Paper>
-                <PrioritizedClientsTable
-                  opportunityId={opportunityId}
-                  projectId={projectId}
-                  status={opportunity.status}
-                />
-              </Paper>
-            ),
-          },
-        ]}
+        tabDefinitions={tabDefinitions}
       />
     </>
   );

--- a/src/modules/ce/components/OpportunityBanner.tsx
+++ b/src/modules/ce/components/OpportunityBanner.tsx
@@ -7,6 +7,7 @@ import { useIsMobile } from '@/hooks/useIsMobile';
 import BeginReferralButton from '@/modules/ce/components/BeginReferralButton';
 import ReferralStatusChip from '@/modules/ce/components/ReferralStatusChip';
 import { clientNameFromRecordWithOptionalClient } from '@/modules/hmis/hmisUtil';
+import { useProjectDashboardContext } from '@/modules/projects/components/ProjectDashboard';
 import { ProjectDashboardRoutes } from '@/routes/routes';
 import {
   CeCandidateFieldsFragment,
@@ -22,6 +23,7 @@ interface Props {
 const OpportunityBanner: React.FC<Props> = ({ opportunity, topCandidate }) => {
   const isTiny = useIsMobile('sm');
   const { referral } = opportunity;
+  const { project } = useProjectDashboardContext();
 
   const header = useMemo(() => {
     if (referral?.status === CeReferralStatus.Accepted) return 'Filled By';
@@ -58,7 +60,7 @@ const OpportunityBanner: React.FC<Props> = ({ opportunity, topCandidate }) => {
       );
     }
 
-    if (topCandidate) {
+    if (topCandidate && project.access.canStartReferrals) {
       return (
         <BeginReferralButton
           opportunityId={opportunity.id}
@@ -68,7 +70,13 @@ const OpportunityBanner: React.FC<Props> = ({ opportunity, topCandidate }) => {
         />
       );
     }
-  }, [referral, opportunity.id, opportunity.projectId, topCandidate]);
+  }, [
+    referral,
+    topCandidate,
+    project.access.canStartReferrals,
+    opportunity.projectId,
+    opportunity.id,
+  ]);
 
   if (!referral && !topCandidate) return;
 

--- a/src/modules/ce/components/PrioritizedClientsTable.tsx
+++ b/src/modules/ce/components/PrioritizedClientsTable.tsx
@@ -8,6 +8,7 @@ import {
   clientBriefName,
   clientNameFromRecordWithOptionalClient,
 } from '@/modules/hmis/hmisUtil';
+import { useProjectDashboardContext } from '@/modules/projects/components/ProjectDashboard';
 import { ClientDashboardRoutes } from '@/routes/routes';
 import {
   CeCandidateFieldsFragment,
@@ -42,6 +43,8 @@ const PrioritizedClientsTable: React.FC<Props> = ({
   projectId,
   status,
 }) => {
+  const { project } = useProjectDashboardContext();
+
   const columns = useMemo(() => {
     return [
       ...COLUMNS,
@@ -52,7 +55,8 @@ const PrioritizedClientsTable: React.FC<Props> = ({
             record={row}
             recordName={`ID ${row.id}`}
             primaryAction={
-              status === CeOpportunityStatus.Open && (
+              status === CeOpportunityStatus.Open &&
+              project.access.canStartReferrals && (
                 <BeginReferralButton
                   opportunityId={opportunityId}
                   projectId={projectId}
@@ -80,7 +84,7 @@ const PrioritizedClientsTable: React.FC<Props> = ({
         ),
       },
     ];
-  }, [opportunityId, projectId, status]);
+  }, [opportunityId, project.access.canStartReferrals, projectId, status]);
 
   return (
     <GenericTableWithData<

--- a/src/modules/ce/components/ProjectCePage.tsx
+++ b/src/modules/ce/components/ProjectCePage.tsx
@@ -1,15 +1,44 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import CommonTabs from '@/components/elements/CommonTabs';
 import PageTitle from '@/components/layout/PageTitle';
 import useSafeParams from '@/hooks/useSafeParams';
 import CreateOpportunityButton from '@/modules/ce/components/CreateOpportunityButton';
 import ProjectOpportunitiesTable from '@/modules/ce/components/ProjectOpportunitiesTable';
 import ProjectReferralsTable from '@/modules/ce/components/ProjectReferralsTable';
+import { useProjectDashboardContext } from '@/modules/projects/components/ProjectDashboard';
 
 const ProjectCePage: React.FC = () => {
   const { projectId } = useSafeParams() as {
     projectId: string;
   };
+
+  const { project } = useProjectDashboardContext();
+
+  const tabDefinitions = useMemo(() => {
+    const defs = [];
+
+    if (project.access.canViewUnits) {
+      defs.push({
+        title: 'Available Units',
+        key: 'opportunities',
+        contents: <ProjectOpportunitiesTable />,
+      });
+    }
+
+    if (project.access.canViewReferrals || project.access.canViewOwnReferrals) {
+      defs.push({
+        title: 'Ongoing Referrals',
+        key: 'referrals',
+        contents: <ProjectReferralsTable />,
+      });
+    }
+
+    return defs;
+  }, [
+    project.access.canViewOwnReferrals,
+    project.access.canViewReferrals,
+    project.access.canViewUnits,
+  ]);
 
   return (
     <>
@@ -17,21 +46,9 @@ const ProjectCePage: React.FC = () => {
         title={'Coordinated Entry'}
         actions={<CreateOpportunityButton projectId={projectId} />}
       />
-
       <CommonTabs
         ariaLabel={'Project CE Tabs'}
-        tabDefinitions={[
-          {
-            title: 'Available Units',
-            key: 'opportunities',
-            contents: <ProjectOpportunitiesTable />,
-          },
-          {
-            title: 'Ongoing Referrals',
-            key: 'referrals',
-            contents: <ProjectReferralsTable />,
-          },
-        ]}
+        tabDefinitions={tabDefinitions}
       />
     </>
   );

--- a/src/modules/ce/components/ProjectReferralsTable.tsx
+++ b/src/modules/ce/components/ProjectReferralsTable.tsx
@@ -67,7 +67,11 @@ export const REFERRAL_COLUMNS: Record<
       referral:
         | CeReferralTableFieldsFragment
         | ClientCeReferralTableFieldsFragment
-    ) => referral.currentStepName,
+    ) => {
+      if (referral.currentSteps && referral.currentSteps.length > 0) {
+        return referral.currentSteps[0].name;
+      }
+    },
   },
   referredBy: {
     header: 'Referred By',

--- a/src/modules/ce/components/ReferralPage.tsx
+++ b/src/modules/ce/components/ReferralPage.tsx
@@ -19,6 +19,7 @@ import useSafeParams from '@/hooks/useSafeParams';
 import AssignContactsButton from '@/modules/ce/components/AssignContactsButton';
 import ReferralStatusChip from '@/modules/ce/components/ReferralStatusChip';
 import { clientBriefName } from '@/modules/hmis/hmisUtil';
+import { useProjectDashboardContext } from '@/modules/projects/components/ProjectDashboard';
 import { ClientDashboardRoutes, ProjectDashboardRoutes } from '@/routes/routes';
 import {
   CeReferralFieldsFragment,
@@ -38,6 +39,8 @@ const ReferralPage: React.FC<Props> = ({}) => {
     opportunityId: string;
     referralId: string;
   };
+
+  const { project } = useProjectDashboardContext();
 
   const {
     data: { ceReferral: referral } = {},
@@ -121,8 +124,12 @@ const ReferralPage: React.FC<Props> = ({}) => {
             Details
           </ButtonLink>
           <Divider orientation='vertical' flexItem />
-          <AssignContactsButton referral={referral} />
-          <Divider orientation='vertical' flexItem />
+          {project.access.canAssignReferralTasks && (
+            <>
+              <AssignContactsButton referral={referral} projectId={projectId} />
+              <Divider orientation='vertical' flexItem />
+            </>
+          )}
           <ButtonLink
             to={generateSafePath(ProjectDashboardRoutes.REFERRAL_STEPS, {
               projectId,

--- a/src/modules/ce/components/ReferralStep.tsx
+++ b/src/modules/ce/components/ReferralStep.tsx
@@ -92,6 +92,9 @@ const ReferralStep: React.FC<Props> = ({}) => {
     submittedValues &&
     createInitialValuesFromSavedValues(itemMap, submittedValues);
 
+  const editable =
+    status === CeReferralStepStatus.InProgress && step?.canCurrentUserPerform;
+
   if (fetchLoading) return <Loading />;
   if (fetchError) throw fetchError;
   if (!step || !formDefinition) return <NotFound />;
@@ -111,7 +114,7 @@ const ReferralStep: React.FC<Props> = ({}) => {
             Start Step
           </StartCeReferralStepButton>
         )}
-        {status === CeReferralStepStatus.InProgress && (
+        {editable ? (
           <DynamicForm
             definition={formDefinition.definition}
             onSubmit={({ valuesByLinkId, confirmed }) => {
@@ -133,8 +136,7 @@ const ReferralStep: React.FC<Props> = ({}) => {
             }}
             initialValues={formState}
           />
-        )}
-        {status === CeReferralStepStatus.Completed && formState && (
+        ) : (
           <DynamicView
             definition={formDefinition.definition}
             values={formState}

--- a/src/modules/ce/components/ReferralStep.tsx
+++ b/src/modules/ce/components/ReferralStep.tsx
@@ -93,7 +93,7 @@ const ReferralStep: React.FC<Props> = ({}) => {
     createInitialValuesFromSavedValues(itemMap, submittedValues);
 
   const editable =
-    status === CeReferralStepStatus.InProgress && step?.canCurrentUserPerform;
+    status === CeReferralStepStatus.InProgress && step?.access.canPerformStep;
 
   if (fetchLoading) return <Loading />;
   if (fetchError) throw fetchError;

--- a/src/modules/ce/components/StartCeReferralStepButton.tsx
+++ b/src/modules/ce/components/StartCeReferralStepButton.tsx
@@ -69,6 +69,8 @@ const StartCeReferralStepButton: React.FC<Props> = ({
 
   if (step.status !== CeReferralStepStatus.Available) return;
 
+  if (!step.canCurrentUserPerform) return;
+
   return (
     <LoadingButton
       loading={loading}

--- a/src/modules/ce/components/StartCeReferralStepButton.tsx
+++ b/src/modules/ce/components/StartCeReferralStepButton.tsx
@@ -69,7 +69,7 @@ const StartCeReferralStepButton: React.FC<Props> = ({
 
   if (step.status !== CeReferralStepStatus.Available) return;
 
-  if (!step.canCurrentUserPerform) return;
+  if (!step.access.canPerformStep) return;
 
   return (
     <LoadingButton

--- a/src/modules/ce/components/client/ClientReferralsPage.tsx
+++ b/src/modules/ce/components/client/ClientReferralsPage.tsx
@@ -1,28 +1,51 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import CommonTabs from '@/components/elements/CommonTabs';
 import PageTitle from '@/components/layout/PageTitle';
+import NotFound from '@/components/pages/NotFound';
 import ClientOpportunitiesTable from '@/modules/ce/components/client/ClientOpportunitiesTable';
 import ClientReferralsTable from '@/modules/ce/components/client/ClientReferralsTable';
+import { useHasRootPermissions } from '@/modules/permissions/useHasPermissionsHooks';
 
 const ClientReferralsPage: React.FC = () => {
+  const [canViewClientEligibleOpportunities] = useHasRootPermissions([
+    'canViewClientEligibleOpportunities',
+  ]);
+  const [canViewAnyReferrals] = useHasRootPermissions([
+    'canViewReferrals',
+    'canViewOwnReferrals',
+  ]);
+
+  const tabDefinitions = useMemo(() => {
+    const defs = [];
+
+    if (canViewAnyReferrals) {
+      defs.push({
+        title: 'All Referrals',
+        key: 'referrals',
+        contents: <ClientReferralsTable />,
+      });
+    }
+
+    if (canViewClientEligibleOpportunities) {
+      defs.push({
+        title: 'Eligible Opportunities',
+        key: 'opportunities',
+        contents: <ClientOpportunitiesTable />,
+      });
+    }
+
+    return defs;
+  }, [canViewAnyReferrals, canViewClientEligibleOpportunities]);
+
+  if (!canViewClientEligibleOpportunities && !canViewAnyReferrals)
+    return <NotFound />;
+
   return (
     <>
       <PageTitle title={'Referrals'} />
-
       <CommonTabs
         ariaLabel={'Client Referrals Tabs'}
-        tabDefinitions={[
-          {
-            title: 'All Referrals',
-            key: 'referrals',
-            contents: <ClientReferralsTable />,
-          },
-          {
-            title: 'Eligible Opportunities',
-            key: 'opportunities',
-            contents: <ClientOpportunitiesTable />,
-          },
-        ]}
+        tabDefinitions={tabDefinitions}
       />
     </>
   );

--- a/src/modules/ce/components/client/ClientReferralsPage.tsx
+++ b/src/modules/ce/components/client/ClientReferralsPage.tsx
@@ -4,13 +4,16 @@ import PageTitle from '@/components/layout/PageTitle';
 import NotFound from '@/components/pages/NotFound';
 import ClientOpportunitiesTable from '@/modules/ce/components/client/ClientOpportunitiesTable';
 import ClientReferralsTable from '@/modules/ce/components/client/ClientReferralsTable';
-import { useHasRootPermissions } from '@/modules/permissions/useHasPermissionsHooks';
+import useClientDashboardContext from '@/modules/client/hooks/useClientDashboardContext';
+import { useHasPermissions } from '@/modules/permissions/useHasPermissionsHooks';
 
 const ClientReferralsPage: React.FC = () => {
-  const [canViewClientEligibleOpportunities] = useHasRootPermissions([
+  const { client } = useClientDashboardContext();
+
+  const canViewClientEligibleOpportunities = useHasPermissions(client?.access, [
     'canViewClientEligibleOpportunities',
   ]);
-  const [canViewAnyReferrals] = useHasRootPermissions([
+  const canViewAnyReferrals = useHasPermissions(client?.access, [
     'canViewReferrals',
     'canViewOwnReferrals',
   ]);

--- a/src/modules/ce/components/client/ClientReferralsTable.tsx
+++ b/src/modules/ce/components/client/ClientReferralsTable.tsx
@@ -43,7 +43,7 @@ const COLUMNS: ColumnDef<ClientCeReferralTableFieldsFragment>[] = [
   REFERRAL_WITH_PROJECT_COLUMNS.projectType,
   REFERRAL_COLUMNS.status,
   REFERRAL_COLUMNS.referredBy,
-  REFERRAL_COLUMNS.step,
+  REFERRAL_COLUMNS.currentSteps,
 ];
 
 const ClientReferralsTable: React.FC = () => {

--- a/src/modules/client/hooks/useClientDashboardNavItems.tsx
+++ b/src/modules/client/hooks/useClientDashboardNavItems.tsx
@@ -53,7 +53,7 @@ export const useClientDashboardNavItems = (
               'canViewReferrals',
               'canViewOwnReferrals',
             ],
-            permissionsMode: 'any',
+            permissionMode: 'any',
           },
           {
             id: 'case-notes',

--- a/src/modules/client/hooks/useClientDashboardNavItems.tsx
+++ b/src/modules/client/hooks/useClientDashboardNavItems.tsx
@@ -13,6 +13,12 @@ export const useClientDashboardNavItems = (
     'canViewCoordinatedEntry',
   ]);
 
+  const [canViewClientReferrals] = useHasRootPermissions([
+    'canViewReferrals',
+    'canViewOwnReferrals',
+    'canViewClientEligibleOpportunities',
+  ]);
+
   const navItems: NavItem<ClientFieldsFragment['access']>[] = useMemo(() => {
     return [
       {
@@ -54,7 +60,7 @@ export const useClientDashboardNavItems = (
             id: 'referrals',
             title: 'Referrals',
             path: ClientDashboardRoutes.REFERRALS,
-            hide: !canViewCoordinatedEntry,
+            hide: !canViewCoordinatedEntry || !canViewClientReferrals,
           },
           {
             id: 'case-notes',
@@ -90,7 +96,7 @@ export const useClientDashboardNavItems = (
         ],
       },
     ];
-  }, [canViewCoordinatedEntry, enabledFeatures]);
+  }, [canViewClientReferrals, canViewCoordinatedEntry, enabledFeatures]);
 
   return navItems;
 };

--- a/src/modules/client/hooks/useClientDashboardNavItems.tsx
+++ b/src/modules/client/hooks/useClientDashboardNavItems.tsx
@@ -9,10 +9,6 @@ import { ClientDashboardFeature, ClientFieldsFragment } from '@/types/gqlTypes';
 export const useClientDashboardNavItems = (
   enabledFeatures: ClientDashboardFeature[]
 ) => {
-  const [canViewCoordinatedEntry] = useHasRootPermissions([
-    'canViewCoordinatedEntry',
-  ]);
-
   const [canViewClientReferrals] = useHasRootPermissions([
     'canViewReferrals',
     'canViewOwnReferrals',
@@ -60,7 +56,7 @@ export const useClientDashboardNavItems = (
             id: 'referrals',
             title: 'Referrals',
             path: ClientDashboardRoutes.REFERRALS,
-            hide: !canViewCoordinatedEntry || !canViewClientReferrals,
+            hide: !canViewClientReferrals,
           },
           {
             id: 'case-notes',
@@ -96,7 +92,7 @@ export const useClientDashboardNavItems = (
         ],
       },
     ];
-  }, [canViewClientReferrals, canViewCoordinatedEntry, enabledFeatures]);
+  }, [canViewClientReferrals, enabledFeatures]);
 
   return navItems;
 };

--- a/src/modules/client/hooks/useClientDashboardNavItems.tsx
+++ b/src/modules/client/hooks/useClientDashboardNavItems.tsx
@@ -1,20 +1,12 @@
 import { useMemo } from 'react';
 
 import { NavItem } from '@/components/layout/dashboard/sideNav/types';
-
-import { useHasRootPermissions } from '@/modules/permissions/useHasPermissionsHooks';
 import { ClientDashboardRoutes } from '@/routes/routes';
 import { ClientDashboardFeature, ClientFieldsFragment } from '@/types/gqlTypes';
 
 export const useClientDashboardNavItems = (
   enabledFeatures: ClientDashboardFeature[]
 ) => {
-  const [canViewClientReferrals] = useHasRootPermissions([
-    'canViewReferrals',
-    'canViewOwnReferrals',
-    'canViewClientEligibleOpportunities',
-  ]);
-
   const navItems: NavItem<ClientFieldsFragment['access']>[] = useMemo(() => {
     return [
       {
@@ -56,7 +48,12 @@ export const useClientDashboardNavItems = (
             id: 'referrals',
             title: 'Referrals',
             path: ClientDashboardRoutes.REFERRALS,
-            hide: !canViewClientReferrals,
+            permissions: [
+              'canViewClientEligibleOpportunities',
+              'canViewReferrals',
+              'canViewOwnReferrals',
+            ],
+            permissionsMode: 'any',
           },
           {
             id: 'case-notes',
@@ -92,7 +89,7 @@ export const useClientDashboardNavItems = (
         ],
       },
     ];
-  }, [canViewClientReferrals, enabledFeatures]);
+  }, [enabledFeatures]);
 
   return navItems;
 };

--- a/src/modules/projects/hooks/useProjectDashboardNavItems.tsx
+++ b/src/modules/projects/hooks/useProjectDashboardNavItems.tsx
@@ -1,7 +1,6 @@
 import { useMemo } from 'react';
 
 import { NavItem } from '@/components/layout/dashboard/sideNav/types';
-import { useHasRootPermissions } from '@/modules/permissions/useHasPermissionsHooks';
 import { ProjectDashboardRoutes } from '@/routes/routes';
 import {
   DataCollectionFeatureRole,
@@ -13,10 +12,6 @@ import {
 export const useProjectDashboardNavItems = (
   project?: ProjectAllFieldsFragment
 ) => {
-  const [canViewCoordinatedEntry] = useHasRootPermissions([
-    'canViewCoordinatedEntry',
-  ]);
-
   const navItems: NavItem<ProjectAccessFieldsFragment>[] = useMemo(() => {
     if (!project) return [];
     const dataCollectionRoles = project.dataCollectionFeatures.map(
@@ -103,7 +98,12 @@ export const useProjectDashboardNavItems = (
             id: 'coordinated-entry',
             title: 'Coordinated Entry',
             path: ProjectDashboardRoutes.CE,
-            hide: !canViewCoordinatedEntry,
+            permissions: [
+              'canViewUnits',
+              'canViewReferrals',
+              'canViewOwnReferrals',
+            ],
+            permissionMode: 'any',
           },
         ],
       },
@@ -146,7 +146,7 @@ export const useProjectDashboardNavItems = (
         ],
       },
     ];
-  }, [project, canViewCoordinatedEntry]);
+  }, [project]);
 
   return navItems;
 };

--- a/src/modules/units/components/UnitManagementTable.tsx
+++ b/src/modules/units/components/UnitManagementTable.tsx
@@ -5,6 +5,7 @@ import { ColumnDef } from '@/components/elements/table/types';
 import GenericTableWithData from '@/modules/dataFetching/components/GenericTableWithData';
 import { useFilters } from '@/modules/hmis/filterUtil';
 import { useHasRootPermissions } from '@/modules/permissions/useHasPermissionsHooks';
+import { useProjectDashboardContext } from '@/modules/projects/components/ProjectDashboard';
 import { useDeleteUnits } from '@/modules/units/hooks/useDeleteUnits';
 import { useUnitCeActions } from '@/modules/units/hooks/useUnitCeActions';
 import { useUnitCeColumns } from '@/modules/units/hooks/useUnitCeColumns';
@@ -27,6 +28,7 @@ const UnitManagementTable = ({
       projectId,
     });
 
+  // TODO(7409) - instead of using the global permission, check project-level config
   const [canViewCoordinatedEntry] = useHasRootPermissions([
     'canViewCoordinatedEntry',
   ]);
@@ -62,7 +64,8 @@ const UnitManagementTable = ({
     type: 'UnitFilterOptions',
   });
 
-  const { getCeActions, loading } = useUnitCeActions({ projectId });
+  const { project } = useProjectDashboardContext();
+  const { getCeActions, loading } = useUnitCeActions({ project });
 
   const rowSecondaryActionConfigs = useCallback(
     (unit: UnitFieldsFragment) => {
@@ -93,7 +96,10 @@ const UnitManagementTable = ({
         UnitFieldsFragment
       >
         defaultPageSize={10}
-        queryVariables={{ id: projectId, ceEnabled: canViewCoordinatedEntry }}
+        queryVariables={{
+          id: projectId,
+          includeCeFields: canViewCoordinatedEntry,
+        }}
         queryDocument={GetUnitsDocument}
         columns={columns}
         pagePath='project.units'

--- a/src/modules/units/components/Units.tsx
+++ b/src/modules/units/components/Units.tsx
@@ -57,6 +57,7 @@ const Units = () => {
     }
   );
 
+  // TODO(7409) - instead of using the global permission, check project-level config
   const [canViewCoordinatedEntry] = useHasRootPermissions([
     'canViewCoordinatedEntry',
   ]);
@@ -73,7 +74,7 @@ const Units = () => {
       createUnits({
         variables: {
           input: { input } as CreateUnitsInput,
-          ceEnabled: canViewCoordinatedEntry,
+          includeCeFields: canViewCoordinatedEntry,
         },
       });
     },

--- a/src/modules/units/hooks/useUnitCeActions.tsx
+++ b/src/modules/units/hooks/useUnitCeActions.tsx
@@ -4,6 +4,7 @@ import { useHasRootPermissions } from '@/modules/permissions/useHasPermissionsHo
 import { ProjectDashboardRoutes } from '@/routes/routes';
 import {
   CeOpportunityStatus,
+  ProjectAllFieldsFragment,
   UnitFieldsFragment,
   useMarkUnitsAvailableMutation,
   useMarkUnitsUnavailableMutation,
@@ -11,9 +12,9 @@ import {
 import { generateSafePath } from '@/utils/pathEncoding';
 
 export const useUnitCeActions = ({
-  projectId,
+  project,
 }: {
-  projectId: string;
+  project: ProjectAllFieldsFragment;
 }): {
   loading: boolean;
   getCeActions: (unit: UnitFieldsFragment) => CommonMenuItem[];
@@ -43,35 +44,37 @@ export const useUnitCeActions = ({
           key: 'viewOpportunity',
           ariaLabel: `View Opportunity for Unit ${unit.id}`,
           to: generateSafePath(ProjectDashboardRoutes.OPPORTUNITY, {
-            projectId,
+            projectId: project.id,
             opportunityId: unit.latestOpportunity.id,
           }),
         });
       }
 
-      if (unit.latestOpportunity && unit.latestOpportunity.active) {
-        // Show this option if the opportunity is active, but disable it if it's locked
-        actions.push({
-          title: 'Mark as Unavailable for Referrals',
-          key: 'markUnavailable',
-          ariaLabel: `Mark Unit ${unit.id} as Unavailable for Referrals`,
-          onClick: () => {
-            markUnitsUnavailable({ variables: { unitIds: [unit.id] } });
-          },
-          disabled:
-            unit.latestOpportunity.status === CeOpportunityStatus.Locked,
-          disabledReason:
-            'Unit with in-progress referral cannot be marked as unavailable',
-        });
-      } else {
-        actions.push({
-          title: 'Mark as Available for Referrals',
-          key: 'markAvailable',
-          ariaLabel: `Mark Unit ${unit.id} as Available for Referrals`,
-          onClick: () => {
-            markUnitsAvailable({ variables: { unitIds: [unit.id] } });
-          },
-        });
+      if (project.access.canManageUnits) {
+        if (unit.latestOpportunity && unit.latestOpportunity.active) {
+          // Show this option if the opportunity is active, but disable it if it's locked
+          actions.push({
+            title: 'Mark as Unavailable for Referrals',
+            key: 'markUnavailable',
+            ariaLabel: `Mark Unit ${unit.id} as Unavailable for Referrals`,
+            onClick: () => {
+              markUnitsUnavailable({ variables: { unitIds: [unit.id] } });
+            },
+            disabled:
+              unit.latestOpportunity.status === CeOpportunityStatus.Locked,
+            disabledReason:
+              'Unit with in-progress referral cannot be marked as unavailable',
+          });
+        } else {
+          actions.push({
+            title: 'Mark as Available for Referrals',
+            key: 'markAvailable',
+            ariaLabel: `Mark Unit ${unit.id} as Available for Referrals`,
+            onClick: () => {
+              markUnitsAvailable({ variables: { unitIds: [unit.id] } });
+            },
+          });
+        }
       }
 
       return actions;
@@ -80,7 +83,8 @@ export const useUnitCeActions = ({
       canViewCoordinatedEntry,
       markUnitsAvailable,
       markUnitsUnavailable,
-      projectId,
+      project.access.canManageUnits,
+      project.id,
     ]
   );
 

--- a/src/modules/units/hooks/useUnitCeActions.tsx
+++ b/src/modules/units/hooks/useUnitCeActions.tsx
@@ -19,6 +19,7 @@ export const useUnitCeActions = ({
   loading: boolean;
   getCeActions: (unit: UnitFieldsFragment) => CommonMenuItem[];
 } => {
+  // TODO(7409) - instead of using the global permission, check project-level config
   const [canViewCoordinatedEntry] = useHasRootPermissions([
     'canViewCoordinatedEntry',
   ]);

--- a/src/modules/units/hooks/useUnitCeColumns.tsx
+++ b/src/modules/units/hooks/useUnitCeColumns.tsx
@@ -3,6 +3,7 @@ import { useHasRootPermissions } from '@/modules/permissions/useHasPermissionsHo
 import { UnitFieldsFragment } from '@/types/gqlTypes';
 
 export const useUnitCeColumns = () => {
+  // TODO(7409) - instead of using the global permission, check project-level config
   const [canViewCoordinatedEntry] = useHasRootPermissions([
     'canViewCoordinatedEntry',
   ]);

--- a/src/routes/protected.tsx
+++ b/src/routes/protected.tsx
@@ -429,34 +429,33 @@ export const protectedRoutes: RouteNode[] = [
           {
             path: ProjectDashboardRoutes.CE,
             element: (
-              <RootPermissionsFilter
-                permissions={['canViewCoordinatedEntry']}
-                otherwise={<NotFound />}
+              <ProjectRoute
+                permissions={[
+                  'canViewUnits',
+                  'canViewReferrals',
+                  'canViewOwnReferrals',
+                ]}
               >
                 <ProjectCePage />
-              </RootPermissionsFilter>
+              </ProjectRoute>
             ),
           },
           {
             path: ProjectDashboardRoutes.OPPORTUNITY,
             element: (
-              <RootPermissionsFilter
-                permissions={['canViewCoordinatedEntry']}
-                otherwise={<NotFound />}
-              >
+              <ProjectRoute permissions={['canViewUnits']}>
                 <Opportunity />
-              </RootPermissionsFilter>
+              </ProjectRoute>
             ),
           },
           {
             path: ProjectDashboardRoutes.REFERRAL,
             element: (
-              <RootPermissionsFilter
-                permissions={['canViewCoordinatedEntry']}
-                otherwise={<NotFound />}
+              <ProjectRoute
+                permissions={['canViewReferrals', 'canViewOwnReferrals']}
               >
                 <ReferralPage />
-              </RootPermissionsFilter>
+              </ProjectRoute>
             ),
             children: [
               {
@@ -779,7 +778,13 @@ export const protectedRoutes: RouteNode[] = [
           {
             path: ClientDashboardRoutes.REFERRALS,
             element: (
-              <RootPermissionsFilter permissions='canViewCoordinatedEntry'>
+              <RootPermissionsFilter
+                permissions={[
+                  'canViewClientEligibleOpportunities',
+                  'canViewReferrals',
+                  'canViewOwnReferrals',
+                ]}
+              >
                 <ClientReferralsPage />
               </RootPermissionsFilter>
             ),

--- a/src/routes/protected.tsx
+++ b/src/routes/protected.tsx
@@ -779,15 +779,17 @@ export const protectedRoutes: RouteNode[] = [
           {
             path: ClientDashboardRoutes.REFERRALS,
             element: (
-              <RootPermissionsFilter
+              <ClientRoute
                 permissions={[
                   'canViewClientEligibleOpportunities',
                   'canViewReferrals',
                   'canViewOwnReferrals',
                 ]}
+                permissionsMode='any'
+                redirectRoute={ClientDashboardRoutes.PROFILE}
               >
                 <ClientReferralsPage />
-              </RootPermissionsFilter>
+              </ClientRoute>
             ),
           },
           { path: '*', element: <Navigate to='profile' replace /> },

--- a/src/routes/protected.tsx
+++ b/src/routes/protected.tsx
@@ -785,7 +785,7 @@ export const protectedRoutes: RouteNode[] = [
                   'canViewReferrals',
                   'canViewOwnReferrals',
                 ]}
-                permissionsMode='any'
+                permissionMode='any'
                 redirectRoute={ClientDashboardRoutes.PROFILE}
               >
                 <ClientReferralsPage />

--- a/src/routes/protected.tsx
+++ b/src/routes/protected.tsx
@@ -820,7 +820,10 @@ export const protectedRoutes: RouteNode[] = [
           {
             path: AdminDashboardRoutes.COORDINATED_ENTRY,
             element: (
-              <RootPermissionsFilter permissions='canViewCoordinatedEntry'>
+              <RootPermissionsFilter
+                permissions='canAdministrateCoordinatedEntry'
+                otherwise={<NotFound />}
+              >
                 <AdminCoordinatedEntry />
               </RootPermissionsFilter>
             ),

--- a/src/types/gqlEnums.ts
+++ b/src/types/gqlEnums.ts
@@ -75,6 +75,10 @@ export const HmisEnums = {
     OTHER: 'Other',
   },
   BoundType: { MAX: 'MAX', MIN: 'MIN' },
+  CeOpportunitySortOption: {
+    DATE_AVAILABLE_EARLIEST_FIRST: 'Date Available, earliest first',
+    DATE_AVAILABLE_LATEST_FIRST: 'Date Available, latest first',
+  },
   CeOpportunityStatus: { closed: 'Closed', locked: 'Locked', open: 'Open' },
   CeReferralStatus: {
     accepted: 'Accepted',
@@ -957,6 +961,8 @@ export const HmisEnums = {
     AVAILABLE_UNIT_TYPES:
       'Unit types that have unoccupied units in the specified project',
     CE_EVENTS: 'Grouped HUD CE Event types',
+    CE_WORKFLOW_TEMPLATE_IDENTIFIERS_INCLUDING_RETIRED:
+      'Templates for CE workflow definitions, including fully retired workflows',
     CLIENT_AUDIT_EVENT_RECORD_TYPES: 'CLIENT_AUDIT_EVENT_RECORD_TYPES',
     COC: 'COC',
     CONTINUUM_PROJECTS: 'Continuum Projects',

--- a/src/types/gqlEnums.ts
+++ b/src/types/gqlEnums.ts
@@ -963,6 +963,8 @@ export const HmisEnums = {
     CURRENT_LIVING_SITUATION: 'CURRENT_LIVING_SITUATION',
     CUSTOM_SERVICE_CATEGORIES: 'CUSTOM_SERVICE_CATEGORIES',
     DESTINATION: 'DESTINATION',
+    ELIGIBLE_REFERRAL_STEP_ASSIGNMENT_USERS:
+      'Current users who can be assigned to referral steps in the specified project',
     ELIGIBLE_STAFF_ASSIGNMENT_USERS:
       'Current users who are eligible for staff assignment',
     ENROLLABLE_PROJECTS: 'Projects that the User can enroll Clients in',

--- a/src/types/gqlEnums.ts
+++ b/src/types/gqlEnums.ts
@@ -970,9 +970,9 @@ export const HmisEnums = {
     CUSTOM_SERVICE_CATEGORIES: 'CUSTOM_SERVICE_CATEGORIES',
     DESTINATION: 'DESTINATION',
     ELIGIBLE_REFERRAL_STEP_ASSIGNMENT_USERS:
-      'Current users who can be assigned to referral steps in the specified project',
+      'Users who can be assigned to referral steps in the specified project',
     ELIGIBLE_STAFF_ASSIGNMENT_USERS:
-      'Current users who are eligible for staff assignment',
+      'Users who are eligible for staff assignment',
     ENROLLABLE_PROJECTS: 'Projects that the User can enroll Clients in',
     ENROLLMENTS_FOR_CLIENT:
       'Enrollments for the client, including WIP and Exited.',

--- a/src/types/gqlObjects.ts
+++ b/src/types/gqlObjects.ts
@@ -761,6 +761,14 @@ export const HmisObjectSchemas: GqlSchema[] = [
     name: 'CeReferralStep',
     fields: [
       {
+        name: 'canCurrentUserPerform',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'Boolean', ofType: null },
+        },
+      },
+      {
         name: 'id',
         type: {
           kind: 'NON_NULL',
@@ -5154,6 +5162,14 @@ export const HmisObjectSchemas: GqlSchema[] = [
     name: 'ProjectAccess',
     fields: [
       {
+        name: 'canAssignReferralTasks',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'Boolean', ofType: null },
+        },
+      },
+      {
         name: 'canDeleteAssessments',
         type: {
           kind: 'NON_NULL',
@@ -5242,7 +5258,31 @@ export const HmisObjectSchemas: GqlSchema[] = [
         },
       },
       {
+        name: 'canPerformAnyReferralTasks',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'Boolean', ofType: null },
+        },
+      },
+      {
+        name: 'canPerformOwnReferralTasks',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'Boolean', ofType: null },
+        },
+      },
+      {
         name: 'canSplitHouseholds',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'Boolean', ofType: null },
+        },
+      },
+      {
+        name: 'canStartReferrals',
         type: {
           kind: 'NON_NULL',
           name: null,
@@ -5274,7 +5314,31 @@ export const HmisObjectSchemas: GqlSchema[] = [
         },
       },
       {
+        name: 'canViewOwnReferrals',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'Boolean', ofType: null },
+        },
+      },
+      {
         name: 'canViewPartialSsn',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'Boolean', ofType: null },
+        },
+      },
+      {
+        name: 'canViewPrioritizedClientLists',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'Boolean', ofType: null },
+        },
+      },
+      {
+        name: 'canViewReferrals',
         type: {
           kind: 'NON_NULL',
           name: null,
@@ -5394,6 +5458,14 @@ export const HmisObjectSchemas: GqlSchema[] = [
       },
       {
         name: 'canAdministrateConfig',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'Boolean', ofType: null },
+        },
+      },
+      {
+        name: 'canAssignReferralTasks',
         type: {
           kind: 'NON_NULL',
           name: null,
@@ -5617,7 +5689,31 @@ export const HmisObjectSchemas: GqlSchema[] = [
         },
       },
       {
+        name: 'canPerformAnyReferralTasks',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'Boolean', ofType: null },
+        },
+      },
+      {
+        name: 'canPerformOwnReferralTasks',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'Boolean', ofType: null },
+        },
+      },
+      {
         name: 'canSplitHouseholds',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'Boolean', ofType: null },
+        },
+      },
+      {
+        name: 'canStartReferrals',
         type: {
           kind: 'NON_NULL',
           name: null,
@@ -5658,6 +5754,14 @@ export const HmisObjectSchemas: GqlSchema[] = [
       },
       {
         name: 'canViewClientContactInfo',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'Boolean', ofType: null },
+        },
+      },
+      {
+        name: 'canViewClientEligibleOpportunities',
         type: {
           kind: 'NON_NULL',
           name: null,
@@ -5761,6 +5865,14 @@ export const HmisObjectSchemas: GqlSchema[] = [
         },
       },
       {
+        name: 'canViewOwnReferrals',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'Boolean', ofType: null },
+        },
+      },
+      {
         name: 'canViewPartialSsn',
         type: {
           kind: 'NON_NULL',
@@ -5769,7 +5881,23 @@ export const HmisObjectSchemas: GqlSchema[] = [
         },
       },
       {
+        name: 'canViewPrioritizedClientLists',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'Boolean', ofType: null },
+        },
+      },
+      {
         name: 'canViewProject',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'Boolean', ofType: null },
+        },
+      },
+      {
+        name: 'canViewReferrals',
         type: {
           kind: 'NON_NULL',
           name: null,

--- a/src/types/gqlObjects.ts
+++ b/src/types/gqlObjects.ts
@@ -5489,6 +5489,14 @@ export const HmisObjectSchemas: GqlSchema[] = [
         },
       },
       {
+        name: 'canAdministrateCoordinatedEntry',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'Boolean', ofType: null },
+        },
+      },
+      {
         name: 'canAssignReferralTasks',
         type: {
           kind: 'NON_NULL',

--- a/src/types/gqlObjects.ts
+++ b/src/types/gqlObjects.ts
@@ -574,6 +574,14 @@ export const HmisObjectSchemas: GqlSchema[] = [
         },
       },
       {
+        name: 'dateAvailable',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'ISO8601Date', ofType: null },
+        },
+      },
+      {
         name: 'expiresAt',
         type: { kind: 'SCALAR', name: 'ISO8601DateTime', ofType: null },
       },
@@ -587,6 +595,14 @@ export const HmisObjectSchemas: GqlSchema[] = [
       },
       {
         name: 'name',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'String', ofType: null },
+        },
+      },
+      {
+        name: 'organizationName',
         type: {
           kind: 'NON_NULL',
           name: null,
@@ -712,8 +728,8 @@ export const HmisObjectSchemas: GqlSchema[] = [
         },
       },
       {
-        name: 'currentStepName',
-        type: { kind: 'SCALAR', name: 'String', ofType: null },
+        name: 'daysOnCurrentSteps',
+        type: { kind: 'SCALAR', name: 'Int', ofType: null },
       },
       {
         name: 'id',
@@ -729,6 +745,14 @@ export const HmisObjectSchemas: GqlSchema[] = [
           kind: 'NON_NULL',
           name: null,
           ofType: { kind: 'ENUM', name: 'CeReferralStatus', ofType: null },
+        },
+      },
+      {
+        name: 'targetOrganizationName',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'String', ofType: null },
         },
       },
       {
@@ -6987,6 +7011,75 @@ export const HmisInputObjectSchemas: GqlInputObjectSchema[] = [
     ],
   },
   {
+    name: 'CeOpportunityFilterOptions',
+    args: [
+      {
+        name: 'availableOnDate',
+        type: { kind: 'SCALAR', name: 'ISO8601Date', ofType: null },
+      },
+      {
+        name: 'organization',
+        type: {
+          kind: 'LIST',
+          name: null,
+          ofType: {
+            kind: 'NON_NULL',
+            name: null,
+            ofType: { kind: 'SCALAR', name: 'ID', ofType: null },
+          },
+        },
+      },
+      {
+        name: 'project',
+        type: {
+          kind: 'LIST',
+          name: null,
+          ofType: {
+            kind: 'NON_NULL',
+            name: null,
+            ofType: { kind: 'SCALAR', name: 'ID', ofType: null },
+          },
+        },
+      },
+      {
+        name: 'projectType',
+        type: {
+          kind: 'LIST',
+          name: null,
+          ofType: {
+            kind: 'NON_NULL',
+            name: null,
+            ofType: { kind: 'ENUM', name: 'ProjectType', ofType: null },
+          },
+        },
+      },
+      {
+        name: 'status',
+        type: {
+          kind: 'LIST',
+          name: null,
+          ofType: {
+            kind: 'NON_NULL',
+            name: null,
+            ofType: { kind: 'ENUM', name: 'CeOpportunityStatus', ofType: null },
+          },
+        },
+      },
+      {
+        name: 'workflowTemplate',
+        type: {
+          kind: 'LIST',
+          name: null,
+          ofType: {
+            kind: 'NON_NULL',
+            name: null,
+            ofType: { kind: 'SCALAR', name: 'String', ofType: null },
+          },
+        },
+      },
+    ],
+  },
+  {
     name: 'CeOpportunityInput',
     args: [
       {
@@ -7010,6 +7103,22 @@ export const HmisInputObjectSchemas: GqlInputObjectSchema[] = [
   {
     name: 'CeReferralFilterOptions',
     args: [
+      {
+        name: 'onCurrentStepSince',
+        type: { kind: 'SCALAR', name: 'ISO8601Date', ofType: null },
+      },
+      {
+        name: 'organization',
+        type: {
+          kind: 'LIST',
+          name: null,
+          ofType: {
+            kind: 'NON_NULL',
+            name: null,
+            ofType: { kind: 'SCALAR', name: 'ID', ofType: null },
+          },
+        },
+      },
       {
         name: 'project',
         type: {
@@ -7043,6 +7152,18 @@ export const HmisInputObjectSchemas: GqlInputObjectSchema[] = [
             kind: 'NON_NULL',
             name: null,
             ofType: { kind: 'ENUM', name: 'CeReferralStatus', ofType: null },
+          },
+        },
+      },
+      {
+        name: 'workflowTemplate',
+        type: {
+          kind: 'LIST',
+          name: null,
+          ofType: {
+            kind: 'NON_NULL',
+            name: null,
+            ofType: { kind: 'SCALAR', name: 'String', ofType: null },
           },
         },
       },
@@ -7152,8 +7273,73 @@ export const HmisInputObjectSchemas: GqlInputObjectSchema[] = [
     ],
   },
   {
+    name: 'ClientCeReferralFilterOptions',
+    args: [
+      {
+        name: 'organization',
+        type: {
+          kind: 'LIST',
+          name: null,
+          ofType: {
+            kind: 'NON_NULL',
+            name: null,
+            ofType: { kind: 'SCALAR', name: 'ID', ofType: null },
+          },
+        },
+      },
+      {
+        name: 'project',
+        type: {
+          kind: 'LIST',
+          name: null,
+          ofType: {
+            kind: 'NON_NULL',
+            name: null,
+            ofType: { kind: 'SCALAR', name: 'ID', ofType: null },
+          },
+        },
+      },
+      {
+        name: 'projectType',
+        type: {
+          kind: 'LIST',
+          name: null,
+          ofType: {
+            kind: 'NON_NULL',
+            name: null,
+            ofType: { kind: 'ENUM', name: 'ProjectType', ofType: null },
+          },
+        },
+      },
+      {
+        name: 'status',
+        type: {
+          kind: 'LIST',
+          name: null,
+          ofType: {
+            kind: 'NON_NULL',
+            name: null,
+            ofType: { kind: 'ENUM', name: 'CeReferralStatus', ofType: null },
+          },
+        },
+      },
+    ],
+  },
+  {
     name: 'ClientEligibleCeOpportunityFilterOptions',
     args: [
+      {
+        name: 'organization',
+        type: {
+          kind: 'LIST',
+          name: null,
+          ofType: {
+            kind: 'NON_NULL',
+            name: null,
+            ofType: { kind: 'SCALAR', name: 'ID', ofType: null },
+          },
+        },
+      },
       {
         name: 'project',
         type: {

--- a/src/types/gqlObjects.ts
+++ b/src/types/gqlObjects.ts
@@ -1260,6 +1260,14 @@ export const HmisObjectSchemas: GqlSchema[] = [
         },
       },
       {
+        name: 'canViewClientEligibleOpportunities',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'Boolean', ofType: null },
+        },
+      },
+      {
         name: 'canViewClientName',
         type: {
           kind: 'NON_NULL',
@@ -1300,7 +1308,23 @@ export const HmisObjectSchemas: GqlSchema[] = [
         },
       },
       {
+        name: 'canViewOwnReferrals',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'Boolean', ofType: null },
+        },
+      },
+      {
         name: 'canViewPartialSsn',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'Boolean', ofType: null },
+        },
+      },
+      {
+        name: 'canViewReferrals',
         type: {
           kind: 'NON_NULL',
           name: null,

--- a/src/types/gqlObjects.ts
+++ b/src/types/gqlObjects.ts
@@ -785,14 +785,6 @@ export const HmisObjectSchemas: GqlSchema[] = [
     name: 'CeReferralStep',
     fields: [
       {
-        name: 'canCurrentUserPerform',
-        type: {
-          kind: 'NON_NULL',
-          name: null,
-          ofType: { kind: 'SCALAR', name: 'Boolean', ofType: null },
-        },
-      },
-      {
         name: 'id',
         type: {
           kind: 'NON_NULL',
@@ -827,6 +819,31 @@ export const HmisObjectSchemas: GqlSchema[] = [
           kind: 'NON_NULL',
           name: null,
           ofType: { kind: 'SCALAR', name: 'String', ofType: null },
+        },
+      },
+      {
+        name: 'updatedAt',
+        type: { kind: 'SCALAR', name: 'ISO8601DateTime', ofType: null },
+      },
+    ],
+  },
+  {
+    name: 'CeReferralStepAccess',
+    fields: [
+      {
+        name: 'canPerformStep',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'Boolean', ofType: null },
+        },
+      },
+      {
+        name: 'id',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'ID', ofType: null },
         },
       },
     ],

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -709,6 +709,7 @@ export type CeReferralStep = {
   __typename?: 'CeReferralStep';
   /** User(s) currently assigned to this step */
   assignees: Array<ApplicationUser>;
+  canCurrentUserPerform: Scalars['Boolean']['output'];
   formDefinition: FormDefinition;
   /** unique identifier for this step based on node and instance */
   id: Scalars['ID']['output'];
@@ -5062,6 +5063,8 @@ export enum PickListType {
   CurrentLivingSituation = 'CURRENT_LIVING_SITUATION',
   CustomServiceCategories = 'CUSTOM_SERVICE_CATEGORIES',
   Destination = 'DESTINATION',
+  /** Current users who can be assigned to referral steps in the specified project */
+  EligibleReferralStepAssignmentUsers = 'ELIGIBLE_REFERRAL_STEP_ASSIGNMENT_USERS',
   /** Current users who are eligible for staff assignment */
   EligibleStaffAssignmentUsers = 'ELIGIBLE_STAFF_ASSIGNMENT_USERS',
   /** Projects that the User can enroll Clients in */
@@ -5996,6 +5999,7 @@ export type ProjectUnitsArgs = {
 
 export type ProjectAccess = {
   __typename?: 'ProjectAccess';
+  canAssignReferralTasks: Scalars['Boolean']['output'];
   canDeleteAssessments: Scalars['Boolean']['output'];
   canDeleteEnrollments: Scalars['Boolean']['output'];
   canDeleteProject: Scalars['Boolean']['output'];
@@ -6007,11 +6011,17 @@ export type ProjectAccess = {
   canManageIncomingReferrals: Scalars['Boolean']['output'];
   canManageOutgoingReferrals: Scalars['Boolean']['output'];
   canManageUnits: Scalars['Boolean']['output'];
+  canPerformAnyReferralTasks: Scalars['Boolean']['output'];
+  canPerformOwnReferralTasks: Scalars['Boolean']['output'];
   canSplitHouseholds: Scalars['Boolean']['output'];
+  canStartReferrals: Scalars['Boolean']['output'];
   canViewDob: Scalars['Boolean']['output'];
   canViewEnrollmentDetails: Scalars['Boolean']['output'];
   canViewFullSsn: Scalars['Boolean']['output'];
+  canViewOwnReferrals: Scalars['Boolean']['output'];
   canViewPartialSsn: Scalars['Boolean']['output'];
+  canViewPrioritizedClientLists: Scalars['Boolean']['output'];
+  canViewReferrals: Scalars['Boolean']['output'];
   canViewUnits: Scalars['Boolean']['output'];
   id: Scalars['ID']['output'];
 };
@@ -6485,6 +6495,7 @@ export type QueryAccess = {
   __typename?: 'QueryAccess';
   canAdministerHmis: Scalars['Boolean']['output'];
   canAdministrateConfig: Scalars['Boolean']['output'];
+  canAssignReferralTasks: Scalars['Boolean']['output'];
   canAuditClients: Scalars['Boolean']['output'];
   canAuditEnrollments: Scalars['Boolean']['output'];
   canAuditUsers: Scalars['Boolean']['output'];
@@ -6512,12 +6523,16 @@ export type QueryAccess = {
   canManageScanCards: Scalars['Boolean']['output'];
   canManageUnits: Scalars['Boolean']['output'];
   canMergeClients: Scalars['Boolean']['output'];
+  canPerformAnyReferralTasks: Scalars['Boolean']['output'];
+  canPerformOwnReferralTasks: Scalars['Boolean']['output'];
   canSplitHouseholds: Scalars['Boolean']['output'];
+  canStartReferrals: Scalars['Boolean']['output'];
   canTransferEnrollments: Scalars['Boolean']['output'];
   canViewAnyConfidentialClientFiles: Scalars['Boolean']['output'];
   canViewAnyNonconfidentialClientFiles: Scalars['Boolean']['output'];
   canViewClientAlerts: Scalars['Boolean']['output'];
   canViewClientContactInfo: Scalars['Boolean']['output'];
+  canViewClientEligibleOpportunities: Scalars['Boolean']['output'];
   canViewClientName: Scalars['Boolean']['output'];
   canViewClientPhoto: Scalars['Boolean']['output'];
   canViewClients: Scalars['Boolean']['output'];
@@ -6530,8 +6545,11 @@ export type QueryAccess = {
   canViewLimitedEnrollmentDetails: Scalars['Boolean']['output'];
   canViewMyDashboard: Scalars['Boolean']['output'];
   canViewOpenEnrollmentSummary: Scalars['Boolean']['output'];
+  canViewOwnReferrals: Scalars['Boolean']['output'];
   canViewPartialSsn: Scalars['Boolean']['output'];
+  canViewPrioritizedClientLists: Scalars['Boolean']['output'];
   canViewProject: Scalars['Boolean']['output'];
+  canViewReferrals: Scalars['Boolean']['output'];
   canViewUnits: Scalars['Boolean']['output'];
   id: Scalars['ID']['output'];
 };
@@ -8463,6 +8481,9 @@ export type RootPermissionsFragment = {
   canEditClients: boolean;
   canViewDob: boolean;
   canViewClientAlerts: boolean;
+  canViewClientEligibleOpportunities: boolean;
+  canViewReferrals: boolean;
+  canViewOwnReferrals: boolean;
   canViewMyDashboard: boolean;
   canViewCoordinatedEntry: boolean;
   canEditOrganization: boolean;
@@ -8522,6 +8543,13 @@ export type ProjectAccessFieldsFragment = {
   canManageOutgoingReferrals: boolean;
   canManageExternalFormSubmissions: boolean;
   canSplitHouseholds: boolean;
+  canViewReferrals: boolean;
+  canViewOwnReferrals: boolean;
+  canViewPrioritizedClientLists: boolean;
+  canStartReferrals: boolean;
+  canPerformAnyReferralTasks: boolean;
+  canPerformOwnReferralTasks: boolean;
+  canAssignReferralTasks: boolean;
 };
 
 export type OrganizationAccessFieldsFragment = {
@@ -8552,6 +8580,9 @@ export type GetRootPermissionsQuery = {
     canEditClients: boolean;
     canViewDob: boolean;
     canViewClientAlerts: boolean;
+    canViewClientEligibleOpportunities: boolean;
+    canViewReferrals: boolean;
+    canViewOwnReferrals: boolean;
     canViewMyDashboard: boolean;
     canViewCoordinatedEntry: boolean;
     canEditOrganization: boolean;
@@ -16148,6 +16179,7 @@ export type CeReferralFieldsFragment = {
     name: string;
     status: CeReferralStepStatus;
     swimlane: string;
+    canCurrentUserPerform: boolean;
     assignees: Array<{
       __typename?: 'ApplicationUser';
       id: string;
@@ -16224,6 +16256,7 @@ export type CeReferralStepSummaryFieldsFragment = {
   name: string;
   status: CeReferralStepStatus;
   swimlane: string;
+  canCurrentUserPerform: boolean;
   assignees: Array<{
     __typename?: 'ApplicationUser';
     id: string;
@@ -16239,6 +16272,7 @@ export type CeReferralStepFieldsFragment = {
   name: string;
   status: CeReferralStepStatus;
   swimlane: string;
+  canCurrentUserPerform: boolean;
   formDefinition: {
     __typename?: 'FormDefinition';
     id: string;
@@ -16824,6 +16858,7 @@ export type StartCeReferralStepMutation = {
       name: string;
       status: CeReferralStepStatus;
       swimlane: string;
+      canCurrentUserPerform: boolean;
       formDefinition: {
         __typename?: 'FormDefinition';
         id: string;
@@ -17363,6 +17398,7 @@ export type SubmitCeReferralStepMutation = {
       name: string;
       status: CeReferralStepStatus;
       swimlane: string;
+      canCurrentUserPerform: boolean;
       formDefinition: {
         __typename?: 'FormDefinition';
         id: string;
@@ -17936,6 +17972,7 @@ export type SubmitCeReferralStepMutation = {
         name: string;
         status: CeReferralStepStatus;
         swimlane: string;
+        canCurrentUserPerform: boolean;
         assignees: Array<{
           __typename?: 'ApplicationUser';
           id: string;
@@ -17981,7 +18018,7 @@ export type SubmitCeReferralStepMutation = {
 
 export type MarkUnitsAvailableMutationVariables = Exact<{
   unitIds: Array<Scalars['ID']['input']> | Scalars['ID']['input'];
-  ceEnabled?: InputMaybe<Scalars['Boolean']['input']>;
+  includeCeFields?: InputMaybe<Scalars['Boolean']['input']>;
 }>;
 
 export type MarkUnitsAvailableMutation = {
@@ -18049,7 +18086,7 @@ export type MarkUnitsAvailableMutation = {
 
 export type MarkUnitsUnavailableMutationVariables = Exact<{
   unitIds: Array<Scalars['ID']['input']> | Scalars['ID']['input'];
-  ceEnabled?: InputMaybe<Scalars['Boolean']['input']>;
+  includeCeFields?: InputMaybe<Scalars['Boolean']['input']>;
 }>;
 
 export type MarkUnitsUnavailableMutation = {
@@ -18134,6 +18171,7 @@ export type AssignParticipantsMutation = {
         name: string;
         status: CeReferralStepStatus;
         swimlane: string;
+        canCurrentUserPerform: boolean;
         assignees: Array<{
           __typename?: 'ApplicationUser';
           id: string;
@@ -18332,6 +18370,7 @@ export type GetCeReferralQuery = {
       name: string;
       status: CeReferralStepStatus;
       swimlane: string;
+      canCurrentUserPerform: boolean;
       assignees: Array<{
         __typename?: 'ApplicationUser';
         id: string;
@@ -18390,6 +18429,7 @@ export type GetCeReferralStepQuery = {
     name: string;
     status: CeReferralStepStatus;
     swimlane: string;
+    canCurrentUserPerform: boolean;
     formDefinition: {
       __typename?: 'FormDefinition';
       id: string;
@@ -34665,6 +34705,13 @@ export type SubmitFormMutation = {
             canManageOutgoingReferrals: boolean;
             canManageExternalFormSubmissions: boolean;
             canSplitHouseholds: boolean;
+            canViewReferrals: boolean;
+            canViewOwnReferrals: boolean;
+            canViewPrioritizedClientLists: boolean;
+            canStartReferrals: boolean;
+            canPerformAnyReferralTasks: boolean;
+            canPerformOwnReferralTasks: boolean;
+            canAssignReferralTasks: boolean;
           };
           user?: {
             __typename: 'ApplicationUser';
@@ -38329,6 +38376,13 @@ export type ProjectAllFieldsFragment = {
     canManageOutgoingReferrals: boolean;
     canManageExternalFormSubmissions: boolean;
     canSplitHouseholds: boolean;
+    canViewReferrals: boolean;
+    canViewOwnReferrals: boolean;
+    canViewPrioritizedClientLists: boolean;
+    canStartReferrals: boolean;
+    canPerformAnyReferralTasks: boolean;
+    canPerformOwnReferralTasks: boolean;
+    canAssignReferralTasks: boolean;
   };
   user?: {
     __typename: 'ApplicationUser';
@@ -39213,6 +39267,13 @@ export type GetProjectQuery = {
       canManageOutgoingReferrals: boolean;
       canManageExternalFormSubmissions: boolean;
       canSplitHouseholds: boolean;
+      canViewReferrals: boolean;
+      canViewOwnReferrals: boolean;
+      canViewPrioritizedClientLists: boolean;
+      canStartReferrals: boolean;
+      canPerformAnyReferralTasks: boolean;
+      canPerformOwnReferralTasks: boolean;
+      canAssignReferralTasks: boolean;
     };
     user?: {
       __typename: 'ApplicationUser';
@@ -39393,6 +39454,13 @@ export type GetProjectPermissionsQuery = {
       canManageOutgoingReferrals: boolean;
       canManageExternalFormSubmissions: boolean;
       canSplitHouseholds: boolean;
+      canViewReferrals: boolean;
+      canViewOwnReferrals: boolean;
+      canViewPrioritizedClientLists: boolean;
+      canStartReferrals: boolean;
+      canPerformAnyReferralTasks: boolean;
+      canPerformOwnReferralTasks: boolean;
+      canAssignReferralTasks: boolean;
     };
   } | null;
 };
@@ -43497,7 +43565,7 @@ export type GetUnitsQueryVariables = Exact<{
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   filters?: InputMaybe<UnitFilterOptions>;
-  ceEnabled?: InputMaybe<Scalars['Boolean']['input']>;
+  includeCeFields?: InputMaybe<Scalars['Boolean']['input']>;
 }>;
 
 export type GetUnitsQuery = {
@@ -43591,7 +43659,7 @@ export type GetProjectUnitTypesQuery = {
 
 export type CreateUnitsMutationVariables = Exact<{
   input: CreateUnitsInput;
-  ceEnabled?: InputMaybe<Scalars['Boolean']['input']>;
+  includeCeFields?: InputMaybe<Scalars['Boolean']['input']>;
 }>;
 
 export type CreateUnitsMutation = {
@@ -43701,7 +43769,7 @@ export type DeleteUnitsMutation = {
 
 export type UpdateUnitsMutationVariables = Exact<{
   input: UpdateUnitsInput;
-  ceEnabled?: InputMaybe<Scalars['Boolean']['input']>;
+  includeCeFields?: InputMaybe<Scalars['Boolean']['input']>;
 }>;
 
 export type UpdateUnitsMutation = {
@@ -44066,6 +44134,9 @@ export const RootPermissionsFragmentDoc = gql`
     canEditClients
     canViewDob
     canViewClientAlerts
+    canViewClientEligibleOpportunities
+    canViewReferrals
+    canViewOwnReferrals
     canViewMyDashboard
     canViewCoordinatedEntry
     canEditOrganization
@@ -44883,6 +44954,7 @@ export const CeReferralStepSummaryFieldsFragmentDoc = gql`
       id
       name
     }
+    canCurrentUserPerform
   }
 `;
 export const CeReferralFieldsFragmentDoc = gql`
@@ -45963,6 +46035,13 @@ export const ProjectAccessFieldsFragmentDoc = gql`
     canManageOutgoingReferrals
     canManageExternalFormSubmissions
     canSplitHouseholds
+    canViewReferrals
+    canViewOwnReferrals
+    canViewPrioritizedClientLists
+    canStartReferrals
+    canPerformAnyReferralTasks
+    canPerformOwnReferralTasks
+    canAssignReferralTasks
   }
 `;
 export const ProjectAllFieldsFragmentDoc = gql`
@@ -46481,7 +46560,7 @@ export const UnitFieldsFragmentDoc = gql`
         ...ClientName
       }
     }
-    ...UnitWithCeFields @include(if: $ceEnabled)
+    ...UnitWithCeFields @include(if: $includeCeFields)
   }
   ${UnitTypeFieldsFragmentDoc}
   ${ClientNameFragmentDoc}
@@ -48563,7 +48642,10 @@ export type SubmitCeReferralStepMutationOptions = Apollo.BaseMutationOptions<
   SubmitCeReferralStepMutationVariables
 >;
 export const MarkUnitsAvailableDocument = gql`
-  mutation MarkUnitsAvailable($unitIds: [ID!]!, $ceEnabled: Boolean = true) {
+  mutation MarkUnitsAvailable(
+    $unitIds: [ID!]!
+    $includeCeFields: Boolean = true
+  ) {
     markUnitsAvailable(unitIds: $unitIds) {
       units {
         ...UnitFields
@@ -48591,7 +48673,7 @@ export type MarkUnitsAvailableMutationFn = Apollo.MutationFunction<
  * const [markUnitsAvailableMutation, { data, loading, error }] = useMarkUnitsAvailableMutation({
  *   variables: {
  *      unitIds: // value for 'unitIds'
- *      ceEnabled: // value for 'ceEnabled'
+ *      includeCeFields: // value for 'includeCeFields'
  *   },
  * });
  */
@@ -48617,7 +48699,10 @@ export type MarkUnitsAvailableMutationOptions = Apollo.BaseMutationOptions<
   MarkUnitsAvailableMutationVariables
 >;
 export const MarkUnitsUnavailableDocument = gql`
-  mutation MarkUnitsUnavailable($unitIds: [ID!]!, $ceEnabled: Boolean = true) {
+  mutation MarkUnitsUnavailable(
+    $unitIds: [ID!]!
+    $includeCeFields: Boolean = true
+  ) {
     markUnitsUnavailable(unitIds: $unitIds) {
       units {
         ...UnitFields
@@ -48645,7 +48730,7 @@ export type MarkUnitsUnavailableMutationFn = Apollo.MutationFunction<
  * const [markUnitsUnavailableMutation, { data, loading, error }] = useMarkUnitsUnavailableMutation({
  *   variables: {
  *      unitIds: // value for 'unitIds'
- *      ceEnabled: // value for 'ceEnabled'
+ *      includeCeFields: // value for 'includeCeFields'
  *   },
  * });
  */
@@ -60396,7 +60481,7 @@ export const GetUnitsDocument = gql`
     $limit: Int = 10
     $offset: Int = 0
     $filters: UnitFilterOptions
-    $ceEnabled: Boolean = false
+    $includeCeFields: Boolean = false
   ) {
     project(id: $id) {
       id
@@ -60429,7 +60514,7 @@ export const GetUnitsDocument = gql`
  *      limit: // value for 'limit'
  *      offset: // value for 'offset'
  *      filters: // value for 'filters'
- *      ceEnabled: // value for 'ceEnabled'
+ *      includeCeFields: // value for 'includeCeFields'
  *   },
  * });
  */
@@ -60567,7 +60652,10 @@ export type GetProjectUnitTypesQueryResult = Apollo.QueryResult<
   GetProjectUnitTypesQueryVariables
 >;
 export const CreateUnitsDocument = gql`
-  mutation CreateUnits($input: CreateUnitsInput!, $ceEnabled: Boolean = false) {
+  mutation CreateUnits(
+    $input: CreateUnitsInput!
+    $includeCeFields: Boolean = false
+  ) {
     createUnits(input: $input) {
       clientMutationId
       units {
@@ -60600,7 +60688,7 @@ export type CreateUnitsMutationFn = Apollo.MutationFunction<
  * const [createUnitsMutation, { data, loading, error }] = useCreateUnitsMutation({
  *   variables: {
  *      input: // value for 'input'
- *      ceEnabled: // value for 'ceEnabled'
+ *      includeCeFields: // value for 'includeCeFields'
  *   },
  * });
  */
@@ -60681,7 +60769,10 @@ export type DeleteUnitsMutationOptions = Apollo.BaseMutationOptions<
   DeleteUnitsMutationVariables
 >;
 export const UpdateUnitsDocument = gql`
-  mutation UpdateUnits($input: UpdateUnitsInput!, $ceEnabled: Boolean = false) {
+  mutation UpdateUnits(
+    $input: UpdateUnitsInput!
+    $includeCeFields: Boolean = false
+  ) {
     updateUnits(input: $input) {
       clientMutationId
       units {
@@ -60714,7 +60805,7 @@ export type UpdateUnitsMutationFn = Apollo.MutationFunction<
  * const [updateUnitsMutation, { data, loading, error }] = useUpdateUnitsMutation({
  *   variables: {
  *      input: // value for 'input'
- *      ceEnabled: // value for 'ceEnabled'
+ *      includeCeFields: // value for 'includeCeFields'
  *   },
  * });
  */

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -5100,9 +5100,9 @@ export enum PickListType {
   CurrentLivingSituation = 'CURRENT_LIVING_SITUATION',
   CustomServiceCategories = 'CUSTOM_SERVICE_CATEGORIES',
   Destination = 'DESTINATION',
-  /** Current users who can be assigned to referral steps in the specified project */
+  /** Users who can be assigned to referral steps in the specified project */
   EligibleReferralStepAssignmentUsers = 'ELIGIBLE_REFERRAL_STEP_ASSIGNMENT_USERS',
-  /** Current users who are eligible for staff assignment */
+  /** Users who are eligible for staff assignment */
   EligibleStaffAssignmentUsers = 'ELIGIBLE_STAFF_ASSIGNMENT_USERS',
   /** Projects that the User can enroll Clients in */
   EnrollableProjects = 'ENROLLABLE_PROJECTS',
@@ -6548,6 +6548,7 @@ export type QueryAccess = {
   __typename?: 'QueryAccess';
   canAdministerHmis: Scalars['Boolean']['output'];
   canAdministrateConfig: Scalars['Boolean']['output'];
+  canAdministrateCoordinatedEntry: Scalars['Boolean']['output'];
   canAssignReferralTasks: Scalars['Boolean']['output'];
   canAuditClients: Scalars['Boolean']['output'];
   canAuditEnrollments: Scalars['Boolean']['output'];
@@ -8539,6 +8540,7 @@ export type RootPermissionsFragment = {
   canViewOwnReferrals: boolean;
   canViewMyDashboard: boolean;
   canViewCoordinatedEntry: boolean;
+  canAdministrateCoordinatedEntry: boolean;
   canEditOrganization: boolean;
   canEditProjectDetails: boolean;
 };
@@ -8638,6 +8640,7 @@ export type GetRootPermissionsQuery = {
     canViewOwnReferrals: boolean;
     canViewMyDashboard: boolean;
     canViewCoordinatedEntry: boolean;
+    canAdministrateCoordinatedEntry: boolean;
     canEditOrganization: boolean;
     canEditProjectDetails: boolean;
   };
@@ -44388,6 +44391,7 @@ export const RootPermissionsFragmentDoc = gql`
     canViewOwnReferrals
     canViewMyDashboard
     canViewCoordinatedEntry
+    canAdministrateCoordinatedEntry
     canEditOrganization
     canEditProjectDetails
   }

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -1011,12 +1011,15 @@ export type ClientAccess = {
   canViewAnyFiles: Scalars['Boolean']['output'];
   canViewAnyNonconfidentialClientFiles: Scalars['Boolean']['output'];
   canViewClientAlerts: Scalars['Boolean']['output'];
+  canViewClientEligibleOpportunities: Scalars['Boolean']['output'];
   canViewClientName: Scalars['Boolean']['output'];
   canViewClientPhoto: Scalars['Boolean']['output'];
   canViewDob: Scalars['Boolean']['output'];
   canViewEnrollmentDetails: Scalars['Boolean']['output'];
   canViewFullSsn: Scalars['Boolean']['output'];
+  canViewOwnReferrals: Scalars['Boolean']['output'];
   canViewPartialSsn: Scalars['Boolean']['output'];
+  canViewReferrals: Scalars['Boolean']['output'];
   id: Scalars['ID']['output'];
 };
 
@@ -8543,9 +8546,6 @@ export type RootPermissionsFragment = {
   canEditClients: boolean;
   canViewDob: boolean;
   canViewClientAlerts: boolean;
-  canViewClientEligibleOpportunities: boolean;
-  canViewReferrals: boolean;
-  canViewOwnReferrals: boolean;
   canViewMyDashboard: boolean;
   canViewCoordinatedEntry: boolean;
   canAdministrateCoordinatedEntry: boolean;
@@ -8573,6 +8573,9 @@ export type ClientAccessFieldsFragment = {
   canManageAnyClientFiles: boolean;
   canManageOwnClientFiles: boolean;
   canUploadClientFiles: boolean;
+  canViewReferrals: boolean;
+  canViewOwnReferrals: boolean;
+  canViewClientEligibleOpportunities: boolean;
 };
 
 export type EnrollmentAccessFieldsFragment = {
@@ -8643,9 +8646,6 @@ export type GetRootPermissionsQuery = {
     canEditClients: boolean;
     canViewDob: boolean;
     canViewClientAlerts: boolean;
-    canViewClientEligibleOpportunities: boolean;
-    canViewReferrals: boolean;
-    canViewOwnReferrals: boolean;
     canViewMyDashboard: boolean;
     canViewCoordinatedEntry: boolean;
     canAdministrateCoordinatedEntry: boolean;
@@ -19417,6 +19417,9 @@ export type ClientFieldsFragment = {
     canManageAnyClientFiles: boolean;
     canManageOwnClientFiles: boolean;
     canUploadClientFiles: boolean;
+    canViewReferrals: boolean;
+    canViewOwnReferrals: boolean;
+    canViewClientEligibleOpportunities: boolean;
   };
   customDataElements: Array<{
     __typename?: 'CustomDataElement';
@@ -19900,6 +19903,9 @@ export type GetClientQuery = {
       canManageAnyClientFiles: boolean;
       canManageOwnClientFiles: boolean;
       canUploadClientFiles: boolean;
+      canViewReferrals: boolean;
+      canViewOwnReferrals: boolean;
+      canViewClientEligibleOpportunities: boolean;
     };
     customDataElements: Array<{
       __typename?: 'CustomDataElement';
@@ -20137,6 +20143,9 @@ export type GetClientPermissionsQuery = {
       canManageAnyClientFiles: boolean;
       canManageOwnClientFiles: boolean;
       canUploadClientFiles: boolean;
+      canViewReferrals: boolean;
+      canViewOwnReferrals: boolean;
+      canViewClientEligibleOpportunities: boolean;
     };
   } | null;
 };
@@ -20669,6 +20678,9 @@ export type GetClientHouseholdMemberCandidatesQuery = {
                 canManageAnyClientFiles: boolean;
                 canManageOwnClientFiles: boolean;
                 canUploadClientFiles: boolean;
+                canViewReferrals: boolean;
+                canViewOwnReferrals: boolean;
+                canViewClientEligibleOpportunities: boolean;
               };
               externalIds: Array<{
                 __typename?: 'ExternalIdentifier';
@@ -21565,6 +21577,9 @@ export type MergeClientsMutation = {
         canManageAnyClientFiles: boolean;
         canManageOwnClientFiles: boolean;
         canUploadClientFiles: boolean;
+        canViewReferrals: boolean;
+        canViewOwnReferrals: boolean;
+        canViewClientEligibleOpportunities: boolean;
       };
       customDataElements: Array<{
         __typename?: 'CustomDataElement';
@@ -25317,6 +25332,9 @@ export type EnrollmentWithHouseholdFieldsFragment = {
           canManageAnyClientFiles: boolean;
           canManageOwnClientFiles: boolean;
           canUploadClientFiles: boolean;
+          canViewReferrals: boolean;
+          canViewOwnReferrals: boolean;
+          canViewClientEligibleOpportunities: boolean;
         };
         externalIds: Array<{
           __typename?: 'ExternalIdentifier';
@@ -26432,6 +26450,9 @@ export type GetEnrollmentWithHouseholdQuery = {
             canManageAnyClientFiles: boolean;
             canManageOwnClientFiles: boolean;
             canUploadClientFiles: boolean;
+            canViewReferrals: boolean;
+            canViewOwnReferrals: boolean;
+            canViewClientEligibleOpportunities: boolean;
           };
           externalIds: Array<{
             __typename?: 'ExternalIdentifier';
@@ -33871,6 +33892,9 @@ export type SubmitFormMutation = {
             canManageAnyClientFiles: boolean;
             canManageOwnClientFiles: boolean;
             canUploadClientFiles: boolean;
+            canViewReferrals: boolean;
+            canViewOwnReferrals: boolean;
+            canViewClientEligibleOpportunities: boolean;
           };
           customDataElements: Array<{
             __typename?: 'CustomDataElement';
@@ -37014,6 +37038,9 @@ export type HouseholdFieldsFragment = {
         canManageAnyClientFiles: boolean;
         canManageOwnClientFiles: boolean;
         canUploadClientFiles: boolean;
+        canViewReferrals: boolean;
+        canViewOwnReferrals: boolean;
+        canViewClientEligibleOpportunities: boolean;
       };
       externalIds: Array<{
         __typename?: 'ExternalIdentifier';
@@ -37093,6 +37120,9 @@ export type HouseholdClientFieldsFragment = {
       canManageAnyClientFiles: boolean;
       canManageOwnClientFiles: boolean;
       canUploadClientFiles: boolean;
+      canViewReferrals: boolean;
+      canViewOwnReferrals: boolean;
+      canViewClientEligibleOpportunities: boolean;
     };
     externalIds: Array<{
       __typename?: 'ExternalIdentifier';
@@ -37269,6 +37299,9 @@ export type JoinHouseholdMutation = {
             canManageAnyClientFiles: boolean;
             canManageOwnClientFiles: boolean;
             canUploadClientFiles: boolean;
+            canViewReferrals: boolean;
+            canViewOwnReferrals: boolean;
+            canViewClientEligibleOpportunities: boolean;
           };
           externalIds: Array<{
             __typename?: 'ExternalIdentifier';
@@ -37356,6 +37389,9 @@ export type JoinHouseholdMutation = {
             canManageAnyClientFiles: boolean;
             canManageOwnClientFiles: boolean;
             canUploadClientFiles: boolean;
+            canViewReferrals: boolean;
+            canViewOwnReferrals: boolean;
+            canViewClientEligibleOpportunities: boolean;
           };
           externalIds: Array<{
             __typename?: 'ExternalIdentifier';
@@ -37456,6 +37492,9 @@ export type SplitHouseholdMutation = {
             canManageAnyClientFiles: boolean;
             canManageOwnClientFiles: boolean;
             canUploadClientFiles: boolean;
+            canViewReferrals: boolean;
+            canViewOwnReferrals: boolean;
+            canViewClientEligibleOpportunities: boolean;
           };
           externalIds: Array<{
             __typename?: 'ExternalIdentifier';
@@ -37543,6 +37582,9 @@ export type SplitHouseholdMutation = {
             canManageAnyClientFiles: boolean;
             canManageOwnClientFiles: boolean;
             canUploadClientFiles: boolean;
+            canViewReferrals: boolean;
+            canViewOwnReferrals: boolean;
+            canViewClientEligibleOpportunities: boolean;
           };
           externalIds: Array<{
             __typename?: 'ExternalIdentifier';
@@ -37639,6 +37681,9 @@ export type GetHouseholdQuery = {
           canManageAnyClientFiles: boolean;
           canManageOwnClientFiles: boolean;
           canUploadClientFiles: boolean;
+          canViewReferrals: boolean;
+          canViewOwnReferrals: boolean;
+          canViewClientEligibleOpportunities: boolean;
         };
         externalIds: Array<{
           __typename?: 'ExternalIdentifier';
@@ -44400,9 +44445,6 @@ export const RootPermissionsFragmentDoc = gql`
     canEditClients
     canViewDob
     canViewClientAlerts
-    canViewClientEligibleOpportunities
-    canViewReferrals
-    canViewOwnReferrals
     canViewMyDashboard
     canViewCoordinatedEntry
     canAdministrateCoordinatedEntry
@@ -45550,6 +45592,9 @@ export const ClientAccessFieldsFragmentDoc = gql`
     canManageAnyClientFiles
     canManageOwnClientFiles
     canUploadClientFiles
+    canViewReferrals
+    canViewOwnReferrals
+    canViewClientEligibleOpportunities
   }
 `;
 export const ClientNameObjectFieldsFragmentDoc = gql`

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -733,9 +733,9 @@ export enum CeReferralStatus {
 
 export type CeReferralStep = {
   __typename?: 'CeReferralStep';
+  access: CeReferralStepAccess;
   /** User(s) currently assigned to this step */
   assignees: Array<ApplicationUser>;
-  canCurrentUserPerform: Scalars['Boolean']['output'];
   formDefinition: FormDefinition;
   /** unique identifier for this step based on node and instance */
   id: Scalars['ID']['output'];
@@ -745,6 +745,14 @@ export type CeReferralStep = {
   stepId?: Maybe<Scalars['ID']['output']>;
   submittedValues?: Maybe<Scalars['JsonObject']['output']>;
   swimlane: Scalars['String']['output'];
+  updatedAt?: Maybe<Scalars['ISO8601DateTime']['output']>;
+  updatedBy?: Maybe<ApplicationUser>;
+};
+
+export type CeReferralStepAccess = {
+  __typename?: 'CeReferralStepAccess';
+  canPerformStep: Scalars['Boolean']['output'];
+  id: Scalars['ID']['output'];
 };
 
 export enum CeReferralStepStatus {
@@ -16317,12 +16325,12 @@ export type CeReferralFieldsFragment = {
     name: string;
     status: CeReferralStepStatus;
     swimlane: string;
-    canCurrentUserPerform: boolean;
     assignees: Array<{
       __typename?: 'ApplicationUser';
       id: string;
       name: string;
     }>;
+    access: { __typename?: 'CeReferralStepAccess'; canPerformStep: boolean };
   }>;
   opportunity: {
     __typename?: 'CeOpportunity';
@@ -16394,12 +16402,12 @@ export type CeReferralStepSummaryFieldsFragment = {
   name: string;
   status: CeReferralStepStatus;
   swimlane: string;
-  canCurrentUserPerform: boolean;
   assignees: Array<{
     __typename?: 'ApplicationUser';
     id: string;
     name: string;
   }>;
+  access: { __typename?: 'CeReferralStepAccess'; canPerformStep: boolean };
 };
 
 export type CeReferralStepFieldsFragment = {
@@ -16410,7 +16418,6 @@ export type CeReferralStepFieldsFragment = {
   name: string;
   status: CeReferralStepStatus;
   swimlane: string;
-  canCurrentUserPerform: boolean;
   formDefinition: {
     __typename?: 'FormDefinition';
     id: string;
@@ -16926,6 +16933,7 @@ export type CeReferralStepFieldsFragment = {
     id: string;
     name: string;
   }>;
+  access: { __typename?: 'CeReferralStepAccess'; canPerformStep: boolean };
 };
 
 export type CreateCeOpportunityMutationVariables = Exact<{
@@ -16996,7 +17004,6 @@ export type StartCeReferralStepMutation = {
       name: string;
       status: CeReferralStepStatus;
       swimlane: string;
-      canCurrentUserPerform: boolean;
       formDefinition: {
         __typename?: 'FormDefinition';
         id: string;
@@ -17512,6 +17519,7 @@ export type StartCeReferralStepMutation = {
         id: string;
         name: string;
       }>;
+      access: { __typename?: 'CeReferralStepAccess'; canPerformStep: boolean };
     };
   } | null;
 };
@@ -17536,7 +17544,6 @@ export type SubmitCeReferralStepMutation = {
       name: string;
       status: CeReferralStepStatus;
       swimlane: string;
-      canCurrentUserPerform: boolean;
       formDefinition: {
         __typename?: 'FormDefinition';
         id: string;
@@ -18052,6 +18059,7 @@ export type SubmitCeReferralStepMutation = {
         id: string;
         name: string;
       }>;
+      access: { __typename?: 'CeReferralStepAccess'; canPerformStep: boolean };
     } | null;
     referral?: {
       __typename?: 'CeReferral';
@@ -18110,12 +18118,15 @@ export type SubmitCeReferralStepMutation = {
         name: string;
         status: CeReferralStepStatus;
         swimlane: string;
-        canCurrentUserPerform: boolean;
         assignees: Array<{
           __typename?: 'ApplicationUser';
           id: string;
           name: string;
         }>;
+        access: {
+          __typename?: 'CeReferralStepAccess';
+          canPerformStep: boolean;
+        };
       }>;
       client?: {
         __typename?: 'Client';
@@ -18309,12 +18320,15 @@ export type AssignParticipantsMutation = {
         name: string;
         status: CeReferralStepStatus;
         swimlane: string;
-        canCurrentUserPerform: boolean;
         assignees: Array<{
           __typename?: 'ApplicationUser';
           id: string;
           name: string;
         }>;
+        access: {
+          __typename?: 'CeReferralStepAccess';
+          canPerformStep: boolean;
+        };
       }>;
       swimlanes: Array<{
         __typename?: 'CeReferralSwimlane';
@@ -18512,12 +18526,12 @@ export type GetCeReferralQuery = {
       name: string;
       status: CeReferralStepStatus;
       swimlane: string;
-      canCurrentUserPerform: boolean;
       assignees: Array<{
         __typename?: 'ApplicationUser';
         id: string;
         name: string;
       }>;
+      access: { __typename?: 'CeReferralStepAccess'; canPerformStep: boolean };
     }>;
     opportunity: {
       __typename?: 'CeOpportunity';
@@ -18571,7 +18585,6 @@ export type GetCeReferralStepQuery = {
     name: string;
     status: CeReferralStepStatus;
     swimlane: string;
-    canCurrentUserPerform: boolean;
     formDefinition: {
       __typename?: 'FormDefinition';
       id: string;
@@ -19087,6 +19100,7 @@ export type GetCeReferralStepQuery = {
       id: string;
       name: string;
     }>;
+    access: { __typename?: 'CeReferralStepAccess'; canPerformStep: boolean };
   } | null;
 };
 
@@ -45267,7 +45281,9 @@ export const CeReferralStepSummaryFieldsFragmentDoc = gql`
       id
       name
     }
-    canCurrentUserPerform
+    access {
+      canPerformStep
+    }
   }
 `;
 export const CeReferralFieldsFragmentDoc = gql`

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -603,10 +603,12 @@ export type CeOpportunity = {
   candidates: CeCandidatesPaginated;
   candidatesGeneratedAt?: Maybe<Scalars['ISO8601DateTime']['output']>;
   categories: Array<Scalars['String']['output']>;
+  dateAvailable: Scalars['ISO8601Date']['output'];
   eligibilityRequirements?: Maybe<Array<CeMatchRule>>;
   expiresAt?: Maybe<Scalars['ISO8601DateTime']['output']>;
   id: Scalars['ID']['output'];
   name: Scalars['String']['output'];
+  organizationName: Scalars['String']['output'];
   priorityScheme?: Maybe<CeMatchRule>;
   projectId: Scalars['ID']['output'];
   projectName: Scalars['String']['output'];
@@ -614,6 +616,7 @@ export type CeOpportunity = {
   /** Active or accepted referral */
   referral?: Maybe<CeReferral>;
   status: CeOpportunityStatus;
+  unit?: Maybe<Unit>;
 };
 
 export type CeOpportunityCandidatesArgs = {
@@ -621,10 +624,27 @@ export type CeOpportunityCandidatesArgs = {
   offset?: InputMaybe<Scalars['Int']['input']>;
 };
 
+export type CeOpportunityFilterOptions = {
+  availableOnDate?: InputMaybe<Scalars['ISO8601Date']['input']>;
+  organization?: InputMaybe<Array<Scalars['ID']['input']>>;
+  project?: InputMaybe<Array<Scalars['ID']['input']>>;
+  projectType?: InputMaybe<Array<ProjectType>>;
+  status?: InputMaybe<Array<CeOpportunityStatus>>;
+  workflowTemplate?: InputMaybe<Array<Scalars['String']['input']>>;
+};
+
 export type CeOpportunityInput = {
   name: Scalars['String']['input'];
   templateId: Scalars['ID']['input'];
 };
+
+/** Opportunity Sorting Options */
+export enum CeOpportunitySortOption {
+  /** Date Available, earliest first */
+  DateAvailableEarliestFirst = 'DATE_AVAILABLE_EARLIEST_FIRST',
+  /** Date Available, latest first */
+  DateAvailableLatestFirst = 'DATE_AVAILABLE_LATEST_FIRST',
+}
 
 export enum CeOpportunityStatus {
   /** Closed */
@@ -670,7 +690,8 @@ export type CeReferral = {
   client?: Maybe<Client>;
   clientId: Scalars['ID']['output'];
   createdAt: Scalars['ISO8601DateTime']['output'];
-  currentStepName?: Maybe<Scalars['String']['output']>;
+  currentSteps?: Maybe<Array<CeReferralStep>>;
+  daysOnCurrentSteps?: Maybe<Scalars['Int']['output']>;
   id: Scalars['ID']['output'];
   opportunity: CeOpportunity;
   referredBy?: Maybe<ApplicationUser>;
@@ -678,15 +699,20 @@ export type CeReferral = {
   steps: Array<CeReferralStep>;
   swimlanes: Array<CeReferralSwimlane>;
   targetEnrollment?: Maybe<Enrollment>;
+  targetOrganizationName: Scalars['String']['output'];
   targetProjectId: Scalars['ID']['output'];
   targetProjectName: Scalars['String']['output'];
   targetProjectType: ProjectType;
+  updatedBy?: Maybe<ApplicationUser>;
 };
 
 export type CeReferralFilterOptions = {
+  onCurrentStepSince?: InputMaybe<Scalars['ISO8601Date']['input']>;
+  organization?: InputMaybe<Array<Scalars['ID']['input']>>;
   project?: InputMaybe<Array<Scalars['ID']['input']>>;
   projectType?: InputMaybe<Array<ProjectType>>;
   status?: InputMaybe<Array<CeReferralStatus>>;
+  workflowTemplate?: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
 export type CeReferralParticipantInput = {
@@ -867,7 +893,7 @@ export type ClientAuditHistoryArgs = {
 
 /** HUD Client */
 export type ClientCeReferralsArgs = {
-  filters?: InputMaybe<CeReferralFilterOptions>;
+  filters?: InputMaybe<ClientCeReferralFilterOptions>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
 };
@@ -896,6 +922,7 @@ export type ClientEligibleCeOpportunitiesArgs = {
   filters?: InputMaybe<ClientEligibleCeOpportunityFilterOptions>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
+  sortOrder?: InputMaybe<CeOpportunitySortOption>;
 };
 
 /** HUD Client */
@@ -1119,6 +1146,13 @@ export type ClientAuditEventsPaginated = {
   pagesCount: Scalars['Int']['output'];
 };
 
+export type ClientCeReferralFilterOptions = {
+  organization?: InputMaybe<Array<Scalars['ID']['input']>>;
+  project?: InputMaybe<Array<Scalars['ID']['input']>>;
+  projectType?: InputMaybe<Array<ProjectType>>;
+  status?: InputMaybe<Array<CeReferralStatus>>;
+};
+
 export type ClientContactPoint = {
   __typename?: 'ClientContactPoint';
   client: Client;
@@ -1166,6 +1200,7 @@ export enum ClientDashboardFeature {
 }
 
 export type ClientEligibleCeOpportunityFilterOptions = {
+  organization?: InputMaybe<Array<Scalars['ID']['input']>>;
   project?: InputMaybe<Array<Scalars['ID']['input']>>;
   projectType?: InputMaybe<Array<ProjectType>>;
 };
@@ -5056,6 +5091,8 @@ export enum PickListType {
   AvailableUnitTypes = 'AVAILABLE_UNIT_TYPES',
   /** Grouped HUD CE Event types */
   CeEvents = 'CE_EVENTS',
+  /** Templates for CE workflow definitions, including fully retired workflows */
+  CeWorkflowTemplateIdentifiersIncludingRetired = 'CE_WORKFLOW_TEMPLATE_IDENTIFIERS_INCLUDING_RETIRED',
   ClientAuditEventRecordTypes = 'CLIENT_AUDIT_EVENT_RECORD_TYPES',
   Coc = 'COC',
   /** Continuum Projects */
@@ -5906,6 +5943,7 @@ export type ProjectCeOpportunitiesArgs = {
   filters?: InputMaybe<ProjectCeOpportunityFilterOptions>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
+  sortOrder?: InputMaybe<CeOpportunitySortOption>;
 };
 
 export type ProjectCeParticipationsArgs = {
@@ -6207,9 +6245,11 @@ export type Query = {
   assessment?: Maybe<Assessment>;
   /** Get the correct Form Definition to use for an assessment, by Role or FormDefinition ID */
   assessmentFormDefinition?: Maybe<FormDefinition>;
+  ceOpportunities: CeOpportunitiesPaginated;
   ceOpportunity?: Maybe<CeOpportunity>;
   ceReferral?: Maybe<CeReferral>;
   ceReferralStep?: Maybe<CeReferralStep>;
+  ceReferrals: CeReferralsPaginated;
   /** Client lookup */
   client?: Maybe<Client>;
   /** Custom forms for collecting and/or displaying custom details for a Client (outside of the Client demographics form) */
@@ -6288,6 +6328,13 @@ export type QueryAssessmentFormDefinitionArgs = {
   role?: InputMaybe<AssessmentRole>;
 };
 
+export type QueryCeOpportunitiesArgs = {
+  filters?: InputMaybe<CeOpportunityFilterOptions>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  sortOrder?: InputMaybe<CeOpportunitySortOption>;
+};
+
 export type QueryCeOpportunityArgs = {
   id: Scalars['ID']['input'];
 };
@@ -6298,6 +6345,12 @@ export type QueryCeReferralArgs = {
 
 export type QueryCeReferralStepArgs = {
   id: Scalars['ID']['input'];
+};
+
+export type QueryCeReferralsArgs = {
+  filters?: InputMaybe<CeReferralFilterOptions>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
 };
 
 export type QueryClientArgs = {
@@ -16116,12 +16169,16 @@ export type CeReferralSummaryFieldsFragment = {
 export type CeReferralTableFieldsFragment = {
   __typename?: 'CeReferral';
   createdAt: string;
-  currentStepName?: string | null;
   id: string;
   status: CeReferralStatus;
   active: boolean;
   clientId: string;
   opportunity: { __typename?: 'CeOpportunity'; id: string; name: string };
+  currentSteps?: Array<{
+    __typename?: 'CeReferralStep';
+    id: string;
+    name: string;
+  }> | null;
   referredBy?: {
     __typename?: 'ApplicationUser';
     id: string;
@@ -16144,12 +16201,16 @@ export type ClientCeReferralTableFieldsFragment = {
   targetProjectName: string;
   targetProjectType: ProjectType;
   createdAt: string;
-  currentStepName?: string | null;
   id: string;
   status: CeReferralStatus;
   active: boolean;
   clientId: string;
   opportunity: { __typename?: 'CeOpportunity'; id: string; name: string };
+  currentSteps?: Array<{
+    __typename?: 'CeReferralStep';
+    id: string;
+    name: string;
+  }> | null;
   referredBy?: {
     __typename?: 'ApplicationUser';
     id: string;
@@ -18244,12 +18305,16 @@ export type GetProjectCeReferralsQuery = {
       nodes: Array<{
         __typename?: 'CeReferral';
         createdAt: string;
-        currentStepName?: string | null;
         id: string;
         status: CeReferralStatus;
         active: boolean;
         clientId: string;
         opportunity: { __typename?: 'CeOpportunity'; id: string; name: string };
+        currentSteps?: Array<{
+          __typename?: 'CeReferralStep';
+          id: string;
+          name: string;
+        }> | null;
         referredBy?: {
           __typename?: 'ApplicationUser';
           id: string;
@@ -18952,7 +19017,7 @@ export type GetClientCeReferralsQueryVariables = Exact<{
   id: Scalars['ID']['input'];
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
-  filters?: InputMaybe<CeReferralFilterOptions>;
+  filters?: InputMaybe<ClientCeReferralFilterOptions>;
 }>;
 
 export type GetClientCeReferralsQuery = {
@@ -18971,12 +19036,16 @@ export type GetClientCeReferralsQuery = {
         targetProjectName: string;
         targetProjectType: ProjectType;
         createdAt: string;
-        currentStepName?: string | null;
         id: string;
         status: CeReferralStatus;
         active: boolean;
         clientId: string;
         opportunity: { __typename?: 'CeOpportunity'; id: string; name: string };
+        currentSteps?: Array<{
+          __typename?: 'CeReferralStep';
+          id: string;
+          name: string;
+        }> | null;
         referredBy?: {
           __typename?: 'ApplicationUser';
           id: string;
@@ -44907,7 +44976,10 @@ export const CeReferralTableFieldsFragmentDoc = gql`
       id
       name
     }
-    currentStepName
+    currentSteps {
+      id
+      name
+    }
     referredBy {
       id
       name
@@ -49368,7 +49440,7 @@ export const GetClientCeReferralsDocument = gql`
     $id: ID!
     $limit: Int = 25
     $offset: Int = 0
-    $filters: CeReferralFilterOptions = null
+    $filters: ClientCeReferralFilterOptions = null
   ) {
     client(id: $id) {
       id


### PR DESCRIPTION
## Description

Summary of changes:
- Update schema to resolve new CE permissions
- (Not strictly related to this ticket) Rename schema arg `ceEnabled` to `includeCeFields`, which I think is more descriptive. I think `ceEnabled` might lead to confusion about the idea that the frontend might be telling the backend whether CE is enabled, which it definitely isn't/shouldn't!
- Update the `CommonTabs` component behavior:
  - If no tab definitions are found, return NotFound
  - If only one tab definition is passed, by default, it removes the Tab wrapping and just returns that tab's content.
  - These changes are to more gracefully support interfaces where the user might have permission to see one tab's contents but not another's. For example, on the Opportunity page a user may see opportunity details but not eligible clients.
- For assigning contacts, resolve the new, more restrictive picklist of users with permission to do referral steps in this project
- Across the app, hide content/actions the user doesn't have permission to view based on the newly added CE permissions
- Across the app, remove many usages of the "fake" permission `canViewCoordinatedEntry`. I think our goal is to get rid of this entirely, in favor of real permissions + project config. I've left some todos related to the project config ticket, as well.

[//]: # 'remove if not applicable'
Depends on hmis-warehouse PR: https://github.com/greenriver/hmis-warehouse/pull/5368

[//]: # 'remove if not applicable'
How to test:
- With the backend branch checked out, update permissions and play around with functionality
- In general, users should not be able to view screens or action buttons for things they don't have permission to do. See CE in HMIS spec doc for permission details
- Example scenario: User has permission to "view own referrals" and "perform own referral tasks." If a referral task is assigned to that user,
  - They can see the referral
  - They can see all tasks
  - They can only _do_ their own task. Action buttons don't show up on the other tasks.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Feature build-out

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
