### PR TITLE
Unit page updates

### DIFF
--- a/src/api/operations/units.fragments.graphql
+++ b/src/api/operations/units.fragments.graphql
@@ -42,6 +42,7 @@ fragment UnitDetailFields on Unit {
   name
   unitSize
   acceptingCeReferrals
+  canBeMarkedAvailableToday
   unitType {
     ...UnitTypeFields
   }

--- a/src/modules/ce/components/unit/OpportunityBanner.tsx
+++ b/src/modules/ce/components/unit/OpportunityBanner.tsx
@@ -12,6 +12,7 @@ import { ProjectDashboardRoutes } from '@/routes/routes';
 import {
   CeCandidateFieldsFragment,
   CeOpportunityFieldsFragment,
+  CeOpportunityStatus,
   CeReferralStatus,
 } from '@/types/gqlTypes';
 import { generateSafePath } from '@/utils/pathEncoding';
@@ -26,7 +27,8 @@ const OpportunityBanner: React.FC<Props> = ({ opportunity, topCandidate }) => {
   const { project } = useProjectDashboardContext();
 
   const header = useMemo(() => {
-    if (referral?.status === CeReferralStatus.Accepted) return 'Filled By';
+    if (referral?.status === CeReferralStatus.Accepted)
+      return 'Accepted Referral';
     if (referral && referral.active) return 'In-Progress Referral';
     if (topCandidate) return 'Top Prioritized Client';
   }, [referral, topCandidate]);
@@ -46,14 +48,14 @@ const OpportunityBanner: React.FC<Props> = ({ opportunity, topCandidate }) => {
       if (referral.status === CeReferralStatus.Accepted) {
         return (
           <ButtonLink color='grayscale' variant='contained' to={to}>
-            View
+            View Referral
           </ButtonLink>
         );
       }
 
       return (
         <ButtonLink to={to} color='primary' variant='contained'>
-          Continue
+          Continue Referral
         </ButtonLink>
       );
     }
@@ -69,6 +71,11 @@ const OpportunityBanner: React.FC<Props> = ({ opportunity, topCandidate }) => {
     }
   }, [referral, topCandidate, project.access.canStartReferrals, opportunity]);
 
