### PR TITLE
Add Assessment Details column

### DIFF
--- a/src/api/operations/assessment.fragments.graphql
+++ b/src/api/operations/assessment.fragments.graphql
@@ -86,3 +86,10 @@ fragment FullAssessment on Assessment {
   ...AssessmentWithRecords
   ...AssessmentWithValues
 }
+
+fragment AssessmentWithCdes on Assessment {
+  ...AssessmentFields
+  customDataElements @include(if: $includeCdes) {
+    ...CustomDataElementFields
+  }
+}

--- a/src/api/operations/assessment.queries.graphql
+++ b/src/api/operations/assessment.queries.graphql
@@ -19,6 +19,7 @@ query GetClientAssessments(
   $sortOrder: AssessmentSortOption = ASSESSMENT_DATE
   $filters: AssessmentFilterOptions = null
   $includeOrganizationName: Boolean = false
+  $includeCdes: Boolean = false
 ) {
   client(id: $id) {
     id
@@ -32,7 +33,7 @@ query GetClientAssessments(
       limit
       nodesCount
       nodes {
-        ...AssessmentFields
+        ...AssessmentWithCdes
         enrollment {
           ...ClientEnrollmentFields
         }
@@ -48,6 +49,7 @@ query GetEnrollmentAssessments(
   $inProgress: Boolean
   $sortOrder: AssessmentSortOption = ASSESSMENT_DATE
   $filters: AssessmentsForEnrollmentFilterOptions
+  $includeCdes: Boolean = false
 ) {
   enrollment(id: $id) {
     id
@@ -62,7 +64,7 @@ query GetEnrollmentAssessments(
       limit
       nodesCount
       nodes {
-        ...AssessmentFields
+        ...AssessmentWithCdes
       }
     }
   }
@@ -75,6 +77,7 @@ query GetHouseholdAssessments(
   $inProgress: Boolean
   $sortOrder: AssessmentSortOption = ASSESSMENT_DATE
   $filters: AssessmentsForHouseholdFilterOptions
+  $includeCdes: Boolean = false
 ) {
   household(id: $id) {
     id
@@ -89,7 +92,7 @@ query GetHouseholdAssessments(
       limit
       nodesCount
       nodes {
-        ...AssessmentFields
+        ...AssessmentWithCdes
         enrollment {
           id
           relationshipToHoH

--- a/src/api/operations/project.queries.graphql
+++ b/src/api/operations/project.queries.graphql
@@ -133,6 +133,7 @@ query GetProjectAssessments(
   $offset: Int = 0
   $sortOrder: AssessmentSortOption = ASSESSMENT_DATE
   $filters: AssessmentsForProjectFilterOptions = null
+  $includeCdes: Boolean = false
 ) {
   project(id: $id) {
     id
@@ -146,7 +147,7 @@ query GetProjectAssessments(
       limit
       nodesCount
       nodes {
-        ...AssessmentFields
+        ...AssessmentWithCdes
         enrollment {
           ...EnrollmentFields
         }

--- a/src/config/theme.ts
+++ b/src/config/theme.ts
@@ -804,3 +804,16 @@ export const customVisuallyHidden: SxProps = {
   ...visuallyHidden,
   position: 'fixed',
 };
+
+/**
+ * Text truncation utility using CSS line clamp
+ * Creates single-line text with ellipsis overflow handling
+ */
+export const textTruncationSx = (maxWidth?: string): SxProps<Theme> => ({
+  whiteSpace: 'pre-wrap',
+  display: '-webkit-box',
+  WebkitBoxOrient: 'vertical',
+  WebkitLineClamp: '1',
+  overflow: 'hidden',
+  ...(maxWidth && { maxWidth }),
+});

--- a/src/modules/assessments/components/pages/ClientAssessmentsPage.tsx
+++ b/src/modules/assessments/components/pages/ClientAssessmentsPage.tsx
@@ -6,6 +6,7 @@ import useSafeParams from '@/hooks/useSafeParams';
 import { ClientAssessmentType } from '@/modules/assessments/assessmentTypes';
 import {
   ASSESSMENT_COLUMNS,
+  ASSESSMENT_DETAILS_COL,
   generateAssessmentPath,
 } from '@/modules/assessments/util';
 import useClientDashboardContext from '@/modules/client/hooks/useClientDashboardContext';
@@ -42,6 +43,7 @@ const COLUMNS: DataColumnDef<
   },
   WITH_ENROLLMENT_COLUMNS.exitDate,
   WITH_ENROLLMENT_COLUMNS.organizationName,
+  ASSESSMENT_DETAILS_COL,
 ];
 
 const ClientAssessmentsPage = () => {

--- a/src/modules/assessments/util.tsx
+++ b/src/modules/assessments/util.tsx
@@ -1,13 +1,29 @@
+import { Stack, Typography } from '@mui/material';
 import { AlwaysPresentLocalConstants } from '../form/util/formUtil';
 import { ClientAssessmentType } from './assessmentTypes';
 import RelativeDateDisplay from '@/components/elements/RelativeDateDisplay';
 import { ColumnDef } from '@/components/elements/table/types';
+import { textTruncationSx } from '@/config/theme';
+import { DataColumnDef } from '@/modules/dataFetching/types';
 import { HhmAssessmentType } from '@/modules/enrollment/components/HouseholdAssessmentsTable';
 import AssessmentDateWithStatusIndicator from '@/modules/hmis/components/AssessmentDateWithStatusIndicator';
-import { clientBriefName, formRoleDisplay } from '@/modules/hmis/hmisUtil';
+import {
+  clientBriefName,
+  customDataElementValueAsString,
+  formRoleDisplay,
+} from '@/modules/hmis/hmisUtil';
 import { ProjectAssessmentType } from '@/modules/projects/components/ProjectAssessments';
 import { EnrollmentDashboardRoutes } from '@/routes/routes';
-import { AssessmentFieldsFragment, AssessmentRole } from '@/types/gqlTypes';
+import {
+  AssessmentFieldsFragment,
+  AssessmentRole,
+  AssessmentWithCdesFragment,
+  DisplayHook,
+  GetClientAssessmentsQueryVariables,
+  GetEnrollmentAssessmentsQueryVariables,
+  GetHouseholdAssessmentsQueryVariables,
+  GetProjectAssessmentsQueryVariables,
+} from '@/types/gqlTypes';
 import { generateSafePath } from '@/utils/pathEncoding';
 
 export const assessmentPrefix = (role: AssessmentRole) => {
@@ -96,6 +112,42 @@ export const ASSESSMENT_COLUMNS: {
           />
         );
     },
+  },
+};
+
+// Assessment Details column for showing custom data elements in tables
+export const ASSESSMENT_DETAILS_COL: DataColumnDef<
+  AssessmentWithCdesFragment,
+  | GetEnrollmentAssessmentsQueryVariables
+  | GetHouseholdAssessmentsQueryVariables
+  | GetClientAssessmentsQueryVariables
+  | GetProjectAssessmentsQueryVariables
+> = {
+  header: 'Assessment Details',
+  key: 'assessmentDetails',
+  render: (assessment) => {
+    return (
+      <Stack>
+        {(assessment.customDataElements || [])
+          .filter((cde) => cde.displayHooks.includes(DisplayHook.TableSummary))
+          .map((cde) => {
+            const val = customDataElementValueAsString(cde);
+            return (
+              <Typography
+                key={cde.key}
+                variant='body2'
+                sx={textTruncationSx('300px')}
+              >
+                {cde.label}: {val}
+              </Typography>
+            );
+          })}
+      </Stack>
+    );
+  },
+  optional: {
+    defaultHidden: true,
+    queryVariableField: 'includeCdes',
   },
 };
 

--- a/src/modules/assessments/util.tsx
+++ b/src/modules/assessments/util.tsx
@@ -133,11 +133,7 @@ export const ASSESSMENT_DETAILS_COL: DataColumnDef<
           .map((cde) => {
             const val = customDataElementValueAsString(cde);
             return (
-              <Typography
-                key={cde.key}
-                variant='body2'
-                sx={textTruncationSx()}
-              >
+              <Typography key={cde.key} variant='body2' sx={textTruncationSx()}>
                 {cde.label}: {val}
               </Typography>
             );

--- a/src/modules/assessments/util.tsx
+++ b/src/modules/assessments/util.tsx
@@ -136,7 +136,7 @@ export const ASSESSMENT_DETAILS_COL: DataColumnDef<
               <Typography
                 key={cde.key}
                 variant='body2'
-                sx={textTruncationSx('300px')}
+                sx={textTruncationSx()}
               >
                 {cde.label}: {val}
               </Typography>

--- a/src/modules/enrollment/components/EnrollmentAssessmentsTable.tsx
+++ b/src/modules/enrollment/components/EnrollmentAssessmentsTable.tsx
@@ -1,6 +1,7 @@
 import { ColumnDef } from '@/components/elements/table/types';
 import {
   ASSESSMENT_COLUMNS,
+  ASSESSMENT_DETAILS_COL,
   generateAssessmentPath,
 } from '@/modules/assessments/util';
 import GenericTableWithData from '@/modules/dataFetching/components/GenericTableWithData';
@@ -23,6 +24,7 @@ const COLUMNS: ColumnDef<AssessmentFieldsFragment>[] = [
   { ...ASSESSMENT_COLUMNS.date, sticky: 'left' },
   ASSESSMENT_COLUMNS.type,
   ASSESSMENT_COLUMNS.lastUpdated,
+  ASSESSMENT_DETAILS_COL,
 ];
 
 const EnrollmentAssessmentsTable: React.FC<Props> = ({

--- a/src/modules/enrollment/components/HouseholdAssessmentsTable.tsx
+++ b/src/modules/enrollment/components/HouseholdAssessmentsTable.tsx
@@ -2,6 +2,7 @@ import { ColumnDef } from '@/components/elements/table/types';
 import {
   ASSESSMENT_CLIENT_NAME_COL,
   ASSESSMENT_COLUMNS,
+  ASSESSMENT_DETAILS_COL,
   generateAssessmentPath,
 } from '@/modules/assessments/util';
 import GenericTableWithData from '@/modules/dataFetching/components/GenericTableWithData';
@@ -25,6 +26,7 @@ const COLUMNS: ColumnDef<HhmAssessmentType>[] = [
   ASSESSMENT_COLUMNS.date,
   ASSESSMENT_COLUMNS.type,
   ASSESSMENT_COLUMNS.lastUpdated,
+  ASSESSMENT_DETAILS_COL,
 ];
 
 interface Props {

--- a/src/modules/projects/components/ProjectAssessments.tsx
+++ b/src/modules/projects/components/ProjectAssessments.tsx
@@ -7,6 +7,7 @@ import useSafeParams from '@/hooks/useSafeParams';
 import {
   ASSESSMENT_CLIENT_NAME_COL,
   ASSESSMENT_COLUMNS,
+  ASSESSMENT_DETAILS_COL,
   generateAssessmentPath,
 } from '@/modules/assessments/util';
 import GenericTableWithData from '@/modules/dataFetching/components/GenericTableWithData';
@@ -33,6 +34,7 @@ const COLUMNS: ColumnDef<ProjectAssessmentType>[] = [
   ASSESSMENT_COLUMNS.type,
   WITH_ENROLLMENT_COLUMNS.entryDate,
   WITH_ENROLLMENT_COLUMNS.exitDate,
+  ASSESSMENT_DETAILS_COL,
 ];
 
 const ProjectAssessments = () => {

--- a/src/modules/services/serviceColumns.tsx
+++ b/src/modules/services/serviceColumns.tsx
@@ -2,6 +2,7 @@ import { Typography } from '@mui/material';
 import { Stack } from '@mui/system';
 
 import { ColumnDef } from '@/components/elements/table/types';
+import { textTruncationSx } from '@/config/theme';
 import { parseAndFormatDate, serviceDetails } from '@/modules/hmis/hmisUtil';
 import {
   ServiceBasicFieldsFragment,
@@ -50,14 +51,7 @@ export const SERVICE_COLUMNS: {
             // eslint-disable-next-line react/no-array-index-key
             key={i}
             variant='body2'
-            sx={{
-              whiteSpace: 'pre-wrap',
-              display: '-webkit-box',
-              WebkitBoxOrient: 'vertical',
-              WebkitLineClamp: '1',
-              overflow: 'hidden',
-              maxWidth: '300px',
-            }}
+            sx={textTruncationSx('300px')}
           >
             {s}
           </Typography>

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -11292,6 +11292,162 @@ export type FullAssessmentFragment = {
   };
 };
 
+export type AssessmentWithCdesFragment = {
+  __typename?: 'Assessment';
+  id: string;
+  lockVersion: number;
+  inProgress: boolean;
+  assessmentDate: string;
+  dataCollectionStage?: DataCollectionStage | null;
+  dateCreated?: string | null;
+  dateUpdated?: string | null;
+  dateDeleted?: string | null;
+  role: AssessmentRole;
+  customDataElements?: Array<{
+    __typename?: 'CustomDataElement';
+    id: string;
+    key: string;
+    label: string;
+    fieldType: CustomDataElementType;
+    repeats: boolean;
+    displayHooks: Array<DisplayHook>;
+    value?: {
+      __typename?: 'CustomDataElementValue';
+      id: string;
+      valueBoolean?: boolean | null;
+      valueDate?: string | null;
+      valueFloat?: number | null;
+      valueInteger?: number | null;
+      valueJson?: any | null;
+      valueString?: string | null;
+      valueText?: string | null;
+      dateCreated?: string | null;
+      dateUpdated?: string | null;
+      valueFile?: {
+        __typename?: 'File';
+        confidential?: boolean | null;
+        contentType?: string | null;
+        effectiveDate?: string | null;
+        expirationDate?: string | null;
+        id: string;
+        name: string;
+        url?: string | null;
+        tags: Array<string>;
+        ownFile: boolean;
+        redacted: boolean;
+        enrollmentId?: string | null;
+        dateCreated?: string | null;
+        dateUpdated?: string | null;
+        enrollment?: { __typename?: 'Enrollment'; id: string } | null;
+        uploadedBy?: {
+          __typename?: 'ApplicationUser';
+          id: string;
+          name: string;
+        } | null;
+        updatedBy?: {
+          __typename?: 'ApplicationUser';
+          id: string;
+          name: string;
+        } | null;
+        user?: {
+          __typename: 'ApplicationUser';
+          id: string;
+          name: string;
+          firstName?: string | null;
+          lastName?: string | null;
+          email: string;
+        } | null;
+      } | null;
+      user?: {
+        __typename: 'ApplicationUser';
+        id: string;
+        name: string;
+        firstName?: string | null;
+        lastName?: string | null;
+        email: string;
+      } | null;
+    } | null;
+    values?: Array<{
+      __typename?: 'CustomDataElementValue';
+      id: string;
+      valueBoolean?: boolean | null;
+      valueDate?: string | null;
+      valueFloat?: number | null;
+      valueInteger?: number | null;
+      valueJson?: any | null;
+      valueString?: string | null;
+      valueText?: string | null;
+      dateCreated?: string | null;
+      dateUpdated?: string | null;
+      valueFile?: {
+        __typename?: 'File';
+        confidential?: boolean | null;
+        contentType?: string | null;
+        effectiveDate?: string | null;
+        expirationDate?: string | null;
+        id: string;
+        name: string;
+        url?: string | null;
+        tags: Array<string>;
+        ownFile: boolean;
+        redacted: boolean;
+        enrollmentId?: string | null;
+        dateCreated?: string | null;
+        dateUpdated?: string | null;
+        enrollment?: { __typename?: 'Enrollment'; id: string } | null;
+        uploadedBy?: {
+          __typename?: 'ApplicationUser';
+          id: string;
+          name: string;
+        } | null;
+        updatedBy?: {
+          __typename?: 'ApplicationUser';
+          id: string;
+          name: string;
+        } | null;
+        user?: {
+          __typename: 'ApplicationUser';
+          id: string;
+          name: string;
+          firstName?: string | null;
+          lastName?: string | null;
+          email: string;
+        } | null;
+      } | null;
+      user?: {
+        __typename: 'ApplicationUser';
+        id: string;
+        name: string;
+        firstName?: string | null;
+        lastName?: string | null;
+        email: string;
+      } | null;
+    }> | null;
+  }>;
+  user?: {
+    __typename: 'ApplicationUser';
+    id: string;
+    name: string;
+    firstName?: string | null;
+    lastName?: string | null;
+    email: string;
+  } | null;
+  createdBy?: {
+    __typename: 'ApplicationUser';
+    id: string;
+    name: string;
+    firstName?: string | null;
+    lastName?: string | null;
+    email: string;
+  } | null;
+  definition: {
+    __typename?: 'FormDefinition';
+    id: string;
+    cacheKey: string;
+    title: string;
+  };
+};
+
 export type GetAssessmentQueryVariables = Exact<{
   id: Scalars['ID']['input'];
 }>;
@@ -13162,6 +13318,7 @@ export type GetClientAssessmentsQueryVariables = Exact<{
   sortOrder?: InputMaybe<AssessmentSortOption>;
   filters?: InputMaybe<AssessmentFilterOptions>;
   includeOrganizationName?: InputMaybe<Scalars['Boolean']['input']>;
+  includeCdes?: InputMaybe<Scalars['Boolean']['input']>;
 }>;
 
 export type GetClientAssessmentsQuery = {
@@ -13205,6 +13362,127 @@ export type GetClientAssessmentsQuery = {
             canViewEnrollmentDetails: boolean;
           };
         };
+        customDataElements?: Array<{
+          __typename?: 'CustomDataElement';
+          id: string;
+          key: string;
+          label: string;
+          fieldType: CustomDataElementType;
+          repeats: boolean;
+          displayHooks: Array<DisplayHook>;
+          value?: {
+            __typename?: 'CustomDataElementValue';
+            id: string;
+            valueBoolean?: boolean | null;
+            valueDate?: string | null;
+            valueFloat?: number | null;
+            valueInteger?: number | null;
+            valueJson?: any | null;
+            valueString?: string | null;
+            valueText?: string | null;
+            dateCreated?: string | null;
+            dateUpdated?: string | null;
+            valueFile?: {
+              __typename?: 'File';
+              confidential?: boolean | null;
+              contentType?: string | null;
+              effectiveDate?: string | null;
+              expirationDate?: string | null;
+              id: string;
+              name: string;
+              url?: string | null;
+              tags: Array<string>;
+              ownFile: boolean;
+              redacted: boolean;
+              enrollmentId?: string | null;
+              dateCreated?: string | null;
+              dateUpdated?: string | null;
+              enrollment?: { __typename?: 'Enrollment'; id: string } | null;
+              uploadedBy?: {
+                __typename?: 'ApplicationUser';
+                id: string;
+                name: string;
+              } | null;
+              updatedBy?: {
+                __typename?: 'ApplicationUser';
+                id: string;
+                name: string;
+              } | null;
+              user?: {
+                __typename: 'ApplicationUser';
+                id: string;
+                name: string;
+                firstName?: string | null;
+                lastName?: string | null;
+                email: string;
+              } | null;
+            } | null;
+            user?: {
+              __typename: 'ApplicationUser';
+              id: string;
+              name: string;
+              firstName?: string | null;
+              lastName?: string | null;
+              email: string;
+            } | null;
+          } | null;
+          values?: Array<{
+            __typename?: 'CustomDataElementValue';
+            id: string;
+            valueBoolean?: boolean | null;
+            valueDate?: string | null;
+            valueFloat?: number | null;
+            valueInteger?: number | null;
+            valueJson?: any | null;
+            valueString?: string | null;
+            valueText?: string | null;
+            dateCreated?: string | null;
+            dateUpdated?: string | null;
+            valueFile?: {
+              __typename?: 'File';
+              confidential?: boolean | null;
+              contentType?: string | null;
+              effectiveDate?: string | null;
+              expirationDate?: string | null;
+              id: string;
+              name: string;
+              url?: string | null;
+              tags: Array<string>;
+              ownFile: boolean;
+              redacted: boolean;
+              enrollmentId?: string | null;
+              dateCreated?: string | null;
+              dateUpdated?: string | null;
+              enrollment?: { __typename?: 'Enrollment'; id: string } | null;
+              uploadedBy?: {
+                __typename?: 'ApplicationUser';
+                id: string;
+                name: string;
+              } | null;
+              updatedBy?: {
+                __typename?: 'ApplicationUser';
+                id: string;
+                name: string;
+              } | null;
+              user?: {
+                __typename: 'ApplicationUser';
+                id: string;
+                name: string;
+                firstName?: string | null;
+                lastName?: string | null;
+                email: string;
+              } | null;
+            } | null;
+            user?: {
+              __typename: 'ApplicationUser';
+              id: string;
+              name: string;
+              firstName?: string | null;
+              lastName?: string | null;
+              email: string;
+            } | null;
+          }> | null;
+        }>;
         user?: {
           __typename: 'ApplicationUser';
           id: string;
@@ -13239,6 +13517,7 @@ export type GetEnrollmentAssessmentsQueryVariables = Exact<{
   inProgress?: InputMaybe<Scalars['Boolean']['input']>;
   sortOrder?: InputMaybe<AssessmentSortOption>;
   filters?: InputMaybe<AssessmentsForEnrollmentFilterOptions>;
+  includeCdes?: InputMaybe<Scalars['Boolean']['input']>;
 }>;
 
 export type GetEnrollmentAssessmentsQuery = {
@@ -13262,6 +13541,127 @@ export type GetEnrollmentAssessmentsQuery = {
         dateUpdated?: string | null;
         dateDeleted?: string | null;
         role: AssessmentRole;
+        customDataElements?: Array<{
+          __typename?: 'CustomDataElement';
+          id: string;
+          key: string;
+          label: string;
+          fieldType: CustomDataElementType;
+          repeats: boolean;
+          displayHooks: Array<DisplayHook>;
+          value?: {
+            __typename?: 'CustomDataElementValue';
+            id: string;
+            valueBoolean?: boolean | null;
+            valueDate?: string | null;
+            valueFloat?: number | null;
+            valueInteger?: number | null;
+            valueJson?: any | null;
+            valueString?: string | null;
+            valueText?: string | null;
+            dateCreated?: string | null;
+            dateUpdated?: string | null;
+            valueFile?: {
+              __typename?: 'File';
+              confidential?: boolean | null;
+              contentType?: string | null;
+              effectiveDate?: string | null;
+              expirationDate?: string | null;
+              id: string;
+              name: string;
+              url?: string | null;
+              tags: Array<string>;
+              ownFile: boolean;
+              redacted: boolean;
+              enrollmentId?: string | null;
+              dateCreated?: string | null;
+              dateUpdated?: string | null;
+              enrollment?: { __typename?: 'Enrollment'; id: string } | null;
+              uploadedBy?: {
+                __typename?: 'ApplicationUser';
+                id: string;
+                name: string;
+              } | null;
+              updatedBy?: {
+                __typename?: 'ApplicationUser';
+                id: string;
+                name: string;
+              } | null;
+              user?: {
+                __typename: 'ApplicationUser';
+                id: string;
+                name: string;
+                firstName?: string | null;
+                lastName?: string | null;
+                email: string;
+              } | null;
+            } | null;
+            user?: {
+              __typename: 'ApplicationUser';
+              id: string;
+              name: string;
+              firstName?: string | null;
+              lastName?: string | null;
+              email: string;
+            } | null;
+          } | null;
+          values?: Array<{
+            __typename?: 'CustomDataElementValue';
+            id: string;
+            valueBoolean?: boolean | null;
+            valueDate?: string | null;
+            valueFloat?: number | null;
+            valueInteger?: number | null;
+            valueJson?: any | null;
+            valueString?: string | null;
+            valueText?: string | null;
+            dateCreated?: string | null;
+            dateUpdated?: string | null;
+            valueFile?: {
+              __typename?: 'File';
+              confidential?: boolean | null;
+              contentType?: string | null;
+              effectiveDate?: string | null;
+              expirationDate?: string | null;
+              id: string;
+              name: string;
+              url?: string | null;
+              tags: Array<string>;
+              ownFile: boolean;
+              redacted: boolean;
+              enrollmentId?: string | null;
+              dateCreated?: string | null;
+              dateUpdated?: string | null;
+              enrollment?: { __typename?: 'Enrollment'; id: string } | null;
+              uploadedBy?: {
+                __typename?: 'ApplicationUser';
+                id: string;
+                name: string;
+              } | null;
+              updatedBy?: {
+                __typename?: 'ApplicationUser';
+                id: string;
+                name: string;
+              } | null;
+              user?: {
+                __typename: 'ApplicationUser';
+                id: string;
+                name: string;
+                firstName?: string | null;
+                lastName?: string | null;
+                email: string;
+              } | null;
+            } | null;
+            user?: {
+              __typename: 'ApplicationUser';
+              id: string;
+              name: string;
+              firstName?: string | null;
+              lastName?: string | null;
+              email: string;
+            } | null;
+          }> | null;
+        }>;
         user?: {
           __typename: 'ApplicationUser';
           id: string;
@@ -13296,6 +13696,7 @@ export type GetHouseholdAssessmentsQueryVariables = Exact<{
   inProgress?: InputMaybe<Scalars['Boolean']['input']>;
   sortOrder?: InputMaybe<AssessmentSortOption>;
   filters?: InputMaybe<AssessmentsForHouseholdFilterOptions>;
+  includeCdes?: InputMaybe<Scalars['Boolean']['input']>;
 }>;
 
 export type GetHouseholdAssessmentsQuery = {
@@ -13333,6 +13734,127 @@ export type GetHouseholdAssessmentsQuery = {
             nameSuffix?: string | null;
           };
         };
+        customDataElements?: Array<{
+          __typename?: 'CustomDataElement';
+          id: string;
+          key: string;
+          label: string;
+          fieldType: CustomDataElementType;
+          repeats: boolean;
+          displayHooks: Array<DisplayHook>;
+          value?: {
+            __typename?: 'CustomDataElementValue';
+            id: string;
+            valueBoolean?: boolean | null;
+            valueDate?: string | null;
+            valueFloat?: number | null;
+            valueInteger?: number | null;
+            valueJson?: any | null;
+            valueString?: string | null;
+            valueText?: string | null;
+            dateCreated?: string | null;
+            dateUpdated?: string | null;
+            valueFile?: {
+              __typename?: 'File';
+              confidential?: boolean | null;
+              contentType?: string | null;
+              effectiveDate?: string | null;
+              expirationDate?: string | null;
+              id: string;
+              name: string;
+              url?: string | null;
+              tags: Array<string>;
+              ownFile: boolean;
+              redacted: boolean;
+              enrollmentId?: string | null;
+              dateCreated?: string | null;
+              dateUpdated?: string | null;
+              enrollment?: { __typename?: 'Enrollment'; id: string } | null;
+              uploadedBy?: {
+                __typename?: 'ApplicationUser';
+                id: string;
+                name: string;
+              } | null;
+              updatedBy?: {
+                __typename?: 'ApplicationUser';
+                id: string;
+                name: string;
+              } | null;
+              user?: {
+                __typename: 'ApplicationUser';
+                id: string;
+                name: string;
+                firstName?: string | null;
+                lastName?: string | null;
+                email: string;
+              } | null;
+            } | null;
+            user?: {
+              __typename: 'ApplicationUser';
+              id: string;
+              name: string;
+              firstName?: string | null;
+              lastName?: string | null;
+              email: string;
+            } | null;
+          } | null;
+          values?: Array<{
+            __typename?: 'CustomDataElementValue';
+            id: string;
+            valueBoolean?: boolean | null;
+            valueDate?: string | null;
+            valueFloat?: number | null;
+            valueInteger?: number | null;
+            valueJson?: any | null;
+            valueString?: string | null;
+            valueText?: string | null;
+            dateCreated?: string | null;
+            dateUpdated?: string | null;
+            valueFile?: {
+              __typename?: 'File';
+              confidential?: boolean | null;
+              contentType?: string | null;
+              effectiveDate?: string | null;
+              expirationDate?: string | null;
+              id: string;
+              name: string;
+              url?: string | null;
+              tags: Array<string>;
+              ownFile: boolean;
+              redacted: boolean;
+              enrollmentId?: string | null;
+              dateCreated?: string | null;
+              dateUpdated?: string | null;
+              enrollment?: { __typename?: 'Enrollment'; id: string } | null;
+              uploadedBy?: {
+                __typename?: 'ApplicationUser';
+                id: string;
+                name: string;
+              } | null;
+              updatedBy?: {
+                __typename?: 'ApplicationUser';
+                id: string;
+                name: string;
+              } | null;
+              user?: {
+                __typename: 'ApplicationUser';
+                id: string;
+                name: string;
+                firstName?: string | null;
+                lastName?: string | null;
+                email: string;
+              } | null;
+            } | null;
+            user?: {
+              __typename: 'ApplicationUser';
+              id: string;
+              name: string;
+              firstName?: string | null;
+              lastName?: string | null;
+              email: string;
+            } | null;
+          }> | null;
+        }>;
         user?: {
           __typename: 'ApplicationUser';
           id: string;
@@ -42955,6 +43477,7 @@ export type GetProjectAssessmentsQueryVariables = Exact<{
   offset?: InputMaybe<Scalars['Int']['input']>;
   sortOrder?: InputMaybe<AssessmentSortOption>;
   filters?: InputMaybe<AssessmentsForProjectFilterOptions>;
+  includeCdes?: InputMaybe<Scalars['Boolean']['input']>;
 }>;
 
 export type GetProjectAssessmentsQuery = {
@@ -43023,6 +43546,127 @@ export type GetProjectAssessmentsQuery = {
             name: string;
           } | null;
         };
+        customDataElements?: Array<{
+          __typename?: 'CustomDataElement';
+          id: string;
+          key: string;
+          label: string;
+          fieldType: CustomDataElementType;
+          repeats: boolean;
+          displayHooks: Array<DisplayHook>;
+          value?: {
+            __typename?: 'CustomDataElementValue';
+            id: string;
+            valueBoolean?: boolean | null;
+            valueDate?: string | null;
+            valueFloat?: number | null;
+            valueInteger?: number | null;
+            valueJson?: any | null;
+            valueString?: string | null;
+            valueText?: string | null;
+            dateCreated?: string | null;
+            dateUpdated?: string | null;
+            valueFile?: {
+              __typename?: 'File';
+              confidential?: boolean | null;
+              contentType?: string | null;
+              effectiveDate?: string | null;
+              expirationDate?: string | null;
+              id: string;
+              name: string;
+              url?: string | null;
+              tags: Array<string>;
+              ownFile: boolean;
+              redacted: boolean;
+              enrollmentId?: string | null;
+              dateCreated?: string | null;
+              dateUpdated?: string | null;
+              enrollment?: { __typename?: 'Enrollment'; id: string } | null;
+              uploadedBy?: {
+                __typename?: 'ApplicationUser';
+                id: string;
+                name: string;
+              } | null;
+              updatedBy?: {
+                __typename?: 'ApplicationUser';
+                id: string;
+                name: string;
+              } | null;
+              user?: {
+                __typename: 'ApplicationUser';
+                id: string;
+                name: string;
+                firstName?: string | null;
+                lastName?: string | null;
+                email: string;
+              } | null;
+            } | null;
+            user?: {
+              __typename: 'ApplicationUser';
+              id: string;
+              name: string;
+              firstName?: string | null;
+              lastName?: string | null;
+              email: string;
+            } | null;
+          } | null;
+          values?: Array<{
+            __typename?: 'CustomDataElementValue';
+            id: string;
+            valueBoolean?: boolean | null;
+            valueDate?: string | null;
+            valueFloat?: number | null;
+            valueInteger?: number | null;
+            valueJson?: any | null;
+            valueString?: string | null;
+            valueText?: string | null;
+            dateCreated?: string | null;
+            dateUpdated?: string | null;
+            valueFile?: {
+              __typename?: 'File';
+              confidential?: boolean | null;
+              contentType?: string | null;
+              effectiveDate?: string | null;
+              expirationDate?: string | null;
+              id: string;
+              name: string;
+              url?: string | null;
+              tags: Array<string>;
+              ownFile: boolean;
+              redacted: boolean;
+              enrollmentId?: string | null;
+              dateCreated?: string | null;
+              dateUpdated?: string | null;
+              enrollment?: { __typename?: 'Enrollment'; id: string } | null;
+              uploadedBy?: {
+                __typename?: 'ApplicationUser';
+                id: string;
+                name: string;
+              } | null;
+              updatedBy?: {
+                __typename?: 'ApplicationUser';
+                id: string;
+                name: string;
+              } | null;
+              user?: {
+                __typename: 'ApplicationUser';
+                id: string;
+                name: string;
+                firstName?: string | null;
+                lastName?: string | null;
+                email: string;
+              } | null;
+            } | null;
+            user?: {
+              __typename: 'ApplicationUser';
+              id: string;
+              name: string;
+              firstName?: string | null;
+              lastName?: string | null;
+              email: string;
+            } | null;
+          }> | null;
+        }>;
         user?: {
           __typename: 'ApplicationUser';
           id: string;
@@ -48690,6 +49334,16 @@ export const FullAssessmentFragmentDoc = gql`
   ${AssessmentWithRecordsFragmentDoc}
   ${AssessmentWithValuesFragmentDoc}
 `;
+export const AssessmentWithCdesFragmentDoc = gql`
+  fragment AssessmentWithCdes on Assessment {
+    ...AssessmentFields
+    customDataElements @include(if: $includeCdes) {
+      ...CustomDataElementFields
+    }
+  }
+  ${AssessmentFieldsFragmentDoc}
+  ${CustomDataElementFieldsFragmentDoc}
+`;
 export const ProjectNameAndTypeFragmentDoc = gql`
   fragment ProjectNameAndType on Project {
     id
@@ -51517,6 +52171,7 @@ export const GetClientAssessmentsDocument = gql`
     $sortOrder: AssessmentSortOption = ASSESSMENT_DATE
     $filters: AssessmentFilterOptions = null
     $includeOrganizationName: Boolean = false
+    $includeCdes: Boolean = false
   ) {
     client(id: $id) {
       id
@@ -51530,7 +52185,7 @@ export const GetClientAssessmentsDocument = gql`
         limit
         nodesCount
         nodes {
-          ...AssessmentFields
+          ...AssessmentWithCdes
           enrollment {
             ...ClientEnrollmentFields
           }
@@ -51538,7 +52193,7 @@ export const GetClientAssessmentsDocument = gql`
       }
     }
   }
-  ${AssessmentFieldsFragmentDoc}
+  ${AssessmentWithCdesFragmentDoc}
   ${ClientEnrollmentFieldsFragmentDoc}
 `;
 
@@ -51560,6 +52215,7 @@ export const GetClientAssessmentsDocument = gql`
  *      sortOrder: // value for 'sortOrder'
  *      filters: // value for 'filters'
  *      includeOrganizationName: // value for 'includeOrganizationName'
+ *      includeCdes: // value for 'includeCdes'
  *   },
  * });
  */
@@ -51629,6 +52285,7 @@ export const GetEnrollmentAssessmentsDocument = gql`
     $inProgress: Boolean
     $sortOrder: AssessmentSortOption = ASSESSMENT_DATE
     $filters: AssessmentsForEnrollmentFilterOptions
+    $includeCdes: Boolean = false
   ) {
     enrollment(id: $id) {
       id
@@ -51643,12 +52300,12 @@ export const GetEnrollmentAssessmentsDocument = gql`
         limit
         nodesCount
         nodes {
-          ...AssessmentFields
+          ...AssessmentWithCdes
         }
       }
     }
   }
-  ${AssessmentFieldsFragmentDoc}
+  ${AssessmentWithCdesFragmentDoc}
 `;
 
 /**
@@ -51669,6 +52326,7 @@ export const GetEnrollmentAssessmentsDocument = gql`
  *      inProgress: // value for 'inProgress'
  *      sortOrder: // value for 'sortOrder'
  *      filters: // value for 'filters'
+ *      includeCdes: // value for 'includeCdes'
  *   },
  * });
  */
@@ -51738,6 +52396,7 @@ export const GetHouseholdAssessmentsDocument = gql`
     $inProgress: Boolean
     $sortOrder: AssessmentSortOption = ASSESSMENT_DATE
     $filters: AssessmentsForHouseholdFilterOptions
+    $includeCdes: Boolean = false
   ) {
     household(id: $id) {
       id
@@ -51752,7 +52411,7 @@ export const GetHouseholdAssessmentsDocument = gql`
         limit
         nodesCount
         nodes {
-          ...AssessmentFields
+          ...AssessmentWithCdes
           enrollment {
             id
             relationshipToHoH
@@ -51764,7 +52423,7 @@ export const GetHouseholdAssessmentsDocument = gql`
       }
     }
   }
-  ${AssessmentFieldsFragmentDoc}
+  ${AssessmentWithCdesFragmentDoc}
   ${ClientNameFragmentDoc}
 `;
 
@@ -51786,6 +52445,7 @@ export const GetHouseholdAssessmentsDocument = gql`
  *      inProgress: // value for 'inProgress'
  *      sortOrder: // value for 'sortOrder'
  *      filters: // value for 'filters'
+ *      includeCdes: // value for 'includeCdes'
  *   },
  * });
  */
@@ -62618,6 +63278,7 @@ export const GetProjectAssessmentsDocument = gql`
     $offset: Int = 0
     $sortOrder: AssessmentSortOption = ASSESSMENT_DATE
     $filters: AssessmentsForProjectFilterOptions = null
+    $includeCdes: Boolean = false
   ) {
     project(id: $id) {
       id
@@ -62631,7 +63292,7 @@ export const GetProjectAssessmentsDocument = gql`
         limit
         nodesCount
         nodes {
-          ...AssessmentFields
+          ...AssessmentWithCdes
           enrollment {
             ...EnrollmentFields
           }
@@ -62639,7 +63300,7 @@ export const GetProjectAssessmentsDocument = gql`
       }
     }
   }
-  ${AssessmentFieldsFragmentDoc}
+  ${AssessmentWithCdesFragmentDoc}
   ${EnrollmentFieldsFragmentDoc}
 `;
 
@@ -62660,6 +63321,7 @@ export const GetProjectAssessmentsDocument = gql`
  *      offset: // value for 'offset'
  *      sortOrder: // value for 'sortOrder'
  *      filters: // value for 'filters'
+ *      includeCdes: // value for 'includeCdes'
  *   },
  * });
  */


### PR DESCRIPTION
## Description

Summary of changes:
- Add new Data Column for displaying the CDEs on an Assessment that have `show_in_summary: true`
- Display this col on the Client, Project, Enrollment, and Household assessment screens
- Resolve CDEs on Assessment conditionally, only if the column is shown
- Add new style util `textTruncationSx` for shared styles between this new column and the similar, existing Service Details column. I've just parked this in `theme.ts`, as it's a bit similar to `customVisuallyHidden`, but let me know if you think there's a better place for it.

[//]: # 'remove if not applicable'
How to test:
- Set some CDEDs to "show_in_summary: true." (See issue comment for ruby script) 
- Fill out an assessment that collects those CDEDs
- View the assessment in the different screens; you should be able to enable the assessment details column and see the summary details
- (unchanged but helpful: Once you enable the column on an enrollment, your preference persists across enrollments)

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
New feature

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
