### PR TITLE
Redirect to project unit page instead of returning NotFound

### DIFF
--- a/src/modules/units/components/UnitPage.tsx
+++ b/src/modules/units/components/UnitPage.tsx
@@ -1,5 +1,6 @@
 import { Alert } from '@mui/material';
 import React, { useEffect, useMemo } from 'react';
+import { Navigate } from 'react-router-dom';
 import CommonTabs from '@/components/elements/CommonTabs';
 import Loading from '@/components/elements/Loading';
 import PageTitle from '@/components/layout/PageTitle';
@@ -11,6 +12,7 @@ import { useProjectDashboardContext } from '@/modules/projects/components/Projec
 import UnitOverview from '@/modules/units/components/UnitOverview';
 import { ProjectDashboardRoutes } from '@/routes/routes';
 import { CeOpportunityStatus, useGetUnitQuery } from '@/types/gqlTypes';
+import { generateSafePath } from '@/utils/pathEncoding';
 
 interface Props {}
 const UnitPage: React.FC<Props> = ({}) => {
@@ -20,9 +22,6 @@ const UnitPage: React.FC<Props> = ({}) => {
   };
 
   const { project, overrideBreadcrumbTitles } = useProjectDashboardContext();
-
-  const { supportsWaitlistReferrals: projectSupportsWaitlistReferrals } =
-    project.coordinatedEntryFeatures || {};
 
   const {
     data: { unit } = {},
@@ -98,12 +97,22 @@ const UnitPage: React.FC<Props> = ({}) => {
   if (!unit) return <NotFound />;
 
   // This page is only available for projects that use waitlists.
-  // Currently there is not really anything to show on a Unit page for projects
-  // that only do direct referrals.
-  if (!projectSupportsWaitlistReferrals) return <NotFound />;
+  // Currently there is not really anything to show on a Unit page for projects that only do direct referrals.
+  // (This condition should never be met because of the redirectRoute provided in route definitions; see protected.tsx)
+  if (!project.coordinatedEntryFeatures?.supportsWaitlistReferrals)
+    return <NotFound />;
 
   // If the unit group doesn't have a workflow template identifier, creating client-list-based referrals will not work
-  if (!unit.unitGroup?.workflowTemplateIdentifier) return <NotFound />;
+  if (!unit.unitGroup?.workflowTemplateIdentifier) {
+    return (
+      <Navigate
+        to={generateSafePath(ProjectDashboardRoutes.UNITS, {
+          projectId: project.id,
+        })}
+        replace
+      />
+    );
+  }
 
   return (
     <>

--- a/src/modules/units/components/UnitPage.tsx
+++ b/src/modules/units/components/UnitPage.tsx
@@ -98,11 +98,12 @@ const UnitPage: React.FC<Props> = ({}) => {
 
   // This page is only available for projects that use waitlists.
   // Currently there is not really anything to show on a Unit page for projects that only do direct referrals.
-  // (This condition should never be met because of the redirectRoute provided in route definitions; see protected.tsx)
+  // (This condition should never be met because of the redirectRoute in the route definition; see protected.tsx)
   if (!project.coordinatedEntryFeatures?.supportsWaitlistReferrals)
     return <NotFound />;
 
-  // If the unit group doesn't have a workflow template identifier, creating client-list-based referrals will not work
+  // If the unit group doesn't have a workflow template identifier, creating client-list-based referrals will not work.
+  // Redirect to the project units page. (redirectRoute in the route definition doesn't handle this)
   if (!unit.unitGroup?.workflowTemplateIdentifier) {
     return (
       <Navigate


### PR DESCRIPTION
## Description

Bugfix I noticed on QA. How to repro:
- Create (or find) a project that both accepts direct referrals and supports waitlist referrals.
- Create (or find) a unit group in that project that only accepts direct referrals. In other words, it doesn't have a regular Workflow Template specified, it only has a Direct Referral Workflow Template
- Create units and mark them available. In the project units / unit group pages, you can't navigate "into" the unit since there's nothing to see, which is correct.
- However, if you navigate to the admin Available Units screen and then click one of these units, you will get a Not Found. Based on the code comment, the desired behavior here is to redirect to the project units screen.
- QA repro example: go to https://qa-hmis.openpath.host/admin/available-units?optionalColumns=unitGroup, click the unit currently in the last row. (200862)

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
