### PR TITLE
Simplify project CE interface for direct referral projects

### DIFF
--- a/src/modules/ce/components/referral/ReferralDetailContent.tsx
+++ b/src/modules/ce/components/referral/ReferralDetailContent.tsx
@@ -207,15 +207,17 @@ const ReferralDetailContent: React.FC<Props> = ({ referral }) => {
           <CommonDetailGrid rows={sourceEnrollmentDetails} />
         </CommonCollapsibleCard>
       )}
-      {eligibilityRequirementsDetails && (
-        <CommonCollapsibleCard
-          title='Eligibility Requirements'
-          TitleComponent='h3'
-          padContent={false}
-        >
-          <CommonDetailGrid rows={eligibilityRequirementsDetails} />
-        </CommonCollapsibleCard>
-      )}
+
+      {eligibilityRequirementsDetails &&
+        eligibilityRequirementsDetails.length > 0 && (
+          <CommonCollapsibleCard
+            title='Eligibility Requirements'
+            TitleComponent='h3'
+            padContent={false}
+          >
+            <CommonDetailGrid rows={eligibilityRequirementsDetails} />
+          </CommonCollapsibleCard>
+        )}
     </Stack>
   );
 };

--- a/src/modules/ce/components/unit/MatchRuleCard.tsx
+++ b/src/modules/ce/components/unit/MatchRuleCard.tsx
@@ -43,6 +43,9 @@ const MatchRuleCard: React.FC<Props> = ({ title, rules }) => {
             </Tooltip>
           </Stack>
         ))}
+        {rules.length === 0 && (
+          <Typography color='text.secondary'>No rules specified.</Typography>
+        )}
       </Stack>
     </CommonCard>
   );

--- a/src/modules/units/components/UnitGroupPage.tsx
+++ b/src/modules/units/components/UnitGroupPage.tsx
@@ -2,7 +2,7 @@ import AddIcon from '@mui/icons-material/Add';
 import EditIcon from '@mui/icons-material/Edit';
 import { Button, Grid, Paper, Stack, Typography } from '@mui/material';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import UnitManagementTable from './UnitManagementTable';
 
 import Loading from '@/components/elements/Loading';