+  const linkToEligibleClients =
+    opportunity &&
+    opportunity.status !== CeOpportunityStatus.Closed &&
+    project.access.canViewPrioritizedClientLists;
+
   if (!referral && !topCandidate) return;
 
   return (
@@ -83,7 +90,7 @@ const OpportunityBanner: React.FC<Props> = ({ opportunity, topCandidate }) => {
         <Typography variant='h5' component='h3'>
           {header}
         </Typography>
-        {!isTiny && (
+        {!isTiny && linkToEligibleClients && (
           <ButtonLink to={'#clients'} startIcon={<PeopleIcon />} variant='text'>
             View All Eligible Clients
           </ButtonLink>
@@ -98,13 +105,17 @@ const OpportunityBanner: React.FC<Props> = ({ opportunity, topCandidate }) => {
           p: 2,
         }}
       >
-        <Stack direction='row' justifyContent='space-between'>
+        <Stack
+          direction='row'
+          justifyContent='space-between'
+          alignItems='center'
+        >
           <Stack gap={4} direction={isTiny ? 'column' : 'row'}>
-            <CommonLabeledTextBlock title='Client'>
+            <CommonLabeledTextBlock title='Client Name'>
               {clientName}
             </CommonLabeledTextBlock>
             {referral && (
-              <CommonLabeledTextBlock title='Status'>
+              <CommonLabeledTextBlock title='Referral Status'>
                 <ReferralStatusChip status={referral.status} />
               </CommonLabeledTextBlock>
             )}

--- a/src/modules/units/columns/unitColumns.tsx
+++ b/src/modules/units/columns/unitColumns.tsx
@@ -44,7 +44,7 @@ export const UNIT_COLUMNS: Record<
     key: 'clients',
     render: (unit: UnitTableRowFieldsFragment) => <UnitOccupants unit={unit} />,
     optional: {
-      defaultHidden: true,
+      defaultHidden: false,
       queryVariableField:
         'includeClientOccupants' as keyof GetUnitsQueryVariables,
     },

--- a/src/modules/units/components/UnitCapacityTable.tsx
+++ b/src/modules/units/components/UnitCapacityTable.tsx
@@ -1,4 +1,6 @@
-import { Box } from '@mui/system';
+import { Divider } from '@mui/material';
+import { Box, Stack } from '@mui/system';
+import { CommonLabeledTextBlock } from '@/components/elements/CommonLabeledTextBlock';
 import Loading from '@/components/elements/Loading';
 import UnitUtilizationByUnitType from '@/modules/units/components/UnitUtilizationByUnitType';
 import { useGetProjectUnitTypesQuery } from '@/types/gqlTypes';
@@ -16,9 +18,25 @@ const UnitCapacityTable = ({ projectId }: { projectId: string }) => {
   if (rows.length === 0) {
     return null;
   }
+  const total = data?.project?.unitTypes
+    .map((type) => type.capacity)
+    .reduce((acc, capacity) => acc + capacity, 0);
+  const vacancies = data?.project?.unitTypes
+    .map((type) => type.availability)
+    .reduce((acc, availability) => acc + availability, 0);
+
   return (
     <Box sx={{ width: '100%' }}>
-      <UnitUtilizationByUnitType unitTypes={rows} variant='grid' />
+      <Stack direction='row' spacing={2} sx={{ mb: 2 }}>
+        <CommonLabeledTextBlock title='Total Units:' horizontal>
+          {total}
+        </CommonLabeledTextBlock>
+        <CommonLabeledTextBlock title='Vacancies:' horizontal>
+          {vacancies}
+        </CommonLabeledTextBlock>
+      </Stack>
+      <Divider sx={{ mb: 2 }} />
+      <UnitUtilizationByUnitType unitTypes={rows} />
     </Box>
   );
 };

--- a/src/modules/units/components/UnitGroupCard.tsx
+++ b/src/modules/units/components/UnitGroupCard.tsx
@@ -1,4 +1,4 @@
-import { Box, Paper, Stack, Typography } from '@mui/material';
+import { Divider, Paper, Stack, Typography } from '@mui/material';
 import ButtonLink from '@/components/elements/ButtonLink';
 import UnitUtilizationByUnitType from '@/modules/units/components/UnitUtilizationByUnitType';
 import { ProjectDashboardRoutes } from '@/routes/routes';
@@ -16,12 +16,14 @@ const UnitGroupCard: React.FC<Props> = ({
   projectId,
   linkToUnitGroup = false,
 }) => {
+  const hasMultipleUnitTypes = unitGroup.unitTypes.length > 1;
   return (
     <Paper sx={{ px: 2, pt: 1, pb: 2 }}>
       <Stack
         justifyContent='space-between'
         direction='row'
         alignItems='flex-start'
+        sx={{ mb: 1 }}
       >
         <div>
           <Typography component='h2' variant='h5' sx={{ mb: 1 }}>
@@ -39,24 +41,29 @@ const UnitGroupCard: React.FC<Props> = ({
               unitGroupId: unitGroup.id,
             })}
             sx={{ mt: 1 }}
+            size='small'
           >
-            View
+            Manage
           </ButtonLink>
         )}
       </Stack>
       {unitGroup.capacity > 0 && (
         <>
-          <Stack direction='row' gap={2}>
-            <Typography variant='body2'>
-              <b>Units:</b> {unitGroup.capacity}
-            </Typography>
-            <Typography variant='body2'>
-              <b>Vacancies:</b> {unitGroup.availability}
-            </Typography>
-          </Stack>
-          <Box sx={{ mt: 2 }}>
-            <UnitUtilizationByUnitType unitTypes={unitGroup.unitTypes} />
-          </Box>
+          {hasMultipleUnitTypes && (
+            <>
+              <Stack direction='row' gap={2}>
+                <Typography variant='body2'>
+                  <b>Total Units:</b> {unitGroup.capacity}
+                </Typography>
+                <Typography variant='body2'>
+                  <b>Vacancies:</b> {unitGroup.availability}
+                </Typography>
+              </Stack>
+
+              <Divider sx={{ my: 2 }} />
+            </>
+          )}
+          <UnitUtilizationByUnitType unitTypes={unitGroup.unitTypes} />
         </>
       )}
       {unitGroup.capacity === 0 && (

--- a/src/modules/units/components/UnitGroupCard.tsx
+++ b/src/modules/units/components/UnitGroupCard.tsx
@@ -38,7 +38,7 @@ const UnitGroupCard: React.FC<Props> = ({
           </div>
           {linkToUnitGroup && projectId && (
             <ButtonLink
-              aria-label={`View ${unitGroup.name}`}
+              aria-label={`Manage ${unitGroup.name}`}
               to={generateSafePath(ProjectDashboardRoutes.UNIT_GROUP, {
                 projectId,
                 unitGroupId: unitGroup.id,

--- a/src/modules/units/components/UnitGroupCard.tsx
+++ b/src/modules/units/components/UnitGroupCard.tsx
@@ -9,44 +9,48 @@ interface Props {
   unitGroup: UnitGroupCapacityFieldsFragment;
   projectId?: string;
   linkToUnitGroup?: boolean;
+  hideTitle?: boolean;
 }
 
 const UnitGroupCard: React.FC<Props> = ({
   unitGroup,
   projectId,
   linkToUnitGroup = false,
+  hideTitle = false,
 }) => {
   const hasMultipleUnitTypes = unitGroup.unitTypes.length > 1;
   return (
-    <Paper sx={{ px: 2, pt: 1, pb: 2 }}>
-      <Stack
-        justifyContent='space-between'
-        direction='row'
-        alignItems='flex-start'
-        sx={{ mb: 1 }}
-      >
-        <div>
-          <Typography component='h2' variant='h5' sx={{ mb: 1 }}>
-            <Typography variant='overline' display='block'>
-              Unit Group
+    <Paper sx={{ px: 2, pt: hideTitle ? 2 : 1, pb: 2 }}>
+      {!hideTitle && (
+        <Stack
+          justifyContent='space-between'
+          direction='row'
+          alignItems='flex-start'
+          sx={{ mb: 1 }}
+        >
+          <div>
+            <Typography component='h2' variant='h5' sx={{ mb: 1 }}>
+              <Typography variant='overline' display='block'>
+                Unit Group
+              </Typography>
+              {unitGroup.name}
             </Typography>
-            {unitGroup.name}
-          </Typography>
-        </div>
-        {linkToUnitGroup && projectId && (
-          <ButtonLink
-            aria-label={`View ${unitGroup.name}`}
-            to={generateSafePath(ProjectDashboardRoutes.UNIT_GROUP, {
-              projectId,
-              unitGroupId: unitGroup.id,
-            })}
-            sx={{ mt: 1 }}
-            size='small'
-          >
-            Manage
-          </ButtonLink>
-        )}
-      </Stack>
+          </div>
+          {linkToUnitGroup && projectId && (
+            <ButtonLink
+              aria-label={`View ${unitGroup.name}`}
+              to={generateSafePath(ProjectDashboardRoutes.UNIT_GROUP, {
+                projectId,
+                unitGroupId: unitGroup.id,
+              })}
+              sx={{ mt: 1 }}
+              size='small'
+            >
+              Manage
+            </ButtonLink>
+          )}
+        </Stack>
+      )}
       {unitGroup.capacity > 0 && (
         <>
           {hasMultipleUnitTypes && (
@@ -59,7 +63,6 @@ const UnitGroupCard: React.FC<Props> = ({
                   <b>Vacancies:</b> {unitGroup.availability}
                 </Typography>
               </Stack>
-
               <Divider sx={{ my: 2 }} />
             </>
           )}

--- a/src/modules/units/components/UnitGroupPage.tsx
+++ b/src/modules/units/components/UnitGroupPage.tsx
@@ -8,9 +8,8 @@ import Loading from '@/components/elements/Loading';
 import PageTitle from '@/components/layout/PageTitle';
 import NotFound from '@/components/pages/NotFound';
 import useSafeParams from '@/hooks/useSafeParams';
+import MatchRuleCard from '@/modules/ce/components/unit/MatchRuleCard';
 import UnitGroupCeConfigurationCard from '@/modules/ce/components/unitGroup/UnitGroupCeConfigurationCard';
-import UnitGroupDefaultContactsCard from '@/modules/ce/components/unitGroup/UnitGroupDefaultContactsCard';
-import UnitGroupEligibilityCard from '@/modules/ce/components/unitGroup/UnitGroupEligibilityCard';
 import { useProjectDashboardContext } from '@/modules/projects/components/ProjectDashboard';
 import CreateUnitsDialog from '@/modules/units/components/CreateUnitsDialog';
 import UnitGroupCard from '@/modules/units/components/UnitGroupCard';
@@ -70,24 +69,9 @@ const UnitGroupPage = () => {
       />
 
       <Grid container spacing={2} sx={{ mb: 2 }}>
-        {coordinatedEntryEnabled && (
-          <Grid item xs={4}>
-            <Stack gap={2}>
-              <UnitGroupCeConfigurationCard unitGroup={unitGroup} />
-              <UnitGroupDefaultContactsCard
-                unitGroup={unitGroup}
-                canEdit={canEditUnitGroup}
-              />
-              <UnitGroupEligibilityCard
-                unitGroup={unitGroup}
-                canEdit={canEditUnitGroup}
-              />
-            </Stack>
-          </Grid>
-        )}
         <Grid item xs={coordinatedEntryEnabled ? 8 : 12}>
           <Stack gap={2}>
-            <UnitGroupCard unitGroup={unitGroup} />
+            <UnitGroupCard unitGroup={unitGroup} hideTitle />
             {!!unitGroup.capacity && (
               <Paper>
                 <UnitManagementTable
@@ -100,6 +84,25 @@ const UnitGroupPage = () => {
             )}
           </Stack>
         </Grid>
+        {coordinatedEntryEnabled && (
+          <Grid item xs={4}>
+            <Stack gap={2}>
+              <UnitGroupCeConfigurationCard unitGroup={unitGroup} />
+              {/* <UnitGroupDefaultContactsCard
+                unitGroup={unitGroup}
+                canEdit={canEditUnitGroup}
+              /> */}
+              {/* <UnitGroupEligibilityCard
+                unitGroup={unitGroup}
+                canEdit={canEditUnitGroup}
+              /> */}
+              <MatchRuleCard
+                title='Eligibility Requirements'
+                rules={unitGroup.eligibilityRequirements || []}
+              />
+            </Stack>
+          </Grid>
+        )}
       </Grid>
 
       <CreateUnitsDialog

--- a/src/modules/units/components/UnitGroupPage.tsx
+++ b/src/modules/units/components/UnitGroupPage.tsx
@@ -88,10 +88,13 @@ const UnitGroupPage = () => {
           <Grid item xs={4}>
             <Stack gap={2}>
               <UnitGroupCeConfigurationCard unitGroup={unitGroup} />
+              {/* TODO(#7538) - support setting default contacts */}
               {/* <UnitGroupDefaultContactsCard
                 unitGroup={unitGroup}
                 canEdit={canEditUnitGroup}
               /> */}
+
+              {/* TODO(#7544) - support configuring eligibility rules */}
               {/* <UnitGroupEligibilityCard
                 unitGroup={unitGroup}
                 canEdit={canEditUnitGroup}

--- a/src/modules/units/components/UnitOverview.tsx
+++ b/src/modules/units/components/UnitOverview.tsx
@@ -1,15 +1,30 @@
-import { Grid } from '@mui/material';
+import { Grid, Paper, Typography } from '@mui/material';
+import { Stack } from '@mui/system';
 import React from 'react';
 
+import LoadingButton from '@/components/elements/LoadingButton';
 import MatchRuleCard from '@/modules/ce/components/unit/MatchRuleCard';
 import OpportunityBanner from '@/modules/ce/components/unit/OpportunityBanner';
-import { UnitDetailFieldsFragment } from '@/types/gqlTypes';
+import { cache } from '@/providers/apolloClient';
+import {
+  UnitDetailFieldsFragment,
+  useMarkUnitsAvailableMutation,
+} from '@/types/gqlTypes';
 
 interface Props {
   unit: UnitDetailFieldsFragment;
 }
 const UnitOverview: React.FC<Props> = ({ unit }) => {
   const opportunity = unit.latestOpportunity;
+  const [
+    markUnitAvailable,
+    { loading: availableLoading, error: availableError },
+  ] = useMarkUnitsAvailableMutation({
+    variables: { unitIds: [unit.id] },
+    onCompleted: () => cache.evict({ id: `Unit:${unit.id}` }),
+  });
+
+  if (availableError) throw availableError;
 
   return (
     <Grid container columnSpacing={6} rowSpacing={4}>
@@ -19,6 +34,28 @@ const UnitOverview: React.FC<Props> = ({ unit }) => {
             topCandidate={opportunity.candidates.nodes[0]}
             opportunity={opportunity}
           />
+        </Grid>
+      )}
+      {unit.canBeMarkedAvailableToday && (
+        <Grid item xs={12}>
+          <Paper sx={{ p: 2, backgroundColor: 'primary.surface' }}>
+            <Stack
+              direction='row'
+              spacing={2}
+              alignItems='center'
+              justifyContent={'space-between'}
+            >
+              <Typography>
+                This unit is not currently accepting referrals.
+              </Typography>
+              <LoadingButton
+                onClick={() => markUnitAvailable()}
+                loading={availableLoading}
+              >
+                Start Accepting Referrals
+              </LoadingButton>
+            </Stack>
+          </Paper>
         </Grid>
       )}
       {unit.eligibilityRequirements && (

--- a/src/modules/units/components/UnitPage.tsx
+++ b/src/modules/units/components/UnitPage.tsx
@@ -80,7 +80,6 @@ const UnitPage: React.FC<Props> = ({}) => {
   if (error) throw error;
   if (!unit) return <NotFound />;
 
-  //ceAvailabilityActionsEnabled && unit.canBeMarkedAvailableToday
   return (
     <>
       <PageTitle title={unit.name} />

--- a/src/modules/units/components/UnitPage.tsx
+++ b/src/modules/units/components/UnitPage.tsx
@@ -86,7 +86,6 @@ const UnitPage: React.FC<Props> = ({}) => {
       <CommonTabs
         ariaLabel={'Eligible Clients and Details tabs'}
         tabDefinitions={tabDefinitions}
-        collapseSingleTab={false}
       />
     </>
   );

--- a/src/modules/units/components/UnitPage.tsx
+++ b/src/modules/units/components/UnitPage.tsx
@@ -1,4 +1,3 @@
-import { Box } from '@mui/material';
 import React, { useEffect, useMemo } from 'react';
 import CommonTabs from '@/components/elements/CommonTabs';
 import Loading from '@/components/elements/Loading';
@@ -7,7 +6,6 @@ import NotFound from '@/components/pages/NotFound';
 import useSafeParams from '@/hooks/useSafeParams';
 
 import PrioritizedClientsTable from '@/modules/ce/components/unit/PrioritizedClientsTable';
-import UnitReferralStatus from '@/modules/ce/components/UnitReferralStatus';
 import { useProjectDashboardContext } from '@/modules/projects/components/ProjectDashboard';
 import UnitOverview from '@/modules/units/components/UnitOverview';
 import { ProjectDashboardRoutes } from '@/routes/routes';
@@ -82,13 +80,10 @@ const UnitPage: React.FC<Props> = ({}) => {
   if (error) throw error;
   if (!unit) return <NotFound />;
 
+  //ceAvailabilityActionsEnabled && unit.canBeMarkedAvailableToday
   return (
     <>
       <PageTitle title={unit.name} />
-      <Box sx={{ mb: 2 }}>
-        <UnitReferralStatus unit={unit} />
-        {/* TODO button to mark as available/unavailable? */}
-      </Box>
       <CommonTabs
         ariaLabel={'Eligible Clients and Details tabs'}
         tabDefinitions={tabDefinitions}

--- a/src/modules/units/components/UnitUtilizationByUnitType.tsx
+++ b/src/modules/units/components/UnitUtilizationByUnitType.tsx
@@ -1,5 +1,6 @@
-import { Grid, Stack, Typography } from '@mui/material';
+import { Divider, Stack, Typography } from '@mui/material';
 
+import { CommonLabeledTextBlock } from '@/components/elements/CommonLabeledTextBlock';
 import UnitUtilizationChart, {
   UnitVisualizationChartLegend,
 } from '@/modules/units/components/UnitUtilizationChart';
@@ -7,44 +8,50 @@ import { UnitTypeCapacityFieldsFragment } from '@/types/gqlTypes';
 
 interface Props {
   unitTypes: UnitTypeCapacityFieldsFragment[];
-  variant?: 'stacked' | 'grid';
 }
 
 // Unit capacity charts grouped by unit type
-const UnitUtilizationByUnitType: React.FC<Props> = ({
-  unitTypes,
-  variant = 'stacked',
-}) => {
-  const hasMultipleUnitTypes = unitTypes.length > 1;
-
+const UnitUtilizationByUnitType: React.FC<Props> = ({ unitTypes }) => {
   return (
-    <Stack gap={1}>
-      {unitTypes.map((unitType, idx) =>
-        variant === 'stacked' ? (
-          <Stack key={unitType.id} gap={0.25}>
-            {hasMultipleUnitTypes && (
-              <Typography variant='body2' color='text.secondary'>
+    <>
+      <Stack
+        gap={2}
+        divider={<Divider orientation='horizontal' flexItem />}
+        sx={{ mb: 2 }}
+      >
+        {unitTypes.map((unitType) => (
+          <Stack key={unitType.id} gap={0.5} key={unitType.id}>
+            <Stack justifyContent={'space-between'} direction='row'>
+              <Typography variant='body2' color='text.primary' fontWeight={600}>
                 {unitType.unitType}
               </Typography>
-            )}
+              <Stack
+                direction='row'
+                spacing={1.5}
+                divider={
+                  <Typography variant='body2' color='text.primary'>
+                    •
+                  </Typography>
+                }
+              >
+                <CommonLabeledTextBlock title='Total:' horizontal>
+                  {unitType.capacity || <>0</>}
+                </CommonLabeledTextBlock>
+                <CommonLabeledTextBlock title='Occupied:' horizontal>
+                  {unitType.capacity - unitType.availability || <>0</>}
+                </CommonLabeledTextBlock>
+                <CommonLabeledTextBlock title='Vacant:' horizontal>
+                  {unitType.availability || <>0</>}
+                </CommonLabeledTextBlock>
+              </Stack>
+            </Stack>
+
             <UnitUtilizationChart unitType={unitType} />
           </Stack>
-        ) : (
-          <Grid container key={unitType.id}>
-            <Grid item xs={3}>
-              <Typography variant='body1' color='text.primary'>
-                {unitType.unitType}
-              </Typography>
-            </Grid>
-            <Grid item xs={9}>
-              <UnitUtilizationChart unitType={unitType} />
-              {idx === unitTypes.length - 1 && <UnitVisualizationChartLegend />}
-            </Grid>
-          </Grid>
-        )
-      )}
-      {variant === 'stacked' && <UnitVisualizationChartLegend />}
-    </Stack>
+        ))}
+      </Stack>
+      <UnitVisualizationChartLegend />
+    </>
   );
 };
 export default UnitUtilizationByUnitType;

--- a/src/modules/units/components/UnitUtilizationByUnitType.tsx
+++ b/src/modules/units/components/UnitUtilizationByUnitType.tsx
@@ -20,7 +20,7 @@ const UnitUtilizationByUnitType: React.FC<Props> = ({ unitTypes }) => {
         sx={{ mb: 2 }}
       >
         {unitTypes.map((unitType) => (
-          <Stack key={unitType.id} gap={0.5} key={unitType.id}>
+          <Stack key={unitType.id} gap={0.5}>
             <Stack justifyContent={'space-between'} direction='row'>
               <Typography variant='body2' color='text.primary' fontWeight={600}>
                 {unitType.unitType}

--- a/src/modules/units/components/UnitUtilizationChart.tsx
+++ b/src/modules/units/components/UnitUtilizationChart.tsx
@@ -22,7 +22,7 @@ export const UnitVisualizationChart: React.FC<Props> = ({ unitType }) => {
         direction='row'
         sx={{
           backgroundColor: 'background.paper',
-          height: '22px',
+          height: '12px',
           borderRadius: '4px',
           overflow: 'hidden',
           width: '100%',
@@ -42,9 +42,7 @@ export const UnitVisualizationChart: React.FC<Props> = ({ unitType }) => {
             width: `${(occupied / total) * 100}%`,
           }}
         >
-          <Typography variant='caption' sx={{ color: 'white' }}>
-            {occupied}
-          </Typography>
+          <Box sx={{ visibility: 'hidden' }}>{occupied}</Box>
         </Box>
         <Box
           sx={{
@@ -52,9 +50,7 @@ export const UnitVisualizationChart: React.FC<Props> = ({ unitType }) => {
             width: `${(referralInProgress / total) * 100}%`,
           }}
         >
-          <Typography variant='caption' sx={{ color: 'white' }}>
-            {referralInProgress}
-          </Typography>
+          <Box sx={{ visibility: 'hidden' }}>{referralInProgress}</Box>
         </Box>
         <Box
           sx={{
@@ -62,9 +58,7 @@ export const UnitVisualizationChart: React.FC<Props> = ({ unitType }) => {
             width: `${(vacant / total) * 100}%`,
           }}
         >
-          <Typography variant='caption' sx={{ color: 'text.primary' }}>
-            {vacant}
-          </Typography>
+          <Box sx={{ visibility: 'hidden' }}>{vacant}</Box>
         </Box>
       </Stack>
     </Box>

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -44871,6 +44871,7 @@ export type UnitDetailFieldsFragment = {
   name: string;
   unitSize?: number | null;
   acceptingCeReferrals: boolean;
+  canBeMarkedAvailableToday: boolean;
   unitType?: {
     __typename?: 'UnitTypeObject';
     id: string;
@@ -45241,6 +45242,7 @@ export type GetUnitQuery = {
     name: string;
     unitSize?: number | null;
     acceptingCeReferrals: boolean;
+    canBeMarkedAvailableToday: boolean;
     unitType?: {
       __typename?: 'UnitTypeObject';
       id: string;
@@ -48644,6 +48646,7 @@ export const UnitDetailFieldsFragmentDoc = gql`
     name
     unitSize
     acceptingCeReferrals
+    canBeMarkedAvailableToday
     unitType {
       ...UnitTypeFields
     }


### PR DESCRIPTION
## Description



Summary of changes:
* Add total unit count and per-unit-type unit count back to (non-CE) units page, per request https://github.com/open-path/Green-River/issues/7914
* Make some Unit/UnitGroup design changes from Figma
* comment-out configuration cards on unit group that aren't implemented yet
* Support marking unit available from unit page, remove random status at the top

<img width="1191" height="571" alt="Screenshot 2025-07-14 at 3 44 35 PM" src="https://github.com/user-attachments/assets/59ab0b73-c166-47f4-be20-dc29cfc75acd" />
<img width="1185" height="533" alt="Screenshot 2025-07-14 at 3 44 31 PM" src="https://github.com/user-attachments/assets/fa80837a-806a-4f1a-9a31-50119d06abfb" />
<img width="1177" height="471" alt="Screenshot 2025-07-14 at 5 40 43 PM" src="https://github.com/user-attachments/assets/f76fcd8f-dc7a-42d5-bde2-2e05ac263b76" />


## Type of change
New feature

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
