### PR TITLE
Update Referral Step form to use common form patterns

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -6921,6 +6921,30 @@
             "deprecationReason": null
           },
           {
+            "name": "customDataElements",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "CustomDataElement",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "formDefinition",
             "description": null,
             "args": [],
@@ -35943,22 +35967,6 @@
                 "deprecationReason": null
               },
               {
-                "name": "input",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "JsonObject",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
                 "name": "referralId",
                 "description": null,
                 "type": {
@@ -35983,6 +35991,38 @@
                   "ofType": {
                     "kind": "SCALAR",
                     "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "valuesByFieldName",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "JsonObject",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "valuesByLinkId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "JsonObject",
                     "ofType": null
                   }
                 },

--- a/src/api/operations/ce.fragments.graphql
+++ b/src/api/operations/ce.fragments.graphql
@@ -275,7 +275,9 @@ fragment CeReferralStepFields on CeReferralStep {
   formDefinition {
     ...FormDefinitionFields
   }
-  submittedValues
+  customDataElements {
+    ...CustomDataElementFields
+  }
 }
 
 # used for resolving assigned steps on the User Dashboard

--- a/src/api/operations/ce.operations.graphql
+++ b/src/api/operations/ce.operations.graphql
@@ -28,14 +28,16 @@ mutation StartCeReferralStep($referralId: ID!, $stepId: ID!) {
 mutation SubmitCeReferralStep(
   $referralId: ID!
   $stepId: ID!
-  $input: JsonObject!
+  $valuesByLinkId: JsonObject!
+  $valuesByFieldName: JsonObject!
   $confirmed: Boolean
   $formDefinitionId: ID!
 ) {
   submitCeReferralStep(
     referralId: $referralId
     stepId: $stepId
-    input: $input
+    valuesByLinkId: $valuesByLinkId
+    valuesByFieldName: $valuesByFieldName
     confirmed: $confirmed
     formDefinitionId: $formDefinitionId
   ) {

--- a/src/api/operations/ce.queries.graphql
+++ b/src/api/operations/ce.queries.graphql
@@ -92,6 +92,9 @@ query GetCeReferral($id: ID!) {
 query GetCeReferralStep($id: ID!) {
   ceReferralStep(id: $id) {
     ...CeReferralStepFields
+    customDataElements {
+      ...CustomDataElementFields
+    }
   }
 }
 

--- a/src/api/operations/ce.queries.graphql
+++ b/src/api/operations/ce.queries.graphql
@@ -92,9 +92,6 @@ query GetCeReferral($id: ID!) {
 query GetCeReferralStep($id: ID!) {
   ceReferralStep(id: $id) {
     ...CeReferralStepFields
-    customDataElements {
-      ...CustomDataElementFields
-    }
   }
 }
 

--- a/src/modules/ce/components/referral/ReferralStep.tsx
+++ b/src/modules/ce/components/referral/ReferralStep.tsx
@@ -16,11 +16,9 @@ import {
 } from '@/modules/errors/util';
 import DynamicForm from '@/modules/form/components/DynamicForm';
 import DynamicView from '@/modules/form/components/viewable/DynamicView';
+import useInitialFormValues from '@/modules/form/hooks/useInitialFormValues';
 import { FormActionTypes } from '@/modules/form/types';
-import {
-  createInitialValuesFromSavedValues,
-  getItemMap,
-} from '@/modules/form/util/formUtil';
+import { getItemMap } from '@/modules/form/util/formUtil';
 import {
   CeReferralStatus,
   CeReferralStepStatus,
@@ -34,7 +32,7 @@ const ReferralStep: React.FC<Props> = ({}) => {
     referralId: string;
     stepId: string;
   };
-  const { referralPath } = useReferralContext();
+  const { referral, referralPath } = useReferralContext();
   const navigate = useNavigate();
 
   const {
@@ -76,17 +74,20 @@ const ReferralStep: React.FC<Props> = ({}) => {
     },
   });
 
-  const { name, status, formDefinition, submittedValues } = step || {};
+  const { name, status, formDefinition } = step || {};
 
   const itemMap = useMemo(
     () => formDefinition && getItemMap(formDefinition.definition),
     [formDefinition]
   );
 
-  const formState =
-    itemMap &&
-    submittedValues &&
-    createInitialValuesFromSavedValues(itemMap, submittedValues);
+  // Display form values based on the Step record (CustomDataElements) rather than the submittedValues field, to be consistent with other form behavior throughout the application.
+  const initialValues = useInitialFormValues({
+    record: step,
+    itemMap,
+    definition: formDefinition?.definition,
+    localConstants: { projectId: referral.opportunity.projectId },
+  });
 
   const editable =
     status === CeReferralStepStatus.InProgress && step?.access.canPerformStep;
@@ -118,12 +119,13 @@ const ReferralStep: React.FC<Props> = ({}) => {
           {editable ? (
             <DynamicForm
               definition={formDefinition.definition}
-              onSubmit={({ valuesByLinkId, confirmed }) => {
+              onSubmit={({ valuesByLinkId, valuesByFieldName, confirmed }) => {
                 submit({
                   variables: {
                     referralId: referralId,
                     stepId: stepId,
-                    input: valuesByLinkId,
+                    valuesByLinkId,
+                    valuesByFieldName,
                     formDefinitionId: formDefinition.id,
                     confirmed,
                   },
@@ -141,12 +143,12 @@ const ReferralStep: React.FC<Props> = ({}) => {
                   },
                 ],
               }}
-              initialValues={formState}
+              initialValues={initialValues}
             />
           ) : (
             <DynamicView
               definition={formDefinition.definition}
-              values={formState}
+              values={initialValues}
             />
           )}
         </Stack>

--- a/src/modules/ce/components/referral/ReferralStep.tsx
+++ b/src/modules/ce/components/referral/ReferralStep.tsx
@@ -1,39 +1,24 @@
 import { Box, Divider, Stack } from '@mui/material';
-import React, { useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import React from 'react';
 import ReferralStepDetails from './ReferralStepDetails';
 import ButtonLink from '@/components/elements/ButtonLink';
 import CommonCard from '@/components/elements/CommonCard';
-import Loading from '@/components/elements/Loading';
+import LoadingSkeleton from '@/components/elements/LoadingSkeleton';
 import { BackIcon } from '@/components/elements/SemanticIcons';
 import NotFound from '@/components/pages/NotFound';
 import useSafeParams from '@/hooks/useSafeParams';
 import { useReferralContext } from '@/modules/ce/components/referral/ReferralPage';
+import ReferralStepForm from '@/modules/ce/components/referral/ReferralStepForm';
 import {
-  emptyErrorState,
-  ErrorState,
-  partitionValidations,
-} from '@/modules/errors/util';
-import DynamicForm from '@/modules/form/components/DynamicForm';
-import DynamicView from '@/modules/form/components/viewable/DynamicView';
-import useInitialFormValues from '@/modules/form/hooks/useInitialFormValues';
-import { FormActionTypes } from '@/modules/form/types';
-import { getItemMap } from '@/modules/form/util/formUtil';
-import {
-  CeReferralStatus,
   CeReferralStepStatus,
   useGetCeReferralStepQuery,
-  useSubmitCeReferralStepMutation,
 } from '@/types/gqlTypes';
 
-interface Props {}
-const ReferralStep: React.FC<Props> = ({}) => {
-  const { referralId, stepId } = useSafeParams() as {
-    referralId: string;
+const ReferralStep: React.FC = ({}) => {
+  const { referral, referralPath } = useReferralContext();
+  const { stepId } = useSafeParams() as {
     stepId: string;
   };
-  const { referral, referralPath } = useReferralContext();
-  const navigate = useNavigate();
 
   const {
     data: { ceReferralStep: step } = {},
@@ -45,60 +30,15 @@ const ReferralStep: React.FC<Props> = ({}) => {
     },
   });
 
-  const [errors, setErrors] = useState<ErrorState>(emptyErrorState);
+  const stepSummary = referral.steps.find((s) => s.stepId === stepId);
 
-  const [submit, { loading: submitLoading }] = useSubmitCeReferralStepMutation({
-    onCompleted: (data) => {
-      const errors = data.submitCeReferralStep?.errors;
-      if (errors && errors.length > 0) {
-        setErrors(partitionValidations(errors));
-        return;
-      }
-
-      setErrors(emptyErrorState);
-
-      const status = data.submitCeReferralStep?.referral?.status;
-      const wayfind =
-        status &&
-        [CeReferralStatus.Rejected, CeReferralStatus.Accepted].includes(status);
-
-      navigate({
-        pathname: referralPath,
-        search: wayfind
-          ? new URLSearchParams({ wayfinding: 'true' }).toString()
-          : undefined,
-      });
-    },
-    onError: (apolloError) => {
-      setErrors({ ...emptyErrorState, apolloError });
-    },
-  });
-
-  const { name, status, formDefinition } = step || {};
-
-  const itemMap = useMemo(
-    () => formDefinition && getItemMap(formDefinition.definition),
-    [formDefinition]
-  );
-
-  // Display form values based on the Step record (CustomDataElements) rather than the submittedValues field, to be consistent with other form behavior throughout the application.
-  const initialValues = useInitialFormValues({
-    record: step,
-    itemMap,
-    definition: formDefinition?.definition,
-    localConstants: { projectId: referral.opportunity.projectId },
-  });
-
-  const editable =
-    status === CeReferralStepStatus.InProgress && step?.access.canPerformStep;
-
-  if (fetchLoading) return <Loading />;
   if (fetchError) throw fetchError;
-  if (!step || !formDefinition) return <NotFound />;
+  if (!stepSummary) return <NotFound />;
+  if (!fetchLoading && !step) return <NotFound />;
 
   if (
     [CeReferralStepStatus.Unavailable, CeReferralStepStatus.Available].includes(
-      step.status
+      stepSummary.status
     )
   ) {
     // The step has to be started from the Referral Steps page
@@ -112,45 +52,12 @@ const ReferralStep: React.FC<Props> = ({}) => {
           Back to All Tasks
         </ButtonLink>
       </Box>
-      <CommonCard title={name}>
+      <CommonCard title={stepSummary.name}>
         <Stack gap={2}>
-          <ReferralStepDetails step={step} />
+          <ReferralStepDetails step={stepSummary} />
           <Divider />
-          {editable ? (
-            <DynamicForm
-              definition={formDefinition.definition}
-              onSubmit={({ valuesByLinkId, valuesByFieldName, confirmed }) => {
-                submit({
-                  variables: {
-                    referralId: referralId,
-                    stepId: stepId,
-                    valuesByLinkId,
-                    valuesByFieldName,
-                    formDefinitionId: formDefinition.id,
-                    confirmed,
-                  },
-                });
-              }}
-              errors={errors}
-              loading={submitLoading}
-              FormActionProps={{
-                config: [
-                  {
-                    id: 'submit',
-                    label: 'Submit',
-                    action: FormActionTypes.Submit,
-                    buttonProps: { variant: 'contained' },
-                  },
-                ],
-              }}
-              initialValues={initialValues}
-            />
-          ) : (
-            <DynamicView
-              definition={formDefinition.definition}
-              values={initialValues}
-            />
-          )}
+          {fetchLoading && !step && <LoadingSkeleton count={1} height={200} />}
+          {step && <ReferralStepForm step={step} />}
         </Stack>
       </CommonCard>
     </Stack>

--- a/src/modules/ce/components/referral/ReferralStepForm.tsx
+++ b/src/modules/ce/components/referral/ReferralStepForm.tsx
@@ -1,0 +1,137 @@
+import React, { useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import NotFound from '@/components/pages/NotFound';
+import useSafeParams from '@/hooks/useSafeParams';
+import { useReferralContext } from '@/modules/ce/components/referral/ReferralPage';
+import {
+  emptyErrorState,
+  ErrorState,
+  partitionValidations,
+} from '@/modules/errors/util';
+import DynamicForm from '@/modules/form/components/DynamicForm';
+import DynamicView from '@/modules/form/components/viewable/DynamicView';
+import useInitialFormValues from '@/modules/form/hooks/useInitialFormValues';
+import { FormActionTypes } from '@/modules/form/types';
+import { getItemMap } from '@/modules/form/util/formUtil';
+import {
+  CeReferralStatus,
+  CeReferralStepFieldsFragment,
+  CeReferralStepStatus,
+  useSubmitCeReferralStepMutation,
+} from '@/types/gqlTypes';
+
+interface Props {
+  step: CeReferralStepFieldsFragment;
+}
+
+/**
+ * Renders a form for a completing or viewing a referral step (task)
+ */
+const ReferralStepForm: React.FC<Props> = ({ step }) => {
+  const { referralId, stepId } = useSafeParams() as {
+    referralId: string;
+    stepId: string;
+  };
+  const { referral, referralPath } = useReferralContext();
+  const navigate = useNavigate();
+
+  const [errors, setErrors] = useState<ErrorState>(emptyErrorState);
+
+  const [submit, { loading: submitLoading }] = useSubmitCeReferralStepMutation({
+    onCompleted: (data) => {
+      const errors = data.submitCeReferralStep?.errors;
+      if (errors && errors.length > 0) {
+        setErrors(partitionValidations(errors));
+        return;
+      }
+
+      setErrors(emptyErrorState);
+
+      const status = data.submitCeReferralStep?.referral?.status;
+      const wayfind =
+        status &&
+        [CeReferralStatus.Rejected, CeReferralStatus.Accepted].includes(status);
+
+      navigate({
+        pathname: referralPath,
+        search: wayfind
+          ? new URLSearchParams({ wayfinding: 'true' }).toString()
+          : undefined,
+      });
+    },
+    onError: (apolloError) => {
+      setErrors({ ...emptyErrorState, apolloError });
+    },
+  });
+
+  const { status, formDefinition } = step || {};
+
+  const itemMap = useMemo(
+    () => formDefinition && getItemMap(formDefinition.definition),
+    [formDefinition]
+  );
+
+  // Display form values based on the Step record (CustomDataElements) rather than the submittedValues field, to be consistent with other form behavior throughout the application.
+  const initialValues = useInitialFormValues({
+    record: step,
+    itemMap,
+    definition: formDefinition?.definition,
+    localConstants: { projectId: referral.opportunity.projectId },
+  });
+
+  const editable =
+    status === CeReferralStepStatus.InProgress && step?.access.canPerformStep;
+
+  if (!step || !formDefinition) return <NotFound />;
+
+  if (
+    [CeReferralStepStatus.Unavailable, CeReferralStepStatus.Available].includes(
+      step.status
+    )
+  ) {
+    // The step has to be started from the Referral Steps page
+    return <NotFound />;
+  }
+
+  return (
+    <>
+      {editable ? (
+        <DynamicForm
+          definition={formDefinition.definition}
+          onSubmit={({ valuesByLinkId, valuesByFieldName, confirmed }) => {
+            submit({
+              variables: {
+                referralId: referralId,
+                stepId: stepId,
+                valuesByLinkId,
+                valuesByFieldName,
+                formDefinitionId: formDefinition.id,
+                confirmed,
+              },
+            });
+          }}
+          errors={errors}
+          loading={submitLoading}
+          FormActionProps={{
+            config: [
+              {
+                id: 'submit',
+                label: 'Submit',
+                action: FormActionTypes.Submit,
+                buttonProps: { variant: 'contained' },
+              },
+            ],
+          }}
+          initialValues={initialValues}
+        />
+      ) : (
+        <DynamicView
+          definition={formDefinition.definition}
+          values={initialValues}
+        />
+      )}
+    </>
+  );
+};
+
+export default ReferralStepForm;

--- a/src/modules/ce/components/referral/ReferralStepForm.tsx
+++ b/src/modules/ce/components/referral/ReferralStepForm.tsx
@@ -1,6 +1,5 @@
 import React, { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import NotFound from '@/components/pages/NotFound';
 import useSafeParams from '@/hooks/useSafeParams';
 import { useReferralContext } from '@/modules/ce/components/referral/ReferralPage';
 import {
@@ -25,7 +24,7 @@ interface Props {
 }
 
 /**
- * Renders a form for a completing or viewing a referral step (task)
+ * Render Referral Step (Task) as a DynamicForm or DynamicView
  */
 const ReferralStepForm: React.FC<Props> = ({ step }) => {
   const { referralId, stepId } = useSafeParams() as {
@@ -81,17 +80,6 @@ const ReferralStepForm: React.FC<Props> = ({ step }) => {
 
   const editable =
     status === CeReferralStepStatus.InProgress && step?.access.canPerformStep;
-
-  if (!step || !formDefinition) return <NotFound />;
-
-  if (
-    [CeReferralStepStatus.Unavailable, CeReferralStepStatus.Available].includes(
-      step.status
-    )
-  ) {
-    // The step has to be started from the Referral Steps page
-    return <NotFound />;
-  }
 
   return (
     <>

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -17007,7 +17007,6 @@ export type CeReferralStepSummaryFieldsFragment = {
 
 export type CeReferralStepFieldsFragment = {
   __typename?: 'CeReferralStep';
-  submittedValues?: any | null;
   id: string;
   stepId?: string | null;
   name: string;
@@ -17525,6 +17524,127 @@ export type CeReferralStepFieldsFragment = {
     };
     updatedBy?: { __typename?: 'ApplicationUser'; name: string } | null;
   };
+  customDataElements: Array<{
+    __typename?: 'CustomDataElement';
+    id: string;
+    key: string;
+    label: string;
+    fieldType: CustomDataElementType;
+    repeats: boolean;
+    displayHooks: Array<DisplayHook>;
+    value?: {
+      __typename?: 'CustomDataElementValue';
+      id: string;
+      valueBoolean?: boolean | null;
+      valueDate?: string | null;
+      valueFloat?: number | null;
+      valueInteger?: number | null;
+      valueJson?: any | null;
+      valueString?: string | null;
+      valueText?: string | null;
+      dateCreated?: string | null;
+      dateUpdated?: string | null;
+      valueFile?: {
+        __typename?: 'File';
+        confidential?: boolean | null;
+        contentType?: string | null;
+        effectiveDate?: string | null;
+        expirationDate?: string | null;
+        id: string;
+        name: string;
+        url?: string | null;
+        tags: Array<string>;
+        ownFile: boolean;
+        redacted: boolean;
+        enrollmentId?: string | null;
+        dateCreated?: string | null;
+        dateUpdated?: string | null;
+        enrollment?: { __typename?: 'Enrollment'; id: string } | null;
+        uploadedBy?: {
+          __typename?: 'ApplicationUser';
+          id: string;
+          name: string;
+        } | null;
+        updatedBy?: {
+          __typename?: 'ApplicationUser';
+          id: string;
+          name: string;
+        } | null;
+        user?: {
+          __typename: 'ApplicationUser';
+          id: string;
+          name: string;
+          firstName?: string | null;
+          lastName?: string | null;
+          email: string;
+        } | null;
+      } | null;
+      user?: {
+        __typename: 'ApplicationUser';
+        id: string;
+        name: string;
+        firstName?: string | null;
+        lastName?: string | null;
+        email: string;
+      } | null;
+    } | null;
+    values?: Array<{
+      __typename?: 'CustomDataElementValue';
+      id: string;
+      valueBoolean?: boolean | null;
+      valueDate?: string | null;
+      valueFloat?: number | null;
+      valueInteger?: number | null;
+      valueJson?: any | null;
+      valueString?: string | null;
+      valueText?: string | null;
+      dateCreated?: string | null;
+      dateUpdated?: string | null;
+      valueFile?: {
+        __typename?: 'File';
+        confidential?: boolean | null;
+        contentType?: string | null;
+        effectiveDate?: string | null;
+        expirationDate?: string | null;
+        id: string;
+        name: string;
+        url?: string | null;
+        tags: Array<string>;
+        ownFile: boolean;
+        redacted: boolean;
+        enrollmentId?: string | null;
+        dateCreated?: string | null;
+        dateUpdated?: string | null;
+        enrollment?: { __typename?: 'Enrollment'; id: string } | null;
+        uploadedBy?: {
+          __typename?: 'ApplicationUser';
+          id: string;
+          name: string;
+        } | null;
+        updatedBy?: {
+          __typename?: 'ApplicationUser';
+          id: string;
+          name: string;
+        } | null;
+        user?: {
+          __typename: 'ApplicationUser';
+          id: string;
+          name: string;
+          firstName?: string | null;
+          lastName?: string | null;
+          email: string;
+        } | null;
+      } | null;
+      user?: {
+        __typename: 'ApplicationUser';
+        id: string;
+        name: string;
+        firstName?: string | null;
+        lastName?: string | null;
+        email: string;
+      } | null;
+    }> | null;
+  }>;
   assignees: Array<{
     __typename?: 'ApplicationUser';
     id: string;
@@ -17645,7 +17765,6 @@ export type StartCeReferralStepMutation = {
     __typename?: 'StartCeReferralStepPayload';
     step: {
       __typename?: 'CeReferralStep';
-      submittedValues?: any | null;
       id: string;
       stepId?: string | null;
       name: string;
@@ -18163,6 +18282,127 @@ export type StartCeReferralStepMutation = {
         };
         updatedBy?: { __typename?: 'ApplicationUser'; name: string } | null;
       };
+      customDataElements: Array<{
+        __typename?: 'CustomDataElement';
+        id: string;
+        key: string;
+        label: string;
+        fieldType: CustomDataElementType;
+        repeats: boolean;
+        displayHooks: Array<DisplayHook>;
+        value?: {
+          __typename?: 'CustomDataElementValue';
+          id: string;
+          valueBoolean?: boolean | null;
+          valueDate?: string | null;
+          valueFloat?: number | null;
+          valueInteger?: number | null;
+          valueJson?: any | null;
+          valueString?: string | null;
+          valueText?: string | null;
+          dateCreated?: string | null;
+          dateUpdated?: string | null;
+          valueFile?: {
+            __typename?: 'File';
+            confidential?: boolean | null;
+            contentType?: string | null;
+            effectiveDate?: string | null;
+            expirationDate?: string | null;
+            id: string;
+            name: string;
+            url?: string | null;
+            tags: Array<string>;
+            ownFile: boolean;
+            redacted: boolean;
+            enrollmentId?: string | null;
+            dateCreated?: string | null;
+            dateUpdated?: string | null;
+            enrollment?: { __typename?: 'Enrollment'; id: string } | null;
+            uploadedBy?: {
+              __typename?: 'ApplicationUser';
+              id: string;
+              name: string;
+            } | null;
+            updatedBy?: {
+              __typename?: 'ApplicationUser';
+              id: string;
+              name: string;
+            } | null;
+            user?: {
+              __typename: 'ApplicationUser';
+              id: string;
+              name: string;
+              firstName?: string | null;
+              lastName?: string | null;
+              email: string;
+            } | null;
+          } | null;
+          user?: {
+            __typename: 'ApplicationUser';
+            id: string;
+            name: string;
+            firstName?: string | null;
+            lastName?: string | null;
+            email: string;
+          } | null;
+        } | null;
+        values?: Array<{
+          __typename?: 'CustomDataElementValue';
+          id: string;
+          valueBoolean?: boolean | null;
+          valueDate?: string | null;
+          valueFloat?: number | null;
+          valueInteger?: number | null;
+          valueJson?: any | null;
+          valueString?: string | null;
+          valueText?: string | null;
+          dateCreated?: string | null;
+          dateUpdated?: string | null;
+          valueFile?: {
+            __typename?: 'File';
+            confidential?: boolean | null;
+            contentType?: string | null;
+            effectiveDate?: string | null;
+            expirationDate?: string | null;
+            id: string;
+            name: string;
+            url?: string | null;
+            tags: Array<string>;
+            ownFile: boolean;
+            redacted: boolean;
+            enrollmentId?: string | null;
+            dateCreated?: string | null;
+            dateUpdated?: string | null;
+            enrollment?: { __typename?: 'Enrollment'; id: string } | null;
+            uploadedBy?: {
+              __typename?: 'ApplicationUser';
+              id: string;
+              name: string;
+            } | null;
+            updatedBy?: {
+              __typename?: 'ApplicationUser';
+              id: string;
+              name: string;
+            } | null;
+            user?: {
+              __typename: 'ApplicationUser';
+              id: string;
+              name: string;
+              firstName?: string | null;
+              lastName?: string | null;
+              email: string;
+            } | null;
+          } | null;
+          user?: {
+            __typename: 'ApplicationUser';
+            id: string;
+            name: string;
+            firstName?: string | null;
+            lastName?: string | null;
+            email: string;
+          } | null;
+        }> | null;
+      }>;
       assignees: Array<{
         __typename?: 'ApplicationUser';
         id: string;
@@ -18188,7 +18428,6 @@ export type SubmitCeReferralStepMutation = {
     __typename?: 'SubmitCeReferralStepPayload';
     step?: {
       __typename?: 'CeReferralStep';
-      submittedValues?: any | null;
       id: string;
       stepId?: string | null;
       name: string;
@@ -18706,6 +18945,127 @@ export type SubmitCeReferralStepMutation = {
         };
         updatedBy?: { __typename?: 'ApplicationUser'; name: string } | null;
       };
+      customDataElements: Array<{
+        __typename?: 'CustomDataElement';
+        id: string;
+        key: string;
+        label: string;
+        fieldType: CustomDataElementType;
+        repeats: boolean;
+        displayHooks: Array<DisplayHook>;
+        value?: {
+          __typename?: 'CustomDataElementValue';
+          id: string;
+          valueBoolean?: boolean | null;
+          valueDate?: string | null;
+          valueFloat?: number | null;
+          valueInteger?: number | null;
+          valueJson?: any | null;
+          valueString?: string | null;
+          valueText?: string | null;
+          dateCreated?: string | null;
+          dateUpdated?: string | null;
+          valueFile?: {
+            __typename?: 'File';
+            confidential?: boolean | null;
+            contentType?: string | null;
+            effectiveDate?: string | null;
+            expirationDate?: string | null;
+            id: string;
+            name: string;
+            url?: string | null;
+            tags: Array<string>;
+            ownFile: boolean;
+            redacted: boolean;
+            enrollmentId?: string | null;
+            dateCreated?: string | null;
+            dateUpdated?: string | null;
+            enrollment?: { __typename?: 'Enrollment'; id: string } | null;
+            uploadedBy?: {
+              __typename?: 'ApplicationUser';
+              id: string;
+              name: string;
+            } | null;
+            updatedBy?: {
+              __typename?: 'ApplicationUser';
+              id: string;
+              name: string;
+            } | null;
+            user?: {
+              __typename: 'ApplicationUser';
+              id: string;
+              name: string;
+              firstName?: string | null;
+              lastName?: string | null;
+              email: string;
+            } | null;
+          } | null;
+          user?: {
+            __typename: 'ApplicationUser';
+            id: string;
+            name: string;
+            firstName?: string | null;
+            lastName?: string | null;
+            email: string;
+          } | null;
+        } | null;
+        values?: Array<{
+          __typename?: 'CustomDataElementValue';
+          id: string;
+          valueBoolean?: boolean | null;
+          valueDate?: string | null;
+          valueFloat?: number | null;
+          valueInteger?: number | null;
+          valueJson?: any | null;
+          valueString?: string | null;
+          valueText?: string | null;
+          dateCreated?: string | null;
+          dateUpdated?: string | null;
+          valueFile?: {
+            __typename?: 'File';
+            confidential?: boolean | null;
+            contentType?: string | null;
+            effectiveDate?: string | null;
+            expirationDate?: string | null;
+            id: string;
+            name: string;
+            url?: string | null;
+            tags: Array<string>;
+            ownFile: boolean;
+            redacted: boolean;
+            enrollmentId?: string | null;
+            dateCreated?: string | null;
+            dateUpdated?: string | null;
+            enrollment?: { __typename?: 'Enrollment'; id: string } | null;
+            uploadedBy?: {
+              __typename?: 'ApplicationUser';
+              id: string;
+              name: string;
+            } | null;
+            updatedBy?: {
+              __typename?: 'ApplicationUser';
+              id: string;
+              name: string;
+            } | null;
+            user?: {
+              __typename: 'ApplicationUser';
+              id: string;
+              name: string;
+              firstName?: string | null;
+              lastName?: string | null;
+              email: string;
+            } | null;
+          } | null;
+          user?: {
+            __typename: 'ApplicationUser';
+            id: string;
+            name: string;
+            firstName?: string | null;
+            lastName?: string | null;
+            email: string;
+          } | null;
+        }> | null;
+      }>;
       assignees: Array<{
         __typename?: 'ApplicationUser';
         id: string;
@@ -19535,7 +19895,6 @@ export type GetCeReferralStepQuery = {
   __typename?: 'Query';
   ceReferralStep?: {
     __typename?: 'CeReferralStep';
-    submittedValues?: any | null;
     id: string;
     stepId?: string | null;
     name: string;
@@ -19543,127 +19902,6 @@ export type GetCeReferralStepQuery = {
     swimlane: string;
     availableAt?: string | null;
     updatedAt?: string | null;
-    customDataElements: Array<{
-      __typename?: 'CustomDataElement';
-      id: string;
-      key: string;
-      label: string;
-      fieldType: CustomDataElementType;
-      repeats: boolean;
-      displayHooks: Array<DisplayHook>;
-      value?: {
-        __typename?: 'CustomDataElementValue';
-        id: string;
-        valueBoolean?: boolean | null;
-        valueDate?: string | null;
-        valueFloat?: number | null;
-        valueInteger?: number | null;
-        valueJson?: any | null;
-        valueString?: string | null;
-        valueText?: string | null;
-        dateCreated?: string | null;
-        dateUpdated?: string | null;
-        valueFile?: {
-          __typename?: 'File';
-          confidential?: boolean | null;
-          contentType?: string | null;
-          effectiveDate?: string | null;
-          expirationDate?: string | null;
-          id: string;
-          name: string;
-          url?: string | null;
-          tags: Array<string>;
-          ownFile: boolean;
-          redacted: boolean;
-          enrollmentId?: string | null;
-          dateCreated?: string | null;
-          dateUpdated?: string | null;
-          enrollment?: { __typename?: 'Enrollment'; id: string } | null;
-          uploadedBy?: {
-            __typename?: 'ApplicationUser';
-            id: string;
-            name: string;
-          } | null;
-          updatedBy?: {
-            __typename?: 'ApplicationUser';
-            id: string;
-            name: string;
-          } | null;
-          user?: {
-            __typename: 'ApplicationUser';
-            id: string;
-            name: string;
-            firstName?: string | null;
-            lastName?: string | null;
-            email: string;
-          } | null;
-        } | null;
-        user?: {
-          __typename: 'ApplicationUser';
-          id: string;
-          name: string;
-          firstName?: string | null;
-          lastName?: string | null;
-          email: string;
-        } | null;
-      } | null;
-      values?: Array<{
-        __typename?: 'CustomDataElementValue';
-        id: string;
-        valueBoolean?: boolean | null;
-        valueDate?: string | null;
-        valueFloat?: number | null;
-        valueInteger?: number | null;
-        valueJson?: any | null;
-        valueString?: string | null;
-        valueText?: string | null;
-        dateCreated?: string | null;
-        dateUpdated?: string | null;
-        valueFile?: {
-          __typename?: 'File';
-          confidential?: boolean | null;
-          contentType?: string | null;
-          effectiveDate?: string | null;
-          expirationDate?: string | null;
-          id: string;
-          name: string;
-          url?: string | null;
-          tags: Array<string>;
-          ownFile: boolean;
-          redacted: boolean;
-          enrollmentId?: string | null;
-          dateCreated?: string | null;
-          dateUpdated?: string | null;
-          enrollment?: { __typename?: 'Enrollment'; id: string } | null;
-          uploadedBy?: {
-            __typename?: 'ApplicationUser';
-            id: string;
-            name: string;
-          } | null;
-          updatedBy?: {
-            __typename?: 'ApplicationUser';
-            id: string;
-            name: string;
-          } | null;
-          user?: {
-            __typename: 'ApplicationUser';
-            id: string;
-            name: string;
-            firstName?: string | null;
-            lastName?: string | null;
-            email: string;
-          } | null;
-        } | null;
-        user?: {
-          __typename: 'ApplicationUser';
-          id: string;
-          name: string;
-          firstName?: string | null;
-          lastName?: string | null;
-          email: string;
-        } | null;
-      }> | null;
-    }>;
     formDefinition: {
       __typename?: 'FormDefinition';
       id: string;
@@ -20174,6 +20412,127 @@ export type GetCeReferralStepQuery = {
       };
       updatedBy?: { __typename?: 'ApplicationUser'; name: string } | null;
     };
+    customDataElements: Array<{
+      __typename?: 'CustomDataElement';
+      id: string;
+      key: string;
+      label: string;
+      fieldType: CustomDataElementType;
+      repeats: boolean;
+      displayHooks: Array<DisplayHook>;
+      value?: {
+        __typename?: 'CustomDataElementValue';
+        id: string;
+        valueBoolean?: boolean | null;
+        valueDate?: string | null;
+        valueFloat?: number | null;
+        valueInteger?: number | null;
+        valueJson?: any | null;
+        valueString?: string | null;
+        valueText?: string | null;
+        dateCreated?: string | null;
+        dateUpdated?: string | null;
+        valueFile?: {
+          __typename?: 'File';
+          confidential?: boolean | null;
+          contentType?: string | null;
+          effectiveDate?: string | null;
+          expirationDate?: string | null;
+          id: string;
+          name: string;
+          url?: string | null;
+          tags: Array<string>;
+          ownFile: boolean;
+          redacted: boolean;
+          enrollmentId?: string | null;
+          dateCreated?: string | null;
+          dateUpdated?: string | null;
+          enrollment?: { __typename?: 'Enrollment'; id: string } | null;
+          uploadedBy?: {
+            __typename?: 'ApplicationUser';
+            id: string;
+            name: string;
+          } | null;
+          updatedBy?: {
+            __typename?: 'ApplicationUser';
+            id: string;
+            name: string;
+          } | null;
+          user?: {
+            __typename: 'ApplicationUser';
+            id: string;
+            name: string;
+            firstName?: string | null;
+            lastName?: string | null;
+            email: string;
+          } | null;
+        } | null;
+        user?: {
+          __typename: 'ApplicationUser';
+          id: string;
+          name: string;
+          firstName?: string | null;
+          lastName?: string | null;
+          email: string;
+        } | null;
+      } | null;
+      values?: Array<{
+        __typename?: 'CustomDataElementValue';
+        id: string;
+        valueBoolean?: boolean | null;
+        valueDate?: string | null;
+        valueFloat?: number | null;
+        valueInteger?: number | null;
+        valueJson?: any | null;
+        valueString?: string | null;
+        valueText?: string | null;
+        dateCreated?: string | null;
+        dateUpdated?: string | null;
+        valueFile?: {
+          __typename?: 'File';
+          confidential?: boolean | null;
+          contentType?: string | null;
+          effectiveDate?: string | null;
+          expirationDate?: string | null;
+          id: string;
+          name: string;
+          url?: string | null;
+          tags: Array<string>;
+          ownFile: boolean;
+          redacted: boolean;
+          enrollmentId?: string | null;
+          dateCreated?: string | null;
+          dateUpdated?: string | null;
+          enrollment?: { __typename?: 'Enrollment'; id: string } | null;
+          uploadedBy?: {
+            __typename?: 'ApplicationUser';
+            id: string;
+            name: string;
+          } | null;
+          updatedBy?: {
+            __typename?: 'ApplicationUser';
+            id: string;
+            name: string;
+          } | null;
+          user?: {
+            __typename: 'ApplicationUser';
+            id: string;
+            name: string;
+            firstName?: string | null;
+            lastName?: string | null;
+            email: string;
+          } | null;
+        } | null;
+        user?: {
+          __typename: 'ApplicationUser';
+          id: string;
+          name: string;
+          firstName?: string | null;
+          lastName?: string | null;
+          email: string;
+        } | null;
+      }> | null;
+    }>;
     assignees: Array<{
       __typename?: 'ApplicationUser';
       id: string;
@@ -47241,10 +47600,13 @@ export const CeReferralStepFieldsFragmentDoc = gql`
     formDefinition {
       ...FormDefinitionFields
     }
-    submittedValues
+    customDataElements {
+      ...CustomDataElementFields
+    }
   }
   ${CeReferralStepSummaryFieldsFragmentDoc}
   ${FormDefinitionFieldsFragmentDoc}
+  ${CustomDataElementFieldsFragmentDoc}
 `;
 export const UserCeReferralStepFieldsFragmentDoc = gql`
   fragment UserCeReferralStepFields on CeReferralStep {
@@ -51687,13 +52049,9 @@ export const GetCeReferralStepDocument = gql`
   query GetCeReferralStep($id: ID!) {
     ceReferralStep(id: $id) {
       ...CeReferralStepFields
-      customDataElements {
-        ...CustomDataElementFields
-      }
     }
   }
   ${CeReferralStepFieldsFragmentDoc}
-  ${CustomDataElementFieldsFragmentDoc}
 `;
 
 /**

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -902,6 +902,7 @@ export type CeReferralStep = {
   /** User(s) currently assigned to this step */
   assignees: Array<ApplicationUser>;
   availableAt?: Maybe<Scalars['ISO8601DateTime']['output']>;
+  customDataElements: Array<CustomDataElement>;
   formDefinition: FormDefinition;
   /** unique identifier for this step based on node and instance */
   id: Scalars['ID']['output'];
@@ -5035,9 +5036,10 @@ export type MutationSubmitAssessmentArgs = {
 export type MutationSubmitCeReferralStepArgs = {
   confirmed?: InputMaybe<Scalars['Boolean']['input']>;
   formDefinitionId: Scalars['ID']['input'];
-  input: Scalars['JsonObject']['input'];
   referralId: Scalars['ID']['input'];
   stepId: Scalars['ID']['input'];
+  valuesByFieldName: Scalars['JsonObject']['input'];
+  valuesByLinkId: Scalars['JsonObject']['input'];
 };
 
 export type MutationSubmitFormArgs = {
@@ -18174,7 +18176,8 @@ export type StartCeReferralStepMutation = {
 export type SubmitCeReferralStepMutationVariables = Exact<{
   referralId: Scalars['ID']['input'];
   stepId: Scalars['ID']['input'];
-  input: Scalars['JsonObject']['input'];
+  valuesByLinkId: Scalars['JsonObject']['input'];
+  valuesByFieldName: Scalars['JsonObject']['input'];
   confirmed?: InputMaybe<Scalars['Boolean']['input']>;
   formDefinitionId: Scalars['ID']['input'];
 }>;
@@ -19540,6 +19543,127 @@ export type GetCeReferralStepQuery = {
     swimlane: string;
     availableAt?: string | null;
     updatedAt?: string | null;
+    customDataElements: Array<{
+      __typename?: 'CustomDataElement';
+      id: string;
+      key: string;
+      label: string;
+      fieldType: CustomDataElementType;
+      repeats: boolean;
+      displayHooks: Array<DisplayHook>;
+      value?: {
+        __typename?: 'CustomDataElementValue';
+        id: string;
+        valueBoolean?: boolean | null;
+        valueDate?: string | null;
+        valueFloat?: number | null;
+        valueInteger?: number | null;
+        valueJson?: any | null;
+        valueString?: string | null;
+        valueText?: string | null;
+        dateCreated?: string | null;
+        dateUpdated?: string | null;
+        valueFile?: {
+          __typename?: 'File';
+          confidential?: boolean | null;
+          contentType?: string | null;
+          effectiveDate?: string | null;
+          expirationDate?: string | null;
+          id: string;
+          name: string;
+          url?: string | null;
+          tags: Array<string>;
+          ownFile: boolean;
+          redacted: boolean;
+          enrollmentId?: string | null;
+          dateCreated?: string | null;
+          dateUpdated?: string | null;
+          enrollment?: { __typename?: 'Enrollment'; id: string } | null;
+          uploadedBy?: {
+            __typename?: 'ApplicationUser';
+            id: string;
+            name: string;
+          } | null;
+          updatedBy?: {
+            __typename?: 'ApplicationUser';
+            id: string;
+            name: string;
+          } | null;
+          user?: {
+            __typename: 'ApplicationUser';
+            id: string;
+            name: string;
+            firstName?: string | null;
+            lastName?: string | null;
+            email: string;
+          } | null;
+        } | null;
+        user?: {
+          __typename: 'ApplicationUser';
+          id: string;
+          name: string;
+          firstName?: string | null;
+          lastName?: string | null;
+          email: string;
+        } | null;
+      } | null;
+      values?: Array<{
+        __typename?: 'CustomDataElementValue';
+        id: string;
+        valueBoolean?: boolean | null;
+        valueDate?: string | null;
+        valueFloat?: number | null;
+        valueInteger?: number | null;
+        valueJson?: any | null;
+        valueString?: string | null;
+        valueText?: string | null;
+        dateCreated?: string | null;
+        dateUpdated?: string | null;
+        valueFile?: {
+          __typename?: 'File';
+          confidential?: boolean | null;
+          contentType?: string | null;
+          effectiveDate?: string | null;
+          expirationDate?: string | null;
+          id: string;
+          name: string;
+          url?: string | null;
+          tags: Array<string>;
+          ownFile: boolean;
+          redacted: boolean;
+          enrollmentId?: string | null;
+          dateCreated?: string | null;
+          dateUpdated?: string | null;
+          enrollment?: { __typename?: 'Enrollment'; id: string } | null;
+          uploadedBy?: {
+            __typename?: 'ApplicationUser';
+            id: string;
+            name: string;
+          } | null;
+          updatedBy?: {
+            __typename?: 'ApplicationUser';
+            id: string;
+            name: string;
+          } | null;
+          user?: {
+            __typename: 'ApplicationUser';
+            id: string;
+            name: string;
+            firstName?: string | null;
+            lastName?: string | null;
+            email: string;
+          } | null;
+        } | null;
+        user?: {
+          __typename: 'ApplicationUser';
+          id: string;
+          name: string;
+          firstName?: string | null;
+          lastName?: string | null;
+          email: string;
+        } | null;
+      }> | null;
+    }>;
     formDefinition: {
       __typename?: 'FormDefinition';
       id: string;
@@ -50670,14 +50794,16 @@ export const SubmitCeReferralStepDocument = gql`
   mutation SubmitCeReferralStep(
     $referralId: ID!
     $stepId: ID!
-    $input: JsonObject!
+    $valuesByLinkId: JsonObject!
+    $valuesByFieldName: JsonObject!
     $confirmed: Boolean
     $formDefinitionId: ID!
   ) {
     submitCeReferralStep(
       referralId: $referralId
       stepId: $stepId
-      input: $input
+      valuesByLinkId: $valuesByLinkId
+      valuesByFieldName: $valuesByFieldName
       confirmed: $confirmed
       formDefinitionId: $formDefinitionId
     ) {
@@ -50726,7 +50852,8 @@ export type SubmitCeReferralStepMutationFn = Apollo.MutationFunction<
  *   variables: {
  *      referralId: // value for 'referralId'
  *      stepId: // value for 'stepId'
- *      input: // value for 'input'
+ *      valuesByLinkId: // value for 'valuesByLinkId'
+ *      valuesByFieldName: // value for 'valuesByFieldName'
  *      confirmed: // value for 'confirmed'
  *      formDefinitionId: // value for 'formDefinitionId'
  *   },
@@ -51560,9 +51687,13 @@ export const GetCeReferralStepDocument = gql`
   query GetCeReferralStep($id: ID!) {
     ceReferralStep(id: $id) {
       ...CeReferralStepFields
+      customDataElements {
+        ...CustomDataElementFields
+      }
     }
   }
   ${CeReferralStepFieldsFragmentDoc}
+  ${CustomDataElementFieldsFragmentDoc}
 `;
 
 /**


### PR DESCRIPTION
## Description
Issue: https://github.com/open-path/Green-River/issues/7876

Summary of changes:
* Refactor ReferralStep into two components to separate out form logic from the rest of display, and to allow for the form loading state to be internal to the card
* Submit both valuesByLinkId and valuesByFieldName values, per the backend change
* Populate the ReferralStepForm based on customDataElements, to be consistent with other forms (by using `useInitialFormValues`)


Depends on hmis-warehouse PR: https://github.com/greenriver/hmis-warehouse/pull/5573


How to test:
* Rerun ce_define_workflows task
   * comment-in the move-in date pieces from the PR to test that
* Create a referral, walk through tasks. Ensure in the db that CDEs are created for each value entered into Task forms.
* Ensure when you re-open tasks that you can see submitted data

## Type of change
New feature

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
