### PR TITLE
Update unit "can't start accepting referrals" tooltip

### DIFF
--- a/src/modules/units/components/UnitBulkActions.tsx
+++ b/src/modules/units/components/UnitBulkActions.tsx
@@ -82,14 +82,13 @@ const UnitBulkActions: React.FC<Props> = ({
           selectedUnitsCount: units.length,
           eligibleUnitsCount: unitIdsToMarkAvailable.length,
 
-          // "Already accepting referrals" is NOT actually the only reason units might be ineligible,
-          // but it's helpful UI simplification.
           // All reasons they might not be able to be marked available (copied from backend):
           // - CE is not enabled, in which case the button won't appear
-          // - Unit group doesn't have a workflow template, in which case the button won't appear
-          // - Unit is already available - that is the case we describe in the tooltip
+          // - Unit is already available - "already accepting referrals"
+          // - Unit group doesn't have a workflow template - "need configuration"
           // - Unit has occupants, in which case it won't be selectable in the table (this is brittle, depends on `deletable` logic)
-          ineligibleText: 'are already accepting referrals',
+          ineligibleText:
+            'are already accepting referrals, or need workflow configuration',
         }),
       };
     }, [units]);


### PR DESCRIPTION
## Description

In https://github.com/greenriver/hmis-frontend/pull/1242, we introduced the ability to do unit bulk actions (mark available/mark unavailable) from the overall Units page, not just the Unit Group page. But we lost the [functionality](https://github.com/greenriver/hmis-frontend/pull/1242/files#diff-0f3613c7ffaa003bc7206d76d09875316a59667b2e7b3c8bc1d098b7d5c4ed8eL40-L43) previously described in the comment here on line 89, where the "Start Accepting Referrals" button would be hidden if the Unit Group isn't correctly configured. 

We could probably address this more gracefully, but I think the quickest way is this simple tooltip text change. This avoids a confusing situation where both "Start" and "Stop" buttons are greyed out and their tooltips give contradictory info.

<img width="1626" height="1284" alt="Screenshot 2025-09-03 at 3 05 57 PM" src="https://github.com/user-attachments/assets/1a115518-abd3-4d1e-b334-10bc87074a6f" />

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
