### PR TITLE
Fix permission bug for direct referrals

### DIFF
--- a/src/modules/ce/components/project/ProjectCeReferralsPage.tsx
+++ b/src/modules/ce/components/project/ProjectCeReferralsPage.tsx
@@ -3,9 +3,11 @@ import ButtonLink from '@/components/elements/ButtonLink';
 import CommonTabs from '@/components/elements/CommonTabs';
 import { SendIcon } from '@/components/elements/SemanticIcons';
 import PageTitle from '@/components/layout/PageTitle';
+import NotFound from '@/components/pages/NotFound';
 import ProjectOutgoingReferralsTable from '@/modules/ce/components/directReferral/ProjectOutgoingReferralsTable';
 import ProjectOpportunitiesTable from '@/modules/ce/components/project/ProjectOpportunitiesTable';
 import ProjectReferralsTable from '@/modules/ce/components/project/ProjectReferralsTable';
+import { useProjectCeVisibility } from '@/modules/ce/hooks/useProjectCeVisibility';
 import { useProjectDashboardContext } from '@/modules/projects/components/ProjectDashboard';
 import { ProjectDashboardRoutes } from '@/routes/routes';
 import { generateSafePath } from '@/utils/pathEncoding';
@@ -13,34 +15,13 @@ import { generateSafePath } from '@/utils/pathEncoding';
 const ProjectCeReferralsPage: React.FC = () => {
   const { project } = useProjectDashboardContext();
 
-  // CE Referral features this project supports
-  const { sendsDirectReferrals, supportsReferrals, supportsWaitlistReferrals } =
-    project.coordinatedEntryFeatures || {};
-
-  // User permissions related to CE Referrals
-  const {
-    canManageOutgoingReferrals,
-    canViewReferrals,
-    canViewOwnReferrals,
-    canViewUnits,
-  } = project.access;
-
-  // If the project supports referrals AND the user can view referrals, show the Referrals tab
-  const showReferralsTab =
-    supportsReferrals && (canViewReferrals || canViewOwnReferrals);
-
-  // If the project supports *waitlist* referrals AND the user can view units, show the Units tab.
-  // Only waitlist (not direct) referrals because it doesn't make sense to link to a unit from here if it doesn't have waitlist.
-  const showAvailableUnitsTab = supportsWaitlistReferrals && canViewUnits;
-
-  // If the project can send direct referrals AND the user has permission to manage outgoing referrals, show the Outgoing Referrals tab
-  const showOutgoingReferrals =
-    sendsDirectReferrals && canManageOutgoingReferrals;
+  const { showReferrals, showAvailableUnits, showOutgoingReferrals } =
+    useProjectCeVisibility(project);
 
   const tabDefinitions = useMemo(() => {
     const defs = [];
 
-    if (showReferralsTab) {
+    if (showReferrals) {
       defs.push({
         title: 'Referrals',
         key: 'referrals',
@@ -48,7 +29,7 @@ const ProjectCeReferralsPage: React.FC = () => {
       });
     }
 
-    if (showAvailableUnitsTab) {
+    if (showAvailableUnits) {
       defs.push({
         title: 'Available Units',
         key: 'available-units',
@@ -64,12 +45,7 @@ const ProjectCeReferralsPage: React.FC = () => {
       });
     }
     return defs;
-  }, [
-    project.id,
-    showAvailableUnitsTab,
-    showOutgoingReferrals,
-    showReferralsTab,
-  ]);
+  }, [project.id, showAvailableUnits, showOutgoingReferrals, showReferrals]);
 
   const actions = useMemo(() => {
     if (showOutgoingReferrals) {
@@ -85,6 +61,10 @@ const ProjectCeReferralsPage: React.FC = () => {
       );
     }
   }, [project.id, showOutgoingReferrals]);
+
+  if (tabDefinitions.length === 0) {
+    return <NotFound />;
+  }
 
   return (
     <>

--- a/src/modules/ce/hooks/useProjectCeVisibility.tsx
+++ b/src/modules/ce/hooks/useProjectCeVisibility.tsx
@@ -1,0 +1,37 @@
+import { useMemo } from 'react';
+import { ProjectAllFieldsFragment } from '@/types/gqlTypes';
+
+export function useProjectCeVisibility(project?: ProjectAllFieldsFragment) {
+  return useMemo(() => {
+    if (!project) return {};
+
+    // CE Referral features this project supports
+    const {
+      sendsDirectReferrals,
+      supportsReferrals,
+      supportsWaitlistReferrals,
+    } = project.coordinatedEntryFeatures || {};
+
+    // User permissions related to CE Referrals
+    const {
+      canManageOutgoingReferrals,
+      canViewReferrals,
+      canViewOwnReferrals,
+      canViewUnits,
+    } = project.access;
+
+    // If the project supports referrals AND the user can view referrals, show the Referrals tab
+    const showReferrals =
+      supportsReferrals && (canViewReferrals || canViewOwnReferrals);
+
+    // If the project supports *waitlist* referrals AND the user can view units, show the Units tab.
+    // Only waitlist (not direct) referrals because it doesn't make sense to link to a unit from here if it doesn't have waitlist.
+    const showAvailableUnits = supportsWaitlistReferrals && canViewUnits;
+
+    // If the project can send direct referrals AND the user has permission to manage outgoing referrals, show the Outgoing Referrals tab
+    const showOutgoingReferrals =
+      sendsDirectReferrals && canManageOutgoingReferrals;
+
+    return { showReferrals, showAvailableUnits, showOutgoingReferrals };
+  }, [project]);
+}

--- a/src/modules/projects/hooks/useProjectDashboardNavItems.tsx
+++ b/src/modules/projects/hooks/useProjectDashboardNavItems.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 
 import { NavItem } from '@/components/layout/dashboard/sideNav/types';
+import { useProjectCeVisibility } from '@/modules/ce/hooks/useProjectCeVisibility';
 import { ProjectDashboardRoutes } from '@/routes/routes';
 import {
   DataCollectionFeatureRole,
@@ -12,6 +13,9 @@ import {
 export const useProjectDashboardNavItems = (
   project?: ProjectAllFieldsFragment
 ) => {
+  const { showReferrals, showAvailableUnits, showOutgoingReferrals } =
+    useProjectCeVisibility(project);
+
   const navItems: NavItem<ProjectAccessFieldsFragment>[] = useMemo(() => {
     if (!project) return [];
 
@@ -105,9 +109,11 @@ export const useProjectDashboardNavItems = (
               'canViewUnits',
               'canViewReferrals',
               'canViewOwnReferrals',
+              'canManageOutgoingReferrals',
             ],
             permissionMode: 'any',
-            hide: !project.coordinatedEntryFeatures,
+            hide:
+              !showReferrals && !showAvailableUnits && !showOutgoingReferrals,
           },
         ],
       },
@@ -154,7 +160,7 @@ export const useProjectDashboardNavItems = (
         ],
       },
     ];
-  }, [project]);
+  }, [project, showAvailableUnits, showOutgoingReferrals, showReferrals]);
 
   return navItems;
 };

