### PR TITLE
Clear cache when household is fully joined

### DIFF
--- a/src/modules/household/components/householdActions/JoinHouseholdDialog.tsx
+++ b/src/modules/household/components/householdActions/JoinHouseholdDialog.tsx
@@ -128,7 +128,10 @@ const JoinHouseholdDialog = ({
     loading: joinLoading,
     error: joinError,
     remainingHousehold,
-  } = usePerformJoinHousehold({ onSuccess });
+  } = usePerformJoinHousehold({
+    onSuccess,
+    donorHouseholdId: donorHousehold?.id,
+  });
 
   const remainingHoh = useMemo(() => {
     return findHohOrRep(remainingHousehold?.householdClients || []);

--- a/src/modules/household/hooks/usePerformJoinHousehold.tsx
+++ b/src/modules/household/hooks/usePerformJoinHousehold.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useState } from 'react';
 import { clientBriefName } from '@/modules/hmis/hmisUtil';
+import { cache } from '@/providers/apolloClient';
 import {
   HouseholdClientFieldsFragment,
   HouseholdFieldsFragment,
@@ -9,8 +10,10 @@ import {
 
 export function usePerformJoinHousehold({
   onSuccess,
+  donorHouseholdId,
 }: {
   onSuccess?: (joinedHousehold: HouseholdFieldsFragment) => void;
+  donorHouseholdId?: string;
 }) {
   const [joinedHousehold, setJoinedHousehold] = useState<
     HouseholdFieldsFragment | undefined
@@ -25,6 +28,12 @@ export function usePerformJoinHousehold({
       if (data.joinHousehold) {
         setJoinedHousehold(data.joinHousehold.receivingHousehold);
         setRemainingHousehold(data.joinHousehold.donorHousehold || undefined);
+
+        if (donorHouseholdId && !data.joinHousehold.donorHousehold) {
+          // There were no remaining members in the donor household, so clear it from the cache
+          cache.evict({ id: `Household:${donorHouseholdId}` });
+        }
+
         onSuccess?.(data.joinHousehold.receivingHousehold);
       }
     },

--- a/src/modules/household/hooks/usePerformJoinHousehold.tsx
+++ b/src/modules/household/hooks/usePerformJoinHousehold.tsx
@@ -30,7 +30,9 @@ export function usePerformJoinHousehold({
         setRemainingHousehold(data.joinHousehold.donorHousehold || undefined);
 
         if (donorHouseholdId && !data.joinHousehold.donorHousehold) {
-          // There were no remaining members in the donor household, so clear it from the cache
+          // If donorHousehold has remaining members, it is updated in the cache
+          // by the donorHousehold resolved on the mutation return value.
+          // Otherwise, clear it from the cache explicitly.
           cache.evict({ id: `Household:${donorHouseholdId}` });
         }
 


### PR DESCRIPTION
## Description

Summary of changes: This PR clears the Household entry from the cache after a household ID no longer exists post-join. This prevents the user from seeing a 500 error as described on the linked ticket.

[//]: # 'remove if not applicable'
Depends on hmis-warehouse PR: Relates to https://github.com/greenriver/hmis-warehouse/pull/5523, but doesn't depend on it

[//]: # 'remove if not applicable'
How to test: See test instructions on the ticket

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
