### PR TITLE
Fix bug in unit group dialog

### DIFF
--- a/src/modules/units/components/UnitGroupFormDialog.tsx
+++ b/src/modules/units/components/UnitGroupFormDialog.tsx
@@ -214,6 +214,8 @@ const UnitGroupFormDialog: React.FC<UnitGroupFormDialogProps> = ({
                 onChange={(_event, option) => {
                   if (isPickListOption(option)) {
                     setWorkflowTemplateIdentifier(option.code);
+                  } else if (!option) {
+                    setWorkflowTemplateIdentifier(null);
                   }
                 }}
               />
@@ -227,6 +229,8 @@ const UnitGroupFormDialog: React.FC<UnitGroupFormDialogProps> = ({
                 onChange={(_event, option) => {
                   if (isPickListOption(option)) {
                     setCeEventType(option.code as EventType);
+                  } else if (!option) {
+                    setCeEventType(null);
                   }
                 }}
               />


### PR DESCRIPTION
## Description

Noticed while reviewing https://github.com/greenriver/hmis-frontend/pull/1242/files, but opening a separate PR since it's unrelated.

You should be able to clear the optional fields in the Unit Group dialog.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
