### PR TITLE
Prevent user from unit management if no permission

### DIFF
--- a/src/modules/units/components/UnitManagementTable.tsx
+++ b/src/modules/units/components/UnitManagementTable.tsx
@@ -74,6 +74,7 @@ const UnitManagementTable: React.FC<Props> = ({
   const { getCeActions, loading } = useUnitCeActions({
     projectId,
     coordinatedEntryFeatures,
+    canManageUnits,
   });
 
   const rowSecondaryActionConfigs = useCallback(

--- a/src/modules/units/components/UnitOverview.tsx
+++ b/src/modules/units/components/UnitOverview.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import LoadingButton from '@/components/elements/LoadingButton';
 import MatchRuleCard from '@/modules/ce/components/unit/MatchRuleCard';
 import OpportunityBanner from '@/modules/ce/components/unit/OpportunityBanner';
+import { useProjectDashboardContext } from '@/modules/projects/components/ProjectDashboard';
 import { cache } from '@/providers/apolloClient';
 import {
   UnitDetailFieldsFragment,
@@ -15,6 +16,8 @@ interface Props {
   unit: UnitDetailFieldsFragment;
 }
 const UnitOverview: React.FC<Props> = ({ unit }) => {
+  const { project } = useProjectDashboardContext();
+
   const opportunity = unit.latestOpportunity;
   const [
     markUnitAvailable,
@@ -48,12 +51,14 @@ const UnitOverview: React.FC<Props> = ({ unit }) => {
               <Typography>
                 This unit is not currently accepting referrals.
               </Typography>
-              <LoadingButton
-                onClick={() => markUnitAvailable()}
-                loading={availableLoading}
-              >
-                Start Accepting Referrals
-              </LoadingButton>
+              {project.access.canManageUnits && (
+                <LoadingButton
+                  onClick={() => markUnitAvailable()}
+                  loading={availableLoading}
+                >
+                  Start Accepting Referrals
+                </LoadingButton>
+              )}
             </Stack>
           </Paper>
         </Grid>

--- a/src/modules/units/hooks/useUnitCeActions.tsx
+++ b/src/modules/units/hooks/useUnitCeActions.tsx
@@ -12,9 +12,11 @@ import { generateSafePath } from '@/utils/pathEncoding';
 export const useUnitCeActions = ({
   projectId,
   coordinatedEntryFeatures,
+  canManageUnits,
 }: {
   projectId: string;
   coordinatedEntryFeatures: Partial<ProjectCoordinatedEntryFeatures>;
+  canManageUnits: boolean;
 }): {
   loading: boolean;
   getCeActions: (unit: UnitTableRowFieldsFragment) => CommonMenuItem[];
@@ -50,7 +52,7 @@ export const useUnitCeActions = ({
       }
 
       // Note: canBeMarkedAvailableToday will be false if there is no workflow template configured
-      if (unit.canBeMarkedAvailableToday) {
+      if (canManageUnits && unit.canBeMarkedAvailableToday) {
         // TODO(#7537) - use canBeMarkedAvailable and implement a confirmation modal enabling the user to specify the "available on date".
         actions.push({
           title: 'Start Accepting Referrals',
@@ -62,7 +64,7 @@ export const useUnitCeActions = ({
         });
       }
 
-      if (unit.canBeMarkedUnavailable) {
+      if (canManageUnits && unit.canBeMarkedUnavailable) {
         actions.push({
           title: 'Stop Accepting Referrals',
           key: 'markUnavailable',
@@ -80,6 +82,7 @@ export const useUnitCeActions = ({
       projectId,
       markUnitsAvailable,
       markUnitsUnavailable,
+      canManageUnits,
     ]
   );
 


### PR DESCRIPTION
## Description

Summary of changes:
Hide "Start Accepting Referrals" button/menu action if the user doesn't have permission to manage units.

[//]: # 'remove if not applicable'
How to test:
- /projects/xxx/unit/xxx#overview - should not see "Start Accepting Referrals" button
- /projects/xxx/units - should not see "Start Accepting Referrals" in table menu for each unit
- /projects/xxx/unitGroup/xxx - should not see "Start Accepting Referrals" in table menu for each unit

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
