### PR TITLE
Remove default filtering from admin referral table

### DIFF
--- a/src/modules/ce/components/admin/AdminReferralsTable.tsx
+++ b/src/modules/ce/components/admin/AdminReferralsTable.tsx
@@ -15,7 +15,6 @@ import {
 } from '@/routes/routes';
 import {
   CeReferralAdminFieldsFragment,
-  CeReferralStatus,
   GetAdminCeReferralsDocument,
   GetAdminCeReferralsQuery,
   GetAdminCeReferralsQueryVariables,
@@ -28,20 +27,21 @@ const COLUMNS: DataColumnDef<
 >[] = [
   REFERRAL_COLUMNS.client,
   REFERRAL_COLUMNS.status,
-  REFERRAL_COLUMNS.currentSteps,
-  REFERRAL_COLUMNS.daysOnCurrentTask,
+  {
+    ...REFERRAL_COLUMNS.currentSteps,
+    optional: { defaultHidden: false },
+  },
+  {
+    ...REFERRAL_COLUMNS.daysOnCurrentTask,
+    optional: { defaultHidden: false },
+  },
   {
     ...REFERRAL_COLUMNS.currentTaskSwimlane,
-    // FIXME(#7832): bug, defaultHidden: false not working
-    // optional: {
-    //   defaultHidden: false,
-    // },
+    optional: { defaultHidden: false },
   },
   {
     ...REFERRAL_COLUMNS.currentTaskAssignees,
-    optional: {
-      defaultHidden: true,
-    },
+    optional: { defaultHidden: true },
   },
   REFERRAL_WITH_PROJECT_COLUMNS.projectName,
   {
@@ -68,14 +68,12 @@ const COLUMNS: DataColumnDef<
     },
   },
   { ...REFERRAL_COLUMNS.referredBy, optional: { defaultHidden: true } },
-  REFERRAL_COLUMNS.date,
+  { ...REFERRAL_COLUMNS.date, optional: { defaultHidden: false } },
   {
     key: 'updatedBy',
     header: 'Last Updated By',
     render: ({ updatedBy }) => updatedBy?.name,
-    // optional: {
-    //   defaultHidden: false,
-    // },
+    optional: { defaultHidden: false },
   },
 ];
 interface Props {}
@@ -136,12 +134,6 @@ const AdminReferralsTable: React.FC<Props> = ({}) => {
       >
         columns={COLUMNS}
         queryVariables={{}}
-        defaultFilterValues={{
-          referralStatus: [
-            CeReferralStatus.Initialized,
-            CeReferralStatus.InProgress,
-          ],
-        }}
         queryDocument={GetAdminCeReferralsDocument}
         pagePath='ceReferrals'
         noData='No referrals'

--- a/src/modules/ce/components/project/ProjectReferralsTable.tsx
+++ b/src/modules/ce/components/project/ProjectReferralsTable.tsx
@@ -6,7 +6,6 @@ import GenericTableWithData from '@/modules/dataFetching/components/GenericTable
 import { useFilters } from '@/modules/hmis/filterUtil';
 import { ProjectDashboardRoutes } from '@/routes/routes';
 import {
-  CeReferralStatus,
   CeReferralTableFieldsFragment,
   GetProjectCeReferralsDocument,
   GetProjectCeReferralsQuery,
@@ -50,12 +49,6 @@ const ProjectReferralsTable: React.FC<Props> = ({ projectId }) => {
         columns={COLUMNS}
         queryVariables={{
           id: projectId,
-        }}
-        defaultFilterValues={{
-          referralStatus: [
-            CeReferralStatus.Initialized,
-            CeReferralStatus.InProgress,
-          ],
         }}
         filters={filters}
         queryDocument={GetProjectCeReferralsDocument}


### PR DESCRIPTION
## Description

* Remove default filters from the Admin referrals table. In-progress referrals are already floated to the top by default.  A few reasons:
  * The use-case for this table is not strongly known. For example you might be going there to review pending denials, vs review stalled referrals, etc. A default filter is annoying if it's not what you need.
  * Now that we have Custom Status support, Initialized/InProgress might not even be the true representation of an in progress referral. In that case, the table could even show up empty by default.
* Make some more columns hideable, turns out https://github.com/open-path/Green-River/issues/7832 may not be a bug (or at least not, for everyone..)
* 
## Type of change
bug/feature

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