@@ -33,10 +33,10 @@ const UnitGroupPage = () => {
   const [dialogOpen, setDialogOpen] = useState<boolean>(false);
   const [editDialogOpen, setEditDialogOpen] = useState<boolean>(false);
 
-  const projectSupportsReferrals = useMemo(
-    () => project.coordinatedEntryFeatures?.supportsReferrals,
-    [project.coordinatedEntryFeatures?.supportsReferrals]
-  );
+  const {
+    supportsReferrals: projectSupportsReferrals,
+    supportsWaitlistReferrals: projectSupportsWaitlistReferrals,
+  } = project.coordinatedEntryFeatures || {};
 
   // Set the breadcrumb so it says the correct name of this unit group
   useEffect(() => {
@@ -91,7 +91,9 @@ const UnitGroupPage = () => {
                 <UnitManagementTable
                   projectId={project.id}
                   unitGroupId={unitGroupId}
-                  projectSupportsReferrals={projectSupportsReferrals}
+                  coordinatedEntryFeatures={
+                    project.coordinatedEntryFeatures || {}
+                  }
                 />
               </Paper>
             </Stack>
@@ -116,14 +118,19 @@ const UnitGroupPage = () => {
                 unitGroup={unitGroup}
                 canEdit={canEditUnitGroup}
               /> */}
-              <MatchRuleCard
-                title='Eligibility Requirements'
-                rules={unitGroup.eligibilityRequirements || []}
-              />
-              <MatchRuleCard
-                title='Prioritization'
-                rules={unitGroup.prioritySchemes || []}
-              />
+
+              {projectSupportsWaitlistReferrals && (
+                <>
+                  <MatchRuleCard
+                    title='Eligibility Requirements'
+                    rules={unitGroup.eligibilityRequirements || []}
+                  />
+                  <MatchRuleCard
+                    title='Prioritization'
+                    rules={unitGroup.prioritySchemes || []}
+                  />
+                </>
+              )}
             </Stack>
           </Grid>
         )}

--- a/src/modules/units/components/UnitManagementTable.tsx
+++ b/src/modules/units/components/UnitManagementTable.tsx
@@ -19,6 +19,7 @@ import {
   GetUnitsDocument,
   GetUnitsQuery,
   GetUnitsQueryVariables,
+  ProjectCoordinatedEntryFeatures,
   UnitTableRowFieldsFragment,
 } from '@/types/gqlTypes';
 import { generateSafePath } from '@/utils/pathEncoding';
@@ -27,7 +28,7 @@ interface Props {
   projectId: string;
   unitGroupId?: string; // if this table is for a specific unit group
   unitGroupsEnabled?: boolean; // TEMP(#7814), remove when all projects moved to unit groups
-  projectSupportsReferrals?: boolean; // whether to show CE details
+  coordinatedEntryFeatures: Partial<ProjectCoordinatedEntryFeatures>;
   noUnitsMessage?: string; // custom message to show when there are no units
 }
 
@@ -40,7 +41,7 @@ const UnitManagementTable: React.FC<Props> = ({
   projectId,
   unitGroupId,
   unitGroupsEnabled = false,
-  projectSupportsReferrals = false,
+  coordinatedEntryFeatures,
   noUnitsMessage,
 }) => {
   const { setUnitToDelete, renderSingleDeleteDialog } = useDeleteUnits({
@@ -54,9 +55,11 @@ const UnitManagementTable: React.FC<Props> = ({
       ...(unitGroupsEnabled ? [UNIT_COLUMNS.unitGroup] : []),
       UNIT_COLUMNS.unitOccupancyStatus,
       UNIT_COLUMNS.clientOccupants,
-      ...(projectSupportsReferrals ? [UNIT_COLUMNS.ceReferralStatus] : []),
+      ...(coordinatedEntryFeatures.supportsReferrals
+        ? [UNIT_COLUMNS.ceReferralStatus]
+        : []),
     ];
-  }, [projectSupportsReferrals, unitGroupsEnabled]);
+  }, [coordinatedEntryFeatures.supportsReferrals, unitGroupsEnabled]);
 
   const filters = useFilters({
     type: 'UnitFilterOptions',
@@ -72,15 +75,13 @@ const UnitManagementTable: React.FC<Props> = ({
 
   const { getCeActions, loading } = useUnitCeActions({
     projectId,
-    projectSupportsReferrals,
+    coordinatedEntryFeatures,
   });
 
   const rowSecondaryActionConfigs = useCallback(
     (unit: UnitTableRowFieldsFragment) => {
-      const actions = [];
-      if (projectSupportsReferrals) {
-        actions.push(...getCeActions(unit));
-      }
+      const actions = getCeActions(unit);
+
       // If unit is occupied, link to hoh Enrollment
       const viewEnrollmentAction = getViewOccupantEnrollmentAction(unit);
       if (viewEnrollmentAction) {
@@ -114,7 +115,6 @@ const UnitManagementTable: React.FC<Props> = ({
       return actions;
     },
     [
-      projectSupportsReferrals,
       unitGroupId,
       unitGroupsEnabled,
       canManageUnits,
@@ -134,7 +134,7 @@ const UnitManagementTable: React.FC<Props> = ({
         defaultPageSize={25}
         queryVariables={{
           id: projectId,
-          includeCeFields: projectSupportsReferrals,
+          includeCeFields: coordinatedEntryFeatures.supportsReferrals,
         }}
         queryDocument={GetUnitsDocument}
         columns={columns}
@@ -159,7 +159,9 @@ const UnitManagementTable: React.FC<Props> = ({
                   projectId={projectId}
                   unitGroupId={unitGroupId}
                   units={selectedRows}
-                  ceAvailabilityActionsEnabled={projectSupportsReferrals}
+                  ceAvailabilityActionsEnabled={
+                    coordinatedEntryFeatures.supportsReferrals
+                  }
                 />
               )
             : undefined,

--- a/src/modules/units/components/UnitOverview.tsx
+++ b/src/modules/units/components/UnitOverview.tsx
@@ -58,19 +58,18 @@ const UnitOverview: React.FC<Props> = ({ unit }) => {
           </Paper>
         </Grid>
       )}
-      {unit.eligibilityRequirements && (
-        <Grid item xs={12} md={6}>
-          <MatchRuleCard
-            title='Eligibility Requirements'
-            rules={unit.eligibilityRequirements}
-          />
-        </Grid>
-      )}
-      {unit.prioritySchemes && (
-        <Grid item xs={12} md={6}>
-          <MatchRuleCard title='Prioritization' rules={unit.prioritySchemes} />
-        </Grid>
-      )}
+      <Grid item xs={12} md={6}>
+        <MatchRuleCard
+          title='Eligibility Requirements'
+          rules={unit.eligibilityRequirements || []}
+        />
+      </Grid>
+      <Grid item xs={12} md={6}>
+        <MatchRuleCard
+          title='Prioritization'
+          rules={unit.prioritySchemes || []}
+        />
+      </Grid>
     </Grid>
   );
 };

--- a/src/modules/units/components/UnitPage.tsx
+++ b/src/modules/units/components/UnitPage.tsx
@@ -53,6 +53,7 @@ const UnitPage: React.FC<Props> = ({}) => {
 
     const opportunity = unit.latestOpportunity;
     if (
+      project.coordinatedEntryFeatures?.supportsWaitlistReferrals &&
       opportunity &&
       opportunity.status !== CeOpportunityStatus.Closed &&
       project.access.canViewPrioritizedClientLists

--- a/src/modules/units/components/UnitPage.tsx
+++ b/src/modules/units/components/UnitPage.tsx
@@ -20,6 +20,9 @@ const UnitPage: React.FC<Props> = ({}) => {
 
   const { project, overrideBreadcrumbTitles } = useProjectDashboardContext();
 
+  const { supportsWaitlistReferrals: projectSupportsWaitlistReferrals } =
+    project.coordinatedEntryFeatures || {};
+
   const {
     data: { unit } = {},
     loading,
@@ -53,7 +56,6 @@ const UnitPage: React.FC<Props> = ({}) => {
 
     const opportunity = unit.latestOpportunity;
     if (
-      project.coordinatedEntryFeatures?.supportsWaitlistReferrals &&
       opportunity &&
       opportunity.status !== CeOpportunityStatus.Closed &&
       project.access.canViewPrioritizedClientLists
@@ -80,6 +82,11 @@ const UnitPage: React.FC<Props> = ({}) => {
   if (loading && !unit) return <Loading />;
   if (error) throw error;
   if (!unit) return <NotFound />;
+
+  // This page is only available for projects that use waitlists.
+  // Currently there is not really anything to show on a Unit page for projects
+  // that only do direct referrals.
+  if (!projectSupportsWaitlistReferrals) return <NotFound />;
 
   return (
     <>

--- a/src/modules/units/components/Units.tsx
+++ b/src/modules/units/components/Units.tsx
@@ -101,7 +101,9 @@ const Units = () => {
               <UnitManagementTable
                 projectId={project.id}
                 unitGroupsEnabled={unitGroupsEnabled}
-                projectSupportsReferrals={projectSupportsReferrals}
+                coordinatedEntryFeatures={
+                  project.coordinatedEntryFeatures || {}
+                }
                 noUnitsMessage={
                   unitGroupsEnabled && unitGroups.length === 0
                     ? 'No units. Add a unit group to get started.'

--- a/src/modules/units/hooks/useUnitCeActions.tsx
+++ b/src/modules/units/hooks/useUnitCeActions.tsx
@@ -2,6 +2,7 @@ import { useCallback } from 'react';
 import { CommonMenuItem } from '@/components/elements/CommonMenuButton';
 import { ProjectDashboardRoutes } from '@/routes/routes';
 import {
+  ProjectCoordinatedEntryFeatures,
   UnitTableRowFieldsFragment,
   useMarkUnitsAvailableMutation,
   useMarkUnitsUnavailableMutation,
@@ -10,10 +11,10 @@ import { generateSafePath } from '@/utils/pathEncoding';
 
 export const useUnitCeActions = ({
   projectId,
-  projectSupportsReferrals,
+  coordinatedEntryFeatures,
 }: {
   projectId: string;
-  projectSupportsReferrals: boolean;
+  coordinatedEntryFeatures: Partial<ProjectCoordinatedEntryFeatures>;
 }): {
   loading: boolean;
   getCeActions: (unit: UnitTableRowFieldsFragment) => CommonMenuItem[];
@@ -30,20 +31,22 @@ export const useUnitCeActions = ({
 
   const getCeActions = useCallback(
     (unit: UnitTableRowFieldsFragment) => {
-      if (!projectSupportsReferrals) return [];
+      if (!coordinatedEntryFeatures.supportsReferrals) return [];
 
       const actions: CommonMenuItem[] = [];
 
       // Always allow linking to Unit page, if the project supports CE referrals, to view/manage eligibility criteria
-      actions.push({
-        title: 'View Unit',
-        key: 'viewUnit',
-        ariaLabel: `View Unit ${unit.id}`,
-        to: generateSafePath(ProjectDashboardRoutes.UNIT, {
-          projectId: projectId,
-          unitId: unit.id,
-        }),
-      });
+      if (coordinatedEntryFeatures.supportsWaitlistReferrals) {
+        actions.push({
+          title: 'View Unit',
+          key: 'viewUnit',
+          ariaLabel: `View Unit ${unit.id}`,
+          to: generateSafePath(ProjectDashboardRoutes.UNIT, {
+            projectId: projectId,
+            unitId: unit.id,
+          }),
+        });
+      }
 
       // Note: canBeMarkedAvailableToday will be false if there is no workflow template configured
       if (unit.canBeMarkedAvailableToday) {
@@ -72,10 +75,10 @@ export const useUnitCeActions = ({
       return actions;
     },
     [
-      projectSupportsReferrals,
+      coordinatedEntryFeatures,
+      projectId,
       markUnitsAvailable,
       markUnitsUnavailable,
-      projectId,
     ]
   );
 

--- a/src/modules/units/hooks/useUnitCeActions.tsx
+++ b/src/modules/units/hooks/useUnitCeActions.tsx
@@ -35,7 +35,8 @@ export const useUnitCeActions = ({
 
       const actions: CommonMenuItem[] = [];
 
-      // Always allow linking to Unit page, if the project supports CE referrals, to view/manage eligibility criteria
+      // Only allow linking to the Unit page, if the project supports CE waitlist-based referrals. In the future
+      // we may want to expand this if we add more functionality to this page that is relevant to Direct-referral projects.
       if (coordinatedEntryFeatures.supportsWaitlistReferrals) {
         actions.push({
           title: 'View Unit',

--- a/src/routes/protected.tsx
+++ b/src/routes/protected.tsx
@@ -478,7 +478,7 @@ export const protectedRoutes: RouteNode[] = [
             element: (
               <ProjectRoute
                 permissions={['canViewUnits']}
-                coordinatedEntryFeatures={['supportsReferrals']}
+                coordinatedEntryFeatures={['supportsWaitlistReferrals']}
               >
                 <UnitPage />
               </ProjectRoute>
@@ -489,7 +489,7 @@ export const protectedRoutes: RouteNode[] = [
             element: (
               <ProjectRoute
                 permissions={['canViewUnits']}
-                coordinatedEntryFeatures={['supportsReferrals']}
+                coordinatedEntryFeatures={['supportsWaitlistReferrals']}
               >
                 <UnitPage />
               </ProjectRoute>


### PR DESCRIPTION
## Description

* Hide Eligibility card from Referral Details if the project has no eligibility requirements
* Show text in MatchRuleCard if there are no cards (unit group and unit page)
* **Removes support for Unit Page** for projects that do not support waitlist referrals. This is an unnecessary page for those projects, it doesn't show anything useful, and adds navigational confusion. I updated the related components to pass around `coordinatedEntryFeatures` directly so it will be easier to flip this back later if/when we need to. (For example, if we add more attributes or functionality to the Unit page).
* **Hide Eligibility/Prioritization cards** for projects that do not support waitlist referrals. These values are only relevant for waitlist-based projects.

## Type of change
feature update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
