### PR TITLE
Patch autofill for 'value_question' autofills

### DIFF
--- a/src/modules/form/util/formUtil.ts
+++ b/src/modules/form/util/formUtil.ts
@@ -506,7 +506,7 @@ const numericValueForFormValue = (
 
 export const getAutofillComparisonValue = (
   av: AutofillValue,
-  values: FormValues,
+  values: FormValues, // only includes values that are determined to be relevant for autofill (see buildAutofillDependencyMap)
   targetItem: FormItem
 ) => {
   if (av.formula) {
@@ -970,6 +970,11 @@ export const buildAutofillDependencyMap = (
         av.sumQuestions.forEach((summedLinkId) => {
           addDependency(summedLinkId);
         });
+      }
+
+      // If this item populates the value from another question, add that dependency
+      if (av.valueQuestion) {
+        addDependency(av.valueQuestion);
       }
 
       // If this autofill is conditional on other items, add those dependencies


### PR DESCRIPTION
## Description

**Issue:**
https://github.com/open-path/Green-River/issues/8130

**Summary of changes:**
* Add support for autofilling using `value_question` field. This is used to autofill a question with the value from another question.
* This _may_ have had previous support and been broken with the RHF refactor, or it may never have been fully supported. It is not exposed in the form builder as an available option.

**How to test:**
See issue for full assessment example, or use snippet below:

```json
{
  "text": "enter a number",
  "type": "INTEGER",
  "link_id": "enter_a_number",
  "disabled_display": "HIDDEN"
},
{
  "text": "the number you entered is:",
  "type": "INTEGER",
  "link_id": "the_number_you_entered_is",
  "required": false,
  "read_only": true,
  "warn_if_empty": false,
  "autofill_values": [
    {
      "value_question": "enter_a_number",
      "autofill_behavior": "ANY"
    }
  ],
  "disabled_display": "HIDDEN"
}
```

## Type of change
Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
