### PR TITLE
Prevent Admin link from appearing in CE envs

### DIFF
--- a/src/modules/admin/components/AdminDashboard.tsx
+++ b/src/modules/admin/components/AdminDashboard.tsx
@@ -19,6 +19,11 @@ import { AdminDashboardRoutes } from '@/routes/routes';
 import { RootPermissionsFragment } from '@/types/gqlTypes';
 
 const navItems: NavItem<RootPermissionsFragment>[] = [
+  // CAUTION: Don't use permissionMode: 'all' on any of these nav items.
+  // If we really need to, then we would also need a logical update to
+  // ToolbarMenu's use of PERMISSIONS_GRANTING_ADMIN_DASHBOARD_ACCESS.
+  // Currently, it gloms all the permissions mentioned here together
+  // and then checks using permissionMode: 'any'.
   {
     id: 'admin-nav',
     type: 'category',
@@ -46,11 +51,7 @@ const navItems: NavItem<RootPermissionsFragment>[] = [
         id: 'coordinated-entry',
         title: 'Coordinated Entry',
         path: AdminDashboardRoutes.COORDINATED_ENTRY,
-        permissions: [
-          'canAdministrateCoordinatedEntry',
-          'canViewCoordinatedEntry',
-        ],
-        permissionMode: 'all',
+        permissions: ['canAdministrateCoordinatedEntry'],
       },
     ],
   },


### PR DESCRIPTION
## Description

Note this bug isn't impacting any users, since it is hidden behind the CE feature flag 👍 

Summary of changes:
- This PR proposes removing usages of `permissionMode: all` on Admin dashboard nav items. (Rather than undertaking the complexity of processing nested permission statements with different permission modes when deciding whether to show the Admin link.)
- I'm pretty sure this is acceptable in both ce-enabled and non-ce-enabled environments, but would love a double check on that. Here's my thinking:
  - Unlike the [Project Referrals link](https://github.com/greenriver/hmis-frontend/pull/1164/files#diff-14b0fa4befa334dac4fabd8fc1a2518a725e7c794d45bfdb7d6985cae4552385R437-R441), which is governed by an existing permission `canViewUnits` that is granted to users in real environments, this one is governed by `canAdministrateCoordinatedEntry`, a brand-new CE permission that isn't granted to real users and won't even be visible until we turn CE on.
  - Broader conversation to get on the same page about: Do we plan to keep `canViewCoordinatedEntry` long term? I've been thinking of it as temporary, something we want to deprecate as soon as permissions and project-based CE config are in place. But is that really true, or are we going to need it (or some version of it) permanently? If we do, then it might be worthwhile to keep using it consistently to gate everything CE-related, which would point towards rejecting what this PR proposes in favor of actually implementing the nested-permissions logic I mentioned above.
  - See https://github.com/greenriver/hmis-frontend/pull/1164 for backstory

How to test: See bug reproduction instructions on linked ticket.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
