### PR TITLE
Auto-expand menu after it is auto-collapsed

### DIFF
--- a/src/components/layout/dashboard/contextHeader/ContextHeader.tsx
+++ b/src/components/layout/dashboard/contextHeader/ContextHeader.tsx
@@ -3,17 +3,21 @@ import MenuIcon from '@mui/icons-material/Menu';
 import { Box, Button } from '@mui/material';
 import React, { ReactNode, useCallback, useMemo } from 'react';
 
-import { useLocation, useNavigate } from 'react-router-dom';
+import { NavigateOptions, useLocation, useNavigate } from 'react-router-dom';
 import CommonStickyBar from '../../CommonStickyBar';
 import {
   CONTEXT_HEADER_HEIGHT,
   STICKY_BAR_HEIGHT,
 } from '../../layoutConstants';
+
 import { useIsMobile } from '@/hooks/useIsMobile';
 import useSafeParams from '@/hooks/useSafeParams';
 import { useClientName } from '@/modules/dataFetching/hooks/useClientName';
 import { clientBriefName } from '@/modules/hmis/hmisUtil';
-import { locationFromDefaultOrLogin } from '@/routes/routeUtil';
+import {
+  locationFromDefaultOrLogin,
+  EXPAND_DESKTOP_NAV_KEY,
+} from '@/routes/routeUtil';
 import { generateSafePath } from '@/utils/pathEncoding';
 
 interface Props {
@@ -70,8 +74,13 @@ const ContextHeader: React.FC<Props> = ({
   const exitFocusMode = useCallback(() => {
     if (!focusMode) return;
 
+    // When navigating out of focus mode, pass special state to re-expand the desktop nav
+    const navOptions: NavigateOptions = {
+      state: { [EXPAND_DESKTOP_NAV_KEY]: true },
+    };
+
     if (location?.state?.focusModeReturnPath) {
-      navigate(location.state.focusModeReturnPath);
+      navigate(location.state.focusModeReturnPath, navOptions);
     } else if (
       locationFromDefaultOrLogin(location) &&
       focusModeDefaultReturnPath
@@ -81,7 +90,7 @@ const ContextHeader: React.FC<Props> = ({
         clientId,
         enrollmentId,
       });
-      navigate(defaultBackPath);
+      navigate(defaultBackPath, navOptions);
     } else {
       navigate(-1);
     }

--- a/src/hooks/useDashboardState.tsx
+++ b/src/hooks/useDashboardState.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useLocation } from 'react-router-dom';
 import useCurrentPath from './useCurrentPath';
 import { useMobileMenu } from '@/components/layout/nav/useMobileMenuContext';
 import {
@@ -6,10 +7,11 @@ import {
   HIDE_NAV_ROUTES,
   NO_PADDING_ROUTES,
 } from '@/routes/routes';
+import { EXPAND_DESKTOP_NAV_KEY } from '@/routes/routeUtil';
 
 export function useDashboardState() {
   const currentPath = useCurrentPath();
-
+  const { state } = useLocation();
   const { mobileNavIsOpen, handleCloseMobileMenu, handleOpenMobileMenu } =
     useMobileMenu();
 
@@ -34,6 +36,14 @@ export function useDashboardState() {
       setFocusMode(undefined);
     }
   }, [currentPath]);
+
+  // Expand desktop nav if specified in location state. This supports re-expanding
+  // the nav when navigating back from a page that auto-collapsed it.
+  useEffect(() => {
+    if (state?.[EXPAND_DESKTOP_NAV_KEY]) {
+      setDesktopNavState(true);
+    }
+  }, [state]);
 
   const handleCloseDesktopMenu = useCallback(() => {
     setDesktopNavState(false);

--- a/src/modules/assessments/components/IndividualAssessmentFormController.tsx
+++ b/src/modules/assessments/components/IndividualAssessmentFormController.tsx
@@ -5,11 +5,13 @@ import {
   AssessmentResponseStatus,
   useAssessmentHandlers,
 } from '../hooks/useAssessmentHandlers';
+
 import IndividualAssessment from '@/modules/assessments/components/IndividualAssessment';
 import { FormActionTypes } from '@/modules/form/types';
 import { DashboardEnrollment } from '@/modules/hmis/types';
 import { cache } from '@/providers/apolloClient';
 import { EnrollmentDashboardRoutes } from '@/routes/routes';
+import { EXPAND_DESKTOP_NAV_KEY } from '@/routes/routeUtil';
 import {
   EnrolledClientFieldsFragment,
   FormDefinitionFieldsFragment,
@@ -43,7 +45,9 @@ const IndividualAssessmentFormController: React.FC<Props> = ({
         generateSafePath(EnrollmentDashboardRoutes.ASSESSMENTS, {
           enrollmentId: enrollment.id,
           clientId: client.id,
-        })
+        }),
+        // Re-expand desktop nav when navigating back to enrollment
+        { state: { [EXPAND_DESKTOP_NAV_KEY]: true } }
       ),
     [navigate, enrollment, client]
   );

--- a/src/routes/routeUtil.ts
+++ b/src/routes/routeUtil.ts
@@ -1,8 +1,12 @@
 import { Location, To } from 'react-router-dom';
 
+// Key used in location state to indicate that the desktop nav should be expanded
+export const EXPAND_DESKTOP_NAV_KEY = 'expandDesktopNav';
+
 export type LocationState = {
   fromLoginRedirect?: boolean;
   backToLabel?: string; // title of page to go back to. Used like `Back to ${backToLabel}`
+  [EXPAND_DESKTOP_NAV_KEY]?: boolean; // whether to expand desktop nav
 };
 
 export const STATE_FROM_LOGIN_REDIRECT: LocationState = {


### PR DESCRIPTION
## Description

* Add support for using react-router-dom Location State to expand desktop nav.
* Set the flag for auto-expanded when leaving "focus mode" (Back to X button in the context header)
* Set the flag for auto-expanded when leaving assessment page after a submission

Issue: https://github.com/open-path/Green-River/issues/7757, test instructions on issue


## Type of change
bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
