### PR TITLE
Only show unit checkboxes if project supports referrals

### DIFF
--- a/src/modules/units/components/UnitManagementTable.tsx
+++ b/src/modules/units/components/UnitManagementTable.tsx
@@ -70,7 +70,9 @@ const UnitManagementTable: React.FC<Props> = ({
 
   const { project } = useProjectDashboardContext();
   const { canManageUnits, canUpdateUnitAvailability } = project.access;
-  const canDoAnyUnitActions = canManageUnits || canUpdateUnitAvailability;
+  const canDoAnyUnitActions =
+    canManageUnits ||
+    (canUpdateUnitAvailability && coordinatedEntryFeatures.supportsReferrals);
 
   const { getCeActions, loading } = useUnitCeActions({
     projectId,


### PR DESCRIPTION
## Description

Summary of changes:
- Login as / impersonate a user who has "can update unit availability" but not "can manage units"
- View the unit management table for a project in which CE is not enabled
- Bug: You can select units in the table, but there's no action to do with them
- Fix: You should not be able to select units

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
