### PR TITLE
Auto-expand menu when exiting Assessment pages

### DIFF
--- a/src/components/layout/dashboard/contextHeader/ContextHeader.tsx
+++ b/src/components/layout/dashboard/contextHeader/ContextHeader.tsx
@@ -86,13 +86,14 @@ const ContextHeader: React.FC<Props> = ({
       navigate(-1);
     }
 
-    handleOpenMenu(); // expand left nav
+    if (!isMobile) handleOpenMenu(); // re-expand left nav on desktop
   }, [
     clientId,
     enrollmentId,
     focusMode,
     focusModeDefaultReturnPath,
     handleOpenMenu,
+    isMobile,
     location,
     navigate,
   ]);

--- a/src/modules/assessments/components/IndividualAssessmentFormController.tsx
+++ b/src/modules/assessments/components/IndividualAssessmentFormController.tsx
@@ -6,6 +6,7 @@ import {
   useAssessmentHandlers,
 } from '../hooks/useAssessmentHandlers';
 import IndividualAssessment from '@/modules/assessments/components/IndividualAssessment';
+import useEnrollmentDashboardContext from '@/modules/enrollment/hooks/useEnrollmentDashboardContext';
 import { FormActionTypes } from '@/modules/form/types';
 import { DashboardEnrollment } from '@/modules/hmis/types';
 import { cache } from '@/providers/apolloClient';
