### PR TITLE
Display validation in toast on ReferralStepAction

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -54690,13 +54690,9 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "CeReferralStep",
-                "ofType": null
-              }
+              "kind": "OBJECT",
+              "name": "CeReferralStep",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/src/api/operations/ce.operations.graphql
+++ b/src/api/operations/ce.operations.graphql
@@ -22,6 +22,9 @@ mutation StartCeReferralStep($referralId: ID!, $stepId: ID!) {
     step {
       ...CeReferralStepFields
     }
+    errors {
+      ...ValidationErrorFields
+    }
   }
 }
 

--- a/src/modules/ce/components/referral/ReferralStepAction.tsx
+++ b/src/modules/ce/components/referral/ReferralStepAction.tsx
@@ -1,7 +1,14 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import ButtonLink from '@/components/elements/ButtonLink';
 import LoadingButton from '@/components/elements/LoadingButton';
+import ValidationErrorSnackbarAlert from '@/modules/errors/components/ValidationErrorSnackbarAlert';
+import {
+  emptyErrorState,
+  ErrorState,
+  hasAnyValue,
+  partitionValidations,
+} from '@/modules/errors/util';
 import { cache } from '@/providers/apolloClient';
 import {
   CeReferralStepStatus,
@@ -19,6 +26,7 @@ interface Props {
 const ReferralStepAction: React.FC<Props> = ({ step, referralId, path }) => {
   const { status, name } = step;
   const navigate = useNavigate();
+  const [errorState, setErrorState] = useState<ErrorState>(emptyErrorState);
 
   const [startStepMutation, { loading, error }] =
     useStartCeReferralStepMutation({
@@ -27,7 +35,12 @@ const ReferralStepAction: React.FC<Props> = ({ step, referralId, path }) => {
         stepId: step.stepId || '',
       },
       onCompleted: (data) => {
-        if (data.startCeReferralStep?.step) {
+        const errors = data.startCeReferralStep?.errors || [];
+        if (errors.length > 0) {
+          setErrorState(partitionValidations(errors));
+        } else if (data.startCeReferralStep?.step) {
+          setErrorState(emptyErrorState);
+
           const step = data.startCeReferralStep?.step;
 
           // The step returned from the mutation is now auto added to the Apollo cache.
@@ -57,14 +70,19 @@ const ReferralStepAction: React.FC<Props> = ({ step, referralId, path }) => {
   // If the step is "Available" (meaning nobody has clicked "Start" yet), we need to perform a mutation to initialize it
   if (status === CeReferralStepStatus.Available && canPerformStep) {
     return (
-      <LoadingButton
-        sx={buttonSx}
-        loading={loading}
-        onClick={() => startStepMutation()}
-        aria-label={`Start step: ${name}`}
-      >
-        Start
-      </LoadingButton>
+      <>
+        {hasAnyValue(errorState) && (
+          <ValidationErrorSnackbarAlert errors={errorState.errors} />
+        )}
+        <LoadingButton
+          sx={buttonSx}
+          loading={loading}
+          onClick={() => startStepMutation()}
+          aria-label={`Start step: ${name}`}
+        >
+          Start
+        </LoadingButton>
+      </>
     );
   }
 

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -8286,7 +8286,7 @@ export type StaffAssignmentsPaginated = {
 export type StartCeReferralStepPayload = {
   __typename?: 'StartCeReferralStepPayload';
   errors: Array<ValidationError>;
-  step: CeReferralStep;
+  step?: Maybe<CeReferralStep>;
 };
 
 /** Form Roles that are used for non-configurable forms. These types of forms are submitted using custom mutations. */
@@ -18904,7 +18904,7 @@ export type StartCeReferralStepMutation = {
   __typename?: 'Mutation';
   startCeReferralStep?: {
     __typename?: 'StartCeReferralStepPayload';
-    step: {
+    step?: {
       __typename?: 'CeReferralStep';
       id: string;
       stepId?: string | null;
@@ -19566,7 +19566,21 @@ export type StartCeReferralStepMutation = {
         name: string;
       } | null;
       access: { __typename?: 'CeReferralStepAccess'; canPerformStep: boolean };
-    };
+    } | null;
+    errors: Array<{
+      __typename?: 'ValidationError';
+      type: ValidationType;
+      attribute: string;
+      readableAttribute?: string | null;
+      message: string;
+      fullMessage: string;
+      severity: ValidationSeverity;
+      id?: string | null;
+      recordId?: string | null;
+      linkId?: string | null;
+      section?: string | null;
+      data?: any | null;
+    }>;
   } | null;
 };
 
@@ -54085,9 +54099,13 @@ export const StartCeReferralStepDocument = gql`
       step {
         ...CeReferralStepFields
       }
+      errors {
+        ...ValidationErrorFields
+      }
     }
   }
   ${CeReferralStepFieldsFragmentDoc}
+  ${ValidationErrorFieldsFragmentDoc}
 `;
 export type StartCeReferralStepMutationFn = Apollo.MutationFunction<
   StartCeReferralStepMutation,


### PR DESCRIPTION
## Description

Summary of changes: Support displaying validation message in a snackbar on the Referral Step action. This is a similar pattern to validations we show elsewhere outside of form context, such as Bulk Services.

[//]: # 'remove if not applicable'
Depends on hmis-warehouse PR: https://github.com/greenriver/hmis-warehouse/pull/5941

[//]: # 'remove if not applicable'
How to test: See issue

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
