### PR TITLE
Display and filter on referral custom statuses

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -4016,6 +4016,66 @@
       },
       {
         "kind": "OBJECT",
+        "name": "CeCustomReferralStatus",
+        "description": null,
+        "isOneOf": null,
+        "fields": [
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "key",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "CeMatchRule",
         "description": null,
         "isOneOf": null,
@@ -5276,6 +5336,18 @@
             "deprecationReason": null
           },
           {
+            "name": "customStatus",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "CeCustomReferralStatus",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "daysOnCurrentSteps",
             "description": null,
             "args": [],
@@ -5918,7 +5990,7 @@
             "deprecationReason": null
           },
           {
-            "name": "status",
+            "name": "referralStatus",
             "description": null,
             "type": {
               "kind": "LIST",
@@ -5927,8 +5999,8 @@
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "ENUM",
-                  "name": "CeReferralStatus",
+                  "kind": "SCALAR",
+                  "name": "String",
                   "ofType": null
                 }
               }
@@ -10719,7 +10791,7 @@
             "deprecationReason": null
           },
           {
-            "name": "status",
+            "name": "referralStatus",
             "description": null,
             "type": {
               "kind": "LIST",
@@ -10728,8 +10800,8 @@
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "ENUM",
-                  "name": "CeReferralStatus",
+                  "kind": "SCALAR",
+                  "name": "String",
                   "ofType": null
                 }
               }
