### PR TITLE
Hide OpportunityBanner for closed referrals

### DIFF
--- a/src/modules/units/components/UnitOverview.tsx
+++ b/src/modules/units/components/UnitOverview.tsx
@@ -28,7 +28,7 @@ const UnitOverview: React.FC<Props> = ({ unit }) => {
 
   return (
     <Grid container columnSpacing={6} rowSpacing={4}>
-      {opportunity && (
+      {opportunity?.active && (
         <Grid item xs={12}>
           <OpportunityBanner
             topCandidate={opportunity.candidates.nodes[0]}


### PR DESCRIPTION
## Description

Hide component from unit page if unit is not accepting referrals. To reproduce: mark a unit as available, then mark it unavailable, then go to unit page.


Prevent UI like this (screenshot from QA)
<img width="1318" height="427" alt="Screenshot 2025-09-09 at 5 08 06 PM" src="https://github.com/user-attachments/assets/5704ae2d-5d44-4bec-be80-1e6055a96247" />

## Type of change
bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
