### PR TITLE
Patch disabled attribute bug on radio buttons

### DIFF
--- a/src/components/elements/input/RadioGroupInput.tsx
+++ b/src/components/elements/input/RadioGroupInput.tsx
@@ -10,7 +10,7 @@ import {
   RadioGroupProps,
 } from '@mui/material';
 import { SxProps } from '@mui/system';
-import { useCallback } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
 import RadioGroupInputOption from '@/components/elements/input/RadioGroupInputOption';
 import { DynamicInputCommonProps } from '@/modules/form/types';
@@ -87,6 +87,20 @@ const RadioGroupInput = ({
     [onChange, value, clearable, props.disabled]
   );
 
+  const fieldsetRef = useRef<HTMLFieldSetElement | null>(null);
+
+  // Accessibility: mark up the fieldset DOM element as `disabled` if appropriate,
+  // because MUI FormControl doesn't pass down the `disabled` prop.
+  useEffect(() => {
+    if (fieldsetRef.current) {
+      if (props.disabled) {
+        fieldsetRef.current.setAttribute('disabled', 'true');
+      } else {
+        fieldsetRef.current.removeAttribute('disabled');
+      }
+    }
+  }, [props.disabled]);
+
   const GroupComponent = checkbox ? FormGroup : RadioGroup;
   const ControlComponent = checkbox ? Checkbox : Radio;
 
@@ -94,8 +108,7 @@ const RadioGroupInput = ({
     <FormControl
       component='fieldset'
       sx={{ maxWidth, ...sx }}
-      // this marks up the fieldset DOM element as `disabled`. MUI FormControl doesn't pass down the `disabled` prop
-      ref={(el) => el && props.disabled && el.setAttribute('disabled', 'true')}
+      ref={fieldsetRef}
     >
       <FormLabel
         error={error}


### PR DESCRIPTION
## Description

Issue: https://github.com/open-path/Green-River/issues/8131

**Summary of changes:** fix bug that appeared when radio moved from disabled state to enabled state. The `fieldset` remained "disabled" which caused the input to have some odd behavior, including not being tabbable, and not allowing me to click on the radio button (however I could click on the label sucessfully). Tested in chrome.



**How to test:** see instructions on issue, or use snippet below
```json
{
  "text": "Enable radio buttons?",
  "type": "BOOLEAN",
  "link_id": "enable_radio_buttons",
  "disabled_display": "HIDDEN"
},
{
  "text": "Radio button that starts out disabled",
  "type": "CHOICE",
  "link_id": "radio_button_that_starts_out_disabled",
  "component": "RADIO_BUTTONS",
  "enable_when": [
    {
      "operator": "EQUAL",
      "question": "enable_radio_buttons",
      "answer_boolean": true
    }
  ],
  "enable_behavior": "ALL",
  "disabled_display": "PROTECTED_WITH_VALUE",
  "pick_list_options": [
    {
      "code": "one"
    },
    {
      "code": "two"
    }
  ]
}
```

## Type of change
bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
