### PR TITLE
Address low-hanging fruit CE improvements

### DIFF
--- a/src/modules/ce/components/project/ProjectOpportunitiesTable.tsx
+++ b/src/modules/ce/components/project/ProjectOpportunitiesTable.tsx
@@ -77,7 +77,7 @@ const ProjectOpportunitiesTable: React.FC<Props> = ({ projectId }) => {
             unitId: row.unit?.id,
           })
         }
-        rowActionTitle='View Opportunity'
+        rowActionTitle='View Unit'
       />
     </Paper>
   );

--- a/src/modules/dataFetching/components/GenericTableWithData.tsx
+++ b/src/modules/dataFetching/components/GenericTableWithData.tsx
@@ -298,10 +298,10 @@ const GenericTableWithData = <
     const isFiltered = Object.values(filterValues).some(hasMeaningfulValue);
     if (isFiltered)
       return `No ${pluralize(
-        startCase(recordType || 'record').toLowerCase()
+        startCase(paginationItemName || recordType || 'record').toLowerCase()
       )} matching selected filters`;
     return noData;
-  }, [noData, filters, filterValues, recordType]);
+  }, [noData, filterValues, filters, paginationItemName, recordType]);
 
   // If this is the first time loading, return loading (hide search headers)
   if (loading && !hasRefetched && !data) return <Loading />;

--- a/src/modules/units/components/UnitPage.tsx
+++ b/src/modules/units/components/UnitPage.tsx
@@ -1,3 +1,4 @@
+import { Alert } from '@mui/material';
 import React, { useEffect, useMemo } from 'react';
 import CommonTabs from '@/components/elements/CommonTabs';
 import Loading from '@/components/elements/Loading';
@@ -63,12 +64,20 @@ const UnitPage: React.FC<Props> = ({}) => {
       defs.push({
         title: 'Eligible Clients',
         key: 'clients',
-        contents: (
-          <PrioritizedClientsTable
-            opportunity={opportunity}
-            unitGroupId={unit.unitGroup?.id}
-          />
-        ),
+        contents:
+          !!unit.eligibilityRequirements &&
+          unit.eligibilityRequirements.length > 0 &&
+          !!unit.prioritySchemes ? (
+            <PrioritizedClientsTable
+              opportunity={opportunity}
+              unitGroupId={unit.unitGroup?.id}
+            />
+          ) : (
+            <Alert severity='warning'>
+              This unit does not have any eligibility or prioritization rules
+              specified.
+            </Alert>
+          ),
       });
     }
 


### PR DESCRIPTION
## Description

I took a stab at some UX text improvements from our CE Bug Bash sheet that seemed like relatively low-hanging fruit.

Summary of changes:
- 'View Unit' instead of 'View Opportunity' in the 3-dots menu on the Project Available Units screen ([qa example](https://qa-hmis.openpath.host/projects/==d2owc1NRbUJIRDR5c1RyRXR3YVZwUT09/ce#available-units))
- 'No available units matching selected filters' instead of 'No ce opportunities matching selected filters' on the global Available Units screen ([qa example](https://qa-hmis.openpath.host/admin/available-units)) 
  - Happy to revert this one if you consider it high risk. Grepping the codebase for `paginationItemName` it _seems_ like it should be okay to me.
- 'This unit does not have any eligibility or prioritization rules specified.' instead of 'The eligible client list for this unit has not been generated yet.' on the unit waitlist page if the unit has no rules

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
UX text improvements

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
