### PR TITLE
Hide Start Referral button without view referral perm

### DIFF
--- a/src/modules/ce/components/unit/OpportunityBanner.tsx
+++ b/src/modules/ce/components/unit/OpportunityBanner.tsx
@@ -59,7 +59,9 @@ const OpportunityBanner: React.FC<Props> = ({ opportunity, topCandidate }) => {
       );
     }
 
-    if (topCandidate && project.access.canStartReferrals) {
+    const canStartReferral =
+      project.access.canStartReferrals && project.access.canViewReferrals;
+    if (topCandidate && canStartReferral) {
       return (
         <StartReferralButton
           opportunity={opportunity}
@@ -68,7 +70,7 @@ const OpportunityBanner: React.FC<Props> = ({ opportunity, topCandidate }) => {
         />
       );
     }
-  }, [referral, topCandidate, project.access.canStartReferrals, opportunity]);
+  }, [referral, topCandidate, project.access, opportunity]);
 
   const linkToEligibleClients =
     opportunity &&

--- a/src/modules/ce/components/unit/PrioritizedClientsTable.tsx
+++ b/src/modules/ce/components/unit/PrioritizedClientsTable.tsx
@@ -43,6 +43,9 @@ const PrioritizedClientsTable: React.FC<Props> = ({ opportunity }) => {
   const { status } = opportunity;
 
   const columns = useMemo(() => {
+    const canStartReferrals =
+      project.access.canStartReferrals && project.access.canViewReferrals;
+
     return [
       ...COLUMNS,
       {
@@ -53,7 +56,7 @@ const PrioritizedClientsTable: React.FC<Props> = ({ opportunity }) => {
             recordName={`ID ${row.id}`}
             primaryAction={
               status === CeOpportunityStatus.Open &&
-              project.access.canStartReferrals && (
+              canStartReferrals && (
                 <StartReferralButton
                   opportunity={opportunity}
                   candidate={row}
@@ -64,7 +67,7 @@ const PrioritizedClientsTable: React.FC<Props> = ({ opportunity }) => {
         ),
       },
     ];
-  }, [project.access.canStartReferrals, opportunity, status]);
+  }, [project.access, opportunity, status]);
 
   // If CandidatePool has not been generated yet (due to change in eligibility or prioritization requirements), show a message
   if (!opportunity.candidatesGeneratedAt) {


### PR DESCRIPTION
## Description

Hide the Start Referral button for users who don't have "can view referral" permission. (This would be a weird combination of permissions that should never happen in real life.)

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Code clean-up

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (eslint)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
