### PR TITLE
Update fetch policy for referral warning

### DIFF
--- a/src/modules/ce/components/directReferral/SendReferralSubForm.tsx
+++ b/src/modules/ce/components/directReferral/SendReferralSubForm.tsx
@@ -48,6 +48,7 @@ const SendReferralSubForm: React.FC<Props> = ({
         sourceEnrollmentId,
         referralMode: ReferralMode.CoordinatedEntry,
       },
+      fetchPolicy: 'network-only', // always fetch the latest data
     });
 
   const [submit, { loading: submitLoading }] =


### PR DESCRIPTION
## Description

**Bug:** if you refer a household to a project, and then _immediately_ refer them again, you don't see the warning message because the graphql response was cached

**Fix**: use `network-only` fetch policy for the GetProjectCanAcceptReferralQuery

Relevant screen:
<img width="528" height="556" alt="Screenshot 2025-11-07 at 12 32 55 PM" src="https://github.com/user-attachments/assets/f4944328-5bb8-49b9-a42b-2d6dfc2b2ca1" />

## Type of change
Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
