### PR TITLE
Update soft-warning on direct referral creation

### DIFF
--- a/src/modules/ce/components/directReferral/SendReferralSubForm.tsx
+++ b/src/modules/ce/components/directReferral/SendReferralSubForm.tsx
@@ -97,8 +97,8 @@ const SendReferralSubForm: React.FC<Props> = ({
       {definitionLoading && <LoadingSkeleton width={'100%'} count={1} />}
       {projectCanAcceptReferral === false && (
         <Alert severity='warning'>
-          At least one client in the household already has an open enrollment in
-          this project.
+          At least one client in the household already has an open enrollment or
+          in-progress referral in this project.
         </Alert>
       )}
       {formDefinition && (


### PR DESCRIPTION
## Description

Summary of changes: Update the soft-warning message to convey that it could refer to either an existing enrollment or an existing referral.

[//]: # 'remove if not applicable'
Depends on hmis-warehouse PR: https://github.com/greenriver/hmis-warehouse/pull/5724

[//]: # 'remove if not applicable'
How to test: See backend PR description

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