--- a/src/routes/protected.tsx
+++ b/src/routes/protected.tsx
@@ -478,6 +478,7 @@ export const protectedRoutes: RouteNode[] = [
                   'canViewUnits',
                   'canViewReferrals',
                   'canViewOwnReferrals',
+                  'canManageOutgoingReferrals',
                 ]}
                 coordinatedEntryFeatures={[
                   'supportsReferrals',


### PR DESCRIPTION
## Description

Summary of changes: Move logic for determining which CE features are visible (based on project config + current user permissions) into a common hook, so it can be used on both the Project Referrals page and the project nav items hook.

**How to test:**
Visit a project that Sends Direct Referrals but does not have any other CE config. 
- Impersonate a user who does not have "can manage outgoing referrals" but DOES have another CE-related permission. ("can view units", "can view referrals", or "can view own referrals"). Click the "Referrals" link in the project left-nav.
  - Before: You will get an [error](https://green-river.sentry.io/issues/6790075818/?alert_rule_id=14743218&alert_type=issue&environment=staging&notification_uuid=c0918e72-bcaf-484e-8420-efccc7341c8f&project=4504006381273088&referrer=slack)
  - After: You should not see the "Referrals" link in the left-nav at all.
- Impersonate a user who does have "can manage outgoing referrals" but does not have any other CE-related permission. 
  - Before: The "Referrals" tab doesn't appear in the project nav, even though it should.
  - After: You can click the "Referrals" tab and see the outgoing referrals screen.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
