### PR TITLE
Fix relative date spacing

### DIFF
--- a/src/modules/ce/components/referral/ReferralTimelineItem.tsx
+++ b/src/modules/ce/components/referral/ReferralTimelineItem.tsx
@@ -45,6 +45,10 @@ const ReferralTimelineItem: React.FC<Props> = ({
       description = HmisEnums.CeReferralAuditEventType[auditEvent.type];
   }
 
+  const byUser = auditEvent.user?.name
+    ? `by ${auditEvent.user.name}`
+    : undefined;
+
   return (
     <TimelineItem>
       <TimelineSeparator>
@@ -63,8 +67,10 @@ const ReferralTimelineItem: React.FC<Props> = ({
           {description}
         </Typography>
         <Typography variant='body2' color='text.primary'>
-          <RelativeDateDisplay dateString={auditEvent.createdAt} />
-          {auditEvent.user?.name ? `by ${auditEvent.user.name}` : ''}
+          <RelativeDateDisplay
+            dateString={auditEvent.createdAt}
+            suffixText={byUser}
+          />
         </Typography>
       </TimelineContent>
     </TimelineItem>

--- a/src/modules/form/components/client/RepeatedInputContainer.tsx
+++ b/src/modules/form/components/client/RepeatedInputContainer.tsx
@@ -63,6 +63,7 @@ const RepeatedInputContainer = <T extends object>({
                 {renderChild(val, idx)}
                 <Stack
                   justifyContent={'space-between'}
+                  gap={1}
                   direction='row'
                   sx={{ mt: 3, fontSize: '.825rem' }}
                 >


### PR DESCRIPTION
## Description

Summary of changes: 
- Fixes https://github.com/greenriver/hmis-frontend/pull/1187#discussion_r2172330080

Usages of `RelativeDateDisplay` I checked:
- [x] `EnrollmentCaseNotes` - used on its own in a table cell
- [x] Assessment columns - used on its own in a table cell
- [x] `ReferralTimelineItem` - fixed here
- [x] `SourceEnrollmentCard` - that's the component for whom I made the buggy change, so it looks fine
- [x] `ClientFilesPage` - used on its own in a table cell
- [x] `useRenderLastUpdated` hook - used in a horizontal Stack in `RepeatedInputContainer`. I don't think any update is strictly necessary here, but I added a `gap` to this stack to ensure there's no horizontal squishing 
- [x] `HudRecordMetadata` - always used in a vertical Stack

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
