### PR TITLE
Add support for rounding to form expressions

### DIFF
--- a/src/modules/form/util/expressions/expressions.evaluateFormula.test.ts
+++ b/src/modules/form/util/expressions/expressions.evaluateFormula.test.ts
@@ -22,4 +22,30 @@ describe('evaluateFormula', () => {
       undefined
     );
   });
+
+  describe('rounding functions', () => {
+    it('rounds division to nearest integer', () => {
+      expect(evaluateFormula('ROUND(a / b)', context({ a: 7, b: 3 }))).toBe(2);
+      expect(evaluateFormula('ROUND(a / b)', context({ a: 8, b: 3 }))).toBe(3);
+    });
+
+    it('rounds division to specific decimal places', () => {
+      expect(
+        evaluateFormula('ROUNDTO(a / b, 2)', context({ a: 10, b: 3 }))
+      ).toBe(3.33);
+      expect(
+        evaluateFormula('ROUNDTO(a / b, 1)', context({ a: 22, b: 7 }))
+      ).toBe(3.1);
+    });
+
+    it('rounds division up (ceiling)', () => {
+      expect(evaluateFormula('CEIL(a / b)', context({ a: 7, b: 3 }))).toBe(3);
+      expect(evaluateFormula('CEIL(a / b)', context({ a: 6, b: 3 }))).toBe(2);
+    });
+
+    it('rounds division down (floor)', () => {
+      expect(evaluateFormula('FLOOR(a / b)', context({ a: 7, b: 3 }))).toBe(2);
+      expect(evaluateFormula('FLOOR(a / b)', context({ a: 8, b: 3 }))).toBe(2);
+    });
+  });
 });

--- a/src/modules/form/util/expressions/expressions.evaluateFormula.test.ts
+++ b/src/modules/form/util/expressions/expressions.evaluateFormula.test.ts
@@ -23,6 +23,37 @@ describe('evaluateFormula', () => {
     );
   });
 
+  describe('division operations', () => {
+    it('handles division by zero', () => {
+      expect(evaluateFormula('a / b', context({ a: 10, b: 0 }))).toBe(Infinity);
+      expect(evaluateFormula('a / b', context({ a: -10, b: 0 }))).toBe(
+        -Infinity
+      );
+      expect(evaluateFormula('a / b', context({ a: 0, b: 0 }))).toBe(NaN);
+    });
+
+    it('handles division by undefined (nil) denominator', () => {
+      expect(evaluateFormula('a / b', context({ a: 10, b: undefined }))).toBe(
+        undefined
+      );
+      expect(evaluateFormula('a / b', context({ a: -10, b: undefined }))).toBe(
+        undefined
+      );
+      expect(evaluateFormula('a / b', context({ a: 0, b: undefined }))).toBe(
+        undefined
+      );
+    });
+
+    it('handles undefined numerator', () => {
+      expect(evaluateFormula('a / b', context({ a: undefined, b: 5 }))).toBe(
+        undefined
+      );
+      expect(evaluateFormula('a / b', context({ a: undefined, b: 0 }))).toBe(
+        undefined
+      );
+    });
+  });
+
   describe('rounding functions', () => {
     it('rounds division to nearest integer', () => {
       expect(evaluateFormula('ROUND(a / b)', context({ a: 7, b: 3 }))).toBe(2);
@@ -46,6 +77,51 @@ describe('evaluateFormula', () => {
     it('rounds division down (floor)', () => {
       expect(evaluateFormula('FLOOR(a / b)', context({ a: 7, b: 3 }))).toBe(2);
       expect(evaluateFormula('FLOOR(a / b)', context({ a: 8, b: 3 }))).toBe(2);
+    });
+
+    it('handles rounding functions with division edge cases', () => {
+      // Division by zero returns Infinity, rounding functions preserve Infinity
+      expect(evaluateFormula('ROUND(a / b)', context({ a: 10, b: 0 }))).toBe(
+        Infinity
+      );
+      expect(evaluateFormula('CEIL(a / b)', context({ a: 10, b: 0 }))).toBe(
+        Infinity
+      );
+      expect(evaluateFormula('FLOOR(a / b)', context({ a: 10, b: 0 }))).toBe(
+        Infinity
+      );
+
+      // Negative division by zero returns -Infinity, rounding functions preserve -Infinity
+      expect(evaluateFormula('ROUND(a / b)', context({ a: -10, b: 0 }))).toBe(
+        -Infinity
+      );
+      expect(evaluateFormula('CEIL(a / b)', context({ a: -10, b: 0 }))).toBe(
+        -Infinity
+      );
+      expect(evaluateFormula('FLOOR(a / b)', context({ a: -10, b: 0 }))).toBe(
+        -Infinity
+      );
+
+      // 0/0 returns NaN, rounding functions preserve NaN
+      expect(evaluateFormula('ROUND(a / b)', context({ a: 0, b: 0 }))).toBe(
+        NaN
+      );
+      expect(evaluateFormula('CEIL(a / b)', context({ a: 0, b: 0 }))).toBe(NaN);
+      expect(evaluateFormula('FLOOR(a / b)', context({ a: 0, b: 0 }))).toBe(
+        NaN
+      );
+
+      // Division by undefined returns undefined (due to error handling),
+      // so rounding functions also return undefined
+      expect(
+        evaluateFormula('ROUND(a / b)', context({ a: 10, b: undefined }))
+      ).toBe(undefined);
+      expect(
+        evaluateFormula('CEIL(a / b)', context({ a: 10, b: undefined }))
+      ).toBe(undefined);
+      expect(
+        evaluateFormula('FLOOR(a / b)', context({ a: 10, b: undefined }))
+      ).toBe(undefined);
     });
   });
 });

--- a/src/modules/form/util/expressions/formulaFunctions.ts
+++ b/src/modules/form/util/expressions/formulaFunctions.ts
@@ -1,4 +1,17 @@
 const formulaFunctions = new Map();
 formulaFunctions.set('ABS', Math.abs);
+
+// Rounding functions
+formulaFunctions.set('ROUND', Math.round);
+formulaFunctions.set('CEIL', Math.ceil);
+formulaFunctions.set('FLOOR', Math.floor);
+
+// Round to specific decimal places
+formulaFunctions.set('ROUNDTO', (value: number, decimals: number) => {
+  if (decimals === undefined || decimals === null) decimals = 0;
+  const factor = Math.pow(10, decimals);
+  return Math.round(value * factor) / factor;
+});
+
 // functions to expose in a formula expression
 export default formulaFunctions;


### PR DESCRIPTION
## Description

Summary of changes:
- Add support for rounding functions to the form expression evaluator

[//]: # 'remove if not applicable'
Test against the json form here: https://qa-hmis.openpath.host/admin/forms/housing_needs_assessment

<img width="760" height="692" alt="Screenshot 2025-08-04 at 3 57 20 PM" src="https://github.com/user-attachments/assets/1bf9be93-daa9-414b-843f-ffb578c1f140" />

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
New feature

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
