### PR TITLE
Display source CE referral on enrollment dashboard

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -6532,6 +6532,22 @@
             "deprecationReason": null
           },
           {
+            "name": "sourceProjectName",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "status",
             "description": null,
             "args": [],
@@ -22496,6 +22512,18 @@
             "type": {
               "kind": "ENUM",
               "name": "NoYesMissing",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sourceCeReferral",
+            "description": "Present if this household was enrolled as the result of a CE referral.",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "CeReferral",
               "ofType": null
             },
             "isDeprecated": false,

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -6520,13 +6520,9 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "ID",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -6536,13 +6532,9 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -22531,7 +22531,7 @@
           },
           {
             "name": "sourceReferralPosting",
-            "description": "Present if this household was enrolled as the result of a referral from another project.",
+            "description": "Present if this household was enrolled as the result of a legacy (pre-CE) referral from another project.",
             "args": [],
             "type": {
               "kind": "OBJECT",

--- a/src/api/operations/enrollment.fragments.graphql
+++ b/src/api/operations/enrollment.fragments.graphql
@@ -149,6 +149,14 @@ fragment AllEnrollmentDetails on Enrollment {
     referredFrom
     referralDate
   }
+  sourceCeReferral {
+    id
+    createdAt
+    sourceProjectName
+    access {
+      canViewReferralDetails
+    }
+  }
 }
 
 # Values that could possibly need to be displayed/edited on the Enrollment Details card

--- a/src/modules/enrollment/components/EnrollmentDetails.tsx
+++ b/src/modules/enrollment/components/EnrollmentDetails.tsx
@@ -121,6 +121,28 @@ const EnrollmentDetails = ({
       );
     }
 
+    if (enrollment.sourceCeReferral) {
+      const referral = enrollment.sourceCeReferral;
+      const referredOn = parseAndFormatDate(referral.createdAt);
+
+      content['Referral Source'] = (
+        <Stack gap={1}>
+          {`Referred from ${referral.sourceProjectName} on ${referredOn}`}
+          {referral.access.canViewReferralDetails && (
+            <RouterLink
+              to={generateSafePath(ProjectDashboardRoutes.REFERRAL, {
+                projectId: enrollment.project.id,
+                referralId: enrollment.sourceCeReferral.id,
+              })}
+              openInNew
+            >
+              View Referral
+            </RouterLink>
+          )}
+        </Stack>
+      );
+    }
+
     const tooltips: Record<string, ReactNode> = {
       'HUD Chronic': (
         <>

--- a/src/modules/enrollment/components/EnrollmentDetails.tsx
+++ b/src/modules/enrollment/components/EnrollmentDetails.tsx
@@ -127,7 +127,7 @@ const EnrollmentDetails = ({
 
       content['Referral Source'] = (
         <Stack gap={1}>
-          {`Referred from ${referral.sourceProjectName} on ${referredOn}`}
+          {`Referred from ${referral.sourceProjectName || 'Unknown Project'} on ${referredOn}`}
           {referral.access.canViewReferralDetails && (
             <RouterLink
               to={generateSafePath(ProjectDashboardRoutes.REFERRAL, {

--- a/src/types/gqlObjects.ts
+++ b/src/types/gqlObjects.ts
@@ -1082,19 +1082,11 @@ export const HmisObjectSchemas: GqlSchema[] = [
       },
       {
         name: 'sourceEnrollmentId',
-        type: {
-          kind: 'NON_NULL',
-          name: null,
-          ofType: { kind: 'SCALAR', name: 'ID', ofType: null },
-        },
+        type: { kind: 'SCALAR', name: 'ID', ofType: null },
       },
       {
         name: 'sourceProjectName',
-        type: {
-          kind: 'NON_NULL',
-          name: null,
-          ofType: { kind: 'SCALAR', name: 'String', ofType: null },
-        },
+        type: { kind: 'SCALAR', name: 'String', ofType: null },
       },
       {
         name: 'status',

--- a/src/types/gqlObjects.ts
+++ b/src/types/gqlObjects.ts
@@ -1089,6 +1089,14 @@ export const HmisObjectSchemas: GqlSchema[] = [
         },
       },
       {
+        name: 'sourceProjectName',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'String', ofType: null },
+        },
+      },
+      {
         name: 'status',
         type: {
           kind: 'NON_NULL',

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -874,6 +874,7 @@ export type CeReferral = {
   /** Limited details about the source enrollment. Available even without full access to the source record. */
   sourceEnrollment?: Maybe<CeReferralSourceEnrollment>;
   sourceEnrollmentId: Scalars['ID']['output'];
+  sourceProjectName: Scalars['String']['output'];
   status: CeReferralStatus;
   steps?: Maybe<Array<CeReferralStep>>;
   swimlanes?: Maybe<Array<CeReferralSwimlane>>;
@@ -3009,6 +3010,8 @@ export type Enrollment = {
   sexualOrientation?: Maybe<SexualOrientation>;
   sexualOrientationOther?: Maybe<Scalars['String']['output']>;
   singleParent?: Maybe<NoYesMissing>;
+  /** Present if this household was enrolled as the result of a CE referral. */
+  sourceCeReferral?: Maybe<CeReferral>;
   /** Present if this household was enrolled as the result of a referral from another project. */
   sourceReferralPosting?: Maybe<ReferralPosting>;
   staffAssignments?: Maybe<Array<StaffAssignment>>;
@@ -28360,6 +28363,16 @@ export type AllEnrollmentDetailsFragment = {
     referredFrom: string;
     referralDate: string;
   } | null;
+  sourceCeReferral?: {
+    __typename?: 'CeReferral';
+    id: string;
+    createdAt: string;
+    sourceProjectName: string;
+    access: {
+      __typename?: 'CeReferralAccess';
+      canViewReferralDetails: boolean;
+    };
+  } | null;
   access: {
     __typename?: 'EnrollmentAccess';
     id: string;
@@ -29817,6 +29830,16 @@ export type GetEnrollmentDetailsQuery = {
       id: string;
       referredFrom: string;
       referralDate: string;
+    } | null;
+    sourceCeReferral?: {
+      __typename?: 'CeReferral';
+      id: string;
+      createdAt: string;
+      sourceProjectName: string;
+      access: {
+        __typename?: 'CeReferralAccess';
+        canViewReferralDetails: boolean;
+      };
     } | null;
     access: {
       __typename?: 'EnrollmentAccess';
@@ -50833,6 +50856,14 @@ export const AllEnrollmentDetailsFragmentDoc = gql`
       id
       referredFrom
       referralDate
+    }
+    sourceCeReferral {
+      id
+      createdAt
+      sourceProjectName
+      access {
+        canViewReferralDetails
+      }
     }
   }
   ${EnrollmentFieldsFragmentDoc}

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -3012,7 +3012,7 @@ export type Enrollment = {
   singleParent?: Maybe<NoYesMissing>;
   /** Present if this household was enrolled as the result of a CE referral. */
   sourceCeReferral?: Maybe<CeReferral>;
-  /** Present if this household was enrolled as the result of a referral from another project. */
+  /** Present if this household was enrolled as the result of a legacy (pre-CE) referral from another project. */
   sourceReferralPosting?: Maybe<ReferralPosting>;
   staffAssignments?: Maybe<Array<StaffAssignment>>;
   status: EnrollmentStatus;

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -873,8 +873,8 @@ export type CeReferral = {
   referredBy?: Maybe<ApplicationUser>;
   /** Limited details about the source enrollment. Available even without full access to the source record. */
   sourceEnrollment?: Maybe<CeReferralSourceEnrollment>;
-  sourceEnrollmentId: Scalars['ID']['output'];
-  sourceProjectName: Scalars['String']['output'];
+  sourceEnrollmentId?: Maybe<Scalars['ID']['output']>;
+  sourceProjectName?: Maybe<Scalars['String']['output']>;
   status: CeReferralStatus;
   steps?: Maybe<Array<CeReferralStep>>;
   swimlanes?: Maybe<Array<CeReferralSwimlane>>;
@@ -17600,7 +17600,7 @@ export type CeOutgoingReferralsTableFieldsFragment = {
   createdAt: string;
   clientId: string;
   clientName?: string | null;
-  sourceEnrollmentId: string;
+  sourceEnrollmentId?: string | null;
   targetProjectId: string;
   targetProjectName: string;
   targetProjectType: ProjectType;
@@ -27219,7 +27219,7 @@ export type GetProjectOutgoingDirectCeReferralsQuery = {
         createdAt: string;
         clientId: string;
         clientName?: string | null;
-        sourceEnrollmentId: string;
+        sourceEnrollmentId?: string | null;
         targetProjectId: string;
         targetProjectName: string;
         targetProjectType: ProjectType;
@@ -28367,7 +28367,7 @@ export type AllEnrollmentDetailsFragment = {
     __typename?: 'CeReferral';
     id: string;
     createdAt: string;
-    sourceProjectName: string;
+    sourceProjectName?: string | null;
     access: {
       __typename?: 'CeReferralAccess';
       canViewReferralDetails: boolean;
@@ -29835,7 +29835,7 @@ export type GetEnrollmentDetailsQuery = {
       __typename?: 'CeReferral';
       id: string;
       createdAt: string;
-      sourceProjectName: string;
+      sourceProjectName?: string | null;
       access: {
         __typename?: 'CeReferralAccess';
         canViewReferralDetails: boolean;


### PR DESCRIPTION
## Description

Summary of changes:
- Resolve `enrollment.sourceCeReferral` on the `AllEnrollmentDetails` fragment
- Display the source referral in the Enrollment Details panel on the Enrollment Overview
- Link to the source referral if the user can view it
- Update the style slightly to stack the link vertically instead of horizontally:
<img width="1518" height="886" alt="Screenshot 2025-11-12 at 1 48 12 PM" src="https://github.com/user-attachments/assets/7b501b25-dff7-418a-a134-270c83cabeb4" />

[//]: # 'remove if not applicable'
Depends on hmis-warehouse PR: https://github.com/greenriver/hmis-warehouse/pull/5999

[//]: # 'remove if not applicable'
How to test: See issue

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
New feature

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
