### PR TITLE
Gig/patch hide ce pages

### DIFF
--- a/src/modules/admin/components/AdminDashboard.tsx
+++ b/src/modules/admin/components/AdminDashboard.tsx
@@ -46,7 +46,11 @@ const navItems: NavItem<RootPermissionsFragment>[] = [
         id: 'coordinated-entry',
         title: 'Coordinated Entry',
         path: AdminDashboardRoutes.COORDINATED_ENTRY,
-        permissions: ['canAdministrateCoordinatedEntry'],
+        permissions: [
+          'canAdministrateCoordinatedEntry',
+          'canViewCoordinatedEntry',
+        ],
+        permissionMode: 'all',
       },
     ],
   },

--- a/src/modules/client/hooks/useClientDashboardNavItems.tsx
+++ b/src/modules/client/hooks/useClientDashboardNavItems.tsx
@@ -1,12 +1,17 @@
 import { useMemo } from 'react';
 
 import { NavItem } from '@/components/layout/dashboard/sideNav/types';
+import { useHasRootPermissions } from '@/modules/permissions/useHasPermissionsHooks';
 import { ClientDashboardRoutes } from '@/routes/routes';
 import { ClientDashboardFeature, ClientFieldsFragment } from '@/types/gqlTypes';
 
 export const useClientDashboardNavItems = (
   enabledFeatures: ClientDashboardFeature[]
 ) => {
+  const [canViewCoordinatedEntry] = useHasRootPermissions([
+    'canViewCoordinatedEntry',
+  ]);
+
   const navItems: NavItem<ClientFieldsFragment['access']>[] = useMemo(() => {
     return [
       {
@@ -54,6 +59,7 @@ export const useClientDashboardNavItems = (
               'canViewOwnReferrals',
             ],
             permissionMode: 'any',
+            hide: !canViewCoordinatedEntry, // feature flag for Coordinated Entry
           },
           {
             id: 'case-notes',
@@ -89,7 +95,7 @@ export const useClientDashboardNavItems = (
         ],
       },
     ];
-  }, [enabledFeatures]);
+  }, [enabledFeatures, canViewCoordinatedEntry]);
 
   return navItems;
 };

--- a/src/modules/projects/hooks/useProjectDashboardNavItems.tsx
+++ b/src/modules/projects/hooks/useProjectDashboardNavItems.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 
 import { NavItem } from '@/components/layout/dashboard/sideNav/types';
+import { useHasRootPermissions } from '@/modules/permissions/useHasPermissionsHooks';
 import { ProjectDashboardRoutes } from '@/routes/routes';
 import {
   DataCollectionFeatureRole,
@@ -12,8 +13,13 @@ import {
 export const useProjectDashboardNavItems = (
   project?: ProjectAllFieldsFragment
 ) => {
+  const [canViewCoordinatedEntry] = useHasRootPermissions([
+    'canViewCoordinatedEntry',
+  ]);
+
   const navItems: NavItem<ProjectAccessFieldsFragment>[] = useMemo(() => {
     if (!project) return [];
+
     const dataCollectionRoles = project.dataCollectionFeatures.map(
       (r) => r.role
     );
@@ -104,6 +110,7 @@ export const useProjectDashboardNavItems = (
               'canViewOwnReferrals',
             ],
             permissionMode: 'any',
+            hide: !canViewCoordinatedEntry,
           },
         ],
       },
@@ -146,7 +153,7 @@ export const useProjectDashboardNavItems = (
         ],
       },
     ];
-  }, [project]);
+  }, [project, canViewCoordinatedEntry]);
 
   return navItems;
 };

--- a/src/routes/protected.tsx
+++ b/src/routes/protected.tsx
@@ -429,15 +429,20 @@ export const protectedRoutes: RouteNode[] = [
           {
             path: ProjectDashboardRoutes.CE,
             element: (
-              <ProjectRoute
-                permissions={[
-                  'canViewUnits',
-                  'canViewReferrals',
-                  'canViewOwnReferrals',
-                ]}
+              <RootPermissionsFilter
+                permissions={['canViewCoordinatedEntry']} // feature flag for Coordinated Entry
+                otherwise={<NotFound />}
               >
-                <ProjectCePage />
-              </ProjectRoute>
+                <ProjectRoute
+                  permissions={[
+                    'canViewUnits',
+                    'canViewReferrals',
+                    'canViewOwnReferrals',
+                  ]}
+                >
+                  <ProjectCePage />
+                </ProjectRoute>
+              </RootPermissionsFilter>
             ),
           },
           {


### PR DESCRIPTION
## Description

Prevent CE nav items from appearing when the CE AppConfigProperty is disabled. This doesn't hide all pages from rendering, but at least hides the nav items that are appearing in non-CE-enabled installations.

https://green-river.sentry.io/issues/6643538285/?alert_rule_id=14743218&alert_type=issue&environment=staging&notification_uuid=a84b3fbc-c8e6-47c0-8e3f-d985a399d090&project=4504006381273088&referrer=slack

[//]: # 'remove if not applicable'
How to test: `AppConfigProperty.find_by(key: "hmis_ce/enabled").update!(value: false)` and navigate application

## Type of change
bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
