### PR TITLE
Fix Bulk Services filter bug

### DIFF
--- a/src/modules/hmis/filterUtil.ts
+++ b/src/modules/hmis/filterUtil.ts
@@ -186,7 +186,11 @@ export const transformDynamicFilters = <FilterOptionsType>(
   filters?: TableFilterType<FilterOptionsType>, // Filter configuration, so we know which ones are dynamic
   filterValues?: Partial<FilterOptionsType> // Current filter values
 ) => {
-  if (!filters || !filterValues) return;
+  if (!filterValues) return;
+
+  // `filterValues` may be present even if `filters` is absent, on tables where `defaultFilterValues` are used without any user-facing filters (such as Bulk Services).
+  // In this case, we know the filters aren't dynamic so we don't need to transform them, just return `filterValues` as-is
+  if (!filters) return filterValues;
 
   // Pull out dynamic filters into separate array
   const dynamicFilters: Array<{ key: string; values: any[] }> = [];


### PR DESCRIPTION
## Description

Summary of changes: Always include `filterValues` in the `GenericTableWithData` query params, even if no `filters` are configured on the table.

[//]: # 'remove if not applicable'
How to reproduce the bug: Visit a project with Bed Nights or Bulk Services. Click "Show By Last Service Date" (mode=list) and select a search param. [QA example](https://qa-hmis.openpath.host/projects/==bWxsc0owS1k4ZmFDU2xmTDhTbDZCZz09/bulk-service?serviceTypeId=116&mode=list&servicePeriodStart=2025-09-11&servicePeriodEnd=2025-09-11)

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
