### PR TITLE
7814 Part 1: Add unit type dropdown to unit group form

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -54866,6 +54866,18 @@
             "deprecationReason": null
           },
           {
+            "name": "unitType",
+            "description": "Unit type for this group",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "UnitTypeObject",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "unitTypes",
             "description": null,
             "args": [],
@@ -55005,6 +55017,18 @@
           },
           {
             "name": "projectId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "ID",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "unitTypeId",
             "description": null,
             "type": {
               "kind": "SCALAR",

--- a/src/api/operations/units.fragments.graphql
+++ b/src/api/operations/units.fragments.graphql
@@ -101,6 +101,9 @@ fragment UnitGroupDetailFields on UnitGroup {
   ...UnitGroupCapacityFields
   workflowTemplateName
   ceEventType
+  unitType {
+    id
+  }
   workflowTemplateIdentifier
   eligibilityRequirements {
     ...CeMatchRuleFields

--- a/src/modules/units/components/UnitGroupFormDialog.tsx
+++ b/src/modules/units/components/UnitGroupFormDialog.tsx
@@ -51,6 +51,9 @@ const UnitGroupFormDialog: React.FC<UnitGroupFormDialogProps> = ({
   const isEditing = !!unitGroup;
 
   const [name, setName] = useState(unitGroup?.name || '');
+  const [unitType, setUnitType] = useState<string | null>(
+    unitGroup?.unitType?.id || null
+  );
   const [workflowTemplateIdentifier, setWorkflowTemplateIdentifier] = useState<
     string | null
   >(unitGroup?.workflowTemplateIdentifier || null);
@@ -106,6 +109,19 @@ const UnitGroupFormDialog: React.FC<UnitGroupFormDialogProps> = ({
         setErrors({ ...emptyErrorState, apolloError }),
     });
 
+  const {
+    data: { pickList: unitTypePickList } = {},
+    loading: unitTypePickListLoading,
+    error: unitTypePickListError,
+  } = useGetPickListQuery({
+    variables: {
+      pickListType: PickListType.PossibleUnitTypesForProject,
+      projectId: projectId,
+    },
+  });
+
+  if (unitTypePickListError) throw unitTypePickListError;
+
   const loading = createLoading || updateLoading;
 
   const handleSubmit = useCallback(() => {
@@ -131,6 +147,7 @@ const UnitGroupFormDialog: React.FC<UnitGroupFormDialogProps> = ({
             projectId,
             workflowTemplateIdentifier,
             ceEventType,
+            unitTypeId: unitType,
           },
         },
       });
@@ -139,11 +156,12 @@ const UnitGroupFormDialog: React.FC<UnitGroupFormDialogProps> = ({
     name,
     isEditing,
     unitGroup,
-    createUnitGroup,
     updateUnitGroup,
     projectId,
     workflowTemplateIdentifier,
     ceEventType,
+    createUnitGroup,
+    unitType,
   ]);
 
   const {
@@ -192,6 +210,21 @@ const UnitGroupFormDialog: React.FC<UnitGroupFormDialogProps> = ({
             label={getRequiredLabel('Unit Group Name', true)}
             value={name}
             onChange={(e) => setName(e.target.value)}
+          />
+          <FormSelect
+            disabled={isEditing}
+            value={unitType ? { code: unitType } : null}
+            label={getRequiredLabel('Unit Type', true)}
+            placeholder='Select Unit Type'
+            loading={unitTypePickListLoading}
+            options={unitTypePickList || []}
+            onChange={(_event, option) => {
+              if (isPickListOption(option)) {
+                setUnitType(option.code);
+              } else if (!option) {
+                setUnitType(null);
+              }
+            }}
           />
           {projectSupportsReferrals && (
             <>
@@ -246,7 +279,7 @@ const UnitGroupFormDialog: React.FC<UnitGroupFormDialogProps> = ({
           <LoadingButton
             onClick={handleSubmit}
             loading={loading}
-            disabled={!name}
+            disabled={!name || !unitType}
           >
             {isEditing ? 'Save Changes' : 'Create'}
           </LoadingButton>

--- a/src/types/gqlObjects.ts
+++ b/src/types/gqlObjects.ts
@@ -9779,6 +9779,10 @@ export const HmisInputObjectSchemas: GqlInputObjectSchema[] = [
       { name: 'name', type: { kind: 'SCALAR', name: 'String', ofType: null } },
       { name: 'projectId', type: { kind: 'SCALAR', name: 'ID', ofType: null } },
       {
+        name: 'unitTypeId',
+        type: { kind: 'SCALAR', name: 'ID', ofType: null },
+      },
+      {
         name: 'workflowTemplateIdentifier',
         type: { kind: 'SCALAR', name: 'String', ofType: null },
       },

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -8401,6 +8401,8 @@ export type UnitGroup = {
   /** @deprecated Replaced by prioritySchemes */
   priorityScheme?: Maybe<CeMatchRule>;
   prioritySchemes?: Maybe<Array<CeMatchRule>>;
+  /** Unit type for this group */
+  unitType?: Maybe<UnitTypeObject>;
   unitTypes: Array<UnitTypeCapacity>;
   units: UnitsPaginated;
   workflowTemplateIdentifier?: Maybe<Scalars['String']['output']>;
@@ -8417,6 +8419,7 @@ export type UnitGroupInput = {
   ceEventType?: InputMaybe<EventType>;
   name?: InputMaybe<Scalars['String']['input']>;
   projectId?: InputMaybe<Scalars['ID']['input']>;
+  unitTypeId?: InputMaybe<Scalars['ID']['input']>;
   workflowTemplateIdentifier?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -46735,6 +46738,7 @@ export type UnitGroupDetailFieldsFragment = {
   name: string;
   capacity: number;
   availability: number;
+  unitType?: { __typename?: 'UnitTypeObject'; id: string } | null;
   eligibilityRequirements?: Array<{
     __typename?: 'CeMatchRule';
     id: string;
@@ -46915,6 +46919,7 @@ export type GetUnitGroupQuery = {
     name: string;
     capacity: number;
     availability: number;
+    unitType?: { __typename?: 'UnitTypeObject'; id: string } | null;
     eligibilityRequirements?: Array<{
       __typename?: 'CeMatchRule';
       id: string;
@@ -47359,6 +47364,7 @@ export type UpdateUnitGroupMutation = {
       name: string;
       capacity: number;
       availability: number;
+      unitType?: { __typename?: 'UnitTypeObject'; id: string } | null;
       eligibilityRequirements?: Array<{
         __typename?: 'CeMatchRule';
         id: string;
@@ -50538,6 +50544,9 @@ export const UnitGroupDetailFieldsFragmentDoc = gql`
     ...UnitGroupCapacityFields
     workflowTemplateName
     ceEventType
+    unitType {
+      id
+    }
     workflowTemplateIdentifier
     eligibilityRequirements {
       ...CeMatchRuleFields


### PR DESCRIPTION
## Description

Summary of changes:
- Add Unit Type dropdown to Unit Group dialog
- Require it when creating a new unit group
- Disable changing it on an existing unit group

Depends on hmis-warehouse PR: https://github.com/greenriver/hmis-warehouse/pull/5691

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
New feature

## Checklist before requesting review
- [ ] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (eslint)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
