### PR TITLE
Propose UI notice for stale opportunities

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -5652,6 +5652,22 @@
             "deprecationReason": null
           },
           {
+            "name": "stale",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "status",
             "description": null,
             "args": [],

--- a/src/api/operations/ce.fragments.graphql
+++ b/src/api/operations/ce.fragments.graphql
@@ -22,6 +22,7 @@ fragment CeOpportunitySummaryFields on CeOpportunity {
 
 fragment CeOpportunityFields on CeOpportunity {
   ...CeOpportunitySummaryFields
+  stale
   candidatesGeneratedAt
   referral {
     ...CeReferralSummaryFields

--- a/src/modules/units/components/UnitOverview.tsx
+++ b/src/modules/units/components/UnitOverview.tsx
@@ -94,9 +94,8 @@ const UnitOverview: React.FC<Props> = ({ unit }) => {
               </LoadingButton>
             }
           >
-            This unit is stale, so the requirements below may appear out of
-            date. To bring them up to date, stop and then re-start accepting
-            referrals.
+            The requirements below may be outdated. To refresh them, stop and
+            re-start accepting referrals for this unit.
           </Alert>
         </Grid>
       )}

--- a/src/modules/units/components/UnitOverview.tsx
+++ b/src/modules/units/components/UnitOverview.tsx
@@ -1,4 +1,4 @@
-import { Grid, Paper, Typography } from '@mui/material';
+import { Alert, Grid, Paper, Typography } from '@mui/material';
 import { Stack } from '@mui/system';
 import React from 'react';
 
@@ -11,6 +11,7 @@ import {
   CeOpportunityStatus,
   UnitDetailFieldsFragment,
   useMarkUnitsAvailableMutation,
+  useMarkUnitsUnavailableMutation,
 } from '@/types/gqlTypes';
 
 interface Props {
@@ -28,7 +29,16 @@ const UnitOverview: React.FC<Props> = ({ unit }) => {
     onCompleted: () => cache.evict({ id: `Unit:${unit.id}` }),
   });
 
+  const [
+    markUnitUnavailable,
+    { loading: unavailableLoading, error: unavailableError },
+  ] = useMarkUnitsUnavailableMutation({
+    variables: { unitIds: [unit.id] },
+    onCompleted: () => cache.evict({ id: `Unit:${unit.id}` }),
+  });
+
   if (availableError) throw availableError;
+  if (unavailableError) throw unavailableError;
 
   return (
     <Grid container columnSpacing={6} rowSpacing={4}>
@@ -67,6 +77,27 @@ const UnitOverview: React.FC<Props> = ({ unit }) => {
               )}
             </Stack>
           </Paper>
+        </Grid>
+      )}
+      {opportunity?.active && opportunity?.stale && (
+        <Grid item xs={12}>
+          <Alert
+            severity='warning'
+            action={
+              <LoadingButton
+                loading={unavailableLoading}
+                color={'warning'}
+                variant={'outlined'}
+                onClick={() => markUnitUnavailable()}
+              >
+                Stop Accepting Referrals
+              </LoadingButton>
+            }
+          >
+            This unit is stale, so the requirements below may appear out of
+            date. To bring them up to date, stop and then re-start accepting
+            referrals.
+          </Alert>
         </Grid>
       )}
       <Grid item xs={12} md={6}>

--- a/src/types/gqlObjects.ts
+++ b/src/types/gqlObjects.ts
@@ -959,6 +959,14 @@ export const HmisObjectSchemas: GqlSchema[] = [
         },
       },
       {
+        name: 'stale',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'Boolean', ofType: null },
+        },
+      },
+      {
         name: 'status',
         type: {
           kind: 'NON_NULL',

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -769,6 +769,7 @@ export type CeOpportunity = {
   projectType: ProjectType;
   /** Active or accepted referral */
   referral?: Maybe<CeReferral>;
+  stale: Scalars['Boolean']['output'];
   status: CeOpportunityStatus;
   unit?: Maybe<Unit>;
 };
@@ -17433,6 +17434,7 @@ export type CeOpportunitySummaryFieldsFragment = {
 
 export type CeOpportunityFieldsFragment = {
   __typename?: 'CeOpportunity';
+  stale: boolean;
   candidatesGeneratedAt?: string | null;
   id: string;
   name: string;
@@ -20247,6 +20249,7 @@ export type SubmitCeReferralStepMutation = {
       opportunity?: {
         __typename?: 'CeOpportunity';
         id: string;
+        stale: boolean;
         candidatesGeneratedAt?: string | null;
         name: string;
         status: CeOpportunityStatus;
@@ -47802,6 +47805,7 @@ export type UnitDetailFieldsFragment = {
   }> | null;
   latestOpportunity?: {
     __typename?: 'CeOpportunity';
+    stale: boolean;
     candidatesGeneratedAt?: string | null;
     id: string;
     name: string;
@@ -48188,6 +48192,7 @@ export type GetUnitQuery = {
     }> | null;
     latestOpportunity?: {
       __typename?: 'CeOpportunity';
+      stale: boolean;
       candidatesGeneratedAt?: string | null;
       id: string;
       name: string;
@@ -51714,6 +51719,7 @@ export const UnitTableRowFieldsFragmentDoc = gql`
 export const CeOpportunityFieldsFragmentDoc = gql`
   fragment CeOpportunityFields on CeOpportunity {
     ...CeOpportunitySummaryFields
+    stale
     candidatesGeneratedAt
     referral {
       ...CeReferralSummaryFields


### PR DESCRIPTION
## Description

Following up from this [thread](https://github.com/greenriver/hmis-warehouse/pull/5997#discussion_r2519725367), this PR adds an Alert on the Unit page if the opportunity is active, but the rules are out of date.

- For now, this won't come up frequently because we are managing rules on the backend, so when we make updates to rules we should remember to refresh open opportunities.
- But, I was thinking that in the future, when we make rules manageable in the UI, we likely will provide the user with some control over whether opportunities get refreshed or not. If they choose not to refresh opportunities, then I think this kind of alert could be helpful for reminding them of why the ruleset listed here may differ from the ruleset listed on the parent Unit Group page.
- We can definitely workshop the language. 
  - "stop and re-start" is a little clunky
  - I also thought about drafting some language along the lines of "the same might also be true for other units in the unit group, so you can also go back up one level to the unit page and do this operation in bulk" (obviously phrased more gracefully than that!), but I think it might be better to just keep it simple.
  - edited to add: perhaps we should also make it clearer that "the requirements may be out of date" = that means the client list might also be outdated

<img width="1854" height="1582" alt="Screenshot 2025-11-12 at 5 17 02 PM" src="https://github.com/user-attachments/assets/6470b379-5305-469c-a8fd-fb837dcda1a8" />

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
New feature

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
