### PR TITLE
Fix Invariant Violation bug on Unit Management table

### DIFF
--- a/src/modules/units/components/UnitManagementTable.tsx
+++ b/src/modules/units/components/UnitManagementTable.tsx
@@ -125,7 +125,7 @@ const UnitManagementTable: React.FC<Props> = ({
         defaultPageSize={25}
         queryVariables={{
           id: projectId,
-          includeCeFields: coordinatedEntryFeatures.supportsReferrals,
+          includeCeFields: coordinatedEntryFeatures.supportsReferrals || false,
         }}
         queryDocument={GetUnitsDocument}
         columns={columns}


### PR DESCRIPTION
## Description

How to reproduce: Visit a project that does not support CE referrals. Try to load the Units page. The Unit Management table spins forever and in the console you can see an error "Invariant Violation."

Fix: 
- Pass a default value of `false` to the `includeCeFields` directive.
- I checked other usages of `includeCeFields`, they have default values of false already.

Should be merged to release-179 before deploying to prod.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
