### PR TITLE
Display user who completed CE referral task

### DIFF
--- a/src/api/operations/ce.fragments.graphql
+++ b/src/api/operations/ce.fragments.graphql
@@ -299,6 +299,10 @@ fragment CeReferralStepSummaryFields on CeReferralStep {
   }
   availableAt
   updatedAt
+  updatedBy {
+    id
+    name
+  }
   access {
     canPerformStep
   }

--- a/src/modules/ce/components/referral/ReferralStepDetails.tsx
+++ b/src/modules/ce/components/referral/ReferralStepDetails.tsx
@@ -28,21 +28,23 @@ const ReferralStepDetails: React.FC<{
     if (status === CeReferralStepStatus.Completed) {
       const date = parseHmisDateString(updatedAt);
       // intentionally format relative datetime as date (eg "Today" instead of "5 minutes ago")
-      if (date) return `Completed ${formatRelativeDate(date)}`;
+      const user = step.updatedBy?.name || 'Unknown User';
+      if (date) return `Completed ${formatRelativeDate(date)} by ${user}`;
     }
     const date = parseHmisDateString(availableAt);
     // intentionally format relative datetime as date (eg "Today" instead of "5 minutes ago")
     if (date) return `Available ${formatRelativeDate(date)}`;
-  }, [availableAt, updatedAt, status]);
+  }, [status, availableAt, updatedAt, step.updatedBy?.name]);
 
   const assigneeText = useMemo(() => {
+    if (status === CeReferralStepStatus.Completed) return;
     if (assignees.length === 0) return;
 
     const assigneeNames = assignees.map(({ id, name }) =>
       id === currentUser?.id ? 'you' : name
     );
     return `Assigned to ${stringifyArray(assigneeNames)}`;
-  }, [assignees, currentUser?.id]);
+  }, [assignees, currentUser?.id, status]);
 
   return (
     <Box>

--- a/src/modules/ce/components/referral/ReferralStepDetails.tsx
+++ b/src/modules/ce/components/referral/ReferralStepDetails.tsx
@@ -37,7 +37,8 @@ const ReferralStepDetails: React.FC<{
   }, [status, availableAt, updatedAt, step.updatedBy?.name]);
 
   const assigneeText = useMemo(() => {
-    if (status === CeReferralStepStatus.Completed) return;
+    if (status === CeReferralStepStatus.Completed) return; // hide and show user who completed step instead
+    if (status === CeReferralStepStatus.Unavailable) return; // hide to reduce confusion, no action can be taken
     if (assignees.length === 0) return;
 
     const assigneeNames = assignees.map(({ id, name }) =>

--- a/src/modules/ce/components/referral/ReferralStepDetails.tsx
+++ b/src/modules/ce/components/referral/ReferralStepDetails.tsx
@@ -20,7 +20,7 @@ import {
 const ReferralStepDetails: React.FC<{
   step: CeReferralStepSummaryFieldsFragment;
 }> = ({ step }) => {
-  const { status, availableAt, updatedAt, assignees } = step;
+  const { status, availableAt, updatedAt, updatedBy, assignees } = step;
   const { user: currentUser } = useAuth();
 
   const dateText = useMemo(() => {
@@ -28,13 +28,13 @@ const ReferralStepDetails: React.FC<{
     if (status === CeReferralStepStatus.Completed) {
       const date = parseHmisDateString(updatedAt);
       // intentionally format relative datetime as date (eg "Today" instead of "5 minutes ago")
-      const user = step.updatedBy?.name || 'Unknown User';
+      const user = updatedBy?.name || 'Unknown User';
       if (date) return `Completed ${formatRelativeDate(date)} by ${user}`;
     }
     const date = parseHmisDateString(availableAt);
     // intentionally format relative datetime as date (eg "Today" instead of "5 minutes ago")
     if (date) return `Available ${formatRelativeDate(date)}`;
-  }, [status, availableAt, updatedAt, step.updatedBy?.name]);
+  }, [status, availableAt, updatedAt, updatedBy]);
 
   const assigneeText = useMemo(() => {
     if (status === CeReferralStepStatus.Completed) return; // hide and show user who completed step instead

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -17125,6 +17125,11 @@ export type CeReferralFieldsFragment = {
       id: string;
       name: string;
     }>;
+    updatedBy?: {
+      __typename?: 'ApplicationUser';
+      id: string;
+      name: string;
+    } | null;
     access: { __typename?: 'CeReferralStepAccess'; canPerformStep: boolean };
   }> | null;
   opportunity?: {
@@ -17317,6 +17322,11 @@ export type CeReferralStepSummaryFieldsFragment = {
     id: string;
     name: string;
   }>;
+  updatedBy?: {
+    __typename?: 'ApplicationUser';
+    id: string;
+    name: string;
+  } | null;
   access: { __typename?: 'CeReferralStepAccess'; canPerformStep: boolean };
 };
 
@@ -17970,6 +17980,11 @@ export type CeReferralStepFieldsFragment = {
     id: string;
     name: string;
   }>;
+  updatedBy?: {
+    __typename?: 'ApplicationUser';
+    id: string;
+    name: string;
+  } | null;
   access: { __typename?: 'CeReferralStepAccess'; canPerformStep: boolean };
 };
 
@@ -18732,6 +18747,11 @@ export type StartCeReferralStepMutation = {
         id: string;
         name: string;
       }>;
+      updatedBy?: {
+        __typename?: 'ApplicationUser';
+        id: string;
+        name: string;
+      } | null;
       access: { __typename?: 'CeReferralStepAccess'; canPerformStep: boolean };
     };
   } | null;
@@ -19400,6 +19420,11 @@ export type SubmitCeReferralStepMutation = {
         id: string;
         name: string;
       }>;
+      updatedBy?: {
+        __typename?: 'ApplicationUser';
+        id: string;
+        name: string;
+      } | null;
       access: { __typename?: 'CeReferralStepAccess'; canPerformStep: boolean };
     } | null;
     referral?: {
@@ -19492,6 +19517,11 @@ export type SubmitCeReferralStepMutation = {
           id: string;
           name: string;
         }>;
+        updatedBy?: {
+          __typename?: 'ApplicationUser';
+          id: string;
+          name: string;
+        } | null;
         access: {
           __typename?: 'CeReferralStepAccess';
           canPerformStep: boolean;
@@ -19798,6 +19828,11 @@ export type AssignParticipantsMutation = {
           id: string;
           name: string;
         }>;
+        updatedBy?: {
+          __typename?: 'ApplicationUser';
+          id: string;
+          name: string;
+        } | null;
         access: {
           __typename?: 'CeReferralStepAccess';
           canPerformStep: boolean;
@@ -20148,6 +20183,11 @@ export type GetCeReferralQuery = {
         id: string;
         name: string;
       }>;
+      updatedBy?: {
+        __typename?: 'ApplicationUser';
+        id: string;
+        name: string;
+      } | null;
       access: { __typename?: 'CeReferralStepAccess'; canPerformStep: boolean };
     }> | null;
     opportunity?: {
@@ -20925,6 +20965,11 @@ export type GetCeReferralStepQuery = {
       id: string;
       name: string;
     }>;
+    updatedBy?: {
+      __typename?: 'ApplicationUser';
+      id: string;
+      name: string;
+    } | null;
     access: { __typename?: 'CeReferralStepAccess'; canPerformStep: boolean };
   } | null;
 };
@@ -48718,6 +48763,10 @@ export const CeReferralStepSummaryFieldsFragmentDoc = gql`
     }
     availableAt
     updatedAt
+    updatedBy {
+      id
+      name
+    }
     access {
       canPerformStep
     }


### PR DESCRIPTION
## Description

* Update interface to display "completed by X user" instead of "Assigned to" for completed tasks
* Hide "Assigned to" for unavailable tasks. Since no action can be taken yet, I think hiding the specific names is clearer. The responsible swimlane name is still displayed.

<img width="783" height="1171" alt="Screenshot 2025-08-29 at 4 50 15 PM" src="https://github.com/user-attachments/assets/4f96d153-5599-4c1d-8927-43f116afe674" />

## Type of change
bug fix / new feature

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
