### PR TITLE
Fix button visibility bug

### DIFF
--- a/src/modules/units/components/UnitBulkActions.tsx
+++ b/src/modules/units/components/UnitBulkActions.tsx
@@ -34,14 +34,14 @@ interface Props {
   projectId: string;
   unitGroupId?: string;
   units: UnitTableRowFieldsFragment[];
-  ceEnabled?: boolean;
+  ceAvailabilityActionsEnabled?: boolean;
 }
 
 const UnitBulkActions: React.FC<Props> = ({
   projectId,
   unitGroupId,
   units,
-  ceEnabled = false,
+  ceAvailabilityActionsEnabled = false,
 }) => {
   // This component's philosophy is to let the user do what they are trying to
   // do as long as it's allowed on *any* of the units they have selected.
@@ -122,7 +122,7 @@ const UnitBulkActions: React.FC<Props> = ({
       flexWrap='wrap'
       sx={{ button: { width: 'auto' } }}
     >
-      {ceEnabled && (
+      {ceAvailabilityActionsEnabled && (
         <>
           <UnitBulkActionButton
             action='start'

--- a/src/modules/units/components/UnitGroupPage.tsx
+++ b/src/modules/units/components/UnitGroupPage.tsx
@@ -1,7 +1,7 @@
 import AddIcon from '@mui/icons-material/Add';
 import { Button, Grid, Paper, Stack } from '@mui/material';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import UnitManagementTable from './UnitManagementTable';
 
 import Loading from '@/components/elements/Loading';
@@ -31,6 +31,10 @@ const UnitGroupPage = () => {
   const [dialogOpen, setDialogOpen] = useState<boolean>(false);
 
   const { coordinatedEntryEnabled } = project;
+
+  const ceAvailabilityActionsEnabled = useMemo(() => {
+    return coordinatedEntryEnabled && !!unitGroup?.workflowTemplateName;
+  }, [coordinatedEntryEnabled, unitGroup?.workflowTemplateName]);
 
   // Set the breadcrumb so it says the correct name of this unit group
   useEffect(() => {
@@ -90,6 +94,7 @@ const UnitGroupPage = () => {
                   projectId={project.id}
                   unitGroupId={unitGroupId}
                   ceEnabled={coordinatedEntryEnabled}
+                  ceAvailabilityActionsEnabled={ceAvailabilityActionsEnabled}
                 />
               </Paper>
             )}

--- a/src/modules/units/components/UnitManagementTable.tsx
+++ b/src/modules/units/components/UnitManagementTable.tsx
@@ -25,6 +25,7 @@ interface Props {
   projectId: string;
   unitGroupId?: string; // if this table is for a specific unit group
   ceEnabled?: boolean; // whether to show CE details
+  ceAvailabilityActionsEnabled?: boolean; // whether to show CE actions for marking units available/unavailable
 }
 
 // Table for managing units within a Project or Unit Group.
@@ -36,6 +37,7 @@ const UnitManagementTable: React.FC<Props> = ({
   projectId,
   unitGroupId,
   ceEnabled = false,
+  ceAvailabilityActionsEnabled = false,
 }) => {
   const { setUnitToDelete, renderSingleDeleteDialog } = useDeleteUnits({
     onSuccess: () => evictUnitsQuery(projectId, unitGroupId),
@@ -60,7 +62,11 @@ const UnitManagementTable: React.FC<Props> = ({
   const { project } = useProjectDashboardContext();
   const canManageUnits = project.access.canManageUnits;
 
-  const { getCeActions, loading } = useUnitCeActions({ project });
+  const { getCeActions, loading } = useUnitCeActions({
+    projectId,
+    ceEnabled,
+    ceAvailabilityActionsEnabled,
+  });
 
   const rowSecondaryActionConfigs = useCallback(
     (unit: UnitTableRowFieldsFragment) => {
@@ -125,7 +131,7 @@ const UnitManagementTable: React.FC<Props> = ({
                   projectId={projectId}
                   unitGroupId={unitGroupId}
                   units={selectedRows}
-                  ceEnabled={ceEnabled}
+                  ceAvailabilityActionsEnabled={ceAvailabilityActionsEnabled}
                 />
               )
             : undefined,

--- a/src/modules/units/components/Units.tsx
+++ b/src/modules/units/components/Units.tsx
@@ -30,7 +30,6 @@ const Units = () => {
     variables: { id: project.id, limit: 100 },
   });
 
-  // Check CE feature flag. TODO replace with project config
   const { coordinatedEntryEnabled } = project;
 
   // For now, we assume that if the project has Coordinated Entry enabled,

--- a/src/modules/units/hooks/useUnitCeActions.tsx
+++ b/src/modules/units/hooks/useUnitCeActions.tsx
@@ -2,7 +2,6 @@ import { useCallback } from 'react';
 import { CommonMenuItem } from '@/components/elements/CommonMenuButton';
 import { ProjectDashboardRoutes } from '@/routes/routes';
 import {
-  ProjectAllFieldsFragment,
   UnitTableRowFieldsFragment,
   useMarkUnitsAvailableMutation,
   useMarkUnitsUnavailableMutation,
@@ -10,9 +9,13 @@ import {
 import { generateSafePath } from '@/utils/pathEncoding';
 
 export const useUnitCeActions = ({
-  project,
+  projectId,
+  ceEnabled,
+  ceAvailabilityActionsEnabled,
 }: {
-  project: ProjectAllFieldsFragment;
+  projectId: string;
+  ceEnabled: boolean;
+  ceAvailabilityActionsEnabled: boolean;
 }): {
   loading: boolean;
   getCeActions: (unit: UnitTableRowFieldsFragment) => CommonMenuItem[];
@@ -29,7 +32,7 @@ export const useUnitCeActions = ({
 
   const getCeActions = useCallback(
     (unit: UnitTableRowFieldsFragment) => {
-      if (!project.coordinatedEntryEnabled) return [];
+      if (!ceEnabled) return [];
 
       const actions: CommonMenuItem[] = [];
 
@@ -39,15 +42,12 @@ export const useUnitCeActions = ({
         key: 'viewUnit',
         ariaLabel: `View Unit ${unit.id}`,
         to: generateSafePath(ProjectDashboardRoutes.UNIT, {
-          projectId: project.id,
+          projectId: projectId,
           unitId: unit.id,
         }),
       });
 
-      // Opportunity creation is only available if the unit has an associated CE Workflow Template
-      const hasWorkflowTemplate = unit.workflowTemplateName;
-
-      if (hasWorkflowTemplate && project.access.canManageUnits) {
+      if (ceAvailabilityActionsEnabled) {
         if (unit.canBeMarkedAvailableToday) {
           // TODO(#7537) - use canBeMarkedAvailable and implement a confirmation modal enabling the user to specify the "available on date".
           actions.push({
@@ -74,7 +74,13 @@ export const useUnitCeActions = ({
 
       return actions;
     },
-    [markUnitsAvailable, markUnitsUnavailable, project]
+    [
+      ceAvailabilityActionsEnabled,
+      ceEnabled,
+      markUnitsAvailable,
+      markUnitsUnavailable,
+      projectId,
+    ]
   );
 
   if (availableError) throw availableError;


### PR DESCRIPTION
## Description

Bug: When a workflow template is not configured for a unit group, the bulk buttons for “Start Accepting” and “Stop Accepting” are still present. They should be hidden. This is a bug in the logic described [here](https://github.com/greenriver/hmis-frontend/blob/release-168/src/modules/units/components/UnitBulkActions.tsx#L89).

This bug is not user-facing since no user environments currently have CE enabled.

Proposed fix: Centralize the logic for whether CE availability-related actions should be enabled. Determine it upstream in the `UnitGroupPage`, and pass it down as a prop to both the `UnitBulkActions` component and the `useUnitCeActions` hook.

[//]: # 'remove if not applicable'
How to test:
- When CE is enabled in the project,
  - Visit a Unit Group page for a group with no workflow template. You should be able to select units and delete them, but the bulk "Start Accepting Referrals" and "Stop Accepting Referrals" buttons should not appear. If you go to the 3-dots menu for any table row, you should not see the individual actions either.
  - Visit a Unit Group page for a group with a workflow template. Bulk availability actions should appear as normal. Individual row actions should appear in the 3-dots menu.
  - Without "can manage units" permission, table rows are not selectable, bulk actions don't appear, and individual menu items don't appear.
- When CE is not enabled in the project,
  - Visit a Units page for a project that doesn't have unit groups. Table rows should be selectable and deletable, but bulk and individual actions related to CE should not appear.
  - Visit a Unit Group page; same

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
