### PR TITLE
Fix referral filter types

### DIFF
--- a/src/modules/ce/components/directReferral/ProjectOutgoingReferralsTable.tsx
+++ b/src/modules/ce/components/directReferral/ProjectOutgoingReferralsTable.tsx
@@ -66,8 +66,8 @@ interface Props {
  */
 const ProjectOutgoingReferralsTable: React.FC<Props> = ({ projectId }) => {
   const filters = useFilters({
-    type: 'CeReferralFilterOptions',
-    omit: ['onCurrentTaskSince', 'workflowTemplate'],
+    type: 'ProjectOutgoingCeReferralFilterOptions',
+    omit: ['organization', 'project', 'projectType'],
   });
 
   return (

--- a/src/modules/ce/components/directReferral/ProjectOutgoingReferralsTable.tsx
+++ b/src/modules/ce/components/directReferral/ProjectOutgoingReferralsTable.tsx
@@ -67,7 +67,6 @@ interface Props {
 const ProjectOutgoingReferralsTable: React.FC<Props> = ({ projectId }) => {
   const filters = useFilters({
     type: 'ProjectOutgoingCeReferralFilterOptions',
-    omit: ['organization', 'project', 'projectType'],
   });
 
   return (

--- a/src/modules/ce/components/project/ProjectReferralsTable.tsx
+++ b/src/modules/ce/components/project/ProjectReferralsTable.tsx
@@ -35,8 +35,7 @@ interface Props {
  */
 const ProjectReferralsTable: React.FC<Props> = ({ projectId }) => {
   const filters = useFilters({
-    type: 'CeReferralFilterOptions',
-    omit: ['organization', 'project', 'projectType', 'workflowTemplate'],
+    type: 'ProjectCeReferralFilterOptions',
   });
 
   return (


### PR DESCRIPTION
## Description

Issue: https://github.com/open-path/Green-River/issues/8473

Fix bug where tables were using the incorrect Filter type for the query. It would be better if we could have type checking here (e.g. ensure the filter type matches the filter type on the query variable type like `GetProjectOutgoingDirectCeReferralsQueryVariables`) but I wasn't able to figure that out in a reasonable timeframe.

## Type of change
Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