@@ -37441,6 +37513,12 @@
             "deprecationReason": null
           },
           {
+            "name": "CE_REFERRAL_STATUSES",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "CE_WORKFLOW_TEMPLATE_IDENTIFIERS",
             "description": "Templates for CE workflow definitions",
             "isDeprecated": false,
@@ -41831,7 +41909,7 @@
         "fields": null,
         "inputFields": [
           {
-            "name": "status",
+            "name": "referralStatus",
             "description": null,
             "type": {
               "kind": "LIST",
@@ -41840,8 +41918,8 @@
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "ENUM",
-                  "name": "CeReferralStatus",
+                  "kind": "SCALAR",
+                  "name": "String",
                   "ofType": null
                 }
               }

--- a/src/api/operations/ce.fragments.graphql
+++ b/src/api/operations/ce.fragments.graphql
@@ -69,6 +69,11 @@ fragment CeCandidateFields on CeCandidate {
 fragment CeReferralSummaryFields on CeReferral {
   id
   status
+  customStatus {
+    id
+    key
+    name
+  }
   active
   clientId
   client {

--- a/src/modules/ce/components/admin/AdminReferralsTable.tsx
+++ b/src/modules/ce/components/admin/AdminReferralsTable.tsx
@@ -137,7 +137,10 @@ const AdminReferralsTable: React.FC<Props> = ({}) => {
         columns={COLUMNS}
         queryVariables={{}}
         defaultFilterValues={{
-          status: [CeReferralStatus.Initialized, CeReferralStatus.InProgress],
+          referralStatus: [
+            CeReferralStatus.Initialized,
+            CeReferralStatus.InProgress,
+          ],
         }}
         queryDocument={GetAdminCeReferralsDocument}
         pagePath='ceReferrals'

--- a/src/modules/ce/components/project/ProjectReferralsTable.tsx
+++ b/src/modules/ce/components/project/ProjectReferralsTable.tsx
@@ -52,7 +52,10 @@ const ProjectReferralsTable: React.FC<Props> = ({ projectId }) => {
           id: projectId,
         }}
         defaultFilterValues={{
-          status: [CeReferralStatus.Initialized, CeReferralStatus.InProgress],
+          referralStatus: [
+            CeReferralStatus.Initialized,
+            CeReferralStatus.InProgress,
+          ],
         }}
         filters={filters}
         queryDocument={GetProjectCeReferralsDocument}

--- a/src/modules/ce/components/referral/ReferralDetailContent.tsx
+++ b/src/modules/ce/components/referral/ReferralDetailContent.tsx
@@ -25,9 +25,7 @@ const ReferralDetailContent: React.FC<Props> = ({ referral }) => {
             {
               id: 'status',
               label: 'Referral Status',
-              value: (
-                <ReferralStatusChip status={referral.status} size='small' />
-              ),
+              value: <ReferralStatusChip referral={referral} size='small' />,
             },
             { id: 'id', label: 'Referral ID', value: referral.id },
             {

--- a/src/modules/ce/components/referral/ReferralMetadataHeader.tsx
+++ b/src/modules/ce/components/referral/ReferralMetadataHeader.tsx
@@ -39,7 +39,7 @@ const ReferralMetadataHeader: React.FC<Props> = ({ referral }) => (
       justifyContent={'space-between'}
       sx={{ '.MuiChip-root': { backgroundColor: 'transparent' } }}
     >
-      <ReferralStatusChip status={referral.status} size='small' />
+      <ReferralStatusChip referral={referral} size='small' />
       <Stack direction='row' alignItems='center' gap={2.5}>
         <DetailText>
           {clientNameFromRecordWithOptionalClient(referral)}

--- a/src/modules/ce/components/referral/ReferralStatusChip.tsx
+++ b/src/modules/ce/components/referral/ReferralStatusChip.tsx
@@ -1,17 +1,30 @@
 import { Chip, ChipProps } from '@mui/material';
 import React from 'react';
 import { InProgressIcon } from '@/components/elements/SemanticIcons';
-import { CeReferralStatus } from '@/types/gqlTypes';
+import { CeReferralFieldsFragment, CeReferralStatus } from '@/types/gqlTypes';
 
 interface Props {
-  status: CeReferralStatus;
+  referral: Pick<CeReferralFieldsFragment, 'status' | 'customStatus'>;
   size?: ChipProps['size'];
 }
-const ReferralStatusChip: React.FC<Props> = ({ status, size }) => {
+const ReferralStatusChip: React.FC<Props> = ({ referral, size }) => {
+  const { status, customStatus } = referral;
+
   const baseChipProps: ChipProps = {
     variant: 'status',
     size,
   };
+
+  if (customStatus) {
+    return (
+      <Chip
+        label={customStatus.name}
+        color='primary'
+        icon={<InProgressIcon />}
+        {...baseChipProps}
+      />
+    );
+  }
 
   switch (status) {
     case CeReferralStatus.Initialized:

--- a/src/modules/ce/components/referral/ReferralStatusChip.tsx
+++ b/src/modules/ce/components/referral/ReferralStatusChip.tsx
@@ -15,32 +15,25 @@ const ReferralStatusChip: React.FC<Props> = ({ referral, size }) => {
     size,
   };
 
-  if (customStatus) {
-    return (
-      <Chip
-        label={customStatus.name}
-        color='primary'
-        icon={<InProgressIcon />}
-        {...baseChipProps}
-      />
-    );
-  }
-
   switch (status) {
     case CeReferralStatus.Initialized:
     case CeReferralStatus.InProgress:
       return (
         <Chip
-          label='In Progress'
+          label={customStatus?.name || 'In Progress'}
           color='primary'
           icon={<InProgressIcon />}
           {...baseChipProps}
         />
       );
     case CeReferralStatus.Accepted:
-      return <Chip label='Accepted' {...baseChipProps} />;
+      return (
+        <Chip label={customStatus?.name || 'Accepted'} {...baseChipProps} />
+      );
     case CeReferralStatus.Rejected:
-      return <Chip label='Declined' {...baseChipProps} />;
+      return (
+        <Chip label={customStatus?.name || 'Declined'} {...baseChipProps} />
+      );
     default:
       return '';
   }

--- a/src/modules/ce/components/unit/OpportunityBanner.tsx
+++ b/src/modules/ce/components/unit/OpportunityBanner.tsx
@@ -105,7 +105,7 @@ const OpportunityBanner: React.FC<Props> = ({ opportunity, topCandidate }) => {
             </CommonLabeledTextBlock>
             {referral && (
               <CommonLabeledTextBlock title='Status'>
-                <ReferralStatusChip status={referral.status} />
+                <ReferralStatusChip referral={referral} />
               </CommonLabeledTextBlock>
             )}
             {!referral && topCandidate && (

--- a/src/modules/ce/referralColumns.tsx
+++ b/src/modules/ce/referralColumns.tsx
@@ -51,7 +51,7 @@ export const REFERRAL_COLUMNS: Record<
       referral:
         | CeReferralTableFieldsFragment
         | ClientCeReferralTableFieldsFragment
-    ) => <ReferralStatusChip status={referral.status} size='small' />,
+    ) => <ReferralStatusChip referral={referral} size='small' />,
     key: 'status',
   },
   currentSteps: {

--- a/src/modules/hmis/filterUtil.ts
+++ b/src/modules/hmis/filterUtil.ts
@@ -58,6 +58,7 @@ const FILTER_NAME_TO_PICK_LIST = {
   assignedStaff: PickListType.EligibleStaffAssignmentUsers,
   workflowTemplate: PickListType.CeWorkflowTemplateIdentifiersIncludingRetired,
   unitType: PickListType.PossibleUnitTypesForProject,
+  referralStatus: PickListType.CeReferralStatuses,
 };
 
 function isPicklistType(

--- a/src/types/gqlEnums.ts
+++ b/src/types/gqlEnums.ts
@@ -984,6 +984,7 @@ export const HmisEnums = {
     AVAILABLE_UNIT_TYPES:
       'Unit types that have unoccupied units in the specified project',
     CE_EVENTS: 'Grouped HUD CE Event types',
+    CE_REFERRAL_STATUSES: 'CE_REFERRAL_STATUSES',
     CE_WORKFLOW_TEMPLATE_IDENTIFIERS: 'Templates for CE workflow definitions',
     CE_WORKFLOW_TEMPLATE_IDENTIFIERS_INCLUDING_RETIRED:
       'Templates for CE workflow definitions, including fully retired workflows',

--- a/src/types/gqlObjects.ts
+++ b/src/types/gqlObjects.ts
@@ -567,6 +567,35 @@ export const HmisObjectSchemas: GqlSchema[] = [
     ],
   },
   {
+    name: 'CeCustomReferralStatus',
+    fields: [
+      {
+        name: 'id',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'ID', ofType: null },
+        },
+      },
+      {
+        name: 'key',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'String', ofType: null },
+        },
+      },
+      {
+        name: 'name',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'String', ofType: null },
+        },
+      },
+    ],
+  },
+  {
     name: 'CeMatchRule',
     fields: [
       {
@@ -7728,14 +7757,14 @@ export const HmisInputObjectSchemas: GqlInputObjectSchema[] = [
         },
       },
       {
-        name: 'status',
+        name: 'referralStatus',
         type: {
           kind: 'LIST',
           name: null,
           ofType: {
             kind: 'NON_NULL',
             name: null,
-            ofType: { kind: 'ENUM', name: 'CeReferralStatus', ofType: null },
+            ofType: { kind: 'SCALAR', name: 'String', ofType: null },
           },
         },
       },
@@ -7896,14 +7925,14 @@ export const HmisInputObjectSchemas: GqlInputObjectSchema[] = [
         },
       },
       {
-        name: 'status',
+        name: 'referralStatus',
         type: {
           kind: 'LIST',
           name: null,
           ofType: {
             kind: 'NON_NULL',
             name: null,
-            ofType: { kind: 'ENUM', name: 'CeReferralStatus', ofType: null },
+            ofType: { kind: 'SCALAR', name: 'String', ofType: null },
           },
         },
       },
@@ -8923,14 +8952,14 @@ export const HmisInputObjectSchemas: GqlInputObjectSchema[] = [
     name: 'ProjectCeReferralFilterOptions',
     args: [
       {
-        name: 'status',
+        name: 'referralStatus',
         type: {
           kind: 'LIST',
           name: null,
           ofType: {
             kind: 'NON_NULL',
             name: null,
-            ofType: { kind: 'ENUM', name: 'CeReferralStatus', ofType: null },
+            ofType: { kind: 'SCALAR', name: 'String', ofType: null },
           },
         },
       },

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -587,6 +587,13 @@ export type CeCandidatesPaginated = {
   pagesCount: Scalars['Int']['output'];
 };
 
+export type CeCustomReferralStatus = {
+  __typename?: 'CeCustomReferralStatus';
+  id: Scalars['ID']['output'];
+  key: Scalars['String']['output'];
+  name: Scalars['String']['output'];
+};
+
 export type CeMatchRule = {
   __typename?: 'CeMatchRule';
   expression: Scalars['String']['output'];
@@ -723,6 +730,7 @@ export type CeReferral = {
   clientId: Scalars['ID']['output'];
   createdAt: Scalars['ISO8601DateTime']['output'];
   currentSteps?: Maybe<Array<CeReferralStep>>;
+  customStatus?: Maybe<CeCustomReferralStatus>;
   daysOnCurrentSteps?: Maybe<Scalars['Int']['output']>;
   id: Scalars['ID']['output'];
   notes: CeReferralNotesPaginated;
@@ -792,7 +800,7 @@ export type CeReferralFilterOptions = {
   organization?: InputMaybe<Array<Scalars['ID']['input']>>;
   project?: InputMaybe<Array<Scalars['ID']['input']>>;
   projectType?: InputMaybe<Array<ProjectType>>;
-  status?: InputMaybe<Array<CeReferralStatus>>;
+  referralStatus?: InputMaybe<Array<Scalars['String']['input']>>;
   workflowTemplate?: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
@@ -1319,7 +1327,7 @@ export type ClientCeReferralFilterOptions = {
   organization?: InputMaybe<Array<Scalars['ID']['input']>>;
   project?: InputMaybe<Array<Scalars['ID']['input']>>;
   projectType?: InputMaybe<Array<ProjectType>>;
-  status?: InputMaybe<Array<CeReferralStatus>>;
+  referralStatus?: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
 export type ClientContactPoint = {
@@ -5307,6 +5315,7 @@ export enum PickListType {
   AvailableUnitTypes = 'AVAILABLE_UNIT_TYPES',
   /** Grouped HUD CE Event types */
   CeEvents = 'CE_EVENTS',
+  CeReferralStatuses = 'CE_REFERRAL_STATUSES',
   /** Templates for CE workflow definitions */
   CeWorkflowTemplateIdentifiers = 'CE_WORKFLOW_TEMPLATE_IDENTIFIERS',
   /** Templates for CE workflow definitions, including fully retired workflows */
@@ -6301,7 +6310,7 @@ export type ProjectCeOpportunityFilterOptions = {
 };
 
 export type ProjectCeReferralFilterOptions = {
-  status?: InputMaybe<Array<CeReferralStatus>>;
+  referralStatus?: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
 export type ProjectCoc = {
@@ -16460,6 +16469,12 @@ export type CeOpportunityFieldsFragment = {
     status: CeReferralStatus;
     active: boolean;
     clientId: string;
+    customStatus?: {
+      __typename?: 'CeCustomReferralStatus';
+      id: string;
+      key: string;
+      name: string;
+    } | null;
     client?: {
       __typename?: 'Client';
       id: string;
@@ -16572,6 +16587,12 @@ export type CeReferralSummaryFieldsFragment = {
   status: CeReferralStatus;
   active: boolean;
   clientId: string;
+  customStatus?: {
+    __typename?: 'CeCustomReferralStatus';
+    id: string;
+    key: string;
+    name: string;
+  } | null;
   client?: {
     __typename?: 'Client';
     id: string;
@@ -16606,6 +16627,12 @@ export type CeReferralTableFieldsFragment = {
   referredBy?: {
     __typename?: 'ApplicationUser';
     id: string;
+    name: string;
+  } | null;
+  customStatus?: {
+    __typename?: 'CeCustomReferralStatus';
+    id: string;
+    key: string;
     name: string;
   } | null;
   client?: {
@@ -16689,6 +16716,12 @@ export type CeReferralAdminFieldsFragment = {
     id: string;
     name: string;
   } | null;
+  customStatus?: {
+    __typename?: 'CeCustomReferralStatus';
+    id: string;
+    key: string;
+    name: string;
+  } | null;
   client?: {
     __typename?: 'Client';
     id: string;
@@ -16729,6 +16762,12 @@ export type ClientCeReferralTableFieldsFragment = {
     name: string;
   } | null;
   access: { __typename?: 'CeReferralAccess'; canViewTargetProject: boolean };
+  customStatus?: {
+    __typename?: 'CeCustomReferralStatus';
+    id: string;
+    key: string;
+    name: string;
+  } | null;
   client?: {
     __typename?: 'Client';
     id: string;
@@ -16822,6 +16861,12 @@ export type CeReferralFieldsFragment = {
     __typename?: 'Enrollment';
     id: string;
     client: { __typename?: 'Client'; id: string };
+  } | null;
+  customStatus?: {
+    __typename?: 'CeCustomReferralStatus';
+    id: string;
+    key: string;
+    name: string;
   } | null;
   client?: {
     __typename?: 'Client';
@@ -17565,6 +17610,12 @@ export type CreateCeReferralMutation = {
       status: CeReferralStatus;
       active: boolean;
       clientId: string;
+      customStatus?: {
+        __typename?: 'CeCustomReferralStatus';
+        id: string;
+        key: string;
+        name: string;
+      } | null;
       client?: {
         __typename?: 'Client';
         id: string;
@@ -18695,6 +18746,12 @@ export type SubmitCeReferralStepMutation = {
           status: CeReferralStatus;
           active: boolean;
           clientId: string;
+          customStatus?: {
+            __typename?: 'CeCustomReferralStatus';
+            id: string;
+            key: string;
+            name: string;
+          } | null;
           client?: {
             __typename?: 'Client';
             id: string;
@@ -18763,6 +18820,12 @@ export type SubmitCeReferralStepMutation = {
           canPerformStep: boolean;
         };
       }>;
+      customStatus?: {
+        __typename?: 'CeCustomReferralStatus';
+        id: string;
+        key: string;
+        name: string;
+      } | null;
       client?: {
         __typename?: 'Client';
         id: string;
@@ -18893,6 +18956,12 @@ export type MarkUnitsAvailableMutation = {
           status: CeReferralStatus;
           active: boolean;
           clientId: string;
+          customStatus?: {
+            __typename?: 'CeCustomReferralStatus';
+            id: string;
+            key: string;
+            name: string;
+          } | null;
           client?: {
             __typename?: 'Client';
             id: string;
@@ -18984,6 +19053,12 @@ export type MarkUnitsUnavailableMutation = {
           status: CeReferralStatus;
           active: boolean;
           clientId: string;
+          customStatus?: {
+            __typename?: 'CeCustomReferralStatus';
+            id: string;
+            key: string;
+            name: string;
+          } | null;
           client?: {
             __typename?: 'Client';
             id: string;
@@ -19194,6 +19269,12 @@ export type GetProjectCeReferralsQuery = {
           id: string;
           name: string;
         } | null;
+        customStatus?: {
+          __typename?: 'CeCustomReferralStatus';
+          id: string;
+          key: string;
+          name: string;
+        } | null;
         client?: {
           __typename?: 'Client';
           id: string;
@@ -19230,6 +19311,12 @@ export type GetCeOpportunityQuery = {
       status: CeReferralStatus;
       active: boolean;
       clientId: string;
+      customStatus?: {
+        __typename?: 'CeCustomReferralStatus';
+        id: string;
+        key: string;
+        name: string;
+      } | null;
       client?: {
         __typename?: 'Client';
         id: string;
@@ -19416,6 +19503,12 @@ export type GetCeReferralQuery = {
       __typename?: 'Enrollment';
       id: string;
       client: { __typename?: 'Client'; id: string };
+    } | null;
+    customStatus?: {
+      __typename?: 'CeCustomReferralStatus';
+      id: string;
+      key: string;
+      name: string;
     } | null;
     client?: {
       __typename?: 'Client';
@@ -20055,6 +20148,12 @@ export type GetClientCeReferralsQuery = {
           __typename?: 'CeReferralAccess';
           canViewTargetProject: boolean;
         };
+        customStatus?: {
+          __typename?: 'CeCustomReferralStatus';
+          id: string;
+          key: string;
+          name: string;
+        } | null;
         client?: {
           __typename?: 'Client';
           id: string;
@@ -20226,6 +20325,12 @@ export type GetAdminCeReferralsQuery = {
       referredBy?: {
         __typename?: 'ApplicationUser';
         id: string;
+        name: string;
+      } | null;
+      customStatus?: {
+        __typename?: 'CeCustomReferralStatus';
+        id: string;
+        key: string;
         name: string;
       } | null;
       client?: {
@@ -44811,6 +44916,12 @@ export type UnitTableRowFieldsFragment = {
       status: CeReferralStatus;
       active: boolean;
       clientId: string;
+      customStatus?: {
+        __typename?: 'CeCustomReferralStatus';
+        id: string;
+        key: string;
+        name: string;
+      } | null;
       client?: {
         __typename?: 'Client';
         id: string;
@@ -44897,6 +45008,12 @@ export type UnitDetailFieldsFragment = {
       status: CeReferralStatus;
       active: boolean;
       clientId: string;
+      customStatus?: {
+        __typename?: 'CeCustomReferralStatus';
+        id: string;
+        key: string;
+        name: string;
+      } | null;
       client?: {
         __typename?: 'Client';
         id: string;
@@ -44961,6 +45078,12 @@ export type UnitWithCeFieldsFragment = {
       status: CeReferralStatus;
       active: boolean;
       clientId: string;
+      customStatus?: {
+        __typename?: 'CeCustomReferralStatus';
+        id: string;
+        key: string;
+        name: string;
+      } | null;
       client?: {
         __typename?: 'Client';
         id: string;
@@ -45115,6 +45238,12 @@ export type GetUnitsQuery = {
             status: CeReferralStatus;
             active: boolean;
             clientId: string;
+            customStatus?: {
+              __typename?: 'CeCustomReferralStatus';
+              id: string;
+              key: string;
+              name: string;
+            } | null;
             client?: {
               __typename?: 'Client';
               id: string;
@@ -45291,6 +45420,12 @@ export type GetUnitQuery = {
         status: CeReferralStatus;
         active: boolean;
         clientId: string;
+        customStatus?: {
+          __typename?: 'CeCustomReferralStatus';
+          id: string;
+          key: string;
+          name: string;
+        } | null;
         client?: {
           __typename?: 'Client';
           id: string;
@@ -45419,6 +45554,12 @@ export type CreateUnitsMutation = {
           status: CeReferralStatus;
           active: boolean;
           clientId: string;
+          customStatus?: {
+            __typename?: 'CeCustomReferralStatus';
+            id: string;
+            key: string;
+            name: string;
+          } | null;
           client?: {
             __typename?: 'Client';
             id: string;
@@ -45552,6 +45693,12 @@ export type UpdateUnitsMutation = {
           status: CeReferralStatus;
           active: boolean;
           clientId: string;
+          customStatus?: {
+            __typename?: 'CeCustomReferralStatus';
+            id: string;
+            key: string;
+            name: string;
+          } | null;
           client?: {
             __typename?: 'Client';
             id: string;
@@ -46726,6 +46873,11 @@ export const CeReferralSummaryFieldsFragmentDoc = gql`
   fragment CeReferralSummaryFields on CeReferral {
     id
     status
+    customStatus {
+      id
+      key
+      name
+    }
     active
     clientId
     client {


### PR DESCRIPTION
## Description

Summary of changes:
- Rename CE Referral `status` filter to `referralStatus`, and resolve the new status filter instead of the basic enum that only contains default statuses
- Update `ReferralStatusChip` component to display custom status if present. For now, I haven't added any custom treatment for custom statuses.

[//]: # 'remove if not applicable'
Depends on hmis-warehouse PR: https://github.com/greenriver/hmis-warehouse/pull/5556

[//]: # 'remove if not applicable'
How to test: See test instructions on backend PR

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
new feature

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
