### PR TITLE
Release 164

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -4206,6 +4206,22 @@
             "deprecationReason": null
           },
           {
+            "name": "dateAvailable",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ISO8601Date",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "eligibilityRequirements",
             "description": null,
             "args": [],
@@ -4255,6 +4271,22 @@
           },
           {
             "name": "name",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "organizationName",
             "description": null,
             "args": [],
             "type": {
@@ -4356,10 +4388,146 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "unit",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Unit",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "CeOpportunityFilterOptions",
+        "description": null,
+        "isOneOf": false,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "availableOnDate",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "ISO8601Date",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "organization",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "project",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectType",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "ProjectType",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "CeOpportunityStatus",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "workflowTemplate",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },
@@ -4405,6 +4573,30 @@
         ],
         "interfaces": null,
         "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "CeOpportunitySortOption",
+        "description": "Opportunity Sorting Options",
+        "isOneOf": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "DATE_AVAILABLE_EARLIEST_FIRST",
+            "description": "Date Available, earliest first",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "DATE_AVAILABLE_LATEST_FIRST",
+            "description": "Date Available, latest first",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
         "possibleTypes": null
       },
       {
@@ -4820,12 +5012,32 @@
             "deprecationReason": null
           },
           {
-            "name": "currentStepName",
+            "name": "currentSteps",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CeReferralStep",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "daysOnCurrentSteps",
             "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
-              "name": "String",
+              "name": "Int",
               "ofType": null
             },
             "isDeprecated": false,
