### PR TITLE
Only allow marking unit available as of today

### DIFF
--- a/src/modules/units/hooks/useUnitCeActions.tsx
+++ b/src/modules/units/hooks/useUnitCeActions.tsx
@@ -48,9 +48,8 @@ export const useUnitCeActions = ({
       const hasWorkflowTemplate = unit.workflowTemplateName;
 
       if (hasWorkflowTemplate && project.access.canManageUnits) {
-        // TODO(#7537) - canBeMarkedAvailable doesn't guarantee that there are no current occupants.
-        // Implement a confirmation modal enabling the user to specify the "available on date".
-        if (unit.canBeMarkedAvailable) {
+        if (unit.canBeMarkedAvailableToday) {
+          // TODO(#7537) - use canBeMarkedAvailable and implement a confirmation modal enabling the user to specify the "available on date".
           actions.push({
             title: 'Start Accepting Referrals',
             key: 'markAvailable',


### PR DESCRIPTION
## Description

Summary of changes:
- Previously: Thinking we would implement "available on date" for MVP, we supported individually marking a unit available that's already currently occupied. Bulk-mark-available is already only possible for units that are unoccupied, so that logic does not need to change.
- Now: Logic is the same for both bulk and individually marking a unit available. It can't be occupied.

[//]: # 'remove if not applicable'
How to test:
- Visit unit management page
- For a unit that is occupied as of today, open the 3-dots menu
- The "start accepting referrals" option should not appear

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Feature followup

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
