### PR TITLE
Follow up on QA items for AHA score

### DIFF
--- a/src/modules/external/aha/components/AhaScore.tsx
+++ b/src/modules/external/aha/components/AhaScore.tsx
@@ -45,11 +45,12 @@ const AhaScore = ({
   // Use RHF to watch the current value of the score field.
   // This is to disable the fetch button after unlocking an assessment that's already fetched the score.
   const values = useDynamicFieldWatchValues([SCORE_LINK_ID]);
-  const existingValue = values[SCORE_LINK_ID];
+  const scoreValue = values[SCORE_LINK_ID];
 
-  const [hasScore, setHasScore] = useState<boolean>(
-    !!existingValue && existingValue >= 0
-  );
+  // If client has no score (-1 is returned), hasScore is false and the button stays enabled
+  const hasScore =
+    scoreValue !== null && scoreValue !== undefined && scoreValue >= 0;
+
   const [hasFetched, setHasFetched] = useState<boolean>(false);
 
   const clientId = handlers?.localConstants.clientId;
@@ -62,36 +63,26 @@ const AhaScore = ({
       const errors = data.fetchAhaScore?.errors || [];
       if (errors.length > 0) {
         setErrorState({ ...emptyErrorState, errors });
-        setHasScore(false);
         return;
       }
 
       setHasFetched(true);
       setErrorState(emptyErrorState);
 
-      if (data.fetchAhaScore?.score) {
-        if (data.fetchAhaScore.score >= 0) {
-          setHasScore(true);
-        }
-
-        if (severalItemsChanged) {
-          severalItemsChanged({
-            values: {
-              [SCORE_LINK_ID]: data.fetchAhaScore.score,
-              [ALT_AHA_FLAG_LINK_ID]: data.fetchAhaScore.altAhaFlag,
-              [DW_CLIENT_LINK_ID]: data.fetchAhaScore.dwClientId,
-              [GENERATOR_LINK_ID]: data.fetchAhaScore.generator,
-            },
-            type: ChangeType.User,
-          });
-        }
-      } else {
-        setHasScore(false);
+      if (data.fetchAhaScore && severalItemsChanged) {
+        severalItemsChanged({
+          values: {
+            [SCORE_LINK_ID]: data.fetchAhaScore.score,
+            [ALT_AHA_FLAG_LINK_ID]: data.fetchAhaScore.altAhaFlag,
+            [DW_CLIENT_LINK_ID]: data.fetchAhaScore.dwClientId,
+            [GENERATOR_LINK_ID]: data.fetchAhaScore.generator,
+          },
+          type: ChangeType.User,
+        });
       }
     },
     onError: (apolloError) => {
       setErrorState({ ...emptyErrorState, apolloError });
-      setHasScore(false);
     },
   });
 
@@ -99,13 +90,7 @@ const AhaScore = ({
   if (!isComponentValid) throw new Error('Invalid Aha form component');
 
   if (viewOnly) {
-    return item.item?.map((i) => {
-      if (i.linkId === SCORE_LINK_ID && !hasScore) {
-        return renderChildItem(i, { value: null });
-      } else {
-        return renderChildItem(i);
-      }
-    });
+    return item.item?.map((i) => renderChildItem(i));
   }
 
   if (!clientId) {

--- a/src/modules/external/aha/components/AhaScore.tsx
+++ b/src/modules/external/aha/components/AhaScore.tsx
@@ -42,7 +42,7 @@ const AhaScore = ({
 
   const [errorState, setErrorState] = useState<ErrorState>(emptyErrorState);
 
-  // Use dynamic field watch to get the current values of the expected link IDs.
+  // Use RHF to watch the current value of the score field.
   // This is to disable the fetch button after unlocking an assessment that's already fetched the score.
   const values = useDynamicFieldWatchValues([SCORE_LINK_ID]);
   const existingValue = values[SCORE_LINK_ID];

--- a/src/modules/external/aha/components/AhaScore.tsx
+++ b/src/modules/external/aha/components/AhaScore.tsx
@@ -47,7 +47,9 @@ const AhaScore = ({
   const values = useDynamicFieldWatchValues([SCORE_LINK_ID]);
   const existingValue = values[SCORE_LINK_ID];
 
-  const [hasScore, setHasScore] = useState<boolean>(!!existingValue);
+  const [hasScore, setHasScore] = useState<boolean>(
+    !!existingValue && existingValue >= 0
+  );
   const [hasFetched, setHasFetched] = useState<boolean>(false);
 
   const clientId = handlers?.localConstants.clientId;
@@ -67,8 +69,10 @@ const AhaScore = ({
       setHasFetched(true);
       setErrorState(emptyErrorState);
 
-      if (data.fetchAhaScore?.score && data.fetchAhaScore.score >= 0) {
-        setHasScore(true);
+      if (data.fetchAhaScore?.score) {
+        if (data.fetchAhaScore.score >= 0) {
+          setHasScore(true);
+        }
 
         if (severalItemsChanged) {
           severalItemsChanged({
@@ -95,7 +99,13 @@ const AhaScore = ({
   if (!isComponentValid) throw new Error('Invalid Aha form component');
 
   if (viewOnly) {
-    return item.item?.map((i) => renderChildItem(i));
+    return item.item?.map((i) => {
+      if (i.linkId === SCORE_LINK_ID && !hasScore) {
+        return renderChildItem(i, { value: null });
+      } else {
+        return renderChildItem(i);
+      }
+    });
   }
 
   if (!clientId) {

--- a/src/modules/external/aha/components/AhaScore.tsx
+++ b/src/modules/external/aha/components/AhaScore.tsx
@@ -5,6 +5,8 @@ import LoadingButton from '@/components/elements/LoadingButton';
 import ApolloErrorAlert from '@/modules/errors/components/ApolloErrorAlert';
 import ErrorAlert from '@/modules/errors/components/ErrorAlert';
 import { emptyErrorState, ErrorState, hasErrors } from '@/modules/errors/util';
+import RequiredLabel from '@/modules/form/components/RequiredLabel';
+import { useDynamicFieldWatchValues } from '@/modules/form/hooks/rhf/useDynamicFieldWatchValues';
 import { ChangeType, GroupItemComponentProps } from '@/modules/form/types';
 import { useFetchAhaScoreMutation } from '@/types/gqlTypes';
 
@@ -29,6 +31,7 @@ const AhaScore = ({
   handlers,
   renderChildItem,
   severalItemsChanged,
+  viewOnly = false,
 }: GroupItemComponentProps) => {
   // Introspect on the group's child elements and ensure items exist for the expected link IDs
   const isComponentValid = useMemo(() => {
@@ -39,7 +42,12 @@ const AhaScore = ({
 
   const [errorState, setErrorState] = useState<ErrorState>(emptyErrorState);
 
-  const [hasScore, setHasScore] = useState<boolean>(false);
+  // Use dynamic field watch to get the current values of the expected link IDs.
+  // This is to disable the fetch button after unlocking an assessment that's already fetched the score.
+  const values = useDynamicFieldWatchValues([SCORE_LINK_ID]);
+  const existingValue = values[SCORE_LINK_ID];
+
+  const [hasScore, setHasScore] = useState<boolean>(!!existingValue);
   const [hasFetched, setHasFetched] = useState<boolean>(false);
 
   const clientId = handlers?.localConstants.clientId;
@@ -83,15 +91,18 @@ const AhaScore = ({
     },
   });
 
-  // console.error instead of throwing an error, so we can still preview how the form looks in non-client contexts
+  // Throw an error if the children don't match the expected structure
+  if (!isComponentValid) throw new Error('Invalid Aha form component');
+
+  if (viewOnly) {
+    return item.item?.map((i) => renderChildItem(i));
+  }
+
   if (!clientId) {
     throw new Error(
       "AhaScore did not receive a client ID, and won't function properly without one."
     );
   }
-
-  // Throw an error if the children don't match the expected structure
-  if (!isComponentValid) throw new Error('Invalid Aha form component');
 
   return (
     <>
@@ -102,12 +113,27 @@ const AhaScore = ({
         </Stack>
       )}
       <Stack direction='column' gap={1} alignItems='flex-start'>
-        <LabelWithContent label={item.text} helperText={item.helperText}>
+        <LabelWithContent
+          label={
+            // Custom solution for visually requiring this field.
+            // Form groups can't be required, but in the individual fields are hidden and/or readonly,
+            // so the normal RequiredLabel logic doesn't work automagically.
+            <RequiredLabel
+              text={item.text || 'AHA Score'}
+              required={true}
+              TypographyProps={{
+                fontWeight: 600,
+              }}
+            />
+          }
+          helperText={item.helperText}
+        >
           <LoadingButton
             loading={loading}
-            disabled={hasScore} // If value has already been fetched, disable the button
+            disabled={hasScore} // If value already exists, disable the button
             type='button'
             onClick={() => fetchAha()}
+            sx={{ my: 1 }}
           >
             Fetch AHA Score
           </LoadingButton>

--- a/src/modules/form/components/viewable/DynamicViewGroup.tsx
+++ b/src/modules/form/components/viewable/DynamicViewGroup.tsx
@@ -11,6 +11,7 @@ import Signature from '../group/Signature';
 import SignatureGroupCard from '../group/SignatureGroupCard';
 import TableGroup from '../group/TableGroup';
 
+import AhaScore from '@/modules/external/aha/components/AhaScore';
 import { Component } from '@/types/gqlTypes';
 
 const DynamicViewGroup = (props: ViewGroupItemComponentProps) => {
@@ -59,6 +60,8 @@ const DynamicViewGroup = (props: ViewGroupItemComponentProps) => {
       return <TableGroup key={props.item.linkId} {...props} viewOnly />;
     case Component.SignatureGroup:
       return <SignatureGroupCard key={props.item.linkId} viewOnly {...props} />;
+    case Component.Aha:
+      return <AhaScore key={props.item.linkId} viewOnly {...props} />;
     default:
       return (
         <QuestionGroup

--- a/src/modules/form/hooks/rhf/useDynamicFieldAutofillValue.tsx
+++ b/src/modules/form/hooks/rhf/useDynamicFieldAutofillValue.tsx
@@ -32,6 +32,7 @@ export const useDynamicFieldAutofillValue = (
     **/
     if (
       !result &&
+      !!item.autofillValues &&
       (item.readOnly || item.type === ItemType.Display) &&
       !viewOnly
     ) {

--- a/src/modules/form/hooks/rhf/useDynamicFieldAutofillValue.tsx
+++ b/src/modules/form/hooks/rhf/useDynamicFieldAutofillValue.tsx
@@ -17,6 +17,12 @@ export const useDynamicFieldAutofillValue = (
   );
 
   return useMemo(() => {
+    // If the item does not have any autofill values defined, return null as there is nothing to evaluate.
+    if (!item.autofillValues) return null;
+
+    // Evaluate the autofill conditions for the item.
+    // Returns an object { value: <computed value> } if there is an autofill value to apply,
+    // or null if no conditions are satisfied.
     const result = autofillValues({
       item,
       values,
@@ -32,7 +38,6 @@ export const useDynamicFieldAutofillValue = (
     **/
     if (
       !result &&
-      !!item.autofillValues &&
       (item.readOnly || item.type === ItemType.Display) &&
       !viewOnly
     ) {

--- a/src/modules/form/types.ts
+++ b/src/modules/form/types.ts
@@ -95,7 +95,7 @@ export interface DynamicViewItemCommonProps {
 }
 
 export type OverrideableDynamicFieldProps = Optional<
-  Omit<DynamicFieldProps, 'item' | 'nestingLevel'>,
+  Omit<DynamicFieldProps, 'item' | 'value' | 'nestingLevel'>,
   'itemChanged' // allow groups to override item changed
 >;
 

--- a/src/modules/form/types.ts
+++ b/src/modules/form/types.ts
@@ -95,7 +95,7 @@ export interface DynamicViewItemCommonProps {
 }
 
 export type OverrideableDynamicFieldProps = Optional<
-  Omit<DynamicFieldProps, 'item' | 'value' | 'nestingLevel'>,
+  Omit<DynamicFieldProps, 'item' | 'nestingLevel'>,
   'itemChanged' // allow groups to override item changed
 >;
 


### PR DESCRIPTION
## Description

- Targets release-173 to follow up on QA that's on that branch. We can retarget to 174 if you prefer since this component isn't in use yet.

Summary of changes:
- Disable re-fetching the score on a previously saved, unlocked assessment.
- _Actually save to the db_ a value of -1 when the score was fetched and couldn't be found. This circumvents the generic required logic on the field, enabling users to save the form after having tried to fetch the score. I'm not totally sold on the incomplete (ts failing) solution I have drafted; I'll add a comment thread to discuss this inline
- Custom override the label to show the score as required.
- Fix bug where autofill values were overwriting previously saved values on readonly fields. I'll add a comment thread to discuss this inline

[//]: # 'remove if not applicable'
How to test: Using the form definition below,
- Test that you can fetch and save AHA score for a client with an MCI uniq id
- Test fetching, submitting, and reopening/unlocking the assessment. The score should still appear and the button to refetch should be disabled.
- Test fetching, "save & submit later", and reopening the assessment. Same as above.
- Test submitting without fetching the score. You should see a validation error.
- Test fetching score on a client that doesn't have an MCI uniq id, or doesn't have one that's available in the external system. You should see "score is not available" message and still be able to submit

<Details>
<Summary>new form JSON to use</Summary>

```json
{
  "item": [
    {
      "item": [
        {
          "text": "Assessment Date",
          "type": "DATE",
          "bounds": [
            {
              "id": "min-assmt-date",
              "type": "MIN",
              "severity": "error",
              "value_local_constant": "$entryDate"
            },
            {
              "id": "max-assmt-date",
              "type": "MAX",
              "severity": "error",
              "value_local_constant": "$today"
            },
            {
              "id": "max-assmt-date-exit",
              "type": "MAX",
              "severity": "error",
              "value_local_constant": "$exitDate"
            }
          ],
          "link_id": "assessment_date",
          "mapping": {
            "field_name": "assessmentDate"
          },
          "required": true,
          "assessment_date": true,
          "disabled_display": "HIDDEN"
        },
        {
          "item": [
            {
              "text": "AHA Score",
              "type": "INTEGER",
              "link_id": "aha_score",
              "mapping": {
                "custom_field_key": "housing_needs_for_ce_aha_score_2"
              },
              "required": true,
              "read_only": true,
              "warn_if_empty": false,
              "disabled_display": "HIDDEN"
            },
            {
              "text": "Alt AHA Flag",
              "type": "BOOLEAN",
              "link_id": "aha_alt_aha_flag",
              "mapping": {
                "custom_field_key": "housing_needs_for_ce_aha_alt_aha_flag"
              },
              "required": false,
              "read_only": true,
              "warn_if_empty": false,
              "disabled_display": "HIDDEN"
            },
            {
              "text": "Data Warehouse Client ID",
              "type": "STRING",
              "hidden": true,
              "link_id": "aha_dw_client_id",
              "mapping": {
                "custom_field_key": "housing_needs_for_ce_aha_dw_client_id"
              },
              "required": false,
              "read_only": true,
              "warn_if_empty": false,
              "disabled_display": "HIDDEN"
            },
            {
              "text": "Generator",
              "type": "STRING",
              "hidden": true,
              "link_id": "aha_generator",
              "mapping": {
                "custom_field_key": "housing_needs_for_ce_aha_generator"
              },
              "required": false,
              "read_only": true,
              "warn_if_empty": false,
              "disabled_display": "HIDDEN"
            }
          ],
          "text": "Allegheny Housing Assessment (AHA) Score",
          "type": "GROUP",
          "link_id": "aha_group",
          "component": "AHA",
          "disabled_display": "HIDDEN"
        }
      ],
      "text": "Allegheny Housing Assessment (AHA) Score",
      "type": "GROUP",
      "link_id": "section_1",
      "disabled_display": "HIDDEN"
    }
  ]
}
```
</Details>

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint) - typescript fails, please see inline comment thread.
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
