### PR TITLE
Fix unit "referral in progress" status permission bug

### DIFF
--- a/src/modules/ce/components/UnitReferralStatus.tsx
+++ b/src/modules/ce/components/UnitReferralStatus.tsx
@@ -1,5 +1,5 @@
 import {
-  CeReferralStatus,
+  CeOpportunityStatus,
   UnitDetailFieldsFragment,
   UnitTableRowFieldsFragment,
 } from '@/types/gqlTypes';
@@ -8,14 +8,16 @@ interface Props {
   unit: UnitDetailFieldsFragment | UnitTableRowFieldsFragment;
 }
 const UnitReferralStatus: React.FC<Props> = ({ unit }) => {
-  const opportunity = unit.latestOpportunity;
-  const referral = opportunity?.referral;
-
   if (unit.acceptingCeReferrals) {
     return 'Accepting Referrals';
   }
 
-  if (referral && referral.status === CeReferralStatus.InProgress) {
+  // If the most recent opportunity is locked, that indicates there is a referral
+  // in progress. Check that instead of checking `referral.status` because
+  // the user may not have access to the referral, but they should still see
+  // an accurate status for this unit.
+  const opportunity = unit.latestOpportunity;
+  if (opportunity?.status === CeOpportunityStatus.Locked) {
     return 'Referral In Progress';
   }
 

--- a/src/modules/ce/components/unit/OpportunityBanner.tsx
+++ b/src/modules/ce/components/unit/OpportunityBanner.tsx
@@ -60,7 +60,9 @@ const OpportunityBanner: React.FC<Props> = ({ opportunity, topCandidate }) => {
     }
 
     const canStartReferral =
-      project.access.canStartReferrals && project.access.canViewReferrals;
+      project.access.canStartReferrals &&
+      project.access.canViewReferrals &&
+      opportunity.status === CeOpportunityStatus.Open;
     if (topCandidate && canStartReferral) {
       return (
         <StartReferralButton

--- a/src/modules/units/components/UnitOverview.tsx
+++ b/src/modules/units/components/UnitOverview.tsx
@@ -8,6 +8,7 @@ import OpportunityBanner from '@/modules/ce/components/unit/OpportunityBanner';
 import { useProjectDashboardContext } from '@/modules/projects/components/ProjectDashboard';
 import { cache } from '@/providers/apolloClient';
 import {
+  CeOpportunityStatus,
   UnitDetailFieldsFragment,
   useMarkUnitsAvailableMutation,
 } from '@/types/gqlTypes';
@@ -34,11 +35,16 @@ const UnitOverview: React.FC<Props> = ({ unit }) => {
       {opportunity?.active && (
         <Grid item xs={12}>
           <OpportunityBanner
-            topCandidate={opportunity.candidates.nodes[0]}
+            topCandidate={
+              opportunity.status === CeOpportunityStatus.Open
+                ? opportunity.candidates.nodes[0]
+                : undefined // dont pass topCandidate for locked referral
+            }
             opportunity={opportunity}
           />
         </Grid>
       )}
+
       {unit.canBeMarkedAvailableToday && (
         <Grid item xs={12}>
           <Paper sx={{ p: 2, backgroundColor: 'primary.surface' }}>


### PR DESCRIPTION
## Description

Patch UI bugs for users who do not have permission to view all Referrals in the project, but do have permission to view units:
1. User should always see "Referral in Progress" Status on a unit, even if they don't have permission to resolve that referral.
2. User should never see "top candidates" on a unit that has a referral in progress, even if they don't have permission to see that referral. Also adds an extra check to ensure we don't expose "Start referral" button on a locked opportunity, even though the other topCandidate change already fixes that, just for good measure.


**How to test**: can mimic scenario by stubbing `opportunity.referral` query on the backend to return nil.

## Type of change
Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
