### PR TITLE
CE UX- link to target enrollment, hide date candidate created

### DIFF
--- a/src/api/operations/ce.fragments.graphql
+++ b/src/api/operations/ce.fragments.graphql
@@ -393,7 +393,5 @@ fragment CeEligibleUnitGroupFields on CeEligibleUnitGroup {
   projectId
   projectType
   organizationName
-  candidateCreatedAt
-  candidateUpdatedAt
   unitsAcceptingReferrals
 }

--- a/src/modules/ce/components/admin/CeClientEligibleUnitGroupsTable.tsx
+++ b/src/modules/ce/components/admin/CeClientEligibleUnitGroupsTable.tsx
@@ -1,8 +1,7 @@
-import { Chip, Paper, Tooltip } from '@mui/material';
+import { Chip, Paper } from '@mui/material';
 import pluralize from 'pluralize';
 import React from 'react';
 
-import RelativeDateDisplay from '@/components/elements/RelativeDateDisplay';
 import GenericTableWithData from '@/modules/dataFetching/components/GenericTableWithData';
 import { DataColumnDef } from '@/modules/dataFetching/types';
 import ProjectTypeChip from '@/modules/hmis/components/ProjectTypeChip';
@@ -53,23 +52,6 @@ const COLUMNS: DataColumnDef<
         variant='status'
       />
     ),
-  },
-  {
-    key: 'candidateCreatedAt',
-    // Date when client became eligible for the pool (not tied to availability)
-    header: (
-      <Tooltip
-        title='Date when the client became eligible'
-        placement='top'
-        arrow
-      >
-        <span>Date Added</span>
-      </Tooltip>
-    ),
-    render: ({ candidateCreatedAt }) => {
-      if (!candidateCreatedAt) return '';
-      return <RelativeDateDisplay dateString={candidateCreatedAt} />;
-    },
   },
 ];
 

--- a/src/modules/ce/components/referral/ReferralDetailContent.tsx
+++ b/src/modules/ce/components/referral/ReferralDetailContent.tsx
@@ -65,6 +65,29 @@ const ReferralDetailContent: React.FC<Props> = ({
             referral.targetProjectName
           ),
       },
+      ...(referral.targetEnrollment
+        ? [
+            {
+              id: 'targetEnrollment',
+              label: 'Destination Enrollment',
+              value: (
+                <RouterLink
+                  to={generateSafePath(
+                    EnrollmentDashboardRoutes.ENROLLMENT_OVERVIEW,
+                    {
+                      clientId: referral.targetEnrollment?.client?.id,
+                      enrollmentId: referral.targetEnrollment?.id,
+                    }
+                  )}
+                  aria-label={`View Enrollment at ${referral.targetProjectName}`}
+                  openInNew
+                >
+                  View Enrollment
+                </RouterLink>
+              ),
+            },
+          ]
+        : []),
     ],
     [linkToProject, referral]
   );

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -18755,8 +18755,6 @@ export type CeEligibleUnitGroupFieldsFragment = {
   projectId: string;
   projectType: ProjectType;
   organizationName: string;
-  candidateCreatedAt: string;
-  candidateUpdatedAt: string;
   unitsAcceptingReferrals: number;
 };
 
@@ -22016,8 +22014,6 @@ export type GetCeClientEligibleUnitGroupsQuery = {
         projectId: string;
         projectType: ProjectType;
         organizationName: string;
-        candidateCreatedAt: string;
-        candidateUpdatedAt: string;
         unitsAcceptingReferrals: number;
       }>;
     };
@@ -50113,8 +50109,6 @@ export const CeEligibleUnitGroupFieldsFragmentDoc = gql`
     projectId
     projectType
     organizationName
-    candidateCreatedAt
-    candidateUpdatedAt
     unitsAcceptingReferrals
   }
 `;


### PR DESCRIPTION
## Description

Summary of changes:
* Hide `candidateCreatedAt`, this field is not stable
* Add link to target enrollment if present and viewable

## Type of change
new feature

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
