### PR TITLE
Always use unit group UI

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -54866,6 +54866,18 @@
             "deprecationReason": null
           },
           {
+            "name": "unitType",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "UnitTypeObject",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "unitTypes",
             "description": null,
             "args": [],

--- a/src/modules/units/components/UnitManagementTable.tsx
+++ b/src/modules/units/components/UnitManagementTable.tsx
@@ -50,14 +50,14 @@ const UnitManagementTable: React.FC<Props> = ({
     return [
       UNIT_COLUMNS.unitType,
       UNIT_COLUMNS.unitId,
-      UNIT_COLUMNS.unitGroup,
+      ...(unitGroupId ? [] : [UNIT_COLUMNS.unitGroup]), // if looking at units in one group, no need to show the unit group col
       UNIT_COLUMNS.unitOccupancyStatus,
       UNIT_COLUMNS.clientOccupants,
       ...(coordinatedEntryFeatures.supportsReferrals
         ? [UNIT_COLUMNS.ceReferralStatus]
         : []),
     ];
-  }, [coordinatedEntryFeatures.supportsReferrals]);
+  }, [coordinatedEntryFeatures.supportsReferrals, unitGroupId]);
 
   const filters = useFilters({
     type: 'UnitFilterOptions',

--- a/src/modules/units/components/UnitManagementTable.tsx
+++ b/src/modules/units/components/UnitManagementTable.tsx
@@ -26,7 +26,6 @@ import { generateSafePath } from '@/utils/pathEncoding';
 interface Props {
   projectId: string;
   unitGroupId?: string; // if this table is for a specific unit group
-  unitGroupsEnabled?: boolean; // TEMP(#7814), remove when all projects moved to unit groups
   projectSupportsReferrals?: boolean; // whether to show CE details
   noUnitsMessage?: string; // custom message to show when there are no units
 }
@@ -39,7 +38,6 @@ interface Props {
 const UnitManagementTable: React.FC<Props> = ({
   projectId,
   unitGroupId,
-  unitGroupsEnabled = false,
   projectSupportsReferrals = false,
   noUnitsMessage,
 }) => {
@@ -51,12 +49,12 @@ const UnitManagementTable: React.FC<Props> = ({
     return [
       UNIT_COLUMNS.unitType,
       UNIT_COLUMNS.unitId,
-      ...(unitGroupsEnabled ? [UNIT_COLUMNS.unitGroup] : []),
+      UNIT_COLUMNS.unitGroup,
       UNIT_COLUMNS.unitOccupancyStatus,
       UNIT_COLUMNS.clientOccupants,
       ...(projectSupportsReferrals ? [UNIT_COLUMNS.ceReferralStatus] : []),
     ];
-  }, [projectSupportsReferrals, unitGroupsEnabled]);
+  }, [projectSupportsReferrals]);
 
   const filters = useFilters({
     type: 'UnitFilterOptions',
@@ -88,14 +86,14 @@ const UnitManagementTable: React.FC<Props> = ({
       }
 
       // Link to Unit Group
-      if (!unitGroupId && unitGroupsEnabled && unit.unitGroup) {
+      if (!unitGroupId) {
         actions.push({
           title: 'View Unit Group',
           key: 'viewGroup',
-          ariaLabel: `'View Unit Group' ${unit.unitGroup.name}`,
+          ariaLabel: `'View Unit Group' ${unit.unitGroup?.name}`,
           to: generateSafePath(ProjectDashboardRoutes.UNIT_GROUP, {
             projectId: project.id,
-            unitGroupId: unit.unitGroup.id,
+            unitGroupId: unit.unitGroup?.id,
           }),
         });
       }
@@ -116,7 +114,6 @@ const UnitManagementTable: React.FC<Props> = ({
     [
       projectSupportsReferrals,
       unitGroupId,
-      unitGroupsEnabled,
       canManageUnits,
       getCeActions,
       project.id,

--- a/src/modules/units/components/Units.tsx
+++ b/src/modules/units/components/Units.tsx
@@ -133,7 +133,7 @@ const Units = () => {
         projectId={project.id}
         open={addUnitsDialogOpen}
         onClose={() => setAddUnitsDialogOpen(false)}
-        allowSelectUnitType={false} //todo @martha - discuss this ux. How should this dialog behave when unit group is new and doesn't yet have an established type?
+        allowSelectUnitType={true} //todo @martha - discuss this ux. How should this dialog behave when unit group is new and doesn't yet have an established type?
         allowSelectUnitGroup={true}
         includeCeFields={projectSupportsReferrals}
         unitGroups={unitGroups}

--- a/src/modules/units/components/Units.tsx
+++ b/src/modules/units/components/Units.tsx
@@ -41,15 +41,6 @@ const Units = () => {
     return data.project.unitGroups.nodes;
   }, [data]);
 
-  // Enable Unit Groups management UI if:
-  // - the project supports CE referrals (direct or waitlist), OR
-  // - the project already has at least one unit group. (This will allow UI to switch over when Units are migrated into Unit Groups)
-  // TODO(#7814) remove this flag once Unit Group migration is complete. At that point all projects will have Unit Groups Enabled.
-  const unitGroupsEnabled = useMemo(
-    () => !!projectSupportsReferrals || unitGroups.length > 0,
-    [projectSupportsReferrals, unitGroups.length]
-  );
-
   if (!project.access.canViewUnits) return <NotFound />;
   if (error) throw error;
   if (loading) return <Loading />;
@@ -65,7 +56,7 @@ const Units = () => {
           >
             {/* If this is a new project with NO unit groups, hide "Add Units" button and instead
             show "Add Unit Group" to add the initial group */}
-            {unitGroupsEnabled && unitGroups.length === 0 ? (
+            {unitGroups.length === 0 ? (
               <Button
                 onClick={() => setAddUnitGroupDialogOpen(true)}
                 startIcon={<AddIcon />}
@@ -100,10 +91,9 @@ const Units = () => {
             <Paper>
               <UnitManagementTable
                 projectId={project.id}
-                unitGroupsEnabled={unitGroupsEnabled}
                 projectSupportsReferrals={projectSupportsReferrals}
                 noUnitsMessage={
-                  unitGroupsEnabled && unitGroups.length === 0
+                  unitGroups.length === 0
                     ? 'No units. Add a unit group to get started.'
                     : undefined
                 }
@@ -143,8 +133,8 @@ const Units = () => {
         projectId={project.id}
         open={addUnitsDialogOpen}
         onClose={() => setAddUnitsDialogOpen(false)}
-        allowSelectUnitType={!unitGroupsEnabled}
-        allowSelectUnitGroup={unitGroupsEnabled}
+        allowSelectUnitType={false} //todo @martha - discuss this ux. How should this dialog behave when unit group is new and doesn't yet have an established type?
+        allowSelectUnitGroup={true}
         includeCeFields={projectSupportsReferrals}
         unitGroups={unitGroups}
       />

--- a/src/modules/units/components/Units.tsx
+++ b/src/modules/units/components/Units.tsx
@@ -133,10 +133,10 @@ const Units = () => {
         projectId={project.id}
         open={addUnitsDialogOpen}
         onClose={() => setAddUnitsDialogOpen(false)}
-        allowSelectUnitType={true} //todo @martha - discuss this ux. How should this dialog behave when unit group is new and doesn't yet have an established type?
+        allowSelectUnitType={false}
         allowSelectUnitGroup={true}
         includeCeFields={projectSupportsReferrals}
-        unitGroups={unitGroups}
+        unitGroups={unitGroups.filter((ug) => ug.unitTypes.length > 0)}
       />
       <UnitGroupFormDialog
         projectId={project.id}

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -8401,6 +8401,7 @@ export type UnitGroup = {
   /** @deprecated Replaced by prioritySchemes */
   priorityScheme?: Maybe<CeMatchRule>;
   prioritySchemes?: Maybe<Array<CeMatchRule>>;
+  unitType?: Maybe<UnitTypeObject>;
   unitTypes: Array<UnitTypeCapacity>;
   units: UnitsPaginated;
   workflowTemplateIdentifier?: Maybe<Scalars['String']['output']>;


### PR DESCRIPTION
## Description

Summary of changes:
- Remove `unitGroupsEnabled` flag
- Default to always using the unit group UI 

[//]: # 'remove if not applicable'
Depends on hmis-warehouse PR: https://github.com/greenriver/hmis-warehouse/pull/5700

How to test:
- Navigate to a project with no units, that is not already using unit groups
- You should be prompted to add a unit group (not a floating unit)

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
New feature

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
