### PR TITLE
Respect new 'can update unit availability' perm

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -43330,6 +43330,22 @@
             "deprecationReason": null
           },
           {
+            "name": "canUpdateUnitAvailability",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "canViewDob",
             "description": null,
             "args": [],
@@ -47966,6 +47982,22 @@
           },
           {
             "name": "canTransferEnrollments",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "canUpdateUnitAvailability",
             "description": null,
             "args": [],
             "type": {

--- a/src/api/operations/access.fragments.graphql
+++ b/src/api/operations/access.fragments.graphql
@@ -87,6 +87,7 @@ fragment ProjectAccessFields on ProjectAccess {
   canEditProjectDetails
   canViewUnits
   canManageUnits
+  canUpdateUnitAvailability
   canManageIncomingReferrals
   canManageOutgoingReferrals
   canManageExternalFormSubmissions

--- a/src/modules/units/components/UnitBulkActions.tsx
+++ b/src/modules/units/components/UnitBulkActions.tsx
@@ -34,6 +34,7 @@ interface Props {
   projectId: string;
   unitGroupId?: string;
   units: UnitTableRowFieldsFragment[];
+  deletionEnabled?: boolean;
   ceAvailabilityActionsEnabled?: boolean;
 }
 
@@ -41,6 +42,7 @@ const UnitBulkActions: React.FC<Props> = ({
   projectId,
   unitGroupId,
   units,
+  deletionEnabled,
   ceAvailabilityActionsEnabled = false,
 }) => {
   // This component's philosophy is to let the user do what they are trying to
@@ -140,9 +142,11 @@ const UnitBulkActions: React.FC<Props> = ({
         </>
       )}
 
-      <ButtonTooltipContainer title={deleteTooltip}>
-        {renderBulkDeleteButton(unitIdsToDelete, disableDelete)}
-      </ButtonTooltipContainer>
+      {deletionEnabled && (
+        <ButtonTooltipContainer title={deleteTooltip}>
+          {renderBulkDeleteButton(unitIdsToDelete, disableDelete)}
+        </ButtonTooltipContainer>
+      )}
     </Stack>
   );
 };

--- a/src/modules/units/components/UnitManagementTable.tsx
+++ b/src/modules/units/components/UnitManagementTable.tsx
@@ -69,12 +69,13 @@ const UnitManagementTable: React.FC<Props> = ({
   });
 
   const { project } = useProjectDashboardContext();
-  const canManageUnits = project.access.canManageUnits;
+  const { canManageUnits, canUpdateUnitAvailability } = project.access;
+  const canDoAnyUnitActions = canManageUnits || canUpdateUnitAvailability;
 
   const { getCeActions, loading } = useUnitCeActions({
     projectId,
     coordinatedEntryFeatures,
-    canManageUnits,
+    canUpdateUnitAvailability,
   });
 
   const rowSecondaryActionConfigs = useCallback(
@@ -113,7 +114,7 @@ const UnitManagementTable: React.FC<Props> = ({
 
       return actions;
     },
-    [unitGroupId, canManageUnits, getCeActions, project.id, setUnitToDelete]
+    [getCeActions, unitGroupId, canManageUnits, project.id, setUnitToDelete]
   );
 
   return (
@@ -132,7 +133,7 @@ const UnitManagementTable: React.FC<Props> = ({
         columns={columns}
         pagePath='project.units'
         noData={noUnitsMessage || 'No units'}
-        selectable={canManageUnits ? 'checkbox' : undefined}
+        selectable={canDoAnyUnitActions ? 'checkbox' : undefined}
         isRowSelectable={(row) =>
           !!(
             row.deletable ||
@@ -144,15 +145,17 @@ const UnitManagementTable: React.FC<Props> = ({
         filters={filters}
         recordType='Unit'
         EnhancedTableToolbarProps={{
-          title: canManageUnits ? 'Manage Units' : 'Units',
-          renderBulkAction: canManageUnits
+          title: canDoAnyUnitActions ? 'Manage Units' : 'Units',
+          renderBulkAction: canDoAnyUnitActions
             ? (_selectedIds, selectedRows) => (
                 <UnitBulkActions
                   projectId={projectId}
                   unitGroupId={unitGroupId}
                   units={selectedRows}
+                  deletionEnabled={canManageUnits}
                   ceAvailabilityActionsEnabled={
-                    coordinatedEntryFeatures.supportsReferrals
+                    coordinatedEntryFeatures.supportsReferrals &&
+                    canUpdateUnitAvailability
                   }
                 />
               )

--- a/src/modules/units/components/UnitOverview.tsx
+++ b/src/modules/units/components/UnitOverview.tsx
@@ -51,7 +51,7 @@ const UnitOverview: React.FC<Props> = ({ unit }) => {
               <Typography>
                 This unit is not currently accepting referrals.
               </Typography>
-              {project.access.canManageUnits && (
+              {project.access.canUpdateUnitAvailability && (
                 <LoadingButton
                   onClick={() => markUnitAvailable()}
                   loading={availableLoading}

--- a/src/modules/units/hooks/useUnitCeActions.tsx
+++ b/src/modules/units/hooks/useUnitCeActions.tsx
@@ -12,11 +12,11 @@ import { generateSafePath } from '@/utils/pathEncoding';
 export const useUnitCeActions = ({
   projectId,
   coordinatedEntryFeatures,
-  canManageUnits,
+  canUpdateUnitAvailability,
 }: {
   projectId: string;
   coordinatedEntryFeatures: Partial<ProjectCoordinatedEntryFeatures>;
-  canManageUnits: boolean;
+  canUpdateUnitAvailability: boolean;
 }): {
   loading: boolean;
   getCeActions: (unit: UnitTableRowFieldsFragment) => CommonMenuItem[];
@@ -52,7 +52,7 @@ export const useUnitCeActions = ({
       }
 
       // Note: canBeMarkedAvailableToday will be false if there is no workflow template configured
-      if (canManageUnits && unit.canBeMarkedAvailableToday) {
+      if (canUpdateUnitAvailability && unit.canBeMarkedAvailableToday) {
         // TODO(#7537) - use canBeMarkedAvailable and implement a confirmation modal enabling the user to specify the "available on date".
         actions.push({
           title: 'Start Accepting Referrals',
@@ -64,7 +64,7 @@ export const useUnitCeActions = ({
         });
       }
 
-      if (canManageUnits && unit.canBeMarkedUnavailable) {
+      if (canUpdateUnitAvailability && unit.canBeMarkedUnavailable) {
         actions.push({
           title: 'Stop Accepting Referrals',
           key: 'markUnavailable',
@@ -82,7 +82,7 @@ export const useUnitCeActions = ({
       projectId,
       markUnitsAvailable,
       markUnitsUnavailable,
-      canManageUnits,
+      canUpdateUnitAvailability,
     ]
   );
 

--- a/src/types/gqlObjects.ts
+++ b/src/types/gqlObjects.ts
@@ -6068,6 +6068,14 @@ export const HmisObjectSchemas: GqlSchema[] = [
         },
       },
       {
+        name: 'canUpdateUnitAvailability',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'Boolean', ofType: null },
+        },
+      },
+      {
         name: 'canViewDob',
         type: {
           kind: 'NON_NULL',
@@ -6577,6 +6585,14 @@ export const HmisObjectSchemas: GqlSchema[] = [
       },
       {
         name: 'canTransferEnrollments',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'Boolean', ofType: null },
+        },
+      },
+      {
+        name: 'canUpdateUnitAvailability',
         type: {
           kind: 'NON_NULL',
           name: null,

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -6500,6 +6500,7 @@ export type ProjectAccess = {
   canPerformOwnReferralTasks: Scalars['Boolean']['output'];
   canSplitHouseholds: Scalars['Boolean']['output'];
   canStartReferrals: Scalars['Boolean']['output'];
+  canUpdateUnitAvailability: Scalars['Boolean']['output'];
   canViewDob: Scalars['Boolean']['output'];
   canViewEnrollmentDetails: Scalars['Boolean']['output'];
   canViewFullSsn: Scalars['Boolean']['output'];
@@ -7097,6 +7098,7 @@ export type QueryAccess = {
   canSplitHouseholds: Scalars['Boolean']['output'];
   canStartReferrals: Scalars['Boolean']['output'];
   canTransferEnrollments: Scalars['Boolean']['output'];
+  canUpdateUnitAvailability: Scalars['Boolean']['output'];
   canViewAnyConfidentialClientFiles: Scalars['Boolean']['output'];
   canViewAnyNonconfidentialClientFiles: Scalars['Boolean']['output'];
   canViewClientAlerts: Scalars['Boolean']['output'];
@@ -9279,6 +9281,7 @@ export type ProjectAccessFieldsFragment = {
   canEditProjectDetails: boolean;
   canViewUnits: boolean;
   canManageUnits: boolean;
+  canUpdateUnitAvailability: boolean;
   canManageIncomingReferrals: boolean;
   canManageOutgoingReferrals: boolean;
   canManageExternalFormSubmissions: boolean;
@@ -37908,6 +37911,7 @@ export type SubmitFormMutation = {
             canEditProjectDetails: boolean;
             canViewUnits: boolean;
             canManageUnits: boolean;
+            canUpdateUnitAvailability: boolean;
             canManageIncomingReferrals: boolean;
             canManageOutgoingReferrals: boolean;
             canManageExternalFormSubmissions: boolean;
@@ -41651,6 +41655,7 @@ export type ProjectAllFieldsFragment = {
     canEditProjectDetails: boolean;
     canViewUnits: boolean;
     canManageUnits: boolean;
+    canUpdateUnitAvailability: boolean;
     canManageIncomingReferrals: boolean;
     canManageOutgoingReferrals: boolean;
     canManageExternalFormSubmissions: boolean;
@@ -42553,6 +42558,7 @@ export type GetProjectQuery = {
       canEditProjectDetails: boolean;
       canViewUnits: boolean;
       canManageUnits: boolean;
+      canUpdateUnitAvailability: boolean;
       canManageIncomingReferrals: boolean;
       canManageOutgoingReferrals: boolean;
       canManageExternalFormSubmissions: boolean;
@@ -42737,6 +42743,7 @@ export type GetProjectPermissionsQuery = {
       canEditProjectDetails: boolean;
       canViewUnits: boolean;
       canManageUnits: boolean;
+      canUpdateUnitAvailability: boolean;
       canManageIncomingReferrals: boolean;
       canManageOutgoingReferrals: boolean;
       canManageExternalFormSubmissions: boolean;
@@ -50318,6 +50325,7 @@ export const ProjectAccessFieldsFragmentDoc = gql`
     canEditProjectDetails
     canViewUnits
     canManageUnits
+    canUpdateUnitAvailability
     canManageIncomingReferrals
     canManageOutgoingReferrals
     canManageExternalFormSubmissions


### PR DESCRIPTION
## Description

Summary of changes:
- Respect new permission `canUpdateUnitAvailability` for CE availability unit actions in 3 places:
  - In bulk on the Unit Management table
  - On an individual unit on the Unit Management table
  - On the Unit page

[//]: # 'remove if not applicable'
Depends on hmis-warehouse PR: https://github.com/greenriver/hmis-warehouse/pull/5740

[//]: # 'remove if not applicable'
How to test: See ticket instructions

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
