### PR TITLE
8123 increase proxy buffer in nginx to support long redirect urls

### DIFF
--- a/docker/templates/default.conf.template
+++ b/docker/templates/default.conf.template
@@ -45,17 +45,6 @@ server {
       proxy_set_header Host $backend_server;
     }
 
-    location /rails/active_storage/blob {
-      set $backend_server ${HMIS_BACKEND};
-      proxy_pass https://$backend_server;
-
-      # include default proxy headers
-      include /etc/nginx/conf.d/proxy_headers.conf;
-
-      # add location specific headers
-      proxy_set_header Host $backend_server;
-    }
-
     location /assets/theme {
       set $backend_server ${HMIS_BACKEND};
       proxy_pass https://$backend_server;

--- a/docker/templates/proxy_headers.conf.template
+++ b/docker/templates/proxy_headers.conf.template
@@ -12,7 +12,7 @@ proxy_set_header X-Forwarded-Host $host;
 
 # We might need to tune buffers
 # proxy_buffers 10 4k;
-# proxy_buffer_size 12k;
+proxy_buffer_size 32k;
 # proxy_busy_buffers_size 16k;
 
 # Defaults to 60 seconds.
@@ -23,4 +23,3 @@ proxy_set_header X-Forwarded-Host $host;
 # enable upstream caching
 proxy_http_version 1.1;
 proxy_set_header Connection "";
-

--- a/docker/templates/proxy_headers.conf.template
+++ b/docker/templates/proxy_headers.conf.template
@@ -11,9 +11,9 @@ proxy_set_header X-Forwarded-Host $host;
 # proxy_set_header Origin "https://${FAKE_ORIGIN_FOR_TESTING}";
 
 # We might need to tune buffers
-# proxy_buffers 10 4k;
+proxy_buffers 8 32k;
 proxy_buffer_size 32k;
-# proxy_busy_buffers_size 16k;
+proxy_busy_buffers_size 64k;
 
 # Defaults to 60 seconds.
 # proxy_connect_timeout       30;


### PR DESCRIPTION
nginx: remove Active Storage proxy; raise proxy header buffer to 32k

- Remove unused /rails/active_storage/blob location from default.conf.template
- Set proxy_buffer_size 32k in proxy_headers.conf.template to accommodate large upstream headers (e.g., Set-Cookie) and avoid “upstream sent too big header” errors