### PR TITLE
Bug fix for legacy outgoing referrals

### DIFF
--- a/src/modules/ce/hooks/useProjectCeVisibility.tsx
+++ b/src/modules/ce/hooks/useProjectCeVisibility.tsx
@@ -20,7 +20,8 @@ export function useProjectCeVisibility(project?: ProjectAllFieldsFragment) {
       canViewUnits,
     } = project.access;
 
-    // If the project supports referrals AND the user can view referrals, show the Referrals tab
+    // If the project supports referrals AND the user can view referrals, show the Referrals tab.
+    // This refers to the "Referrals" sub-tab within the referral page, not the project page Referrals tab.
     const showReferrals =
       supportsReferrals && (canViewReferrals || canViewOwnReferrals);
 
@@ -32,13 +33,20 @@ export function useProjectCeVisibility(project?: ProjectAllFieldsFragment) {
     const showOutgoingReferrals =
       sendsDirectReferrals && canManageOutgoingReferrals;
 
+    // When to enable the 'Legacy Referrals' tab:
+    //   1) if the user has "canManageIncomingReferrals". This is a legacy perm that enables the ability to manage incoming legacy referrals.
+    //   2) if the user has "canManageOutgoingReferrals" and outgoing CE referrals are _not_ enabled. This permission is shared across legacy and CE.
+    //      This means that if the project had legacy outgoing referrals, but now CE Outgoing Direct Referrals are enabled, the Legacy
+    //      Referral tab will no longer be visible. (Unless the user has "canManageIncomingReferrals", in which case the legacy tab always shows.)
+    const showLegacyReferrals =
+      project.access.canManageIncomingReferrals ||
+      (!sendsDirectReferrals && canManageOutgoingReferrals);
+
     return {
       showReferrals,
       showAvailableUnits,
       showOutgoingReferrals,
-      // If user has 'canManageIncomingReferrals' in the project, they can see the legacy incoming referrals tab. This tab will be deprecated and removed once all projects are
-      // using CE referrals instead.
-      showLegacyReferrals: project.access.canManageIncomingReferrals,
+      showLegacyReferrals,
     };
   }, [project]);
 }

--- a/src/modules/ce/hooks/useProjectCeVisibility.tsx
+++ b/src/modules/ce/hooks/useProjectCeVisibility.tsx
@@ -21,7 +21,7 @@ export function useProjectCeVisibility(project?: ProjectAllFieldsFragment) {
     } = project.access;
 
     // If the project supports referrals AND the user can view referrals, show the Referrals tab.
-    // This refers to the "Referrals" sub-tab within the referral page, not the project page Referrals tab.
+    // This refers to the "Referrals" sub-tab within the Project Referrals page, not the Project Referrals page itself.
     const showReferrals =
       supportsReferrals && (canViewReferrals || canViewOwnReferrals);
 

--- a/src/modules/projects/hooks/useProjectDashboardNavItems.tsx
+++ b/src/modules/projects/hooks/useProjectDashboardNavItems.tsx
@@ -13,8 +13,12 @@ import {
 export const useProjectDashboardNavItems = (
   project?: ProjectAllFieldsFragment
 ) => {
-  const { showReferrals, showAvailableUnits, showOutgoingReferrals } =
-    useProjectCeVisibility(project);
+  const {
+    showReferrals,
+    showAvailableUnits,
+    showOutgoingReferrals,
+    showLegacyReferrals,
+  } = useProjectCeVisibility(project);
 
   const navItems: NavItem<ProjectAccessFieldsFragment>[] = useMemo(() => {
     if (!project) return [];
@@ -22,6 +26,10 @@ export const useProjectDashboardNavItems = (
     const dataCollectionRoles = project.dataCollectionFeatures.map(
       (r) => r.role
     );
+
+    const ceReferralsTabEnabled =
+      showReferrals || showAvailableUnits || showOutgoingReferrals;
+    const legacyReferralTabEnabled = showLegacyReferrals;
 
     return [
       {
@@ -90,23 +98,10 @@ export const useProjectDashboardNavItems = (
             hide: !project.serviceTypes.find((s) => s.supportsBulkAssignment),
           },
           {
-            // Legacy Referral page. Hidden if CE is enabled for the project.
             id: 'referrals',
             title: 'Referrals',
-            path: ProjectDashboardRoutes.REFERRALS,
-            permissions: [
-              'canManageIncomingReferrals',
-              'canManageOutgoingReferrals',
-            ],
-            permissionMode: 'any',
-            hide: !!project.coordinatedEntryFeatures,
-          },
-          {
-            id: 'ce-referrals',
-            title: 'Referrals',
             path: ProjectDashboardRoutes.CE,
-            hide:
-              !showReferrals && !showAvailableUnits && !showOutgoingReferrals,
+            hide: !ceReferralsTabEnabled && !legacyReferralTabEnabled,
           },
         ],
       },
@@ -153,7 +148,13 @@ export const useProjectDashboardNavItems = (
         ],
       },
     ];
-  }, [project, showAvailableUnits, showOutgoingReferrals, showReferrals]);
+  }, [
+    project,
+    showAvailableUnits,
+    showLegacyReferrals,
+    showOutgoingReferrals,
+    showReferrals,
+  ]);
 
   return navItems;
 };

--- a/src/modules/projects/hooks/useProjectDashboardNavItems.tsx
+++ b/src/modules/projects/hooks/useProjectDashboardNavItems.tsx
@@ -27,10 +27,6 @@ export const useProjectDashboardNavItems = (
       (r) => r.role
     );
 
-    const ceReferralsTabEnabled =
-      showReferrals || showAvailableUnits || showOutgoingReferrals;
-    const legacyReferralTabEnabled = showLegacyReferrals;
-
     return [
       {
         id: 'project-nav',
@@ -101,7 +97,13 @@ export const useProjectDashboardNavItems = (
             id: 'referrals',
             title: 'Referrals',
             path: ProjectDashboardRoutes.CE,
-            hide: !ceReferralsTabEnabled && !legacyReferralTabEnabled,
+            // If none of the components within the CE page are visible, hide from the left-hand nav
+            hide: !(
+              showReferrals ||
+              showAvailableUnits ||
+              showOutgoingReferrals ||
+              showLegacyReferrals
+            ),
           },
         ],
       },


### PR DESCRIPTION
## Description

Fix a bug introduced in https://github.com/greenriver/hmis-frontend/pull/1243
Issue: https://github.com/open-path/Green-River/issues/8119
Comment: https://github.com/open-path/Green-River/issues/8119#issuecomment-3250128760

Bug repro:
* Set up a user who has "can manage outgoing referrals" in a project
* Disable all CE configuration for that project
* **Bug:** User sees "page not found" on referral page
* **Desired behavior:** User sees legacy referral page containing table of outgoing referrals



## Type of change
Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