@@ -36,17 +37,19 @@ const IndividualAssessmentFormController: React.FC<Props> = ({
   editingDefinition,
   assessment,
 }) => {
+  const { handleOpenDesktopMenu } = useEnrollmentDashboardContext();
   const navigate = useNavigate();
-  const navigateToEnrollment = useCallback(
-    () =>
-      navigate(
-        generateSafePath(EnrollmentDashboardRoutes.ASSESSMENTS, {
-          enrollmentId: enrollment.id,
-          clientId: client.id,
-        })
-      ),
-    [navigate, enrollment, client]
-  );
+
+  const navigateToEnrollment = useCallback(() => {
+    navigate(
+      generateSafePath(EnrollmentDashboardRoutes.ASSESSMENTS, {
+        enrollmentId: enrollment.id,
+        clientId: client.id,
+      })
+    );
+    // Assessment is always displayed in 'focus mode', so re-expand desktop nav when navigating way.
+    handleOpenDesktopMenu();
+  }, [enrollment.id, client.id, navigate, handleOpenDesktopMenu]);
 
   const onCompletedMutation = useCallback(
     (status: AssessmentResponseStatus) => {

--- a/src/modules/assessments/components/household/HouseholdSummaryTabPanel.tsx
+++ b/src/modules/assessments/components/household/HouseholdSummaryTabPanel.tsx
@@ -9,6 +9,7 @@ import {
   useMemo,
   useState,
 } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { assessmentPrefix } from '../../util';
 
 import AlwaysMountedTabPanel from './AlwaysMountedTabPanel';
@@ -19,13 +20,14 @@ import {
   tabPanelA11yProps,
 } from './util';
 
-import BackButtonLink from '@/components/elements/BackButtonLink';
+import BackButton from '@/components/elements/BackButton';
 import LoadingButton from '@/components/elements/LoadingButton';
 import LoadingSkeleton from '@/components/elements/LoadingSkeleton';
 import TitleCard from '@/components/elements/TitleCard';
 import useSafeParams from '@/hooks/useSafeParams';
 import HouseholdSummaryExitHelpCard from '@/modules/assessments/components/household/HouseholdSummaryExitHelpCard';
 import HouseholdSummaryIntakeHelpCard from '@/modules/assessments/components/household/HouseholdSummaryIntakeHelpCard';
+import useEnrollmentDashboardContext from '@/modules/enrollment/hooks/useEnrollmentDashboardContext';
 import ApolloErrorAlert from '@/modules/errors/components/ApolloErrorAlert';
 import ValidationErrorList from '@/modules/errors/components/ValidationErrorList';
 import { useValidationDialog } from '@/modules/errors/hooks/useValidationDialog';
@@ -144,17 +146,23 @@ const HouseholdSummaryTabPanel = memo(
 
     const { renderValidationDialog } = useValidationDialog({ errorState });
 
+    const { handleOpenDesktopMenu } = useEnrollmentDashboardContext();
+    const navigate = useNavigate();
     const { clientId, enrollmentId } = useSafeParams() as {
       clientId: string;
       enrollmentId: string;
     };
-    const enrollmentPath = generateSafePath(
-      EnrollmentDashboardRoutes.ENROLLMENT_OVERVIEW,
-      {
-        clientId,
-        enrollmentId,
-      }
-    );
+
+    const navigateToEnrollment = useCallback(() => {
+      navigate(
+        generateSafePath(EnrollmentDashboardRoutes.ENROLLMENT_OVERVIEW, {
+          clientId,
+          enrollmentId,
+        })
+      );
+      // Household Assessments are always displayed in 'focus mode', so re-expand desktop nav when navigating way.
+      handleOpenDesktopMenu();
+    }, [navigate, clientId, enrollmentId, handleOpenDesktopMenu]);
 
     return (
       <AlwaysMountedTabPanel
@@ -217,9 +225,9 @@ const HouseholdSummaryTabPanel = memo(
             </TitleCard>
             {(submitResponseData?.submitHouseholdAssessments?.assessments ||
               allSubmitted) && (
-              <BackButtonLink sx={{ my: 4 }} to={enrollmentPath}>
+              <BackButton sx={{ my: 4 }} onClick={navigateToEnrollment}>
                 Back to Enrollment
-              </BackButtonLink>
+              </BackButton>
             )}
           </Grid>
         </Grid>

--- a/src/modules/enrollment/components/pages/EnrollmentDashboard.tsx
+++ b/src/modules/enrollment/components/pages/EnrollmentDashboard.tsx
@@ -58,7 +58,8 @@ const EnrollmentDashboard: React.FC = () => {
 
   const navItems = useEnrollmentDashboardNavItems(enabledFeatures);
 
-  const { currentPath, focusMode, ...dashboardState } = useDashboardState();
+  const { currentPath, focusMode, handleOpenDesktopMenu, ...dashboardState } =
+    useDashboardState();
 
   const outletContext: EnrollmentDashboardContext | undefined = useMemo(
     () =>
@@ -69,9 +70,10 @@ const EnrollmentDashboard: React.FC = () => {
             enrollment,
             enrollmentLoading: loading,
             getEnrollmentFeature,
+            handleOpenDesktopMenu,
           }
         : undefined,
-    [client, enrollment, loading, getEnrollmentFeature]
+    [client, enrollment, loading, getEnrollmentFeature, handleOpenDesktopMenu]
   );
 
   const breadCrumbConfig = useEnrollmentBreadcrumbConfig(outletContext);
@@ -112,6 +114,7 @@ const EnrollmentDashboard: React.FC = () => {
       navLabel='Enrollment'
       {...dashboardState}
       focusMode={focusMode}
+      handleOpenDesktopMenu={handleOpenDesktopMenu}
     >
       <Container maxWidth='xl' disableGutters>
         <LocalVersionCoordinationPrompt
@@ -138,6 +141,7 @@ export type EnrollmentDashboardContext = {
   getEnrollmentFeature: (
     role: DataCollectionFeatureRole
   ) => DataCollectionFeature | void;
+  handleOpenDesktopMenu: VoidFunction;
 };
 
 export function isEnrollmentDashboardContext(


### PR DESCRIPTION
## Description

Issue: https://github.com/open-path/Green-River/issues/7757

1. When navigating away from Assessment pages after submission, re-expand the nav menu on desktop.
2. Fix bug where mobile menu would flicker when leaving assessment page from existing back button mechanism

Note: the left nav still does not auto-expand when using the browser Back functionality. (That could be a future enhancement, but was too much code churn to introduce referer state, though I did explore this approach a bit. There are a _lot_ of places where we link to an assessment page).


## Type of change
Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
