### PR TITLE
Avoid spurious console warning

### DIFF
--- a/src/modules/form/util/formUtil.ts
+++ b/src/modules/form/util/formUtil.ts
@@ -431,8 +431,9 @@ const evaluateEnableWhen = ({
       }
       break;
     case EnableOperator.Includes:
-      if (Array.isArray(currentValue)) {
-        result = !!currentValue.find((v) => v === comparisonValue);
+      const currentValues = currentValue || []; // if null, fall back to [] to avoid console warning
+      if (Array.isArray(currentValues)) {
+        result = !!currentValues.find((v) => v === comparisonValue);
       } else {
         console.warn(
           "Can't use INCLUDES operator without array comparison value"


### PR DESCRIPTION
## Description

Summary of changes:
- When evaluating a form `enableWhen` condition, don't warn in the console if current value is null instead of an array.

[//]: # 'remove if not applicable'
How to test:
- Open a form which has an `INCLUDES` operator in an `enableWhen` condition.
- Before: Console warning `Can't use INCLUDES operator without array comparison value Error Component Stack`
- After: No warning

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Cleanup

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
