### PR TITLE
Filter CE candidate lists to exclude recently declined

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -5675,7 +5675,7 @@
         "fields": null,
         "inputFields": [
           {
-            "name": "excludeRecentlyDeclined",
+            "name": "excludeDeclinedClients",
             "description": null,
             "type": {
               "kind": "SCALAR",

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -5361,6 +5361,18 @@
             "description": null,
             "args": [
               {
+                "name": "filters",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "CeOpportunityCandidatesFilterOptions",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
                 "name": "limit",
                 "description": null,
                 "type": {
@@ -5652,6 +5664,30 @@
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "CeOpportunityCandidatesFilterOptions",
+        "description": null,
+        "isOneOf": false,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "excludeRecentlyDeclined",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": "false",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },

--- a/src/api/operations/ce.fragments.graphql
+++ b/src/api/operations/ce.fragments.graphql
@@ -26,12 +26,6 @@ fragment CeOpportunityFields on CeOpportunity {
   referral {
     ...CeReferralSummaryFields
   }
-  eligibilityRequirements {
-    ...CeMatchRuleFields
-  }
-  prioritySchemes {
-    ...CeMatchRuleFields
-  }
 }
 
 fragment CeOpportunityAdminFields on CeOpportunity {

--- a/src/api/operations/ce.queries.graphql
+++ b/src/api/operations/ce.queries.graphql
@@ -46,11 +46,12 @@ query GetCeOpportunityCandidates(
   $opportunityId: ID!
   $limit: Int = 25
   $offset: Int = 0
+  $filters: CeOpportunityCandidatesFilterOptions
 ) {
   ceOpportunity(id: $opportunityId) {
     id
     candidatesGeneratedAt
-    candidates(limit: $limit, offset: $offset) {
+    candidates(limit: $limit, offset: $offset, filters: $filters) {
       offset
       limit
       nodesCount

--- a/src/api/operations/ce.queries.graphql
+++ b/src/api/operations/ce.queries.graphql
@@ -36,12 +36,6 @@ query GetProjectCeReferrals(
   }
 }
 
-query GetCeOpportunity($id: ID!) {
-  ceOpportunity(id: $id) {
-    ...CeOpportunityFields
-  }
-}
-
 query GetCeOpportunityCandidates(
   $opportunityId: ID!
   $limit: Int = 25

--- a/src/api/operations/units.fragments.graphql
+++ b/src/api/operations/units.fragments.graphql
@@ -57,7 +57,11 @@ fragment UnitDetailFields on Unit {
   }
   latestOpportunity @include(if: $includeCeFields) {
     ...CeOpportunityFields
-    candidates(limit: 1, offset: 0) {
+    candidates(
+      limit: 1
+      offset: 0
+      filters: { excludeRecentlyDeclined: true }
+    ) {
       offset
       limit
       nodesCount

--- a/src/api/operations/units.fragments.graphql
+++ b/src/api/operations/units.fragments.graphql
@@ -57,11 +57,7 @@ fragment UnitDetailFields on Unit {
   }
   latestOpportunity @include(if: $includeCeFields) {
     ...CeOpportunityFields
-    candidates(
-      limit: 1
-      offset: 0
-      filters: { excludeRecentlyDeclined: true }
-    ) {
+    candidates(limit: 1, offset: 0, filters: { excludeDeclinedClients: true }) {
       offset
       limit
       nodesCount

--- a/src/modules/ce/components/unit/PrioritizedClientsTable.tsx
+++ b/src/modules/ce/components/unit/PrioritizedClientsTable.tsx
@@ -144,7 +144,7 @@ const PrioritizedClientsTable: React.FC<Props> = ({
           noData={'No clients are currently eligible for this unit.'}
           filters={filters}
           defaultFilterValues={{
-            excludeRecentlyDeclined: true,
+            excludeDeclinedClients: true,
           }}
         />
       </Paper>

--- a/src/modules/ce/components/unit/PrioritizedClientsTable.tsx
+++ b/src/modules/ce/components/unit/PrioritizedClientsTable.tsx
@@ -8,6 +8,7 @@ import { ColumnDef } from '@/components/elements/table/types';
 import { configurableCeColumns } from '@/modules/ce/components/admin/AdminCeClientsTable';
 import StartReferralButton from '@/modules/ce/components/unit/StartReferralButton';
 import GenericTableWithData from '@/modules/dataFetching/components/GenericTableWithData';
+import { useFilters } from '@/modules/hmis/filterUtil';
 import {
   formatRelativeDateTime,
   parseAndFormatDateTime,
@@ -94,6 +95,10 @@ const PrioritizedClientsTable: React.FC<Props> = ({
     ];
   }, [project.access, tableConfigLookup, status, opportunity]);
 
+  const filters = useFilters({
+    type: 'CeOpportunityCandidatesFilterOptions',
+  });
+
   // If CandidatePool has not been generated yet (due to change in eligibility or prioritization requirements), show a message
   if (!opportunity.candidatesGeneratedAt) {
     return (
@@ -137,6 +142,10 @@ const PrioritizedClientsTable: React.FC<Props> = ({
           pagePath='ceOpportunity.candidates'
           paginationItemName='client'
           noData={'No clients are currently eligible for this unit.'}
+          filters={filters}
+          defaultFilterValues={{
+            excludeRecentlyDeclined: true,
+          }}
         />
       </Paper>
     </Stack>

--- a/src/types/gqlObjects.ts
+++ b/src/types/gqlObjects.ts
@@ -8278,7 +8278,7 @@ export const HmisInputObjectSchemas: GqlInputObjectSchema[] = [
     name: 'CeOpportunityCandidatesFilterOptions',
     args: [
       {
-        name: 'excludeRecentlyDeclined',
+        name: 'excludeDeclinedClients',
         type: { kind: 'SCALAR', name: 'Boolean', ofType: null },
       },
     ],

--- a/src/types/gqlObjects.ts
+++ b/src/types/gqlObjects.ts
@@ -8275,6 +8275,15 @@ export const HmisInputObjectSchemas: GqlInputObjectSchema[] = [
     ],
   },
   {
+    name: 'CeOpportunityCandidatesFilterOptions',
+    args: [
+      {
+        name: 'excludeRecentlyDeclined',
+        type: { kind: 'SCALAR', name: 'Boolean', ofType: null },
+      },
+    ],
+  },
+  {
     name: 'CeOpportunityFilterOptions',
     args: [
       {

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -779,7 +779,7 @@ export type CeOpportunityCandidatesArgs = {
 };
 
 export type CeOpportunityCandidatesFilterOptions = {
-  excludeRecentlyDeclined?: InputMaybe<Scalars['Boolean']['input']>;
+  excludeDeclinedClients?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type CeOpportunityFilterOptions = {
@@ -51874,7 +51874,7 @@ export const UnitDetailFieldsFragmentDoc = gql`
       candidates(
         limit: 1
         offset: 0
-        filters: { excludeRecentlyDeclined: true }
+        filters: { excludeDeclinedClients: true }
       ) {
         offset
         limit

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -773,8 +773,13 @@ export type CeOpportunityCandidateLookupArgs = {
 };
 
 export type CeOpportunityCandidatesArgs = {
+  filters?: InputMaybe<CeOpportunityCandidatesFilterOptions>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
+};
+
+export type CeOpportunityCandidatesFilterOptions = {
+  excludeRecentlyDeclined?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type CeOpportunityFilterOptions = {
@@ -20941,6 +20946,7 @@ export type GetCeOpportunityCandidatesQueryVariables = Exact<{
   opportunityId: Scalars['ID']['input'];
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
+  filters?: InputMaybe<CeOpportunityCandidatesFilterOptions>;
 }>;
 
 export type GetCeOpportunityCandidatesQuery = {
@@ -51998,7 +52004,11 @@ export const UnitDetailFieldsFragmentDoc = gql`
     }
     latestOpportunity @include(if: $includeCeFields) {
       ...CeOpportunityFields
-      candidates(limit: 1, offset: 0) {
+      candidates(
+        limit: 1
+        offset: 0
+        filters: { excludeRecentlyDeclined: true }
+      ) {
         offset
         limit
         nodesCount
@@ -54810,11 +54820,12 @@ export const GetCeOpportunityCandidatesDocument = gql`
     $opportunityId: ID!
     $limit: Int = 25
     $offset: Int = 0
+    $filters: CeOpportunityCandidatesFilterOptions
   ) {
     ceOpportunity(id: $opportunityId) {
       id
       candidatesGeneratedAt
-      candidates(limit: $limit, offset: $offset) {
+      candidates(limit: $limit, offset: $offset, filters: $filters) {
         offset
         limit
         nodesCount
@@ -54842,6 +54853,7 @@ export const GetCeOpportunityCandidatesDocument = gql`
  *      opportunityId: // value for 'opportunityId'
  *      limit: // value for 'limit'
  *      offset: // value for 'offset'
+ *      filters: // value for 'filters'
  *   },
  * });
  */

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -17472,24 +17472,6 @@ export type CeOpportunityFieldsFragment = {
       name: string;
     } | null;
   } | null;
-  eligibilityRequirements?: Array<{
-    __typename?: 'CeMatchRule';
-    id: string;
-    name: string;
-    ownerType: CeMatchRuleOwner;
-    expression: string;
-    projectTypes: Array<ProjectType>;
-    funders?: Array<FundingSource> | null;
-  }> | null;
-  prioritySchemes?: Array<{
-    __typename?: 'CeMatchRule';
-    id: string;
-    name: string;
-    ownerType: CeMatchRuleOwner;
-    expression: string;
-    projectTypes: Array<ProjectType>;
-    funders?: Array<FundingSource> | null;
-  }> | null;
   unit?: {
     __typename?: 'Unit';
     id: string;
@@ -20298,15 +20280,6 @@ export type SubmitCeReferralStepMutation = {
             name: string;
           } | null;
         } | null;
-        prioritySchemes?: Array<{
-          __typename?: 'CeMatchRule';
-          id: string;
-          name: string;
-          ownerType: CeMatchRuleOwner;
-          expression: string;
-          projectTypes: Array<ProjectType>;
-          funders?: Array<FundingSource> | null;
-        }> | null;
         unit?: {
           __typename?: 'Unit';
           id: string;
@@ -20876,69 +20849,6 @@ export type GetProjectCeReferralsQuery = {
         } | null;
       }>;
     };
-  } | null;
-};
-
-export type GetCeOpportunityQueryVariables = Exact<{
-  id: Scalars['ID']['input'];
-}>;
-
-export type GetCeOpportunityQuery = {
-  __typename?: 'Query';
-  ceOpportunity?: {
-    __typename?: 'CeOpportunity';
-    candidatesGeneratedAt?: string | null;
-    id: string;
-    name: string;
-    status: CeOpportunityStatus;
-    active: boolean;
-    projectId: string;
-    projectName: string;
-    dateAvailable: string;
-    referral?: {
-      __typename?: 'CeReferral';
-      id: string;
-      status: CeReferralStatus;
-      active: boolean;
-      clientId: string;
-      clientName?: string | null;
-      origin: CeReferralOrigin;
-      customStatus?: {
-        __typename?: 'CeCustomReferralStatus';
-        id: string;
-        key: string;
-        name: string;
-      } | null;
-    } | null;
-    eligibilityRequirements?: Array<{
-      __typename?: 'CeMatchRule';
-      id: string;
-      name: string;
-      ownerType: CeMatchRuleOwner;
-      expression: string;
-      projectTypes: Array<ProjectType>;
-      funders?: Array<FundingSource> | null;
-    }> | null;
-    prioritySchemes?: Array<{
-      __typename?: 'CeMatchRule';
-      id: string;
-      name: string;
-      ownerType: CeMatchRuleOwner;
-      expression: string;
-      projectTypes: Array<ProjectType>;
-      funders?: Array<FundingSource> | null;
-    }> | null;
-    unit?: {
-      __typename?: 'Unit';
-      id: string;
-      name: string;
-      unitType?: {
-        __typename?: 'UnitTypeObject';
-        id: string;
-        description?: string | null;
-      } | null;
-      unitGroup?: { __typename?: 'UnitGroup'; id: string; name: string } | null;
-    } | null;
   } | null;
 };
 
@@ -48033,24 +47943,6 @@ export type UnitDetailFieldsFragment = {
         name: string;
       } | null;
     } | null;
-    eligibilityRequirements?: Array<{
-      __typename?: 'CeMatchRule';
-      id: string;
-      name: string;
-      ownerType: CeMatchRuleOwner;
-      expression: string;
-      projectTypes: Array<ProjectType>;
-      funders?: Array<FundingSource> | null;
-    }> | null;
-    prioritySchemes?: Array<{
-      __typename?: 'CeMatchRule';
-      id: string;
-      name: string;
-      ownerType: CeMatchRuleOwner;
-      expression: string;
-      projectTypes: Array<ProjectType>;
-      funders?: Array<FundingSource> | null;
-    }> | null;
     unit?: {
       __typename?: 'Unit';
       id: string;
@@ -48437,24 +48329,6 @@ export type GetUnitQuery = {
           name: string;
         } | null;
       } | null;
-      eligibilityRequirements?: Array<{
-        __typename?: 'CeMatchRule';
-        id: string;
-        name: string;
-        ownerType: CeMatchRuleOwner;
-        expression: string;
-        projectTypes: Array<ProjectType>;
-        funders?: Array<FundingSource> | null;
-      }> | null;
-      prioritySchemes?: Array<{
-        __typename?: 'CeMatchRule';
-        id: string;
-        name: string;
-        ownerType: CeMatchRuleOwner;
-        expression: string;
-        projectTypes: Array<ProjectType>;
-        funders?: Array<FundingSource> | null;
-      }> | null;
       unit?: {
         __typename?: 'Unit';
         id: string;
@@ -51964,16 +51838,9 @@ export const CeOpportunityFieldsFragmentDoc = gql`
     referral {
       ...CeReferralSummaryFields
     }
-    eligibilityRequirements {
-      ...CeMatchRuleFields
-    }
-    prioritySchemes {
-      ...CeMatchRuleFields
-    }
   }
   ${CeOpportunitySummaryFieldsFragmentDoc}
   ${CeReferralSummaryFieldsFragmentDoc}
-  ${CeMatchRuleFieldsFragmentDoc}
 `;
 export const CeCandidateFieldsFragmentDoc = gql`
   fragment CeCandidateFields on CeCandidate {
@@ -54731,89 +54598,6 @@ export type GetProjectCeReferralsSuspenseQueryHookResult = ReturnType<
 export type GetProjectCeReferralsQueryResult = Apollo.QueryResult<
   GetProjectCeReferralsQuery,
   GetProjectCeReferralsQueryVariables
->;
-export const GetCeOpportunityDocument = gql`
-  query GetCeOpportunity($id: ID!) {
-    ceOpportunity(id: $id) {
-      ...CeOpportunityFields
-    }
-  }
-  ${CeOpportunityFieldsFragmentDoc}
-`;
-
-/**
- * __useGetCeOpportunityQuery__
- *
- * To run a query within a React component, call `useGetCeOpportunityQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetCeOpportunityQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetCeOpportunityQuery({
- *   variables: {
- *      id: // value for 'id'
- *   },
- * });
- */
-export function useGetCeOpportunityQuery(
-  baseOptions: Apollo.QueryHookOptions<
-    GetCeOpportunityQuery,
-    GetCeOpportunityQueryVariables
-  > &
-    (
-      | { variables: GetCeOpportunityQueryVariables; skip?: boolean }
-      | { skip: boolean }
-    )
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<GetCeOpportunityQuery, GetCeOpportunityQueryVariables>(
-    GetCeOpportunityDocument,
-    options
-  );
-}
-export function useGetCeOpportunityLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetCeOpportunityQuery,
-    GetCeOpportunityQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<
-    GetCeOpportunityQuery,
-    GetCeOpportunityQueryVariables
-  >(GetCeOpportunityDocument, options);
-}
-export function useGetCeOpportunitySuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<
-        GetCeOpportunityQuery,
-        GetCeOpportunityQueryVariables
-      >
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions };
-  return Apollo.useSuspenseQuery<
-    GetCeOpportunityQuery,
-    GetCeOpportunityQueryVariables
-  >(GetCeOpportunityDocument, options);
-}
-export type GetCeOpportunityQueryHookResult = ReturnType<
-  typeof useGetCeOpportunityQuery
->;
-export type GetCeOpportunityLazyQueryHookResult = ReturnType<
-  typeof useGetCeOpportunityLazyQuery
->;
-export type GetCeOpportunitySuspenseQueryHookResult = ReturnType<
-  typeof useGetCeOpportunitySuspenseQuery
->;
-export type GetCeOpportunityQueryResult = Apollo.QueryResult<
-  GetCeOpportunityQuery,
-  GetCeOpportunityQueryVariables
 >;
 export const GetCeOpportunityCandidatesDocument = gql`
   query GetCeOpportunityCandidates(


### PR DESCRIPTION
## Description

Summary of changes:
- By default, in the opportunity candidates table, turn on the filter to exclude recently declined candidates.
- Exclude recently declined clients from the "top candidate" queried on a unit, so that the client shown on the unit's actionable banner isn't a recently declined client. 

<img width="1660" height="1170" alt="Screenshot 2025-10-23 at 6 08 18 PM" src="https://github.com/user-attachments/assets/6a61d8ab-02f6-472b-a5cd-833e38cee9ff" />

[//]: # 'remove if not applicable'
Depends on hmis-warehouse PR: https://github.com/greenriver/hmis-warehouse/pull/5933

[//]: # 'remove if not applicable'
How to test: See issue description

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
New feature

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