@@ -4952,6 +5164,22 @@
             "deprecationReason": null
           },
           {
+            "name": "targetOrganizationName",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "targetProjectId",
             "description": null,
             "args": [],
@@ -4998,6 +5226,18 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "updatedBy",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ApplicationUser",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -5012,6 +5252,38 @@
         "isOneOf": false,
         "fields": null,
         "inputFields": [
+          {
+            "name": "onCurrentStepSince",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "ISO8601Date",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "organization",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "project",
             "description": null,
@@ -5064,6 +5336,26 @@
                 "ofType": {
                   "kind": "ENUM",
                   "name": "CeReferralStatus",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "workflowTemplate",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
                   "ofType": null
                 }
               }
@@ -5955,7 +6247,7 @@
                 "description": null,
                 "type": {
                   "kind": "INPUT_OBJECT",
-                  "name": "CeReferralFilterOptions",
+                  "name": "ClientCeReferralFilterOptions",
                   "ofType": null
                 },
                 "defaultValue": null,
@@ -6328,6 +6620,18 @@
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "sortOrder",
+                "description": null,
+                "type": {
+                  "kind": "ENUM",
+                  "name": "CeOpportunitySortOption",
                   "ofType": null
                 },
                 "defaultValue": null,
@@ -8791,6 +9095,98 @@
         "possibleTypes": null
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "ClientCeReferralFilterOptions",
+        "description": null,
+        "isOneOf": false,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "organization",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "project",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectType",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "ProjectType",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "status",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "CeReferralStatus",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "OBJECT",
         "name": "ClientContactPoint",
         "description": null,
@@ -9051,6 +9447,26 @@
         "isOneOf": false,
         "fields": null,
         "inputFields": [
+          {
+            "name": "organization",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "project",
             "description": null,
@@ -35181,6 +35597,12 @@
             "deprecationReason": null
           },
           {
+            "name": "CE_WORKFLOW_TEMPLATE_IDENTIFIERS_INCLUDING_RETIRED",
+            "description": "Templates for CE workflow definitions, including fully retired workflows",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "CLIENT_AUDIT_EVENT_RECORD_TYPES",
             "description": null,
             "isDeprecated": false,
@@ -37732,6 +38154,18 @@
                 "type": {
                   "kind": "SCALAR",
                   "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "sortOrder",
+                "description": null,
+                "type": {
+                  "kind": "ENUM",
+                  "name": "CeOpportunitySortOption",
                   "ofType": null
                 },
                 "defaultValue": null,
@@ -40742,6 +41176,71 @@
             "deprecationReason": null
           },
           {
+            "name": "ceOpportunities",
+            "description": null,
+            "args": [
+              {
+                "name": "filters",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "CeOpportunityFilterOptions",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "sortOrder",
+                "description": null,
+                "type": {
+                  "kind": "ENUM",
+                  "name": "CeOpportunitySortOption",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "CeOpportunitiesPaginated",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "ceOpportunity",
             "description": null,
             "args": [
@@ -40824,6 +41323,59 @@
               "kind": "OBJECT",
               "name": "CeReferralStep",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ceReferrals",
+            "description": null,
+            "args": [
+              {
+                "name": "filters",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "CeReferralFilterOptions",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "CeReferralsPaginated",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/src/api/operations/ce.fragments.graphql
+++ b/src/api/operations/ce.fragments.graphql
@@ -22,6 +22,17 @@ fragment CeOpportunityFields on CeOpportunity {
   }
 }
 
+fragment CeOpportunityAdminFields on CeOpportunity {
+  ...CeOpportunitySummaryFields
+  projectType
+  organizationName
+  dateAvailable
+  unit {
+    id
+    name
+  }
+}
+
 fragment ClientCeOpportunitySummaryFields on CeOpportunity {
   candidatesGeneratedAt
   ...CeOpportunitySummaryFields
@@ -61,10 +72,44 @@ fragment CeReferralTableFields on CeReferral {
     id
     name
   }
-  currentStepName
+  currentSteps {
+    id
+    name
+  }
   referredBy {
     id
     name
+  }
+}
+
+fragment CeReferralAdminFields on CeReferral {
+  ...CeReferralTableFields
+  targetProjectId
+  targetProjectName
+  targetProjectType
+  targetEnrollment {
+    id
+  }
+  targetOrganizationName
+  daysOnCurrentSteps
+  currentSteps {
+    id
+    name
+  }
+  updatedBy {
+    id
+    name
+  }
+  opportunity {
+    id
+    name
+    unit @include(if: $includeUnit) {
+      id
+      name
+      unitType {
+        ...UnitTypeFields
+      }
+    }
   }
 }
 

--- a/src/api/operations/ce.queries.graphql
+++ b/src/api/operations/ce.queries.graphql
@@ -76,7 +76,7 @@ query GetClientCeReferrals(
   $id: ID!
   $limit: Int = 25
   $offset: Int = 0
-  $filters: CeReferralFilterOptions = null
+  $filters: ClientCeReferralFilterOptions = null
 ) {
   client(id: $id) {
     id
@@ -106,6 +106,43 @@ query GetClientEligibleOpportunities(
       nodes {
         ...ClientCeOpportunitySummaryFields
       }
+    }
+  }
+}
+
+query GetAdminCeOpportunities(
+  $limit: Int = 25
+  $offset: Int = 0
+  $filters: CeOpportunityFilterOptions = null
+  $sortOrder: CeOpportunitySortOption = null
+) {
+  ceOpportunities(
+    limit: $limit
+    offset: $offset
+    filters: $filters
+    sortOrder: $sortOrder
+  ) {
+    offset
+    limit
+    nodesCount
+    nodes {
+      ...CeOpportunityAdminFields
+    }
+  }
+}
+
+query GetAdminCeReferrals(
+  $limit: Int = 3
+  $offset: Int = 0
+  $filters: CeReferralFilterOptions = null
+  $includeUnit: Boolean = false
+) {
+  ceReferrals(limit: $limit, offset: $offset, filters: $filters) {
+    offset
+    limit
+    nodesCount
+    nodes {
+      ...CeReferralAdminFields
     }
   }
 }

--- a/src/api/operations/referralPosting.fragments.graphql
+++ b/src/api/operations/referralPosting.fragments.graphql
@@ -27,7 +27,6 @@ fragment ReferralPostingDetailFields on ReferralPosting {
   id
   assignedDate
   chronic
-  hudChronic
   denialNote
   denialReason
   needsWheelchairAccessibleUnit

--- a/src/components/elements/CommonSnackbar.tsx
+++ b/src/components/elements/CommonSnackbar.tsx
@@ -1,0 +1,23 @@
+import { Snackbar, SnackbarProps } from '@mui/material';
+
+interface CommonSnackbarProps extends SnackbarProps {}
+
+const CommonSnackbar: React.FC<CommonSnackbarProps> = ({
+  children,
+  onClose,
+  open,
+  ...props
+}) => (
+  <Snackbar
+    TransitionProps={{ appear: false }}
+    open={open}
+    onClose={onClose}
+    anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+    {...props}
+    sx={{ marginTop: '100px', ...props.sx }}
+  >
+    {children}
+  </Snackbar>
+);
+
+export default CommonSnackbar;

--- a/src/components/elements/CommonTabs.tsx
+++ b/src/components/elements/CommonTabs.tsx
@@ -30,6 +30,7 @@ const CommonTabs: React.FC<CommonTabsProps> = ({
   const [internalValue, setInternalValue] = useHashState({
     initial: tabDefinitions[0].key,
     skip: !!onChangeTab,
+    clearSearch: true,
   });
 
   const currentKey = useMemo(() => {

--- a/src/components/elements/CommonTruncatedList.tsx
+++ b/src/components/elements/CommonTruncatedList.tsx
@@ -1,0 +1,26 @@
+import { Box, Chip, Tooltip } from '@mui/material';
+import React from 'react';
+
+interface Props {
+  items: string[];
+}
+
+const CommonTruncatedList: React.FC<Props> = ({ items }) => {
+  if (items.length === 0) return null;
+
+  const first = items[0];
+  const rest = items.slice(1);
+
+  return (
+    <Box aria-label={items.join(', ')}>
+      {first}{' '}
+      {rest.length > 0 && (
+        <Tooltip arrow title={rest.join(', ')}>
+          <Chip sx={{ mb: 0.5 }} size='small' label={`+${rest.length} more`} />
+        </Tooltip>
+      )}
+    </Box>
+  );
+};
+
+export default CommonTruncatedList;

--- a/src/components/elements/SnackbarAlert.tsx
+++ b/src/components/elements/SnackbarAlert.tsx
@@ -1,6 +1,7 @@
-import { Alert, AlertProps, AlertTitle, Snackbar } from '@mui/material';
+import { Alert, AlertProps, AlertTitle } from '@mui/material';
 
 import { ReactNode } from 'react';
+import CommonSnackbar from '@/components/elements/CommonSnackbar';
 
 interface Props {
   open: boolean;
@@ -9,6 +10,7 @@ interface Props {
   alertProps?: AlertProps;
   title?: string;
 }
+
 const SnackbarAlert: React.FC<Props> = ({
   open,
   onClose,
@@ -17,23 +19,19 @@ const SnackbarAlert: React.FC<Props> = ({
   title,
 }) => {
   return (
-    <Snackbar
-      TransitionProps={{ appear: false }} // disabled transition since it looks a bit junky
+    <CommonSnackbar
       open={open}
       onClose={onClose}
       anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
-      sx={({ shadows }) => ({
-        boxShadow: shadows[6],
-        borderRadius: 2, // matches Alert
+      sx={{
         '.MuiAlertTitle-root': { fontWeight: 600 },
-        marginTop: '100px',
-      })}
+      }}
     >
       <Alert onClose={onClose} {...alertProps}>
         {title && <AlertTitle sx={{ mb: 0 }}>{title}</AlertTitle>}
         {children}
       </Alert>
-    </Snackbar>
+    </CommonSnackbar>
   );
 };
 

--- a/src/config/theme.ts
+++ b/src/config/theme.ts
@@ -440,6 +440,14 @@ const createThemeOptions = (theme: Theme) => ({
         variant: 'contained',
       },
     },
+    MuiSnackbar: {
+      styleOverrides: {
+        root: theme.unstable_sx({
+          boxShadow: theme.shadows[4],
+          borderRadius: 2,
+        }),
+      },
+    },
     MuiAlert: {
       styleOverrides: {
         // override default transparent bg

--- a/src/hooks/useHashState.ts.ts
+++ b/src/hooks/useHashState.ts.ts
@@ -4,11 +4,13 @@ import { useLocation, useNavigate } from 'react-router-dom';
 interface UseHashStateParams {
   initial: string;
   skip?: boolean;
+  clearSearch?: boolean;
 }
 
 const useHashState = ({
   initial,
   skip,
+  clearSearch,
 }: UseHashStateParams): [string, (newValue: string) => void] => {
   const { pathname, search, hash } = useLocation();
   const navigate = useNavigate();
@@ -27,7 +29,14 @@ const useHashState = ({
     hashValue,
     (newValue: string) => {
       if (newValue === hash) return;
-      navigate({ pathname, search, hash: newValue }, { replace: false });
+      navigate(
+        {
+          pathname,
+          search: clearSearch ? undefined : search,
+          hash: newValue,
+        },
+        { replace: false }
+      );
     },
   ];
 };

--- a/src/hooks/useSearchParamState.ts
+++ b/src/hooks/useSearchParamState.ts
@@ -140,7 +140,7 @@ const useSearchParamsState = ({
   // `initial` is NOT passed to `useSearchParams` here, since react-router-dom's
   // useSearchParams's `defaultInit` prop auto-populates the internal state, but not
   // the search params that appear in the url. See the useEffect below
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [searchParams] = useSearchParams();
 
   const [mounted, setMounted] = useState(false);
 
@@ -208,9 +208,16 @@ const useSearchParamsState = ({
           }
         }
       }
-      setSearchParams({ ...currentParams, ...newValues });
+      // `navigate` instead of `useSearchParams` as workaround for https://github.com/remix-run/react-router/issues/8393
+      const accumulator = new URLSearchParams();
+      populateParams({ ...currentParams, ...newValues }, accumulator);
+      navigate({
+        pathname,
+        hash,
+        search: accumulator.toString(),
+      });
     },
-    [paramsDefinition, searchParams, setSearchParams]
+    [hash, navigate, paramsDefinition, pathname, searchParams]
   );
   return [values, setValues];
 };

--- a/src/modules/admin/components/AdminDashboard.tsx
+++ b/src/modules/admin/components/AdminDashboard.tsx
@@ -42,6 +42,12 @@ const navItems: NavItem<RootPermissionsFragment>[] = [
         path: AdminDashboardRoutes.CLIENT_MERGE_HISTORY,
         permissions: ['canMergeClients'],
       },
+      {
+        id: 'coordinated-entry',
+        title: 'Coordinated Entry',
+        path: AdminDashboardRoutes.COORDINATED_ENTRY,
+        permissions: ['canViewCoordinatedEntry'], // TODO (#7506) - update permission
+      },
     ],
   },
   {

--- a/src/modules/bulkServices/components/AssignServiceButton.tsx
+++ b/src/modules/bulkServices/components/AssignServiceButton.tsx
@@ -14,6 +14,8 @@ import CommonDialog from '@/components/elements/CommonDialog';
 import ClientAlertStack from '@/modules/clientAlerts/components/ClientAlertStack';
 import useClientAlerts from '@/modules/clientAlerts/hooks/useClientAlerts';
 import ApolloErrorAlert from '@/modules/errors/components/ApolloErrorAlert';
+
+import ValidationErrorSnackbarAlert from '@/modules/errors/components/ValidationErrorSnackbarAlert';
 import FormDialogActionContent from '@/modules/form/components/FormDialogActionContent';
 import { clientBriefName } from '@/modules/hmis/hmisUtil';
 import {
@@ -38,7 +40,7 @@ const AssignServiceButton: React.FC<Props> = ({
   disabledReason,
   serviceTypeName,
 }) => {
-  const { bulkAssign, bulkRemove, loading, apolloError } =
+  const { bulkAssign, bulkRemove, loading, apolloError, validationErrors } =
     useBulkAssignMutations();
 
   // Locally disable the button while the table refetches, AFTER this specific mutation has completed
@@ -131,6 +133,9 @@ const AssignServiceButton: React.FC<Props> = ({
           {buttonText}
         </LoadingButton>
       </ButtonTooltipContainer>
+      {validationErrors.length > 0 && (
+        <ValidationErrorSnackbarAlert errors={validationErrors} />
+      )}
       {apolloError && <ApolloErrorAlert error={apolloError} />}
       <CommonDialog fullWidth open={clientAlertDialogOpen}>
         <DialogTitle>{alertModalTitle}</DialogTitle>

--- a/src/modules/bulkServices/components/MultiAssignServiceButton.tsx
+++ b/src/modules/bulkServices/components/MultiAssignServiceButton.tsx
@@ -6,6 +6,7 @@ import ButtonTooltipContainer from '@/components/elements/ButtonTooltipContainer
 import LoadingButton from '@/components/elements/LoadingButton';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import ApolloErrorAlert from '@/modules/errors/components/ApolloErrorAlert';
+import ValidationErrorSnackbarAlert from '@/modules/errors/components/ValidationErrorSnackbarAlert';
 import {
   BulkAssignServiceInput,
   BulkServicesClientSearchQuery,
@@ -31,7 +32,8 @@ const MultiAssignServiceButton: React.FC<Props> = ({
   clients,
   queryVariables,
 }) => {
-  const { bulkAssign, bulkRemove, apolloError } = useBulkAssignMutations();
+  const { bulkAssign, bulkRemove, apolloError, validationErrors } =
+    useBulkAssignMutations();
 
   // Use internal loading state, so that buttons appear as if they are loading even while table refetches.
   // We never clear the loading state in this component, except on error.
@@ -39,8 +41,9 @@ const MultiAssignServiceButton: React.FC<Props> = ({
   const [loading, setLoading] = useState<LoadingStates>(initialLoadingState);
 
   useEffect(() => {
-    if (apolloError) setLoading(initialLoadingState);
-  }, [apolloError]);
+    if (apolloError || validationErrors.length > 0)
+      setLoading(initialLoadingState);
+  }, [apolloError, validationErrors]);
 
   const { clientIdsToAssign, clientIdsToRemove, numToEnroll } = useMemo(() => {
     const toAssign: string[] = [];
@@ -127,6 +130,9 @@ const MultiAssignServiceButton: React.FC<Props> = ({
           </LoadingButton>
         </ButtonTooltipContainer>
       </Stack>
+      {validationErrors.length > 0 && (
+        <ValidationErrorSnackbarAlert errors={validationErrors} />
+      )}
       {apolloError && <ApolloErrorAlert error={apolloError} />}
     </>
   );

--- a/src/modules/bulkServices/hooks/useBulkAssignMutations.tsx
+++ b/src/modules/bulkServices/hooks/useBulkAssignMutations.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import {
   BulkServicesClientSearchDocument,
   useBulkAssignServiceMutation,
@@ -12,16 +13,31 @@ const refetchQueries = [
 ];
 
 export function useBulkAssignMutations() {
-  const [bulkAssign, { loading: assignLoading, error: assignErr }] =
-    useBulkAssignServiceMutation({ refetchQueries });
+  const [
+    bulkAssign,
+    { loading: assignLoading, error: assignErr, data: assignData },
+  ] = useBulkAssignServiceMutation({ refetchQueries });
 
-  const [bulkRemove, { loading: removeLoading, error: removeErr }] =
-    useBulkRemoveServiceMutation({ refetchQueries });
+  const [
+    bulkRemove,
+    { loading: removeLoading, error: removeErr, data: removeData },
+  ] = useBulkRemoveServiceMutation({ refetchQueries });
+
+  const validationErrors = useMemo(() => {
+    if (assignData?.bulkAssignService?.errors?.length) {
+      return assignData.bulkAssignService.errors;
+    }
+    if (removeData?.bulkRemoveService?.errors?.length) {
+      return removeData.bulkRemoveService.errors;
+    }
+    return [];
+  }, [assignData, removeData]);
 
   return {
     bulkAssign,
     bulkRemove,
     loading: assignLoading || removeLoading,
     apolloError: assignErr || removeErr,
-  } as const;
+    validationErrors,
+  };
 }

--- a/src/modules/ce/components/ProjectOpportunitiesTable.tsx
+++ b/src/modules/ce/components/ProjectOpportunitiesTable.tsx
@@ -17,6 +17,12 @@ export const OPPORTUNITY_COLUMNS: Record<
   string,
   ColumnDef<CeOpportunitySummaryFieldsFragment>
 > = {
+  project: {
+    header: 'Project',
+    key: 'project',
+    sticky: 'left',
+    render: 'projectName',
+  },
   name: {
     header: 'Opportunity',
     key: 'name',

--- a/src/modules/ce/components/ProjectReferralsTable.tsx
+++ b/src/modules/ce/components/ProjectReferralsTable.tsx
@@ -1,5 +1,6 @@
 import { Paper } from '@mui/material';
 import React from 'react';
+import CommonTruncatedList from '@/components/elements/CommonTruncatedList';
 import { ColumnDef } from '@/components/elements/table/types';
 import useSafeParams from '@/hooks/useSafeParams';
 import ReferralStatusChip from '@/modules/ce/components/ReferralStatusChip';
@@ -60,14 +61,17 @@ export const REFERRAL_COLUMNS: Record<
     ) => <ReferralStatusChip status={referral.status} />,
     key: 'status',
   },
-  step: {
-    header: 'Current Step',
-    key: 'step',
-    render: (
-      referral:
-        | CeReferralTableFieldsFragment
-        | ClientCeReferralTableFieldsFragment
-    ) => referral.currentStepName,
+  currentSteps: {
+    key: 'currentSteps',
+    header: 'Current Steps',
+    render: (referral) => {
+      if (!referral.currentSteps || referral.currentSteps.length === 0) return;
+      return (
+        <CommonTruncatedList
+          items={referral.currentSteps?.map((s) => s.name)}
+        />
+      );
+    },
   },
   referredBy: {
     header: 'Referred By',
@@ -86,7 +90,7 @@ const COLUMNS: ColumnDef<CeReferralTableFieldsFragment>[] = [
   REFERRAL_COLUMNS.opportunity,
   REFERRAL_COLUMNS.date,
   REFERRAL_COLUMNS.status,
-  REFERRAL_COLUMNS.step,
+  REFERRAL_COLUMNS.currentSteps,
 ];
 
 interface Props {}

--- a/src/modules/ce/components/admin/AdminCoordinatedEntry.tsx
+++ b/src/modules/ce/components/admin/AdminCoordinatedEntry.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import AdminReferralsTable from './AdminReferralsTable';
+import CommonTabs from '@/components/elements/CommonTabs';
+import PageTitle from '@/components/layout/PageTitle';
+import AdminOpportunitiesTable from '@/modules/ce/components/admin/AdminOpportunitiesTable';
+
+const AdminCoordinatedEntry: React.FC = () => {
+  return (
+    <>
+      <PageTitle title='Coordinated Entry' overlineText='Admin' />
+      <CommonTabs
+        ariaLabel={'Admin CE Tabs'}
+        tabDefinitions={[
+          {
+            title: 'Available Units',
+            key: 'opportunities',
+            contents: <AdminOpportunitiesTable />,
+          },
+          {
+            title: 'Referrals',
+            key: 'referrals',
+            contents: <AdminReferralsTable />,
+          },
+        ]}
+      />
+    </>
+  );
+};
+
+export default AdminCoordinatedEntry;

--- a/src/modules/ce/components/admin/AdminOpportunitiesTable.tsx
+++ b/src/modules/ce/components/admin/AdminOpportunitiesTable.tsx
@@ -1,0 +1,99 @@
+import { Paper } from '@mui/material';
+import React from 'react';
+import DateWithRelativeTooltip from '@/components/elements/DateWithRelativeTooltip';
+import { ColumnDef } from '@/components/elements/table/types';
+import { OPPORTUNITY_COLUMNS } from '@/modules/ce/components/ProjectOpportunitiesTable';
+import GenericTableWithData from '@/modules/dataFetching/components/GenericTableWithData';
+import ProjectTypeChip from '@/modules/hmis/components/ProjectTypeChip';
+import { useFilters } from '@/modules/hmis/filterUtil';
+import { ProjectDashboardRoutes } from '@/routes/routes';
+import {
+  CeOpportunityAdminFieldsFragment,
+  CeOpportunitySortOption,
+  CeOpportunityStatus,
+  GetAdminCeOpportunitiesDocument,
+  GetAdminCeOpportunitiesQuery,
+  GetAdminCeOpportunitiesQueryVariables,
+} from '@/types/gqlTypes';
+import { generateSafePath } from '@/utils/pathEncoding';
+
+const COLUMNS: ColumnDef<CeOpportunityAdminFieldsFragment>[] = [
+  OPPORTUNITY_COLUMNS.project,
+  {
+    header: 'Project Type',
+    key: 'projectType',
+    render: ({ projectType }) => <ProjectTypeChip projectType={projectType} />,
+  },
+  {
+    header: 'Organization',
+    key: 'organization',
+    render: 'organizationName',
+  },
+  {
+    header: 'Unit',
+    key: 'unit',
+    render: ({ unit }) => unit?.name,
+  },
+  {
+    header: 'Date Available',
+    key: 'dateAvailable',
+    render: ({ dateAvailable }) => {
+      if (dateAvailable)
+        return <DateWithRelativeTooltip dateString={dateAvailable} />;
+      return 'Available now';
+    },
+  },
+];
+
+interface Props {}
+const AdminOpportunitiesTable: React.FC<Props> = ({}) => {
+  const filters = useFilters({
+    type: 'CeOpportunityFilterOptions',
+    omit: ['status'],
+  });
+
+  return (
+    <Paper>
+      <GenericTableWithData<
+        GetAdminCeOpportunitiesQuery,
+        GetAdminCeOpportunitiesQueryVariables,
+        CeOpportunityAdminFieldsFragment
+      >
+        columns={COLUMNS}
+        queryVariables={{
+          filters: {
+            status: [CeOpportunityStatus.Open],
+          },
+        }}
+        defaultSortOption={CeOpportunitySortOption.DateAvailableEarliestFirst}
+        queryDocument={GetAdminCeOpportunitiesDocument}
+        recordType='CeOpportunity'
+        pagePath='ceOpportunities'
+        noData='No opportunities'
+        paginationItemName='opportunities'
+        filters={filters}
+        defaultFilterValues={{
+          status: [CeOpportunityStatus.Open],
+        }}
+        rowLinkTo={(row) =>
+          generateSafePath(ProjectDashboardRoutes.OPPORTUNITY, {
+            projectId: row.projectId,
+            opportunityId: row.id,
+          })
+        }
+        rowActionTitle='View Opportunity'
+        rowSecondaryActionConfigs={(row) => [
+          {
+            key: 'project',
+            title: 'View Project',
+            to: generateSafePath(ProjectDashboardRoutes.OVERVIEW, {
+              projectId: row.projectId,
+            }),
+          },
+        ]}
+      />
+    </Paper>
+  );
+};
+
+export default AdminOpportunitiesTable;

--- a/src/modules/ce/components/admin/AdminReferralsTable.tsx
+++ b/src/modules/ce/components/admin/AdminReferralsTable.tsx
@@ -1,0 +1,144 @@
+import { Paper } from '@mui/material';
+import { isNil } from 'lodash-es';
+import React, { useCallback } from 'react';
+import { REFERRAL_WITH_PROJECT_COLUMNS } from '@/modules/ce/components/client/ClientReferralsTable';
+import { REFERRAL_COLUMNS } from '@/modules/ce/components/ProjectReferralsTable';
+import GenericTableWithData from '@/modules/dataFetching/components/GenericTableWithData';
+import { DataColumnDef } from '@/modules/dataFetching/types';
+import { useFilters } from '@/modules/hmis/filterUtil';
+import {
+  ClientDashboardRoutes,
+  EnrollmentDashboardRoutes,
+  ProjectDashboardRoutes,
+} from '@/routes/routes';
+import {
+  CeReferralAdminFieldsFragment,
+  CeReferralStatus,
+  GetAdminCeReferralsDocument,
+  GetAdminCeReferralsQuery,
+  GetAdminCeReferralsQueryVariables,
+} from '@/types/gqlTypes';
+import { generateSafePath } from '@/utils/pathEncoding';
+
+const COLUMNS: DataColumnDef<
+  CeReferralAdminFieldsFragment,
+  GetAdminCeReferralsQueryVariables
+>[] = [
+  REFERRAL_COLUMNS.client,
+  REFERRAL_COLUMNS.status,
+  REFERRAL_COLUMNS.currentSteps,
+  {
+    // TODO - Ideally this column "Time in Current Step" should correspond with the filter "On Current Step Since..."
+    // aka, they should have the same title and use the same unit (days)
+    key: 'daysOnCurrentSteps',
+    header: 'Days on Current Step',
+    render: ({ daysOnCurrentSteps }) => {
+      if (isNil(daysOnCurrentSteps)) return; // no open steps
+      if (daysOnCurrentSteps === 0) return '< 1 day';
+      return `${daysOnCurrentSteps} day${daysOnCurrentSteps > 1 ? 's' : ''}`;
+    },
+  },
+  REFERRAL_WITH_PROJECT_COLUMNS.projectName,
+  REFERRAL_WITH_PROJECT_COLUMNS.projectType,
+  {
+    key: 'organization',
+    header: 'Organization',
+    render: 'targetOrganizationName',
+  },
+  {
+    header: 'Unit',
+    key: 'unit',
+    render: ({ opportunity }) => opportunity.unit?.name,
+    optional: {
+      defaultHidden: true,
+      queryVariableField: 'includeUnit',
+    },
+  },
+  REFERRAL_COLUMNS.referredBy,
+  {
+    key: 'updatedBy',
+    header: 'Last Updated By',
+    render: ({ updatedBy }) => updatedBy?.name,
+  },
+];
+interface Props {}
+const AdminReferralsTable: React.FC<Props> = ({}) => {
+  const filters = useFilters({
+    type: 'CeReferralFilterOptions',
+  });
+
+  const rowSecondaryActions = useCallback(
+    (row: CeReferralAdminFieldsFragment) => {
+      const actions = [];
+
+      if (row.client) {
+        // If client is not present, this user doesn't have permission to view
+        actions.push({
+          key: 'client',
+          title: 'View Client Profile',
+          to: generateSafePath(ClientDashboardRoutes.PROFILE, {
+            clientId: row.client.id,
+          }),
+        });
+
+        if (row.targetEnrollment) {
+          // link to target enrollment if it exists
+          actions.push({
+            key: 'enrollment',
+            title: 'View Enrollment',
+            to: generateSafePath(
+              EnrollmentDashboardRoutes.ENROLLMENT_OVERVIEW,
+              {
+                clientId: row.client.id,
+                enrollmentId: row.targetEnrollment.id,
+              }
+            ),
+          });
+        }
+      }
+
+      actions.push({
+        key: 'project',
+        title: 'View Project',
+        to: generateSafePath(ProjectDashboardRoutes.OVERVIEW, {
+          projectId: row.targetProjectId,
+        }),
+      });
+
+      return actions;
+    },
+    []
+  );
+
+  return (
+    <Paper>
+      <GenericTableWithData<
+        GetAdminCeReferralsQuery,
+        GetAdminCeReferralsQueryVariables,
+        CeReferralAdminFieldsFragment
+      >
+        columns={COLUMNS}
+        queryVariables={{}}
+        defaultFilterValues={{
+          status: [CeReferralStatus.Initialized, CeReferralStatus.InProgress],
+        }}
+        queryDocument={GetAdminCeReferralsDocument}
+        pagePath='ceReferrals'
+        noData='No referrals'
+        paginationItemName='referrals'
+        filters={filters}
+        rowLinkTo={(row) =>
+          generateSafePath(ProjectDashboardRoutes.REFERRAL_DETAILS, {
+            projectId: row.targetProjectId,
+            opportunityId: row.opportunity.id,
+            referralId: row.id,
+          })
+        }
+        rowActionTitle='View Referral'
+        rowSecondaryActionConfigs={rowSecondaryActions}
+      />
+    </Paper>
+  );
+};
+
+export default AdminReferralsTable;

--- a/src/modules/ce/components/client/ClientReferralsTable.tsx
+++ b/src/modules/ce/components/client/ClientReferralsTable.tsx
@@ -8,6 +8,7 @@ import ProjectTypeChip from '@/modules/hmis/components/ProjectTypeChip';
 import { useFilters } from '@/modules/hmis/filterUtil';
 import { ProjectDashboardRoutes } from '@/routes/routes';
 import {
+  CeReferralAdminFieldsFragment,
   CeReferralStatus,
   ClientCeReferralTableFieldsFragment,
   GetClientCeReferralsDocument,
@@ -16,21 +17,30 @@ import {
 } from '@/types/gqlTypes';
 import { generateSafePath } from '@/utils/pathEncoding';
 
-const COLUMNS: ColumnDef<ClientCeReferralTableFieldsFragment>[] = [
-  { ...REFERRAL_COLUMNS.date, sticky: 'left' },
-  {
+export const REFERRAL_WITH_PROJECT_COLUMNS: {
+  [key: string]: ColumnDef<
+    ClientCeReferralTableFieldsFragment | CeReferralAdminFieldsFragment
+  >;
+} = {
+  projectName: {
     header: 'Project Name',
     key: 'projectName',
     render: (referral: ClientCeReferralTableFieldsFragment) =>
       referral.targetProjectName,
   },
-  {
+  projectType: {
     header: 'Project Type',
     key: 'projectType',
     render: (referral: ClientCeReferralTableFieldsFragment) => (
       <ProjectTypeChip projectType={referral.targetProjectType} />
     ),
   },
+};
+
+const COLUMNS: ColumnDef<ClientCeReferralTableFieldsFragment>[] = [
+  { ...REFERRAL_COLUMNS.date, sticky: 'left' },
+  REFERRAL_WITH_PROJECT_COLUMNS.projectName,
+  REFERRAL_WITH_PROJECT_COLUMNS.projectType,
   REFERRAL_COLUMNS.status,
   REFERRAL_COLUMNS.referredBy,
   REFERRAL_COLUMNS.step,

--- a/src/modules/enrollment/columns/HouseholdStaff.tsx
+++ b/src/modules/enrollment/columns/HouseholdStaff.tsx
@@ -1,5 +1,5 @@
-import { Box, Chip, Tooltip } from '@mui/material';
 import React from 'react';
+import CommonTruncatedList from '@/components/elements/CommonTruncatedList';
 import { StaffAssignmentDetailsFragment } from '@/types/gqlTypes';
 
 interface Props {
@@ -7,25 +7,11 @@ interface Props {
 }
 
 const HouseholdStaff: React.FC<Props> = ({ staffAssignments }) => {
-  if (staffAssignments.length === 0) return null;
-
   const allNames = staffAssignments.map(
     (staffAssignment) => staffAssignment.user.name
   );
 
-  const first = allNames[0];
-  const rest = allNames.slice(1);
-
-  return (
-    <Box aria-label={allNames.join(', ')}>
-      {first}{' '}
-      {rest.length > 0 && (
-        <Tooltip arrow title={rest.join(', ')}>
-          <Chip sx={{ mb: 0.5 }} size='small' label={`+${rest.length} more`} />
-        </Tooltip>
-      )}
-    </Box>
-  );
+  return <CommonTruncatedList items={allNames} />;
 };
 
 export default HouseholdStaff;

--- a/src/modules/enrollment/components/EnrollmentDetails.tsx
+++ b/src/modules/enrollment/components/EnrollmentDetails.tsx
@@ -89,9 +89,12 @@ const EnrollmentDetails = ({
       );
     }
 
-    if (enrollment.client.hudChronic !== null) {
+    // HUD Chronic field is hidden if it is Null, which indicates that the user lacks access can_view_hud_chronic_status, or that the client has no open enrollments.
+    // HUD Chronic field is also hidden if the Enrollment is exited. (The Client may have a chronicity status from other open enrollments, but there is no need to display that on the Exited enrollment.)
+    if (enrollment.client.hudChronic !== null && !enrollment.exitDate) {
       content['HUD Chronic'] = yesNo(enrollment.client.hudChronic);
     }
+
     if (
       enrollment.sourceReferralPosting &&
       enrollment.project.access.canManageIncomingReferrals
@@ -118,9 +121,18 @@ const EnrollmentDetails = ({
       );
     }
 
-    const tooltips: Record<string, string> = {
-      'HUD Chronic':
-        'Whether this client is considered chronically homeless, as of today. Follows the HUD definition for Chronic at PIT.',
+    const tooltips: Record<string, ReactNode> = {
+      'HUD Chronic': (
+        <>
+          Indicates whether the client is currently considered chronically
+          homeless, based on the HUD definition for Chronic at Point-In-Time.
+          <br />
+          <br />A client qualifies as chronically homeless if they have a
+          disabling condition and have been continuously homeless for at least
+          12 months, or have experienced at least four episodes of homelessness
+          in the past three years, totaling 12 or more months.
+        </>
+      ),
     };
 
     return Object.entries(content).map(([id, value], index) => ({

--- a/src/modules/errors/components/ApolloErrorAlert.tsx
+++ b/src/modules/errors/components/ApolloErrorAlert.tsx
@@ -1,18 +1,12 @@
 import { ApolloError } from '@apollo/client';
-import {
-  Alert,
-  AlertProps,
-  AlertTitle,
-  Box,
-  Button,
-  Snackbar,
-} from '@mui/material';
+import { Alert, AlertProps, AlertTitle, Box, Button } from '@mui/material';
 import isString from 'lodash-es/isString';
 
 import { forwardRef, useEffect, useMemo, useState } from 'react';
 
 import { isServerError, UNKNOWN_ERROR_HEADING } from '../util';
 import ApolloErrorTrace from './ApolloErrorTrace';
+import CommonSnackbar from '@/components/elements/CommonSnackbar';
 
 const showDeveloperInfo = import.meta.env.MODE === 'development';
 
@@ -70,16 +64,12 @@ const SnackbarAlert: React.FC<BaseAlertProps> = ({
   }, [errors]);
 
   return (
-    <Snackbar
+    <CommonSnackbar
       open={counter > 0}
       onClose={handleClose}
-      anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
-      sx={({ shadows }) => ({
-        boxShadow: shadows[4],
-        borderRadius: 2,
+      sx={{
         '.MuiAlertTitle-root': { fontWeight: 600 },
-        marginTop: '100px',
-      })}
+      }}
     >
       <BaseAlert
         errors={errors}
@@ -90,7 +80,7 @@ const SnackbarAlert: React.FC<BaseAlertProps> = ({
         }}
         {...props}
       />
-    </Snackbar>
+    </CommonSnackbar>
   );
 };
 

--- a/src/modules/errors/components/ValidationErrorSnackbarAlert.tsx
+++ b/src/modules/errors/components/ValidationErrorSnackbarAlert.tsx
@@ -1,0 +1,43 @@
+import { useCallback, useState } from 'react';
+import SnackbarAlert from '@/components/elements/SnackbarAlert';
+import ValidationErrorList from '@/modules/errors/components/ValidationErrorList';
+import { UNKNOWN_VALIDATION_ERROR_HEADING } from '@/modules/errors/util';
+import { ValidationError } from '@/types/gqlTypes';
+
+interface Props {
+  errors: ValidationError[];
+}
+
+/**
+ * Snackbar alert component for displaying validation errors.
+ *
+ * NOTE: for form submission, the preferred way to display
+ * ValidationErrors is within the form, and then warnings
+ * displayed in a Confirmable Dialog. (NOT ValidationErrorSnackbarAlert)
+ *
+ * This "Snackbar" approach for displaying ValidationErrors was
+ * introduced for the BulkAssignService workflow, where we don't
+ * have an existing pattern for displaying errors and warnings.
+ * (It could use further implrovement by displaying Warnings in a
+ * _confirmable_, and Errors with some more explanatory text and clearer
+ * information about which client the message pertains too. (For example
+ * explaining that a client would have an overlapping enrollment because
+ * they have an entry date on X, which is a common error with the Bed Night workflow)
+ */
+const ValidationErrorSnackbarAlert: React.FC<Props> = ({ errors }) => {
+  const [open, setOpen] = useState(true);
+  const closeSnackbar = useCallback(() => setOpen(false), []);
+
+  return (
+    <SnackbarAlert
+      title={UNKNOWN_VALIDATION_ERROR_HEADING}
+      open={open}
+      onClose={closeSnackbar}
+      alertProps={{ severity: 'error' }}
+    >
+      <ValidationErrorList errors={errors} />
+    </SnackbarAlert>
+  );
+};
+
+export default ValidationErrorSnackbarAlert;

--- a/src/modules/external/mci/components/alerts.tsx
+++ b/src/modules/external/mci/components/alerts.tsx
@@ -33,7 +33,7 @@ export const getClearanceAlertText = (
       return {
         title: 'MCI ID Found',
         // If this is a duplicate but we're editing an existing Client record, skip the message about "cancel and search again", since it doesn't make sense. In this case, the user can create the duplicate MCI ID but the clients should be merged eventually.
-        subtitle: `This client already exists in HMIS. ${state.existingClient ? null : 'Please cancel and search again.'}`,
+        subtitle: `This client already exists in HMIS. ${state.existingClient ? '' : 'Please cancel and search again.'}`,
         rightAlignButton: true,
       };
     case 'one_match':

--- a/src/modules/hmis/filterUtil.ts
+++ b/src/modules/hmis/filterUtil.ts
@@ -56,6 +56,7 @@ const FILTER_NAME_TO_PICK_LIST = {
   clientRecordType: PickListType.ClientAuditEventRecordTypes,
   enrollmentRecordType: PickListType.EnrollmentAuditEventRecordTypes,
   assignedStaff: PickListType.EligibleStaffAssignmentUsers,
+  workflowTemplate: PickListType.CeWorkflowTemplateIdentifiersIncludingRetired,
 };
 
 function isPicklistType(

--- a/src/modules/referrals/components/ReferralPostingDetails.tsx
+++ b/src/modules/referrals/components/ReferralPostingDetails.tsx
@@ -1,5 +1,4 @@
 import { Box, Grid, Stack, Typography } from '@mui/material';
-import { isNil } from 'lodash-es';
 import { ReactNode, useMemo } from 'react';
 
 import { CommonUnstyledList } from '@/components/CommonUnstyledList';
@@ -8,9 +7,9 @@ import RouterLink from '@/components/elements/RouterLink';
 import YesNoDisplay from '@/components/elements/YesNoDisplay';
 import { hasMeaningfulValue } from '@/modules/form/util/formUtil';
 import {
+  customDataElementValueAsString,
   parseAndFormatDate,
   parseAndFormatDateTime,
-  customDataElementValueAsString,
 } from '@/modules/hmis/hmisUtil';
 import ReferralPostingStatusDisplay from '@/modules/referrals/components/ReferralPostingStatusDisplay';
 import { EnrollmentDashboardRoutes } from '@/routes/routes';
@@ -53,28 +52,24 @@ const ProjectReferralPostingDetails: React.FC<Props> = ({
     ['Assigned At', parseAndFormatDateTime(referralPosting.assignedDate)],
   ];
 
+  // If household was referred to a particular unit type, show it
+  if (referralPosting.unitType?.description) {
+    standardDetails.push(['Unit Type', referralPosting.unitType.description]);
+  }
+
   const externalDetails: Array<[string, ReactNode]> = useMemo(() => {
     if (!externalReferrals) return [];
 
     return [
-      ['Referral ID', referralPosting.referralIdentifier],
-      ['Unit Type', referralPosting?.unitType?.description],
-      ['Score', referralPosting.score],
+      ['Referral ID', referralPosting.referralIdentifier], // External system identifier
+      ['Score', referralPosting.score], // External system score
       [
-        'Chronically Homeless',
+        'Chronically Homeless', // External system chronicity status
         <YesNoDisplay
           booleanValue={referralPosting.chronic}
           fallback={<NotCollectedText variant='body2' />}
         />,
       ],
-      [
-        'HUD Chronically Homeless' as string,
-        !isNil(referralPosting.hudChronic) ? (
-          <YesNoDisplay booleanValue={referralPosting.hudChronic} />
-        ) : (
-          (undefined as ReactNode)
-        ),
-      ] as const,
       [
         'Needs Wheelchair Accessible Unit',
         <YesNoDisplay
@@ -82,7 +77,7 @@ const ProjectReferralPostingDetails: React.FC<Props> = ({
           fallback={<NotCollectedText variant='body2' />}
         />,
       ],
-    ].filter((ary): ary is [string, ReactNode] => !!ary[1]);
+    ];
   }, [externalReferrals, referralPosting]);
 
   const customDetails: Array<[string, ReactNode]> = useMemo(() => {
@@ -91,6 +86,7 @@ const ProjectReferralPostingDetails: React.FC<Props> = ({
       customDataElementValueAsString(element),
     ]);
   }, [referralPosting]);
+
   return (
     <Grid container columnSpacing={6} rowSpacing={2}>
       {[standardDetails, externalDetails, customDetails]

--- a/src/routes/protected.tsx
+++ b/src/routes/protected.tsx
@@ -51,6 +51,7 @@ import BulkServicesPage from '@/modules/bulkServices/components/BulkServicesPage
 import ClientCaseNotes from '@/modules/caseNotes/components/ClientCaseNotes';
 import EnrollmentCaseNotes from '@/modules/caseNotes/components/EnrollmentCaseNotes';
 
+import AdminCoordinatedEntry from '@/modules/ce/components/admin/AdminCoordinatedEntry';
 import ClientReferralsPage from '@/modules/ce/components/client/ClientReferralsPage';
 import Opportunity from '@/modules/ce/components/Opportunity';
 import ProjectCePage from '@/modules/ce/components/ProjectCePage';
@@ -808,6 +809,14 @@ export const protectedRoutes: RouteNode[] = [
             element: (
               <RootPermissionsFilter permissions='canMergeClients'>
                 <AdminClientMerge />
+              </RootPermissionsFilter>
+            ),
+          },
+          {
+            path: AdminDashboardRoutes.COORDINATED_ENTRY,
+            element: (
+              <RootPermissionsFilter permissions='canViewCoordinatedEntry'>
+                <AdminCoordinatedEntry />
               </RootPermissionsFilter>
             ),
           },

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -15,6 +15,7 @@ export const Routes = {
 
 const adminDashboardRoutes = {
   CLIENT_MERGE_HISTORY: 'client-merge-history',
+  COORDINATED_ENTRY: 'coordinated-entry',
   PERFORM_CLIENT_MERGES: 'client-merge-history/candidates',
   AC_DENIALS: 'referral-denials',
   AC_DENIAL_DETAILS: 'referral-denials/:referralPostingId',

--- a/src/types/gqlEnums.ts
+++ b/src/types/gqlEnums.ts
@@ -75,6 +75,10 @@ export const HmisEnums = {
     OTHER: 'Other',
   },
   BoundType: { MAX: 'MAX', MIN: 'MIN' },
+  CeOpportunitySortOption: {
+    DATE_AVAILABLE_EARLIEST_FIRST: 'Date Available, earliest first',
+    DATE_AVAILABLE_LATEST_FIRST: 'Date Available, latest first',
+  },
   CeOpportunityStatus: { closed: 'Closed', locked: 'Locked', open: 'Open' },
   CeReferralStatus: {
     accepted: 'Accepted',
@@ -957,6 +961,8 @@ export const HmisEnums = {
     AVAILABLE_UNIT_TYPES:
       'Unit types that have unoccupied units in the specified project',
     CE_EVENTS: 'Grouped HUD CE Event types',
+    CE_WORKFLOW_TEMPLATE_IDENTIFIERS_INCLUDING_RETIRED:
+      'Templates for CE workflow definitions, including fully retired workflows',
     CLIENT_AUDIT_EVENT_RECORD_TYPES: 'CLIENT_AUDIT_EVENT_RECORD_TYPES',
     COC: 'COC',
     CONTINUUM_PROJECTS: 'Continuum Projects',

--- a/src/types/gqlObjects.ts
+++ b/src/types/gqlObjects.ts
@@ -574,6 +574,14 @@ export const HmisObjectSchemas: GqlSchema[] = [
         },
       },
       {
+        name: 'dateAvailable',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'ISO8601Date', ofType: null },
+        },
+      },
+      {
         name: 'expiresAt',
         type: { kind: 'SCALAR', name: 'ISO8601DateTime', ofType: null },
       },
@@ -587,6 +595,14 @@ export const HmisObjectSchemas: GqlSchema[] = [
       },
       {
         name: 'name',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'String', ofType: null },
+        },
+      },
+      {
+        name: 'organizationName',
         type: {
           kind: 'NON_NULL',
           name: null,
@@ -712,8 +728,8 @@ export const HmisObjectSchemas: GqlSchema[] = [
         },
       },
       {
-        name: 'currentStepName',
-        type: { kind: 'SCALAR', name: 'String', ofType: null },
+        name: 'daysOnCurrentSteps',
+        type: { kind: 'SCALAR', name: 'Int', ofType: null },
       },
       {
         name: 'id',
@@ -729,6 +745,14 @@ export const HmisObjectSchemas: GqlSchema[] = [
           kind: 'NON_NULL',
           name: null,
           ofType: { kind: 'ENUM', name: 'CeReferralStatus', ofType: null },
+        },
+      },
+      {
+        name: 'targetOrganizationName',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'String', ofType: null },
         },
       },
       {
@@ -6859,6 +6883,75 @@ export const HmisInputObjectSchemas: GqlInputObjectSchema[] = [
     ],
   },
   {
+    name: 'CeOpportunityFilterOptions',
+    args: [
+      {
+        name: 'availableOnDate',
+        type: { kind: 'SCALAR', name: 'ISO8601Date', ofType: null },
+      },
+      {
+        name: 'organization',
+        type: {
+          kind: 'LIST',
+          name: null,
+          ofType: {
+            kind: 'NON_NULL',
+            name: null,
+            ofType: { kind: 'SCALAR', name: 'ID', ofType: null },
+          },
+        },
+      },
+      {
+        name: 'project',
+        type: {
+          kind: 'LIST',
+          name: null,
+          ofType: {
+            kind: 'NON_NULL',
+            name: null,
+            ofType: { kind: 'SCALAR', name: 'ID', ofType: null },
+          },
+        },
+      },
+      {
+        name: 'projectType',
+        type: {
+          kind: 'LIST',
+          name: null,
+          ofType: {
+            kind: 'NON_NULL',
+            name: null,
+            ofType: { kind: 'ENUM', name: 'ProjectType', ofType: null },
+          },
+        },
+      },
+      {
+        name: 'status',
+        type: {
+          kind: 'LIST',
+          name: null,
+          ofType: {
+            kind: 'NON_NULL',
+            name: null,
+            ofType: { kind: 'ENUM', name: 'CeOpportunityStatus', ofType: null },
+          },
+        },
+      },
+      {
+        name: 'workflowTemplate',
+        type: {
+          kind: 'LIST',
+          name: null,
+          ofType: {
+            kind: 'NON_NULL',
+            name: null,
+            ofType: { kind: 'SCALAR', name: 'String', ofType: null },
+          },
+        },
+      },
+    ],
+  },
+  {
     name: 'CeOpportunityInput',
     args: [
       {
@@ -6882,6 +6975,22 @@ export const HmisInputObjectSchemas: GqlInputObjectSchema[] = [
   {
     name: 'CeReferralFilterOptions',
     args: [
+      {
+        name: 'onCurrentStepSince',
+        type: { kind: 'SCALAR', name: 'ISO8601Date', ofType: null },
+      },
+      {
+        name: 'organization',
+        type: {
+          kind: 'LIST',
+          name: null,
+          ofType: {
+            kind: 'NON_NULL',
+            name: null,
+            ofType: { kind: 'SCALAR', name: 'ID', ofType: null },
+          },
+        },
+      },
       {
         name: 'project',
         type: {
@@ -6915,6 +7024,18 @@ export const HmisInputObjectSchemas: GqlInputObjectSchema[] = [
             kind: 'NON_NULL',
             name: null,
             ofType: { kind: 'ENUM', name: 'CeReferralStatus', ofType: null },
+          },
+        },
+      },
+      {
+        name: 'workflowTemplate',
+        type: {
+          kind: 'LIST',
+          name: null,
+          ofType: {
+            kind: 'NON_NULL',
+            name: null,
+            ofType: { kind: 'SCALAR', name: 'String', ofType: null },
           },
         },
       },
@@ -7024,8 +7145,73 @@ export const HmisInputObjectSchemas: GqlInputObjectSchema[] = [
     ],
   },
   {
+    name: 'ClientCeReferralFilterOptions',
+    args: [
+      {
+        name: 'organization',
+        type: {
+          kind: 'LIST',
+          name: null,
+          ofType: {
+            kind: 'NON_NULL',
+            name: null,
+            ofType: { kind: 'SCALAR', name: 'ID', ofType: null },
+          },
+        },
+      },
+      {
+        name: 'project',
+        type: {
+          kind: 'LIST',
+          name: null,
+          ofType: {
+            kind: 'NON_NULL',
+            name: null,
+            ofType: { kind: 'SCALAR', name: 'ID', ofType: null },
+          },
+        },
+      },
+      {
+        name: 'projectType',
+        type: {
+          kind: 'LIST',
+          name: null,
+          ofType: {
+            kind: 'NON_NULL',
+            name: null,
+            ofType: { kind: 'ENUM', name: 'ProjectType', ofType: null },
+          },
+        },
+      },
+      {
+        name: 'status',
+        type: {
+          kind: 'LIST',
+          name: null,
+          ofType: {
+            kind: 'NON_NULL',
+            name: null,
+            ofType: { kind: 'ENUM', name: 'CeReferralStatus', ofType: null },
+          },
+        },
+      },
+    ],
+  },
+  {
     name: 'ClientEligibleCeOpportunityFilterOptions',
     args: [
+      {
+        name: 'organization',
+        type: {
+          kind: 'LIST',
+          name: null,
+          ofType: {
+            kind: 'NON_NULL',
+            name: null,
+            ofType: { kind: 'SCALAR', name: 'ID', ofType: null },
+          },
+        },
+      },
       {
         name: 'project',
         type: {

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -40772,7 +40772,6 @@ export type UpdateReferralPostingMutation = {
       id: string;
       assignedDate: string;
       chronic?: boolean | null;
-      hudChronic?: boolean | null;
       denialNote?: string | null;
       denialReason?: ReferralPostingDenialReasonType | null;
       needsWheelchairAccessibleUnit?: boolean | null;
@@ -41012,7 +41011,6 @@ export type GetReferralPostingQuery = {
     id: string;
     assignedDate: string;
     chronic?: boolean | null;
-    hudChronic?: boolean | null;
     denialNote?: string | null;
     denialReason?: ReferralPostingDenialReasonType | null;
     needsWheelchairAccessibleUnit?: boolean | null;
@@ -41292,7 +41290,6 @@ export type ReferralPostingDetailFieldsFragment = {
   id: string;
   assignedDate: string;
   chronic?: boolean | null;
-  hudChronic?: boolean | null;
   denialNote?: string | null;
   denialReason?: ReferralPostingDenialReasonType | null;
   needsWheelchairAccessibleUnit?: boolean | null;
@@ -46176,7 +46173,6 @@ export const ReferralPostingDetailFieldsFragmentDoc = gql`
     id
     assignedDate
     chronic
-    hudChronic
     denialNote
     denialReason
     needsWheelchairAccessibleUnit

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -603,10 +603,12 @@ export type CeOpportunity = {
   candidates: CeCandidatesPaginated;
   candidatesGeneratedAt?: Maybe<Scalars['ISO8601DateTime']['output']>;
   categories: Array<Scalars['String']['output']>;
+  dateAvailable: Scalars['ISO8601Date']['output'];
   eligibilityRequirements?: Maybe<Array<CeMatchRule>>;
   expiresAt?: Maybe<Scalars['ISO8601DateTime']['output']>;
   id: Scalars['ID']['output'];
   name: Scalars['String']['output'];
+  organizationName: Scalars['String']['output'];
   priorityScheme?: Maybe<CeMatchRule>;
   projectId: Scalars['ID']['output'];
   projectName: Scalars['String']['output'];
@@ -614,6 +616,7 @@ export type CeOpportunity = {
   /** Active or accepted referral */
   referral?: Maybe<CeReferral>;
   status: CeOpportunityStatus;
+  unit?: Maybe<Unit>;
 };
 
 export type CeOpportunityCandidatesArgs = {
@@ -621,10 +624,27 @@ export type CeOpportunityCandidatesArgs = {
   offset?: InputMaybe<Scalars['Int']['input']>;
 };
 
+export type CeOpportunityFilterOptions = {
+  availableOnDate?: InputMaybe<Scalars['ISO8601Date']['input']>;
+  organization?: InputMaybe<Array<Scalars['ID']['input']>>;
+  project?: InputMaybe<Array<Scalars['ID']['input']>>;
+  projectType?: InputMaybe<Array<ProjectType>>;
+  status?: InputMaybe<Array<CeOpportunityStatus>>;
+  workflowTemplate?: InputMaybe<Array<Scalars['String']['input']>>;
+};
+
 export type CeOpportunityInput = {
   name: Scalars['String']['input'];
   templateId: Scalars['ID']['input'];
 };
+
+/** Opportunity Sorting Options */
+export enum CeOpportunitySortOption {
+  /** Date Available, earliest first */
+  DateAvailableEarliestFirst = 'DATE_AVAILABLE_EARLIEST_FIRST',
+  /** Date Available, latest first */
+  DateAvailableLatestFirst = 'DATE_AVAILABLE_LATEST_FIRST',
+}
 
 export enum CeOpportunityStatus {
   /** Closed */
@@ -670,7 +690,8 @@ export type CeReferral = {
   client?: Maybe<Client>;
   clientId: Scalars['ID']['output'];
   createdAt: Scalars['ISO8601DateTime']['output'];
-  currentStepName?: Maybe<Scalars['String']['output']>;
+  currentSteps?: Maybe<Array<CeReferralStep>>;
+  daysOnCurrentSteps?: Maybe<Scalars['Int']['output']>;
   id: Scalars['ID']['output'];
   opportunity: CeOpportunity;
   referredBy?: Maybe<ApplicationUser>;
@@ -678,15 +699,20 @@ export type CeReferral = {
   steps: Array<CeReferralStep>;
   swimlanes: Array<CeReferralSwimlane>;
   targetEnrollment?: Maybe<Enrollment>;
+  targetOrganizationName: Scalars['String']['output'];
   targetProjectId: Scalars['ID']['output'];
   targetProjectName: Scalars['String']['output'];
   targetProjectType: ProjectType;
+  updatedBy?: Maybe<ApplicationUser>;
 };
 
 export type CeReferralFilterOptions = {
+  onCurrentStepSince?: InputMaybe<Scalars['ISO8601Date']['input']>;
+  organization?: InputMaybe<Array<Scalars['ID']['input']>>;
   project?: InputMaybe<Array<Scalars['ID']['input']>>;
   projectType?: InputMaybe<Array<ProjectType>>;
   status?: InputMaybe<Array<CeReferralStatus>>;
+  workflowTemplate?: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
 export type CeReferralParticipantInput = {
@@ -866,7 +892,7 @@ export type ClientAuditHistoryArgs = {
 
 /** HUD Client */
 export type ClientCeReferralsArgs = {
-  filters?: InputMaybe<CeReferralFilterOptions>;
+  filters?: InputMaybe<ClientCeReferralFilterOptions>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
 };
@@ -895,6 +921,7 @@ export type ClientEligibleCeOpportunitiesArgs = {
   filters?: InputMaybe<ClientEligibleCeOpportunityFilterOptions>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
+  sortOrder?: InputMaybe<CeOpportunitySortOption>;
 };
 
 /** HUD Client */
@@ -1118,6 +1145,13 @@ export type ClientAuditEventsPaginated = {
   pagesCount: Scalars['Int']['output'];
 };
 
+export type ClientCeReferralFilterOptions = {
+  organization?: InputMaybe<Array<Scalars['ID']['input']>>;
+  project?: InputMaybe<Array<Scalars['ID']['input']>>;
+  projectType?: InputMaybe<Array<ProjectType>>;
+  status?: InputMaybe<Array<CeReferralStatus>>;
+};
+
 export type ClientContactPoint = {
   __typename?: 'ClientContactPoint';
   client: Client;
@@ -1165,6 +1199,7 @@ export enum ClientDashboardFeature {
 }
 
 export type ClientEligibleCeOpportunityFilterOptions = {
+  organization?: InputMaybe<Array<Scalars['ID']['input']>>;
   project?: InputMaybe<Array<Scalars['ID']['input']>>;
   projectType?: InputMaybe<Array<ProjectType>>;
 };
@@ -5055,6 +5090,8 @@ export enum PickListType {
   AvailableUnitTypes = 'AVAILABLE_UNIT_TYPES',
   /** Grouped HUD CE Event types */
   CeEvents = 'CE_EVENTS',
+  /** Templates for CE workflow definitions, including fully retired workflows */
+  CeWorkflowTemplateIdentifiersIncludingRetired = 'CE_WORKFLOW_TEMPLATE_IDENTIFIERS_INCLUDING_RETIRED',
   ClientAuditEventRecordTypes = 'CLIENT_AUDIT_EVENT_RECORD_TYPES',
   Coc = 'COC',
   /** Continuum Projects */
@@ -5903,6 +5940,7 @@ export type ProjectCeOpportunitiesArgs = {
   filters?: InputMaybe<ProjectCeOpportunityFilterOptions>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
+  sortOrder?: InputMaybe<CeOpportunitySortOption>;
 };
 
 export type ProjectCeParticipationsArgs = {
@@ -6197,9 +6235,11 @@ export type Query = {
   assessment?: Maybe<Assessment>;
   /** Get the correct Form Definition to use for an assessment, by Role or FormDefinition ID */
   assessmentFormDefinition?: Maybe<FormDefinition>;
+  ceOpportunities: CeOpportunitiesPaginated;
   ceOpportunity?: Maybe<CeOpportunity>;
   ceReferral?: Maybe<CeReferral>;
   ceReferralStep?: Maybe<CeReferralStep>;
+  ceReferrals: CeReferralsPaginated;
   /** Client lookup */
   client?: Maybe<Client>;
   /** Custom forms for collecting and/or displaying custom details for a Client (outside of the Client demographics form) */
@@ -6278,6 +6318,13 @@ export type QueryAssessmentFormDefinitionArgs = {
   role?: InputMaybe<AssessmentRole>;
 };
 
+export type QueryCeOpportunitiesArgs = {
+  filters?: InputMaybe<CeOpportunityFilterOptions>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  sortOrder?: InputMaybe<CeOpportunitySortOption>;
+};
+
 export type QueryCeOpportunityArgs = {
   id: Scalars['ID']['input'];
 };
@@ -6288,6 +6335,12 @@ export type QueryCeReferralArgs = {
 
 export type QueryCeReferralStepArgs = {
   id: Scalars['ID']['input'];
+};
+
+export type QueryCeReferralsArgs = {
+  filters?: InputMaybe<CeReferralFilterOptions>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
 };
 
 export type QueryClientArgs = {
@@ -16028,6 +16081,22 @@ export type CeOpportunityFieldsFragment = {
   } | null;
 };
 
+export type CeOpportunityAdminFieldsFragment = {
+  __typename?: 'CeOpportunity';
+  projectType: ProjectType;
+  organizationName: string;
+  dateAvailable: string;
+  id: string;
+  name: string;
+  categories: Array<string>;
+  status: CeOpportunityStatus;
+  active: boolean;
+  expiresAt?: string | null;
+  projectId: string;
+  projectName: string;
+  unit?: { __typename?: 'Unit'; id: string; name: string } | null;
+};
+
 export type ClientCeOpportunitySummaryFieldsFragment = {
   __typename?: 'CeOpportunity';
   candidatesGeneratedAt?: string | null;
@@ -16085,12 +16154,74 @@ export type CeReferralSummaryFieldsFragment = {
 export type CeReferralTableFieldsFragment = {
   __typename?: 'CeReferral';
   createdAt: string;
-  currentStepName?: string | null;
   id: string;
   status: CeReferralStatus;
   active: boolean;
   clientId: string;
   opportunity: { __typename?: 'CeOpportunity'; id: string; name: string };
+  currentSteps?: Array<{
+    __typename?: 'CeReferralStep';
+    id: string;
+    name: string;
+  }> | null;
+  referredBy?: {
+    __typename?: 'ApplicationUser';
+    id: string;
+    name: string;
+  } | null;
+  client?: {
+    __typename?: 'Client';
+    id: string;
+    lockVersion: number;
+    firstName?: string | null;
+    middleName?: string | null;
+    lastName?: string | null;
+    nameSuffix?: string | null;
+  } | null;
+};
+
+export type CeReferralAdminFieldsFragment = {
+  __typename?: 'CeReferral';
+  targetProjectId: string;
+  targetProjectName: string;
+  targetProjectType: ProjectType;
+  targetOrganizationName: string;
+  daysOnCurrentSteps?: number | null;
+  createdAt: string;
+  id: string;
+  status: CeReferralStatus;
+  active: boolean;
+  clientId: string;
+  targetEnrollment?: { __typename?: 'Enrollment'; id: string } | null;
+  currentSteps?: Array<{
+    __typename?: 'CeReferralStep';
+    id: string;
+    name: string;
+  }> | null;
+  updatedBy?: {
+    __typename?: 'ApplicationUser';
+    id: string;
+    name: string;
+  } | null;
+  opportunity: {
+    __typename?: 'CeOpportunity';
+    id: string;
+    name: string;
+    unit?: {
+      __typename?: 'Unit';
+      id: string;
+      name: string;
+      unitType?: {
+        __typename?: 'UnitTypeObject';
+        id: string;
+        description?: string | null;
+        bedType?: InventoryBedType | null;
+        unitSize?: number | null;
+        dateUpdated: string;
+        dateCreated: string;
+      } | null;
+    } | null;
+  };
   referredBy?: {
     __typename?: 'ApplicationUser';
     id: string;
@@ -16113,12 +16244,16 @@ export type ClientCeReferralTableFieldsFragment = {
   targetProjectName: string;
   targetProjectType: ProjectType;
   createdAt: string;
-  currentStepName?: string | null;
   id: string;
   status: CeReferralStatus;
   active: boolean;
   clientId: string;
   opportunity: { __typename?: 'CeOpportunity'; id: string; name: string };
+  currentSteps?: Array<{
+    __typename?: 'CeReferralStep';
+    id: string;
+    name: string;
+  }> | null;
   referredBy?: {
     __typename?: 'ApplicationUser';
     id: string;
@@ -18206,12 +18341,16 @@ export type GetProjectCeReferralsQuery = {
       nodes: Array<{
         __typename?: 'CeReferral';
         createdAt: string;
-        currentStepName?: string | null;
         id: string;
         status: CeReferralStatus;
         active: boolean;
         clientId: string;
         opportunity: { __typename?: 'CeOpportunity'; id: string; name: string };
+        currentSteps?: Array<{
+          __typename?: 'CeReferralStep';
+          id: string;
+          name: string;
+        }> | null;
         referredBy?: {
           __typename?: 'ApplicationUser';
           id: string;
@@ -18912,7 +19051,7 @@ export type GetClientCeReferralsQueryVariables = Exact<{
   id: Scalars['ID']['input'];
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
-  filters?: InputMaybe<CeReferralFilterOptions>;
+  filters?: InputMaybe<ClientCeReferralFilterOptions>;
 }>;
 
 export type GetClientCeReferralsQuery = {
@@ -18931,12 +19070,16 @@ export type GetClientCeReferralsQuery = {
         targetProjectName: string;
         targetProjectType: ProjectType;
         createdAt: string;
-        currentStepName?: string | null;
         id: string;
         status: CeReferralStatus;
         active: boolean;
         clientId: string;
         opportunity: { __typename?: 'CeOpportunity'; id: string; name: string };
+        currentSteps?: Array<{
+          __typename?: 'CeReferralStep';
+          id: string;
+          name: string;
+        }> | null;
         referredBy?: {
           __typename?: 'ApplicationUser';
           id: string;
@@ -18988,6 +19131,112 @@ export type GetClientEligibleOpportunitiesQuery = {
       }>;
     };
   } | null;
+};
+
+export type GetAdminCeOpportunitiesQueryVariables = Exact<{
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  filters?: InputMaybe<CeOpportunityFilterOptions>;
+  sortOrder?: InputMaybe<CeOpportunitySortOption>;
+}>;
+
+export type GetAdminCeOpportunitiesQuery = {
+  __typename?: 'Query';
+  ceOpportunities: {
+    __typename?: 'CeOpportunitiesPaginated';
+    offset: number;
+    limit: number;
+    nodesCount: number;
+    nodes: Array<{
+      __typename?: 'CeOpportunity';
+      projectType: ProjectType;
+      organizationName: string;
+      dateAvailable: string;
+      id: string;
+      name: string;
+      categories: Array<string>;
+      status: CeOpportunityStatus;
+      active: boolean;
+      expiresAt?: string | null;
+      projectId: string;
+      projectName: string;
+      unit?: { __typename?: 'Unit'; id: string; name: string } | null;
+    }>;
+  };
+};
+
+export type GetAdminCeReferralsQueryVariables = Exact<{
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  filters?: InputMaybe<CeReferralFilterOptions>;
+  includeUnit?: InputMaybe<Scalars['Boolean']['input']>;
+}>;
+
+export type GetAdminCeReferralsQuery = {
+  __typename?: 'Query';
+  ceReferrals: {
+    __typename?: 'CeReferralsPaginated';
+    offset: number;
+    limit: number;
+    nodesCount: number;
+    nodes: Array<{
+      __typename?: 'CeReferral';
+      targetProjectId: string;
+      targetProjectName: string;
+      targetProjectType: ProjectType;
+      targetOrganizationName: string;
+      daysOnCurrentSteps?: number | null;
+      createdAt: string;
+      id: string;
+      status: CeReferralStatus;
+      active: boolean;
+      clientId: string;
+      targetEnrollment?: { __typename?: 'Enrollment'; id: string } | null;
+      currentSteps?: Array<{
+        __typename?: 'CeReferralStep';
+        id: string;
+        name: string;
+      }> | null;
+      updatedBy?: {
+        __typename?: 'ApplicationUser';
+        id: string;
+        name: string;
+      } | null;
+      opportunity: {
+        __typename?: 'CeOpportunity';
+        id: string;
+        name: string;
+        unit?: {
+          __typename?: 'Unit';
+          id: string;
+          name: string;
+          unitType?: {
+            __typename?: 'UnitTypeObject';
+            id: string;
+            description?: string | null;
+            bedType?: InventoryBedType | null;
+            unitSize?: number | null;
+            dateUpdated: string;
+            dateCreated: string;
+          } | null;
+        } | null;
+      };
+      referredBy?: {
+        __typename?: 'ApplicationUser';
+        id: string;
+        name: string;
+      } | null;
+      client?: {
+        __typename?: 'Client';
+        id: string;
+        lockVersion: number;
+        firstName?: string | null;
+        middleName?: string | null;
+        lastName?: string | null;
+        nameSuffix?: string | null;
+      } | null;
+    }>;
+  };
 };
 
 export type ClientSearchResultFieldsFragment = {
@@ -44809,6 +45058,19 @@ export const CeOpportunityFieldsFragmentDoc = gql`
   ${CeReferralSummaryFieldsFragmentDoc}
   ${CeMatchRuleFieldsFragmentDoc}
 `;
+export const CeOpportunityAdminFieldsFragmentDoc = gql`
+  fragment CeOpportunityAdminFields on CeOpportunity {
+    ...CeOpportunitySummaryFields
+    projectType
+    organizationName
+    dateAvailable
+    unit {
+      id
+      name
+    }
+  }
+  ${CeOpportunitySummaryFieldsFragmentDoc}
+`;
 export const ClientCeOpportunitySummaryFieldsFragmentDoc = gql`
   fragment ClientCeOpportunitySummaryFields on CeOpportunity {
     candidatesGeneratedAt
@@ -44836,13 +45098,60 @@ export const CeReferralTableFieldsFragmentDoc = gql`
       id
       name
     }
-    currentStepName
+    currentSteps {
+      id
+      name
+    }
     referredBy {
       id
       name
     }
   }
   ${CeReferralSummaryFieldsFragmentDoc}
+`;
+export const UnitTypeFieldsFragmentDoc = gql`
+  fragment UnitTypeFields on UnitTypeObject {
+    id
+    description
+    bedType
+    unitSize
+    dateUpdated
+    dateCreated
+  }
+`;
+export const CeReferralAdminFieldsFragmentDoc = gql`
+  fragment CeReferralAdminFields on CeReferral {
+    ...CeReferralTableFields
+    targetProjectId
+    targetProjectName
+    targetProjectType
+    targetEnrollment {
+      id
+    }
+    targetOrganizationName
+    daysOnCurrentSteps
+    currentSteps {
+      id
+      name
+    }
+    updatedBy {
+      id
+      name
+    }
+    opportunity {
+      id
+      name
+      unit @include(if: $includeUnit) {
+        id
+        name
+        unitType {
+          ...UnitTypeFields
+        }
+      }
+    }
+  }
+  ${CeReferralTableFieldsFragmentDoc}
+  ${UnitTypeFieldsFragmentDoc}
 `;
 export const ClientCeReferralTableFieldsFragmentDoc = gql`
   fragment ClientCeReferralTableFields on CeReferral {
@@ -46240,16 +46549,6 @@ export const ReferralPostingDetailFieldsFragmentDoc = gql`
   ${ClientIdentificationFieldsFragmentDoc}
   ${ClientIdentifierFieldsFragmentDoc}
   ${CustomDataElementFieldsFragmentDoc}
-`;
-export const UnitTypeFieldsFragmentDoc = gql`
-  fragment UnitTypeFields on UnitTypeObject {
-    id
-    description
-    bedType
-    unitSize
-    dateUpdated
-    dateCreated
-  }
 `;
 export const ReferralRequestFieldsFragmentDoc = gql`
   fragment ReferralRequestFields on ReferralRequest {
@@ -49283,7 +49582,7 @@ export const GetClientCeReferralsDocument = gql`
     $id: ID!
     $limit: Int = 25
     $offset: Int = 0
-    $filters: CeReferralFilterOptions = null
+    $filters: ClientCeReferralFilterOptions = null
   ) {
     client(id: $id) {
       id
@@ -49482,6 +49781,195 @@ export type GetClientEligibleOpportunitiesSuspenseQueryHookResult = ReturnType<
 export type GetClientEligibleOpportunitiesQueryResult = Apollo.QueryResult<
   GetClientEligibleOpportunitiesQuery,
   GetClientEligibleOpportunitiesQueryVariables
+>;
+export const GetAdminCeOpportunitiesDocument = gql`
+  query GetAdminCeOpportunities(
+    $limit: Int = 25
+    $offset: Int = 0
+    $filters: CeOpportunityFilterOptions = null
+    $sortOrder: CeOpportunitySortOption = null
+  ) {
+    ceOpportunities(
+      limit: $limit
+      offset: $offset
+      filters: $filters
+      sortOrder: $sortOrder
+    ) {
+      offset
+      limit
+      nodesCount
+      nodes {
+        ...CeOpportunityAdminFields
+      }
+    }
+  }
+  ${CeOpportunityAdminFieldsFragmentDoc}
+`;
+
+/**
+ * __useGetAdminCeOpportunitiesQuery__
+ *
+ * To run a query within a React component, call `useGetAdminCeOpportunitiesQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetAdminCeOpportunitiesQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetAdminCeOpportunitiesQuery({
+ *   variables: {
+ *      limit: // value for 'limit'
+ *      offset: // value for 'offset'
+ *      filters: // value for 'filters'
+ *      sortOrder: // value for 'sortOrder'
+ *   },
+ * });
+ */
+export function useGetAdminCeOpportunitiesQuery(
+  baseOptions?: Apollo.QueryHookOptions<
+    GetAdminCeOpportunitiesQuery,
+    GetAdminCeOpportunitiesQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    GetAdminCeOpportunitiesQuery,
+    GetAdminCeOpportunitiesQueryVariables
+  >(GetAdminCeOpportunitiesDocument, options);
+}
+export function useGetAdminCeOpportunitiesLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GetAdminCeOpportunitiesQuery,
+    GetAdminCeOpportunitiesQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    GetAdminCeOpportunitiesQuery,
+    GetAdminCeOpportunitiesQueryVariables
+  >(GetAdminCeOpportunitiesDocument, options);
+}
+export function useGetAdminCeOpportunitiesSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        GetAdminCeOpportunitiesQuery,
+        GetAdminCeOpportunitiesQueryVariables
+      >
+) {
+  const options =
+    baseOptions === Apollo.skipToken
+      ? baseOptions
+      : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<
+    GetAdminCeOpportunitiesQuery,
+    GetAdminCeOpportunitiesQueryVariables
+  >(GetAdminCeOpportunitiesDocument, options);
+}
+export type GetAdminCeOpportunitiesQueryHookResult = ReturnType<
+  typeof useGetAdminCeOpportunitiesQuery
+>;
+export type GetAdminCeOpportunitiesLazyQueryHookResult = ReturnType<
+  typeof useGetAdminCeOpportunitiesLazyQuery
+>;
+export type GetAdminCeOpportunitiesSuspenseQueryHookResult = ReturnType<
+  typeof useGetAdminCeOpportunitiesSuspenseQuery
+>;
+export type GetAdminCeOpportunitiesQueryResult = Apollo.QueryResult<
+  GetAdminCeOpportunitiesQuery,
+  GetAdminCeOpportunitiesQueryVariables
+>;
+export const GetAdminCeReferralsDocument = gql`
+  query GetAdminCeReferrals(
+    $limit: Int = 3
+    $offset: Int = 0
+    $filters: CeReferralFilterOptions = null
+    $includeUnit: Boolean = false
+  ) {
+    ceReferrals(limit: $limit, offset: $offset, filters: $filters) {
+      offset
+      limit
+      nodesCount
+      nodes {
+        ...CeReferralAdminFields
+      }
+    }
+  }
+  ${CeReferralAdminFieldsFragmentDoc}
+`;
+
+/**
+ * __useGetAdminCeReferralsQuery__
+ *
+ * To run a query within a React component, call `useGetAdminCeReferralsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetAdminCeReferralsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetAdminCeReferralsQuery({
+ *   variables: {
+ *      limit: // value for 'limit'
+ *      offset: // value for 'offset'
+ *      filters: // value for 'filters'
+ *      includeUnit: // value for 'includeUnit'
+ *   },
+ * });
+ */
+export function useGetAdminCeReferralsQuery(
+  baseOptions?: Apollo.QueryHookOptions<
+    GetAdminCeReferralsQuery,
+    GetAdminCeReferralsQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    GetAdminCeReferralsQuery,
+    GetAdminCeReferralsQueryVariables
+  >(GetAdminCeReferralsDocument, options);
+}
+export function useGetAdminCeReferralsLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GetAdminCeReferralsQuery,
+    GetAdminCeReferralsQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    GetAdminCeReferralsQuery,
+    GetAdminCeReferralsQueryVariables
+  >(GetAdminCeReferralsDocument, options);
+}
+export function useGetAdminCeReferralsSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        GetAdminCeReferralsQuery,
+        GetAdminCeReferralsQueryVariables
+      >
+) {
+  const options =
+    baseOptions === Apollo.skipToken
+      ? baseOptions
+      : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<
+    GetAdminCeReferralsQuery,
+    GetAdminCeReferralsQueryVariables
+  >(GetAdminCeReferralsDocument, options);
+}
+export type GetAdminCeReferralsQueryHookResult = ReturnType<
+  typeof useGetAdminCeReferralsQuery
+>;
+export type GetAdminCeReferralsLazyQueryHookResult = ReturnType<
+  typeof useGetAdminCeReferralsLazyQuery
+>;
+export type GetAdminCeReferralsSuspenseQueryHookResult = ReturnType<
+  typeof useGetAdminCeReferralsSuspenseQuery
+>;
+export type GetAdminCeReferralsQueryResult = Apollo.QueryResult<
+  GetAdminCeReferralsQuery,
+  GetAdminCeReferralsQueryVariables
 >;
 export const SearchClientsDocument = gql`
   query SearchClients(

--- a/yarn.lock
+++ b/yarn.lock
@@ -5734,38 +5734,7 @@ esbuild-register@^3.5.0:
   dependencies:
     debug "^4.3.4"
 
-"esbuild@^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0":
-  version "0.25.2"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.25.2.tgz#55a1d9ebcb3aa2f95e8bba9e900c1a5061bc168b"
-  integrity sha512-16854zccKPnC+toMywC+uKNeYSv+/eXkevRAfwRD/G9Cleq66m8XFIrigkbvauLLlCfDL45Q2cWegSg53gGBnQ==
-  optionalDependencies:
-    "@esbuild/aix-ppc64" "0.25.2"
-    "@esbuild/android-arm" "0.25.2"
-    "@esbuild/android-arm64" "0.25.2"
-    "@esbuild/android-x64" "0.25.2"
-    "@esbuild/darwin-arm64" "0.25.2"
-    "@esbuild/darwin-x64" "0.25.2"
-    "@esbuild/freebsd-arm64" "0.25.2"
-    "@esbuild/freebsd-x64" "0.25.2"
-    "@esbuild/linux-arm" "0.25.2"
-    "@esbuild/linux-arm64" "0.25.2"
-    "@esbuild/linux-ia32" "0.25.2"
-    "@esbuild/linux-loong64" "0.25.2"
-    "@esbuild/linux-mips64el" "0.25.2"
-    "@esbuild/linux-ppc64" "0.25.2"
-    "@esbuild/linux-riscv64" "0.25.2"
-    "@esbuild/linux-s390x" "0.25.2"
-    "@esbuild/linux-x64" "0.25.2"
-    "@esbuild/netbsd-arm64" "0.25.2"
-    "@esbuild/netbsd-x64" "0.25.2"
-    "@esbuild/openbsd-arm64" "0.25.2"
-    "@esbuild/openbsd-x64" "0.25.2"
-    "@esbuild/sunos-x64" "0.25.2"
-    "@esbuild/win32-arm64" "0.25.2"
-    "@esbuild/win32-ia32" "0.25.2"
-    "@esbuild/win32-x64" "0.25.2"
-
-esbuild@^0.25.0:
+"esbuild@^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0", esbuild@^0.25.0:
   version "0.25.4"
   resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.25.4.tgz#bb9a16334d4ef2c33c7301a924b8b863351a0854"
   integrity sha512-8pgjLUcUjcgDg+2Q4NYXnPbo/vncAY4UmyaCm0jZevERqCHZIaWwdJHkf8XQtu4AxSKCdvrUbT0XUr1IdZzI8Q==
@@ -9667,15 +9636,10 @@ semver@^6.0.0, semver@^6.3.0, semver@^6.3.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.3.5:
+semver@^7.3.5, semver@^7.3.7, semver@^7.5.0, semver@^7.5.3, semver@^7.5.4, semver@^7.6.0, semver@^7.6.2:
   version "7.7.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.2.tgz#67d99fdcd35cec21e6f8b87a7fd515a33f982b58"
   integrity sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==
-
-semver@^7.3.7, semver@^7.5.0, semver@^7.5.3, semver@^7.5.4, semver@^7.6.0, semver@^7.6.2:
-  version "7.7.1"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.1.tgz#abd5098d82b18c6c81f6074ff2647fd3e7220c9f"
-  integrity sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==
 
 sentence-case@^3.0.4:
   version "3.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1286,125 +1286,250 @@
   resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.25.2.tgz#b87036f644f572efb2b3c75746c97d1d2d87ace8"
   integrity sha512-wCIboOL2yXZym2cgm6mlA742s9QeJ8DjGVaL39dLN4rRwrOgOyYSnOaFPhKZGLb2ngj4EyfAFjsNJwPXZvseag==
 
+"@esbuild/aix-ppc64@0.25.4":
+  version "0.25.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.25.4.tgz#830d6476cbbca0c005136af07303646b419f1162"
+  integrity sha512-1VCICWypeQKhVbE9oW/sJaAmjLxhVqacdkvPLEjwlttjfwENRSClS8EjBz0KzRyFSCPDIkuXW34Je/vk7zdB7Q==
+
 "@esbuild/android-arm64@0.25.2":
   version "0.25.2"
   resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.25.2.tgz#5ca7dc20a18f18960ad8d5e6ef5cf7b0a256e196"
   integrity sha512-5ZAX5xOmTligeBaeNEPnPaeEuah53Id2tX4c2CVP3JaROTH+j4fnfHCkr1PjXMd78hMst+TlkfKcW/DlTq0i4w==
+
+"@esbuild/android-arm64@0.25.4":
+  version "0.25.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.25.4.tgz#d11d4fc299224e729e2190cacadbcc00e7a9fd67"
+  integrity sha512-bBy69pgfhMGtCnwpC/x5QhfxAz/cBgQ9enbtwjf6V9lnPI/hMyT9iWpR1arm0l3kttTr4L0KSLpKmLp/ilKS9A==
 
 "@esbuild/android-arm@0.25.2":
   version "0.25.2"
   resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.25.2.tgz#3c49f607b7082cde70c6ce0c011c362c57a194ee"
   integrity sha512-NQhH7jFstVY5x8CKbcfa166GoV0EFkaPkCKBQkdPJFvo5u+nGXLEH/ooniLb3QI8Fk58YAx7nsPLozUWfCBOJA==
 
+"@esbuild/android-arm@0.25.4":
+  version "0.25.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.25.4.tgz#5660bd25080553dd2a28438f2a401a29959bd9b1"
+  integrity sha512-QNdQEps7DfFwE3hXiU4BZeOV68HHzYwGd0Nthhd3uCkkEKK7/R6MTgM0P7H7FAs5pU/DIWsviMmEGxEoxIZ+ZQ==
+
 "@esbuild/android-x64@0.25.2":
   version "0.25.2"
   resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.25.2.tgz#8a00147780016aff59e04f1036e7cb1b683859e2"
   integrity sha512-Ffcx+nnma8Sge4jzddPHCZVRvIfQ0kMsUsCMcJRHkGJ1cDmhe4SsrYIjLUKn1xpHZybmOqCWwB0zQvsjdEHtkg==
+
+"@esbuild/android-x64@0.25.4":
+  version "0.25.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.25.4.tgz#18ddde705bf984e8cd9efec54e199ac18bc7bee1"
+  integrity sha512-TVhdVtQIFuVpIIR282btcGC2oGQoSfZfmBdTip2anCaVYcqWlZXGcdcKIUklfX2wj0JklNYgz39OBqh2cqXvcQ==
 
 "@esbuild/darwin-arm64@0.25.2":
   version "0.25.2"
   resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.25.2.tgz#486efe7599a8d90a27780f2bb0318d9a85c6c423"
   integrity sha512-MpM6LUVTXAzOvN4KbjzU/q5smzryuoNjlriAIx+06RpecwCkL9JpenNzpKd2YMzLJFOdPqBpuub6eVRP5IgiSA==
 
+"@esbuild/darwin-arm64@0.25.4":
+  version "0.25.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.25.4.tgz#b0b7fb55db8fc6f5de5a0207ae986eb9c4766e67"
+  integrity sha512-Y1giCfM4nlHDWEfSckMzeWNdQS31BQGs9/rouw6Ub91tkK79aIMTH3q9xHvzH8d0wDru5Ci0kWB8b3up/nl16g==
+
 "@esbuild/darwin-x64@0.25.2":
   version "0.25.2"
   resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.25.2.tgz#95ee222aacf668c7a4f3d7ee87b3240a51baf374"
   integrity sha512-5eRPrTX7wFyuWe8FqEFPG2cU0+butQQVNcT4sVipqjLYQjjh8a8+vUTfgBKM88ObB85ahsnTwF7PSIt6PG+QkA==
+
+"@esbuild/darwin-x64@0.25.4":
+  version "0.25.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.25.4.tgz#e6813fdeba0bba356cb350a4b80543fbe66bf26f"
+  integrity sha512-CJsry8ZGM5VFVeyUYB3cdKpd/H69PYez4eJh1W/t38vzutdjEjtP7hB6eLKBoOdxcAlCtEYHzQ/PJ/oU9I4u0A==
 
 "@esbuild/freebsd-arm64@0.25.2":
   version "0.25.2"
   resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.2.tgz#67efceda8554b6fc6a43476feba068fb37fa2ef6"
   integrity sha512-mLwm4vXKiQ2UTSX4+ImyiPdiHjiZhIaE9QvC7sw0tZ6HoNMjYAqQpGyui5VRIi5sGd+uWq940gdCbY3VLvsO1w==
 
+"@esbuild/freebsd-arm64@0.25.4":
+  version "0.25.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.4.tgz#dc11a73d3ccdc308567b908b43c6698e850759be"
+  integrity sha512-yYq+39NlTRzU2XmoPW4l5Ifpl9fqSk0nAJYM/V/WUGPEFfek1epLHJIkTQM6bBs1swApjO5nWgvr843g6TjxuQ==
+
 "@esbuild/freebsd-x64@0.25.2":
   version "0.25.2"
   resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.25.2.tgz#88a9d7ecdd3adadbfe5227c2122d24816959b809"
   integrity sha512-6qyyn6TjayJSwGpm8J9QYYGQcRgc90nmfdUb0O7pp1s4lTY+9D0H9O02v5JqGApUyiHOtkz6+1hZNvNtEhbwRQ==
+
+"@esbuild/freebsd-x64@0.25.4":
+  version "0.25.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.25.4.tgz#91da08db8bd1bff5f31924c57a81dab26e93a143"
+  integrity sha512-0FgvOJ6UUMflsHSPLzdfDnnBBVoCDtBTVyn/MrWloUNvq/5SFmh13l3dvgRPkDihRxb77Y17MbqbCAa2strMQQ==
 
 "@esbuild/linux-arm64@0.25.2":
   version "0.25.2"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.25.2.tgz#87be1099b2bbe61282333b084737d46bc8308058"
   integrity sha512-gq/sjLsOyMT19I8obBISvhoYiZIAaGF8JpeXu1u8yPv8BE5HlWYobmlsfijFIZ9hIVGYkbdFhEqC0NvM4kNO0g==
 
+"@esbuild/linux-arm64@0.25.4":
+  version "0.25.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.25.4.tgz#efc15e45c945a082708f9a9f73bfa8d4db49728a"
+  integrity sha512-+89UsQTfXdmjIvZS6nUnOOLoXnkUTB9hR5QAeLrQdzOSWZvNSAXAtcRDHWtqAUtAmv7ZM1WPOOeSxDzzzMogiQ==
+
 "@esbuild/linux-arm@0.25.2":
   version "0.25.2"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.25.2.tgz#72a285b0fe64496e191fcad222185d7bf9f816f6"
   integrity sha512-UHBRgJcmjJv5oeQF8EpTRZs/1knq6loLxTsjc3nxO9eXAPDLcWW55flrMVc97qFPbmZP31ta1AZVUKQzKTzb0g==
+
+"@esbuild/linux-arm@0.25.4":
+  version "0.25.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.25.4.tgz#9b93c3e54ac49a2ede6f906e705d5d906f6db9e8"
+  integrity sha512-kro4c0P85GMfFYqW4TWOpvmF8rFShbWGnrLqlzp4X1TNWjRY3JMYUfDCtOxPKOIY8B0WC8HN51hGP4I4hz4AaQ==
 
 "@esbuild/linux-ia32@0.25.2":
   version "0.25.2"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.25.2.tgz#337a87a4c4dd48a832baed5cbb022be20809d737"
   integrity sha512-bBYCv9obgW2cBP+2ZWfjYTU+f5cxRoGGQ5SeDbYdFCAZpYWrfjjfYwvUpP8MlKbP0nwZ5gyOU/0aUzZ5HWPuvQ==
 
+"@esbuild/linux-ia32@0.25.4":
+  version "0.25.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.25.4.tgz#be8ef2c3e1d99fca2d25c416b297d00360623596"
+  integrity sha512-yTEjoapy8UP3rv8dB0ip3AfMpRbyhSN3+hY8mo/i4QXFeDxmiYbEKp3ZRjBKcOP862Ua4b1PDfwlvbuwY7hIGQ==
+
 "@esbuild/linux-loong64@0.25.2":
   version "0.25.2"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.25.2.tgz#1b81aa77103d6b8a8cfa7c094ed3d25c7579ba2a"
   integrity sha512-SHNGiKtvnU2dBlM5D8CXRFdd+6etgZ9dXfaPCeJtz+37PIUlixvlIhI23L5khKXs3DIzAn9V8v+qb1TRKrgT5w==
+
+"@esbuild/linux-loong64@0.25.4":
+  version "0.25.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.25.4.tgz#b0840a2707c3fc02eec288d3f9defa3827cd7a87"
+  integrity sha512-NeqqYkrcGzFwi6CGRGNMOjWGGSYOpqwCjS9fvaUlX5s3zwOtn1qwg1s2iE2svBe4Q/YOG1q6875lcAoQK/F4VA==
 
 "@esbuild/linux-mips64el@0.25.2":
   version "0.25.2"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.25.2.tgz#afbe380b6992e7459bf7c2c3b9556633b2e47f30"
   integrity sha512-hDDRlzE6rPeoj+5fsADqdUZl1OzqDYow4TB4Y/3PlKBD0ph1e6uPHzIQcv2Z65u2K0kpeByIyAjCmjn1hJgG0Q==
 
+"@esbuild/linux-mips64el@0.25.4":
+  version "0.25.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.25.4.tgz#2a198e5a458c9f0e75881a4e63d26ba0cf9df39f"
+  integrity sha512-IcvTlF9dtLrfL/M8WgNI/qJYBENP3ekgsHbYUIzEzq5XJzzVEV/fXY9WFPfEEXmu3ck2qJP8LG/p3Q8f7Zc2Xg==
+
 "@esbuild/linux-ppc64@0.25.2":
   version "0.25.2"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.25.2.tgz#6bf8695cab8a2b135cca1aa555226dc932d52067"
   integrity sha512-tsHu2RRSWzipmUi9UBDEzc0nLc4HtpZEI5Ba+Omms5456x5WaNuiG3u7xh5AO6sipnJ9r4cRWQB2tUjPyIkc6g==
+
+"@esbuild/linux-ppc64@0.25.4":
+  version "0.25.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.25.4.tgz#64f4ae0b923d7dd72fb860b9b22edb42007cf8f5"
+  integrity sha512-HOy0aLTJTVtoTeGZh4HSXaO6M95qu4k5lJcH4gxv56iaycfz1S8GO/5Jh6X4Y1YiI0h7cRyLi+HixMR+88swag==
 
 "@esbuild/linux-riscv64@0.25.2":
   version "0.25.2"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.25.2.tgz#43c2d67a1a39199fb06ba978aebb44992d7becc3"
   integrity sha512-k4LtpgV7NJQOml/10uPU0s4SAXGnowi5qBSjaLWMojNCUICNu7TshqHLAEbkBdAszL5TabfvQ48kK84hyFzjnw==
 
+"@esbuild/linux-riscv64@0.25.4":
+  version "0.25.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.25.4.tgz#fb2844b11fdddd39e29d291c7cf80f99b0d5158d"
+  integrity sha512-i8JUDAufpz9jOzo4yIShCTcXzS07vEgWzyX3NH2G7LEFVgrLEhjwL3ajFE4fZI3I4ZgiM7JH3GQ7ReObROvSUA==
+
 "@esbuild/linux-s390x@0.25.2":
   version "0.25.2"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.25.2.tgz#419e25737ec815c6dce2cd20d026e347cbb7a602"
   integrity sha512-GRa4IshOdvKY7M/rDpRR3gkiTNp34M0eLTaC1a08gNrh4u488aPhuZOCpkF6+2wl3zAN7L7XIpOFBhnaE3/Q8Q==
+
+"@esbuild/linux-s390x@0.25.4":
+  version "0.25.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.25.4.tgz#1466876e0aa3560c7673e63fdebc8278707bc750"
+  integrity sha512-jFnu+6UbLlzIjPQpWCNh5QtrcNfMLjgIavnwPQAfoGx4q17ocOU9MsQ2QVvFxwQoWpZT8DvTLooTvmOQXkO51g==
 
 "@esbuild/linux-x64@0.25.2":
   version "0.25.2"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.25.2.tgz#22451f6edbba84abe754a8cbd8528ff6e28d9bcb"
   integrity sha512-QInHERlqpTTZ4FRB0fROQWXcYRD64lAoiegezDunLpalZMjcUcld3YzZmVJ2H/Cp0wJRZ8Xtjtj0cEHhYc/uUg==
 
+"@esbuild/linux-x64@0.25.4":
+  version "0.25.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.25.4.tgz#c10fde899455db7cba5f11b3bccfa0e41bf4d0cd"
+  integrity sha512-6e0cvXwzOnVWJHq+mskP8DNSrKBr1bULBvnFLpc1KY+d+irZSgZ02TGse5FsafKS5jg2e4pbvK6TPXaF/A6+CA==
+
 "@esbuild/netbsd-arm64@0.25.2":
   version "0.25.2"
   resolved "https://registry.yarnpkg.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.2.tgz#744affd3b8d8236b08c5210d828b0698a62c58ac"
   integrity sha512-talAIBoY5M8vHc6EeI2WW9d/CkiO9MQJ0IOWX8hrLhxGbro/vBXJvaQXefW2cP0z0nQVTdQ/eNyGFV1GSKrxfw==
+
+"@esbuild/netbsd-arm64@0.25.4":
+  version "0.25.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.4.tgz#02e483fbcbe3f18f0b02612a941b77be76c111a4"
+  integrity sha512-vUnkBYxZW4hL/ie91hSqaSNjulOnYXE1VSLusnvHg2u3jewJBz3YzB9+oCw8DABeVqZGg94t9tyZFoHma8gWZQ==
 
 "@esbuild/netbsd-x64@0.25.2":
   version "0.25.2"
   resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.25.2.tgz#dbbe7521fd6d7352f34328d676af923fc0f8a78f"
   integrity sha512-voZT9Z+tpOxrvfKFyfDYPc4DO4rk06qamv1a/fkuzHpiVBMOhpjK+vBmWM8J1eiB3OLSMFYNaOaBNLXGChf5tg==
 
+"@esbuild/netbsd-x64@0.25.4":
+  version "0.25.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.25.4.tgz#ec401fb0b1ed0ac01d978564c5fc8634ed1dc2ed"
+  integrity sha512-XAg8pIQn5CzhOB8odIcAm42QsOfa98SBeKUdo4xa8OvX8LbMZqEtgeWE9P/Wxt7MlG2QqvjGths+nq48TrUiKw==
+
 "@esbuild/openbsd-arm64@0.25.2":
   version "0.25.2"
   resolved "https://registry.yarnpkg.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.2.tgz#f9caf987e3e0570500832b487ce3039ca648ce9f"
   integrity sha512-dcXYOC6NXOqcykeDlwId9kB6OkPUxOEqU+rkrYVqJbK2hagWOMrsTGsMr8+rW02M+d5Op5NNlgMmjzecaRf7Tg==
+
+"@esbuild/openbsd-arm64@0.25.4":
+  version "0.25.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.4.tgz#f272c2f41cfea1d91b93d487a51b5c5ca7a8c8c4"
+  integrity sha512-Ct2WcFEANlFDtp1nVAXSNBPDxyU+j7+tId//iHXU2f/lN5AmO4zLyhDcpR5Cz1r08mVxzt3Jpyt4PmXQ1O6+7A==
 
 "@esbuild/openbsd-x64@0.25.2":
   version "0.25.2"
   resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.25.2.tgz#d2bb6a0f8ffea7b394bb43dfccbb07cabd89f768"
   integrity sha512-t/TkWwahkH0Tsgoq1Ju7QfgGhArkGLkF1uYz8nQS/PPFlXbP5YgRpqQR3ARRiC2iXoLTWFxc6DJMSK10dVXluw==
 
+"@esbuild/openbsd-x64@0.25.4":
+  version "0.25.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.25.4.tgz#2e25950bc10fa9db1e5c868e3d50c44f7c150fd7"
+  integrity sha512-xAGGhyOQ9Otm1Xu8NT1ifGLnA6M3sJxZ6ixylb+vIUVzvvd6GOALpwQrYrtlPouMqd/vSbgehz6HaVk4+7Afhw==
+
 "@esbuild/sunos-x64@0.25.2":
   version "0.25.2"
   resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.25.2.tgz#49b437ed63fe333b92137b7a0c65a65852031afb"
   integrity sha512-cfZH1co2+imVdWCjd+D1gf9NjkchVhhdpgb1q5y6Hcv9TP6Zi9ZG/beI3ig8TvwT9lH9dlxLq5MQBBgwuj4xvA==
+
+"@esbuild/sunos-x64@0.25.4":
+  version "0.25.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.25.4.tgz#cd596fa65a67b3b7adc5ecd52d9f5733832e1abd"
+  integrity sha512-Mw+tzy4pp6wZEK0+Lwr76pWLjrtjmJyUB23tHKqEDP74R3q95luY/bXqXZeYl4NYlvwOqoRKlInQialgCKy67Q==
 
 "@esbuild/win32-arm64@0.25.2":
   version "0.25.2"
   resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.25.2.tgz#081424168463c7d6c7fb78f631aede0c104373cf"
   integrity sha512-7Loyjh+D/Nx/sOTzV8vfbB3GJuHdOQyrOryFdZvPHLf42Tk9ivBU5Aedi7iyX+x6rbn2Mh68T4qq1SDqJBQO5Q==
 
+"@esbuild/win32-arm64@0.25.4":
+  version "0.25.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.25.4.tgz#b4dbcb57b21eeaf8331e424c3999b89d8951dc88"
+  integrity sha512-AVUP428VQTSddguz9dO9ngb+E5aScyg7nOeJDrF1HPYu555gmza3bDGMPhmVXL8svDSoqPCsCPjb265yG/kLKQ==
+
 "@esbuild/win32-ia32@0.25.2":
   version "0.25.2"
   resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.25.2.tgz#3f9e87143ddd003133d21384944a6c6cadf9693f"
   integrity sha512-WRJgsz9un0nqZJ4MfhabxaD9Ft8KioqU3JMinOTvobbX6MOSUigSBlogP8QB3uxpJDsFS6yN+3FDBdqE5lg9kg==
 
+"@esbuild/win32-ia32@0.25.4":
+  version "0.25.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.25.4.tgz#410842e5d66d4ece1757634e297a87635eb82f7a"
+  integrity sha512-i1sW+1i+oWvQzSgfRcxxG2k4I9n3O9NRqy8U+uugaT2Dy7kLO9Y7wI72haOahxceMX8hZAzgGou1FhndRldxRg==
+
 "@esbuild/win32-x64@0.25.2":
   version "0.25.2"
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.25.2.tgz#839f72c2decd378f86b8f525e1979a97b920c67d"
   integrity sha512-kM3HKb16VIXZyIeVrM1ygYmZBKybX8N4p754bw390wGO3Tf2j4L2/WYL+4suWujpgf6GBYs3jv7TyUivdd05JA==
+
+"@esbuild/win32-x64@0.25.4":
+  version "0.25.4"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.25.4.tgz#0b17ec8a70b2385827d52314c1253160a0b9bacc"
+  integrity sha512-nOT2vZNw6hJ+z43oP1SPea/G/6AbN6X+bGNhNuq8NtRHy4wsMhw765IKLNmnjek7GvjWBYQ8Q5VBoYTFg9y1UQ==
 
 "@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.4.0":
   version "4.4.0"
@@ -2578,105 +2703,105 @@
     estree-walker "^2.0.2"
     picomatch "^2.3.1"
 
-"@rollup/rollup-android-arm-eabi@4.40.0":
-  version "4.40.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.40.0.tgz#d964ee8ce4d18acf9358f96adc408689b6e27fe3"
-  integrity sha512-+Fbls/diZ0RDerhE8kyC6hjADCXA1K4yVNlH0EYfd2XjyH0UGgzaQ8MlT0pCXAThfxv3QUAczHaL+qSv1E4/Cg==
+"@rollup/rollup-android-arm-eabi@4.40.2":
+  version "4.40.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.40.2.tgz#c228d00a41f0dbd6fb8b7ea819bbfbf1c1157a10"
+  integrity sha512-JkdNEq+DFxZfUwxvB58tHMHBHVgX23ew41g1OQinthJ+ryhdRk67O31S7sYw8u2lTjHUPFxwar07BBt1KHp/hg==
 
-"@rollup/rollup-android-arm64@4.40.0":
-  version "4.40.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.40.0.tgz#9b5e130ecc32a5fc1e96c09ff371743ee71a62d3"
-  integrity sha512-PPA6aEEsTPRz+/4xxAmaoWDqh67N7wFbgFUJGMnanCFs0TV99M0M8QhhaSCks+n6EbQoFvLQgYOGXxlMGQe/6w==
+"@rollup/rollup-android-arm64@4.40.2":
+  version "4.40.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.40.2.tgz#e2b38d0c912169fd55d7e38d723aada208d37256"
+  integrity sha512-13unNoZ8NzUmnndhPTkWPWbX3vtHodYmy+I9kuLxN+F+l+x3LdVF7UCu8TWVMt1POHLh6oDHhnOA04n8oJZhBw==
 
-"@rollup/rollup-darwin-arm64@4.40.0":
-  version "4.40.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.40.0.tgz#ef439182c739b20b3c4398cfc03e3c1249ac8903"
-  integrity sha512-GwYOcOakYHdfnjjKwqpTGgn5a6cUX7+Ra2HeNj/GdXvO2VJOOXCiYYlRFU4CubFM67EhbmzLOmACKEfvp3J1kQ==
+"@rollup/rollup-darwin-arm64@4.40.2":
+  version "4.40.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.40.2.tgz#1fddb3690f2ae33df16d334c613377f05abe4878"
+  integrity sha512-Gzf1Hn2Aoe8VZzevHostPX23U7N5+4D36WJNHK88NZHCJr7aVMG4fadqkIf72eqVPGjGc0HJHNuUaUcxiR+N/w==
 
-"@rollup/rollup-darwin-x64@4.40.0":
-  version "4.40.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.40.0.tgz#d7380c1531ab0420ca3be16f17018ef72dd3d504"
-  integrity sha512-CoLEGJ+2eheqD9KBSxmma6ld01czS52Iw0e2qMZNpPDlf7Z9mj8xmMemxEucinev4LgHalDPczMyxzbq+Q+EtA==
+"@rollup/rollup-darwin-x64@4.40.2":
+  version "4.40.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.40.2.tgz#818298d11c8109e1112590165142f14be24b396d"
+  integrity sha512-47N4hxa01a4x6XnJoskMKTS8XZ0CZMd8YTbINbi+w03A2w4j1RTlnGHOz/P0+Bg1LaVL6ufZyNprSg+fW5nYQQ==
 
-"@rollup/rollup-freebsd-arm64@4.40.0":
-  version "4.40.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.40.0.tgz#cbcbd7248823c6b430ce543c59906dd3c6df0936"
-  integrity sha512-r7yGiS4HN/kibvESzmrOB/PxKMhPTlz+FcGvoUIKYoTyGd5toHp48g1uZy1o1xQvybwwpqpe010JrcGG2s5nkg==
+"@rollup/rollup-freebsd-arm64@4.40.2":
+  version "4.40.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.40.2.tgz#91a28dc527d5bed7f9ecf0e054297b3012e19618"
+  integrity sha512-8t6aL4MD+rXSHHZUR1z19+9OFJ2rl1wGKvckN47XFRVO+QL/dUSpKA2SLRo4vMg7ELA8pzGpC+W9OEd1Z/ZqoQ==
 
-"@rollup/rollup-freebsd-x64@4.40.0":
-  version "4.40.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.40.0.tgz#96bf6ff875bab5219c3472c95fa6eb992586a93b"
-  integrity sha512-mVDxzlf0oLzV3oZOr0SMJ0lSDd3xC4CmnWJ8Val8isp9jRGl5Dq//LLDSPFrasS7pSm6m5xAcKaw3sHXhBjoRw==
+"@rollup/rollup-freebsd-x64@4.40.2":
+  version "4.40.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.40.2.tgz#28acadefa76b5c7bede1576e065b51d335c62c62"
+  integrity sha512-C+AyHBzfpsOEYRFjztcYUFsH4S7UsE9cDtHCtma5BK8+ydOZYgMmWg1d/4KBytQspJCld8ZIujFMAdKG1xyr4Q==
 
-"@rollup/rollup-linux-arm-gnueabihf@4.40.0":
-  version "4.40.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.40.0.tgz#d80cd62ce6d40f8e611008d8dbf03b5e6bbf009c"
-  integrity sha512-y/qUMOpJxBMy8xCXD++jeu8t7kzjlOCkoxxajL58G62PJGBZVl/Gwpm7JK9+YvlB701rcQTzjUZ1JgUoPTnoQA==
+"@rollup/rollup-linux-arm-gnueabihf@4.40.2":
+  version "4.40.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.40.2.tgz#819691464179cbcd9a9f9d3dc7617954840c6186"
+  integrity sha512-de6TFZYIvJwRNjmW3+gaXiZ2DaWL5D5yGmSYzkdzjBDS3W+B9JQ48oZEsmMvemqjtAFzE16DIBLqd6IQQRuG9Q==
 
-"@rollup/rollup-linux-arm-musleabihf@4.40.0":
-  version "4.40.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.40.0.tgz#75440cfc1e8d0f87a239b4c31dfeaf4719b656b7"
-  integrity sha512-GoCsPibtVdJFPv/BOIvBKO/XmwZLwaNWdyD8TKlXuqp0veo2sHE+A/vpMQ5iSArRUz/uaoj4h5S6Pn0+PdhRjg==
+"@rollup/rollup-linux-arm-musleabihf@4.40.2":
+  version "4.40.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.40.2.tgz#d149207039e4189e267e8724050388effc80d704"
+  integrity sha512-urjaEZubdIkacKc930hUDOfQPysezKla/O9qV+O89enqsqUmQm8Xj8O/vh0gHg4LYfv7Y7UsE3QjzLQzDYN1qg==
 
-"@rollup/rollup-linux-arm64-gnu@4.40.0":
-  version "4.40.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.40.0.tgz#ac527485ecbb619247fb08253ec8c551a0712e7c"
-  integrity sha512-L5ZLphTjjAD9leJzSLI7rr8fNqJMlGDKlazW2tX4IUF9P7R5TMQPElpH82Q7eNIDQnQlAyiNVfRPfP2vM5Avvg==
+"@rollup/rollup-linux-arm64-gnu@4.40.2":
+  version "4.40.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.40.2.tgz#fa72ebddb729c3c6d88973242f1a2153c83e86ec"
+  integrity sha512-KlE8IC0HFOC33taNt1zR8qNlBYHj31qGT1UqWqtvR/+NuCVhfufAq9fxO8BMFC22Wu0rxOwGVWxtCMvZVLmhQg==
 
-"@rollup/rollup-linux-arm64-musl@4.40.0":
-  version "4.40.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.40.0.tgz#74d2b5cb11cf714cd7d1682e7c8b39140e908552"
-  integrity sha512-ATZvCRGCDtv1Y4gpDIXsS+wfFeFuLwVxyUBSLawjgXK2tRE6fnsQEkE4csQQYWlBlsFztRzCnBvWVfcae/1qxQ==
+"@rollup/rollup-linux-arm64-musl@4.40.2":
+  version "4.40.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.40.2.tgz#2054216e34469ab8765588ebf343d531fc3c9228"
+  integrity sha512-j8CgxvfM0kbnhu4XgjnCWJQyyBOeBI1Zq91Z850aUddUmPeQvuAy6OiMdPS46gNFgy8gN1xkYyLgwLYZG3rBOg==
 
-"@rollup/rollup-linux-loongarch64-gnu@4.40.0":
-  version "4.40.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.40.0.tgz#a0a310e51da0b5fea0e944b0abd4be899819aef6"
-  integrity sha512-wG9e2XtIhd++QugU5MD9i7OnpaVb08ji3P1y/hNbxrQ3sYEelKJOq1UJ5dXczeo6Hj2rfDEL5GdtkMSVLa/AOg==
+"@rollup/rollup-linux-loongarch64-gnu@4.40.2":
+  version "4.40.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.40.2.tgz#818de242291841afbfc483a84f11e9c7a11959bc"
+  integrity sha512-Ybc/1qUampKuRF4tQXc7G7QY9YRyeVSykfK36Y5Qc5dmrIxwFhrOzqaVTNoZygqZ1ZieSWTibfFhQ5qK8jpWxw==
 
-"@rollup/rollup-linux-powerpc64le-gnu@4.40.0":
-  version "4.40.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.40.0.tgz#4077e2862b0ac9f61916d6b474d988171bd43b83"
-  integrity sha512-vgXfWmj0f3jAUvC7TZSU/m/cOE558ILWDzS7jBhiCAFpY2WEBn5jqgbqvmzlMjtp8KlLcBlXVD2mkTSEQE6Ixw==
+"@rollup/rollup-linux-powerpc64le-gnu@4.40.2":
+  version "4.40.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.40.2.tgz#0bb4cb8fc4a2c635f68c1208c924b2145eb647cb"
+  integrity sha512-3FCIrnrt03CCsZqSYAOW/k9n625pjpuMzVfeI+ZBUSDT3MVIFDSPfSUgIl9FqUftxcUXInvFah79hE1c9abD+Q==
 
-"@rollup/rollup-linux-riscv64-gnu@4.40.0":
-  version "4.40.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.40.0.tgz#5812a1a7a2f9581cbe12597307cc7ba3321cf2f3"
-  integrity sha512-uJkYTugqtPZBS3Z136arevt/FsKTF/J9dEMTX/cwR7lsAW4bShzI2R0pJVw+hcBTWF4dxVckYh72Hk3/hWNKvA==
+"@rollup/rollup-linux-riscv64-gnu@4.40.2":
+  version "4.40.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.40.2.tgz#4b3b8e541b7b13e447ae07774217d98c06f6926d"
+  integrity sha512-QNU7BFHEvHMp2ESSY3SozIkBPaPBDTsfVNGx3Xhv+TdvWXFGOSH2NJvhD1zKAT6AyuuErJgbdvaJhYVhVqrWTg==
 
-"@rollup/rollup-linux-riscv64-musl@4.40.0":
-  version "4.40.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.40.0.tgz#973aaaf4adef4531375c36616de4e01647f90039"
-  integrity sha512-rKmSj6EXQRnhSkE22+WvrqOqRtk733x3p5sWpZilhmjnkHkpeCgWsFFo0dGnUGeA+OZjRl3+VYq+HyCOEuwcxQ==
+"@rollup/rollup-linux-riscv64-musl@4.40.2":
+  version "4.40.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.40.2.tgz#e065405e67d8bd64a7d0126c931bd9f03910817f"
+  integrity sha512-5W6vNYkhgfh7URiXTO1E9a0cy4fSgfE4+Hl5agb/U1sa0kjOLMLC1wObxwKxecE17j0URxuTrYZZME4/VH57Hg==
 
-"@rollup/rollup-linux-s390x-gnu@4.40.0":
-  version "4.40.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.40.0.tgz#9bad59e907ba5bfcf3e9dbd0247dfe583112f70b"
-  integrity sha512-SpnYlAfKPOoVsQqmTFJ0usx0z84bzGOS9anAC0AZ3rdSo3snecihbhFTlJZ8XMwzqAcodjFU4+/SM311dqE5Sw==
+"@rollup/rollup-linux-s390x-gnu@4.40.2":
+  version "4.40.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.40.2.tgz#dda3265bbbfe16a5d0089168fd07f5ebb2a866fe"
+  integrity sha512-B7LKIz+0+p348JoAL4X/YxGx9zOx3sR+o6Hj15Y3aaApNfAshK8+mWZEf759DXfRLeL2vg5LYJBB7DdcleYCoQ==
 
-"@rollup/rollup-linux-x64-gnu@4.40.0":
-  version "4.40.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.40.0.tgz#68b045a720bd9b4d905f462b997590c2190a6de0"
-  integrity sha512-RcDGMtqF9EFN8i2RYN2W+64CdHruJ5rPqrlYw+cgM3uOVPSsnAQps7cpjXe9be/yDp8UC7VLoCoKC8J3Kn2FkQ==
+"@rollup/rollup-linux-x64-gnu@4.40.2":
+  version "4.40.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.40.2.tgz#90993269b8b995b4067b7b9d72ff1c360ef90a17"
+  integrity sha512-lG7Xa+BmBNwpjmVUbmyKxdQJ3Q6whHjMjzQplOs5Z+Gj7mxPtWakGHqzMqNER68G67kmCX9qX57aRsW5V0VOng==
 
-"@rollup/rollup-linux-x64-musl@4.40.0":
-  version "4.40.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.40.0.tgz#8e703e2c2ad19ba7b2cb3d8c3a4ad11d4ee3a282"
-  integrity sha512-HZvjpiUmSNx5zFgwtQAV1GaGazT2RWvqeDi0hV+AtC8unqqDSsaFjPxfsO6qPtKRRg25SisACWnJ37Yio8ttaw==
+"@rollup/rollup-linux-x64-musl@4.40.2":
+  version "4.40.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.40.2.tgz#fdf5b09fd121eb8d977ebb0fda142c7c0167b8de"
+  integrity sha512-tD46wKHd+KJvsmije4bUskNuvWKFcTOIM9tZ/RrmIvcXnbi0YK/cKS9FzFtAm7Oxi2EhV5N2OpfFB348vSQRXA==
 
-"@rollup/rollup-win32-arm64-msvc@4.40.0":
-  version "4.40.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.40.0.tgz#c5bee19fa670ff5da5f066be6a58b4568e9c650b"
-  integrity sha512-UtZQQI5k/b8d7d3i9AZmA/t+Q4tk3hOC0tMOMSq2GlMYOfxbesxG4mJSeDp0EHs30N9bsfwUvs3zF4v/RzOeTQ==
+"@rollup/rollup-win32-arm64-msvc@4.40.2":
+  version "4.40.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.40.2.tgz#6397e1e012db64dfecfed0774cb9fcf89503d716"
+  integrity sha512-Bjv/HG8RRWLNkXwQQemdsWw4Mg+IJ29LK+bJPW2SCzPKOUaMmPEppQlu/Fqk1d7+DX3V7JbFdbkh/NMmurT6Pg==
 
-"@rollup/rollup-win32-ia32-msvc@4.40.0":
-  version "4.40.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.40.0.tgz#846e02c17044bd922f6f483a3b4d36aac6e2b921"
-  integrity sha512-+m03kvI2f5syIqHXCZLPVYplP8pQch9JHyXKZ3AGMKlg8dCyr2PKHjwRLiW53LTrN/Nc3EqHOKxUxzoSPdKddA==
+"@rollup/rollup-win32-ia32-msvc@4.40.2":
+  version "4.40.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.40.2.tgz#df0991464a52a35506103fe18d29913bf8798a0c"
+  integrity sha512-dt1llVSGEsGKvzeIO76HToiYPNPYPkmjhMHhP00T9S4rDern8P2ZWvWAQUEJ+R1UdMWJ/42i/QqJ2WV765GZcA==
 
-"@rollup/rollup-win32-x64-msvc@4.40.0":
-  version "4.40.0"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.40.0.tgz#fd92d31a2931483c25677b9c6698106490cbbc76"
-  integrity sha512-lpPE1cLfP5oPzVjKMx10pgBmKELQnFJXHgvtHCtuJWOv8MxqdEIMNtgHgBFf7Ea2/7EuVwa9fodWUfXAlXZLZQ==
+"@rollup/rollup-win32-x64-msvc@4.40.2":
+  version "4.40.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.40.2.tgz#8dae04d01a2cbd84d6297d99356674c6b993f0fc"
+  integrity sha512-bwspbWB04XJpeElvsp+DCylKfF4trJDa2Y9Go8O6A7YLX2LIKGcNK/CYImJN6ZP4DcuOHB4Utl3iCbnR62DudA==
 
 "@sentry-internal/browser-utils@8.33.1":
   version "8.33.1"
@@ -3759,22 +3884,22 @@
     chai "^5.1.1"
     tinyrainbow "^1.2.0"
 
-"@vitest/expect@3.1.1":
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@vitest/expect/-/expect-3.1.1.tgz#d64ddfdcf9e877d805e1eee67bd845bf0708c6c2"
-  integrity sha512-q/zjrW9lgynctNbwvFtQkGK9+vvHA5UzVi2V8APrp1C6fG6/MuYYkmlx4FubuqLycCeSdHD5aadWfua/Vr0EUA==
+"@vitest/expect@3.1.3":
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/@vitest/expect/-/expect-3.1.3.tgz#bbca175cd2f23d7de9448a215baed8f3d7abd7b7"
+  integrity sha512-7FTQQuuLKmN1Ig/h+h/GO+44Q1IlglPlR2es4ab7Yvfx+Uk5xsv+Ykk+MEt/M2Yn/xGmzaLKxGw2lgy2bwuYqg==
   dependencies:
-    "@vitest/spy" "3.1.1"
-    "@vitest/utils" "3.1.1"
+    "@vitest/spy" "3.1.3"
+    "@vitest/utils" "3.1.3"
     chai "^5.2.0"
     tinyrainbow "^2.0.0"
 
-"@vitest/mocker@3.1.1":
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@vitest/mocker/-/mocker-3.1.1.tgz#7689d99f87498684c71e9fe9defdbd13ffb7f1ac"
-  integrity sha512-bmpJJm7Y7i9BBELlLuuM1J1Q6EQ6K5Ye4wcyOpOMXMcePYKSIYlpcrCm4l/O6ja4VJA5G2aMJiuZkZdnxlC3SA==
+"@vitest/mocker@3.1.3":
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/@vitest/mocker/-/mocker-3.1.3.tgz#121d0f2fcca20c9ccada9e2d6e761f7fc687f4ce"
+  integrity sha512-PJbLjonJK82uCWHjzgBJZuR7zmAOrSvKk1QBxrennDIgtH4uK0TB1PvYmc0XBCigxxtiAVPfWtAdy4lpz8SQGQ==
   dependencies:
-    "@vitest/spy" "3.1.1"
+    "@vitest/spy" "3.1.3"
     estree-walker "^3.0.3"
     magic-string "^0.30.17"
 
@@ -3792,27 +3917,27 @@
   dependencies:
     tinyrainbow "^1.2.0"
 
-"@vitest/pretty-format@3.1.1", "@vitest/pretty-format@^3.1.1":
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@vitest/pretty-format/-/pretty-format-3.1.1.tgz#5b4d577771daccfced47baf3bf026ad59b52c283"
-  integrity sha512-dg0CIzNx+hMMYfNmSqJlLSXEmnNhMswcn3sXO7Tpldr0LiGmg3eXdLLhwkv2ZqgHb/d5xg5F7ezNFRA1fA13yA==
+"@vitest/pretty-format@3.1.3", "@vitest/pretty-format@^3.1.3":
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/@vitest/pretty-format/-/pretty-format-3.1.3.tgz#760b9eab5f253d7d2e7dcd28ef34570f584023d4"
+  integrity sha512-i6FDiBeJUGLDKADw2Gb01UtUNb12yyXAqC/mmRWuYl+m/U9GS7s8us5ONmGkGpUUo7/iAYzI2ePVfOZTYvUifA==
   dependencies:
     tinyrainbow "^2.0.0"
 
-"@vitest/runner@3.1.1":
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@vitest/runner/-/runner-3.1.1.tgz#76b598700737089d66c74272b2e1c94ca2891a49"
-  integrity sha512-X/d46qzJuEDO8ueyjtKfxffiXraPRfmYasoC4i5+mlLEJ10UvPb0XH5M9C3gWuxd7BAQhpK42cJgJtq53YnWVA==
+"@vitest/runner@3.1.3":
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/@vitest/runner/-/runner-3.1.3.tgz#b268fa90fca38fab363f1107f057c0a2a141ee45"
+  integrity sha512-Tae+ogtlNfFei5DggOsSUvkIaSuVywujMj6HzR97AHK6XK8i3BuVyIifWAm/sE3a15lF5RH9yQIrbXYuo0IFyA==
   dependencies:
-    "@vitest/utils" "3.1.1"
+    "@vitest/utils" "3.1.3"
     pathe "^2.0.3"
 
-"@vitest/snapshot@3.1.1":
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@vitest/snapshot/-/snapshot-3.1.1.tgz#42b6aa0d0e2b3b48b95a5c76efdcc66a44cb11f3"
-  integrity sha512-bByMwaVWe/+1WDf9exFxWWgAixelSdiwo2p33tpqIlM14vW7PRV5ppayVXtfycqze4Qhtwag5sVhX400MLBOOw==
+"@vitest/snapshot@3.1.3":
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/@vitest/snapshot/-/snapshot-3.1.3.tgz#39a8f9f8c6ba732ffde59adeacf0a549bef11e76"
+  integrity sha512-XVa5OPNTYUsyqG9skuUkFzAeFnEzDp8hQu7kZ0N25B1+6KjGm4hWLtURyBbsIAOekfWQ7Wuz/N/XXzgYO3deWQ==
   dependencies:
-    "@vitest/pretty-format" "3.1.1"
+    "@vitest/pretty-format" "3.1.3"
     magic-string "^0.30.17"
     pathe "^2.0.3"
 
@@ -3823,10 +3948,10 @@
   dependencies:
     tinyspy "^3.0.0"
 
-"@vitest/spy@3.1.1":
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@vitest/spy/-/spy-3.1.1.tgz#deca0b025e151302ab514f38390fd7777e294837"
-  integrity sha512-+EmrUOOXbKzLkTDwlsc/xrwOlPDXyVk3Z6P6K4oiCndxz7YLpp/0R0UsWVOKT0IXWjjBJuSMk6D27qipaupcvQ==
+"@vitest/spy@3.1.3":
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/@vitest/spy/-/spy-3.1.3.tgz#ca81e2b4f0c3d6c75f35defa77c3336f39c8f605"
+  integrity sha512-x6w+ctOEmEXdWaa6TO4ilb7l9DxPR5bwEb6hILKuxfU1NqWT2mpJD9NJN7t3OTfxmVlOMrvtoFJGdgyzZ605lQ==
   dependencies:
     tinyspy "^3.0.2"
 
@@ -3840,12 +3965,12 @@
     loupe "^3.1.1"
     tinyrainbow "^1.2.0"
 
-"@vitest/utils@3.1.1":
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@vitest/utils/-/utils-3.1.1.tgz#2893c30219ab6bdf109f07ce5cd287fe8058438d"
-  integrity sha512-1XIjflyaU2k3HMArJ50bwSh3wKWPD6Q47wz/NUSmRV0zNywPc4w79ARjg/i/aNINHwA+mIALhUVqD9/aUvZNgg==
+"@vitest/utils@3.1.3":
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/@vitest/utils/-/utils-3.1.3.tgz#4f31bdfd646cd82d30bfa730d7410cb59d529669"
+  integrity sha512-2Ltrpht4OmHO9+c/nmHtF09HWiyWdworqnHIwjfvDyWjuwKbdkcS9AnhsDn+8E2RM4x++foD1/tNuLPVvWG1Rg==
   dependencies:
-    "@vitest/pretty-format" "3.1.1"
+    "@vitest/pretty-format" "3.1.3"
     loupe "^3.1.3"
     tinyrainbow "^2.0.0"
 
@@ -5266,9 +5391,9 @@ detect-indent@^6.0.0:
   integrity sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==
 
 detect-libc@^2.0.0:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.0.3.tgz#f0cd503b40f9939b894697d19ad50895e30cf700"
-  integrity sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.0.4.tgz#f04715b8ba815e53b4d8109655b6508a6865a7e8"
+  integrity sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==
 
 detect-newline@^3.0.0:
   version "3.1.0"
@@ -5554,10 +5679,10 @@ es-iterator-helpers@^1.0.19:
     iterator.prototype "^1.1.2"
     safe-array-concat "^1.1.2"
 
-es-module-lexer@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.6.0.tgz#da49f587fd9e68ee2404fe4e256c0c7d3a81be21"
-  integrity sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==
+es-module-lexer@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.7.0.tgz#9159601561880a85f2734560a9099b2c31e5372a"
+  integrity sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==
 
 es-object-atoms@^1.0.0, es-object-atoms@^1.1.1:
   version "1.1.1"
@@ -5609,7 +5734,7 @@ esbuild-register@^3.5.0:
   dependencies:
     debug "^4.3.4"
 
-"esbuild@^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0", esbuild@^0.25.0:
+"esbuild@^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0":
   version "0.25.2"
   resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.25.2.tgz#55a1d9ebcb3aa2f95e8bba9e900c1a5061bc168b"
   integrity sha512-16854zccKPnC+toMywC+uKNeYSv+/eXkevRAfwRD/G9Cleq66m8XFIrigkbvauLLlCfDL45Q2cWegSg53gGBnQ==
@@ -5639,6 +5764,37 @@ esbuild-register@^3.5.0:
     "@esbuild/win32-arm64" "0.25.2"
     "@esbuild/win32-ia32" "0.25.2"
     "@esbuild/win32-x64" "0.25.2"
+
+esbuild@^0.25.0:
+  version "0.25.4"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.25.4.tgz#bb9a16334d4ef2c33c7301a924b8b863351a0854"
+  integrity sha512-8pgjLUcUjcgDg+2Q4NYXnPbo/vncAY4UmyaCm0jZevERqCHZIaWwdJHkf8XQtu4AxSKCdvrUbT0XUr1IdZzI8Q==
+  optionalDependencies:
+    "@esbuild/aix-ppc64" "0.25.4"
+    "@esbuild/android-arm" "0.25.4"
+    "@esbuild/android-arm64" "0.25.4"
+    "@esbuild/android-x64" "0.25.4"
+    "@esbuild/darwin-arm64" "0.25.4"
+    "@esbuild/darwin-x64" "0.25.4"
+    "@esbuild/freebsd-arm64" "0.25.4"
+    "@esbuild/freebsd-x64" "0.25.4"
+    "@esbuild/linux-arm" "0.25.4"
+    "@esbuild/linux-arm64" "0.25.4"
+    "@esbuild/linux-ia32" "0.25.4"
+    "@esbuild/linux-loong64" "0.25.4"
+    "@esbuild/linux-mips64el" "0.25.4"
+    "@esbuild/linux-ppc64" "0.25.4"
+    "@esbuild/linux-riscv64" "0.25.4"
+    "@esbuild/linux-s390x" "0.25.4"
+    "@esbuild/linux-x64" "0.25.4"
+    "@esbuild/netbsd-arm64" "0.25.4"
+    "@esbuild/netbsd-x64" "0.25.4"
+    "@esbuild/openbsd-arm64" "0.25.4"
+    "@esbuild/openbsd-x64" "0.25.4"
+    "@esbuild/sunos-x64" "0.25.4"
+    "@esbuild/win32-arm64" "0.25.4"
+    "@esbuild/win32-ia32" "0.25.4"
+    "@esbuild/win32-x64" "0.25.4"
 
 escalade@^3.1.1, escalade@^3.2.0:
   version "3.2.0"
@@ -5956,7 +6112,7 @@ expect-playwright@^0.8.0:
   resolved "https://registry.yarnpkg.com/expect-playwright/-/expect-playwright-0.8.0.tgz#6d4ebe0bdbdd3c1693d880d97153b96a129ae4e8"
   integrity sha512-+kn8561vHAY+dt+0gMqqj1oY+g5xWrsuGMk4QGxotT2WS545nVqqjs37z6hrYfIuucwqthzwJfCJUEYqixyljg==
 
-expect-type@^1.2.0:
+expect-type@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/expect-type/-/expect-type-1.2.1.tgz#af76d8b357cf5fa76c41c09dafb79c549e75f71f"
   integrity sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw==
@@ -6046,7 +6202,7 @@ fd-package-json@^1.2.0:
   dependencies:
     walk-up-path "^3.0.1"
 
-fdir@^6.4.3, fdir@^6.4.4:
+fdir@^6.4.4:
   version "6.4.4"
   resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.4.4.tgz#1cfcf86f875a883e19a8fab53622cfe992e8d2f9"
   integrity sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==
@@ -8278,9 +8434,9 @@ mute-stream@0.0.8:
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
 nan@^2.17.0:
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.19.0.tgz#bb58122ad55a6c5bc973303908d5b16cfdd5a8c0"
-  integrity sha512-nO1xXxfh/RWNxfd/XPfbIfFk5vgLsAxUR9y5O0cHMJu/AW9U95JLXqthYHjEp+8gQ5p96K9jUp8nbVOxCdRbtw==
+  version "2.22.2"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.22.2.tgz#6b504fd029fb8f38c0990e52ad5c26772fdacfbb"
+  integrity sha512-DANghxFkS1plDdRsX0X9pm0Z6SJNN6gBdtXfanwoZ8hooC5gosGFSBGRYHUVPz1asKA/kMRqDRdHrluZ61SpBQ==
 
 nanoid@^3.1.32, nanoid@^3.3.8:
   version "3.3.11"
@@ -9408,32 +9564,32 @@ rollup-plugin-visualizer@^5.6.0:
     yargs "^17.3.1"
 
 rollup@^4.34.9:
-  version "4.40.0"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-4.40.0.tgz#13742a615f423ccba457554f006873d5a4de1920"
-  integrity sha512-Noe455xmA96nnqH5piFtLobsGbCij7Tu+tb3c1vYjNbTkfzGqXqQXG3wJaYXkRZuQ0vEYN4bhwg7QnIrqB5B+w==
+  version "4.40.2"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-4.40.2.tgz#778e88b7a197542682b3e318581f7697f55f0619"
+  integrity sha512-tfUOg6DTP4rhQ3VjOO6B4wyrJnGOX85requAXvqYTHsOgb2TFJdZ3aWpT8W2kPoypSGP7dZUyzxJ9ee4buM5Fg==
   dependencies:
     "@types/estree" "1.0.7"
   optionalDependencies:
-    "@rollup/rollup-android-arm-eabi" "4.40.0"
-    "@rollup/rollup-android-arm64" "4.40.0"
-    "@rollup/rollup-darwin-arm64" "4.40.0"
-    "@rollup/rollup-darwin-x64" "4.40.0"
-    "@rollup/rollup-freebsd-arm64" "4.40.0"
-    "@rollup/rollup-freebsd-x64" "4.40.0"
-    "@rollup/rollup-linux-arm-gnueabihf" "4.40.0"
-    "@rollup/rollup-linux-arm-musleabihf" "4.40.0"
-    "@rollup/rollup-linux-arm64-gnu" "4.40.0"
-    "@rollup/rollup-linux-arm64-musl" "4.40.0"
-    "@rollup/rollup-linux-loongarch64-gnu" "4.40.0"
-    "@rollup/rollup-linux-powerpc64le-gnu" "4.40.0"
-    "@rollup/rollup-linux-riscv64-gnu" "4.40.0"
-    "@rollup/rollup-linux-riscv64-musl" "4.40.0"
-    "@rollup/rollup-linux-s390x-gnu" "4.40.0"
-    "@rollup/rollup-linux-x64-gnu" "4.40.0"
-    "@rollup/rollup-linux-x64-musl" "4.40.0"
-    "@rollup/rollup-win32-arm64-msvc" "4.40.0"
-    "@rollup/rollup-win32-ia32-msvc" "4.40.0"
-    "@rollup/rollup-win32-x64-msvc" "4.40.0"
+    "@rollup/rollup-android-arm-eabi" "4.40.2"
+    "@rollup/rollup-android-arm64" "4.40.2"
+    "@rollup/rollup-darwin-arm64" "4.40.2"
+    "@rollup/rollup-darwin-x64" "4.40.2"
+    "@rollup/rollup-freebsd-arm64" "4.40.2"
+    "@rollup/rollup-freebsd-x64" "4.40.2"
+    "@rollup/rollup-linux-arm-gnueabihf" "4.40.2"
+    "@rollup/rollup-linux-arm-musleabihf" "4.40.2"
+    "@rollup/rollup-linux-arm64-gnu" "4.40.2"
+    "@rollup/rollup-linux-arm64-musl" "4.40.2"
+    "@rollup/rollup-linux-loongarch64-gnu" "4.40.2"
+    "@rollup/rollup-linux-powerpc64le-gnu" "4.40.2"
+    "@rollup/rollup-linux-riscv64-gnu" "4.40.2"
+    "@rollup/rollup-linux-riscv64-musl" "4.40.2"
+    "@rollup/rollup-linux-s390x-gnu" "4.40.2"
+    "@rollup/rollup-linux-x64-gnu" "4.40.2"
+    "@rollup/rollup-linux-x64-musl" "4.40.2"
+    "@rollup/rollup-win32-arm64-msvc" "4.40.2"
+    "@rollup/rollup-win32-ia32-msvc" "4.40.2"
+    "@rollup/rollup-win32-x64-msvc" "4.40.2"
     fsevents "~2.3.2"
 
 run-async@^2.4.0:
@@ -9511,7 +9667,12 @@ semver@^6.0.0, semver@^6.3.0, semver@^6.3.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.3.5, semver@^7.3.7, semver@^7.5.0, semver@^7.5.3, semver@^7.5.4, semver@^7.6.0, semver@^7.6.2:
+semver@^7.3.5:
+  version "7.7.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.2.tgz#67d99fdcd35cec21e6f8b87a7fd515a33f982b58"
+  integrity sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==
+
+semver@^7.3.7, semver@^7.5.0, semver@^7.5.3, semver@^7.5.4, semver@^7.6.0, semver@^7.6.2:
   version "7.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.1.tgz#abd5098d82b18c6c81f6074ff2647fd3e7220c9f"
   integrity sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==
@@ -9761,7 +9922,7 @@ stackback@0.0.2:
   resolved "https://registry.yarnpkg.com/stackback/-/stackback-0.0.2.tgz#1ac8a0d9483848d1695e418b6d031a3c3ce68e3b"
   integrity sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==
 
-std-env@^3.8.1:
+std-env@^3.9.0:
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/std-env/-/std-env-3.9.0.tgz#1a6f7243b339dca4c9fd55e1c7504c77ef23e8f1"
   integrity sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==
@@ -10094,7 +10255,7 @@ tinyexec@^0.3.2:
   resolved "https://registry.yarnpkg.com/tinyexec/-/tinyexec-0.3.2.tgz#941794e657a85e496577995c6eef66f53f42b3d2"
   integrity sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==
 
-tinyglobby@^0.2.12:
+tinyglobby@^0.2.13:
   version "0.2.13"
   resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.13.tgz#a0e46515ce6cbcd65331537e57484af5a7b2ff7e"
   integrity sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==
@@ -10500,14 +10661,14 @@ v8-to-istanbul@^9.0.1:
     "@types/istanbul-lib-coverage" "^2.0.1"
     convert-source-map "^2.0.0"
 
-vite-node@3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/vite-node/-/vite-node-3.1.1.tgz#ad186c07859a6e5fca7c7f563e55fb11b16557bc"
-  integrity sha512-V+IxPAE2FvXpTCHXyNem0M+gWm6J7eRyWPR6vYoG/Gl+IscNOjXzztUhimQgTxaAoUoj40Qqimaa0NLIOOAH4w==
+vite-node@3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/vite-node/-/vite-node-3.1.3.tgz#d021ced40b5a057305eaea9ce62c610c33b60a48"
+  integrity sha512-uHV4plJ2IxCl4u1up1FQRrqclylKAogbtBfOTwcuJ28xFi+89PZ57BRh+naIRvH70HPwxy5QHYzg1OrEaC7AbA==
   dependencies:
     cac "^6.7.14"
     debug "^4.4.0"
-    es-module-lexer "^1.6.0"
+    es-module-lexer "^1.7.0"
     pathe "^2.0.3"
     vite "^5.0.0 || ^6.0.0"
 
@@ -10521,43 +10682,44 @@ vite-plugin-mkcert@^1.17.8:
     picocolors "^1.1.1"
 
 "vite@^5.0.0 || ^6.0.0", vite@^6.2.0:
-  version "6.3.2"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-6.3.2.tgz#4c1bb01b1cea853686a191657bbc14272a038f0a"
-  integrity sha512-ZSvGOXKGceizRQIZSz7TGJ0pS3QLlVY/9hwxVh17W3re67je1RKYzFHivZ/t0tubU78Vkyb9WnHPENSBCzbckg==
+  version "6.3.5"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-6.3.5.tgz#fec73879013c9c0128c8d284504c6d19410d12a3"
+  integrity sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==
   dependencies:
     esbuild "^0.25.0"
-    fdir "^6.4.3"
+    fdir "^6.4.4"
     picomatch "^4.0.2"
     postcss "^8.5.3"
     rollup "^4.34.9"
-    tinyglobby "^0.2.12"
+    tinyglobby "^0.2.13"
   optionalDependencies:
     fsevents "~2.3.3"
 
 vitest@^3.0.7:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/vitest/-/vitest-3.1.1.tgz#39fa2356e510513fccdc5d16465a9fc066ef1fc6"
-  integrity sha512-kiZc/IYmKICeBAZr9DQ5rT7/6bD9G7uqQEki4fxazi1jdVl2mWGzedtBs5s6llz59yQhVb7FFY2MbHzHCnT79Q==
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/vitest/-/vitest-3.1.3.tgz#0b0b01932408cd3af61867f4468d28bd83406ffb"
+  integrity sha512-188iM4hAHQ0km23TN/adso1q5hhwKqUpv+Sd6p5sOuh6FhQnRNW3IsiIpvxqahtBabsJ2SLZgmGSpcYK4wQYJw==
   dependencies:
-    "@vitest/expect" "3.1.1"
-    "@vitest/mocker" "3.1.1"
-    "@vitest/pretty-format" "^3.1.1"
-    "@vitest/runner" "3.1.1"
-    "@vitest/snapshot" "3.1.1"
-    "@vitest/spy" "3.1.1"
-    "@vitest/utils" "3.1.1"
+    "@vitest/expect" "3.1.3"
+    "@vitest/mocker" "3.1.3"
+    "@vitest/pretty-format" "^3.1.3"
+    "@vitest/runner" "3.1.3"
+    "@vitest/snapshot" "3.1.3"
+    "@vitest/spy" "3.1.3"
+    "@vitest/utils" "3.1.3"
     chai "^5.2.0"
     debug "^4.4.0"
-    expect-type "^1.2.0"
+    expect-type "^1.2.1"
     magic-string "^0.30.17"
     pathe "^2.0.3"
-    std-env "^3.8.1"
+    std-env "^3.9.0"
     tinybench "^2.9.0"
     tinyexec "^0.3.2"
+    tinyglobby "^0.2.13"
     tinypool "^1.0.2"
     tinyrainbow "^2.0.0"
     vite "^5.0.0 || ^6.0.0"
-    vite-node "3.1.1"
+    vite-node "3.1.3"
     why-is-node-running "^2.3.0"
 
 void-elements@3.1.0:


### PR DESCRIPTION
## Description

Summary of changes:
Fixes but in interaction between auto fill and calculated values, as seen on income
This change means that display-only fields (where item.type === ItemType.Display) will always be autofilled, even if they're marked as dirty. Assumption is that display fields can't be edited by users so there's no need to preserve their value.

[//]: # 'remove if not applicable'
Depends on hmis-warehouse PR:

[//]: # 'remove if not applicable'
See GH issue

## Type of change
Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
