### PR TITLE
Support redirect from Unit page to All Units page

### DIFF
--- a/src/components/accessWrappers/ProjectRoute.tsx
+++ b/src/components/accessWrappers/ProjectRoute.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { Navigate } from 'react-router-dom';
 
 import Loading from '../elements/Loading';
@@ -37,43 +38,47 @@ const ProjectRoute: React.FC<
     permissionsArray
   );
 
+  const redirectOrNotFound = useMemo(
+    () =>
+      redirectRoute ? (
+        <Navigate
+          to={generateSafePath(redirectRoute, { projectId: project.id })}
+          replace
+        />
+      ) : (
+        <NotFound />
+      ),
+    [project.id, redirectRoute]
+  );
+
   if (
     dataCollectionFeature &&
     !project.dataCollectionFeatures
       .map((f) => f.role)
       .includes(dataCollectionFeature)
   ) {
-    return <NotFound />;
+    return redirectOrNotFound;
   }
 
   // If the route requires a coordinated entry feature, check that it is enabled
   if (coordinatedEntryFeatures && coordinatedEntryFeatures.length > 0) {
-    if (!project.coordinatedEntryFeatures) return <NotFound />; // No coordinated entry features in this project
+    if (!project.coordinatedEntryFeatures) return redirectOrNotFound; // No coordinated entry features in this project
 
     // Check that ANY of the specified features are true
     const anyFeatureEnabled = coordinatedEntryFeatures.some(
       (feature) => project.coordinatedEntryFeatures?.[feature] === true
     );
-
-    if (!anyFeatureEnabled) return <NotFound />;
+    if (!anyFeatureEnabled) return redirectOrNotFound;
   }
 
   // If no permissions are specified, we assume the route is accessible
   if (loading) return <Loading />;
 
   if (permissionsArray.length > 0 && !hasPermission) {
-    return redirectRoute ? (
-      <Navigate
-        to={generateSafePath(redirectRoute, {
-          projectId: project.id,
-        })}
-        replace
-      />
-    ) : (
-      <NotFound />
-    );
+    return redirectOrNotFound;
   }
 
   return <>{children}</>;
 };
+
 export default ProjectRoute;

--- a/src/modules/ce/components/admin/AdminOpportunitiesTable.tsx
+++ b/src/modules/ce/components/admin/AdminOpportunitiesTable.tsx
@@ -79,12 +79,13 @@ const AdminOpportunitiesTable: React.FC<Props> = ({}) => {
         recordType='CeOpportunity'
         pagePath='ceOpportunities'
         noData='No available units'
-        paginationItemName='unit'
+        paginationItemName='available unit'
         filters={filters}
         defaultFilterValues={{
           status: [CeOpportunityStatus.Open],
         }}
         rowLinkTo={(row) =>
+          // Link to Unit Page. If the project doesn't support waitlists, this will redirect to the All Units page.
           generateSafePath(ProjectDashboardRoutes.UNIT, {
             projectId: row.projectId,
             unitId: row.unit?.id,

--- a/src/routes/protected.tsx
+++ b/src/routes/protected.tsx
@@ -474,6 +474,7 @@ export const protectedRoutes: RouteNode[] = [
               <ProjectRoute
                 permissions={['canViewUnits']}
                 coordinatedEntryFeatures={['supportsWaitlistReferrals']}
+                redirectRoute={ProjectDashboardRoutes.UNITS}
               >
                 <UnitPage />
               </ProjectRoute>


### PR DESCRIPTION
## Description

https://github.com/open-path/Green-River/issues/8124#issuecomment-3271697068

Bug: the CE Admin Available Units table links to the Unit Page, which displays "Not Found" if the project does not support waitlist-based referrals. This PR patches that by adding a redirect to the All Units Page if Unit page is not available.


We will likely want to revisit this-- it may be better for Available Units table to conditionally link (and display information to differentiate), but it currently doesn't have knowledge as to which Units are for "waitlist-based" vs "direct", so that will require some additional graphql work. We also may add back the Unit page at some point for direct referrals if needed. 

This PR solves the immediate bug so the user is not presented with an action that links to "Not Found".



## Type of change
bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
