### PR TITLE
Fix misc keyboard accessibility issues

### DIFF
--- a/src/components/elements/input/LabeledCheckbox.tsx
+++ b/src/components/elements/input/LabeledCheckbox.tsx
@@ -6,17 +6,12 @@ import {
   FormGroup,
   FormHelperText,
 } from '@mui/material';
-import {
-  KeyboardEventHandler,
-  Ref,
-  SyntheticEvent,
-  useCallback,
-  useMemo,
-} from 'react';
+import { Ref, useMemo } from 'react';
 
 import { horizontalInputSx } from './TextInput';
 
 import { DynamicInputCommonProps } from '@/modules/form/types';
+import { preventImplicitSubmission } from '@/utils/forms';
 
 export interface Props
   extends Omit<FormControlLabelProps, 'control' | 'label'>,
@@ -55,19 +50,6 @@ const LabeledCheckbox = ({
       { backgroundColor: 'white', '&:hover': { backgroundColor: '#F7F9FD' } }
     : { '.MuiSvgIcon-root': { backgroundColor: 'white' } };
 
-  // Prevent form submission on Enter. Enter should toggle the state.
-  const onKeyDown: KeyboardEventHandler<HTMLButtonElement> = useCallback(
-    (e) => {
-      if (e.key === 'Enter') {
-        e.preventDefault();
-        const checked = (e.target as HTMLInputElement).checked;
-        (e.target as HTMLInputElement).checked = !checked;
-        if (onChange) onChange(e as SyntheticEvent, !checked);
-      }
-    },
-    [onChange]
-  );
-
   // Determine the checked state based on the value OR checked prop
   const checked = useMemo(() => {
     if (props.checked !== undefined) {
@@ -86,7 +68,7 @@ const LabeledCheckbox = ({
           control={
             <Checkbox
               sx={{ width: inputWidth, ...checkboxSx }}
-              onKeyDown={onKeyDown}
+              onKeyDown={preventImplicitSubmission}
               aria-label={ariaLabel}
               inputRef={inputRef}
             />

--- a/src/components/elements/input/NumberInput.tsx
+++ b/src/components/elements/input/NumberInput.tsx
@@ -8,6 +8,7 @@ import {
   OnValueChange,
 } from 'react-number-format';
 import TextInput, { TextInputProps } from './TextInput';
+import { preventImplicitSubmission } from '@/utils/forms';
 
 // protect from integer overflows
 const withValueLimit = ({ floatValue }: NumberFormatValues) => {
@@ -111,6 +112,7 @@ const NumberInput: React.FC<Props> = ({
         min,
         max,
         'aria-labelledby': ariaLabelledBy,
+        onKeyDown: preventImplicitSubmission,
         ...inputProps,
       }}
       placeholder={currency ? '0' : undefined}

--- a/src/components/elements/input/RadioGroupInputOption.tsx
+++ b/src/components/elements/input/RadioGroupInputOption.tsx
@@ -1,8 +1,9 @@
 import { Checkbox, FormControlLabel, Radio } from '@mui/material';
-import { KeyboardEventHandler, useCallback, useId } from 'react';
+import { useCallback, useId } from 'react';
 
 import CommonHtmlContent from '@/components/elements/CommonHtmlContent';
 import { PickListOption } from '@/types/gqlTypes';
+import { preventImplicitSubmission } from '@/utils/forms';
 
 interface Props {
   option: PickListOption;
@@ -38,16 +39,6 @@ const RadioGroupInputOption: React.FC<Props> = ({
     [onChange, disabled, option]
   );
 
-  // Prevent form submission on Enter. Enter should toggle the state.
-  const onKeyDown: KeyboardEventHandler<HTMLButtonElement> = useCallback(
-    (e) => {
-      if (e.key === 'Enter' || e.key === ' ' || e.code === 'Space') {
-        handleClick(e);
-      }
-    },
-    [handleClick]
-  );
-
   return (
     <>
       <FormControlLabel
@@ -58,7 +49,7 @@ const RadioGroupInputOption: React.FC<Props> = ({
         control={
           <ControlComponent
             disabled={disabled}
-            onKeyDown={onKeyDown}
+            onKeyDown={preventImplicitSubmission}
             data-checked={checked}
             inputProps={{
               'aria-labelledby': helperText

--- a/src/components/elements/input/RadioGroupInputOption.tsx
+++ b/src/components/elements/input/RadioGroupInputOption.tsx
@@ -1,5 +1,5 @@
 import { Checkbox, FormControlLabel, Radio } from '@mui/material';
-import { useCallback, useId } from 'react';
+import { KeyboardEventHandler, useCallback, useId } from 'react';
 
 import CommonHtmlContent from '@/components/elements/CommonHtmlContent';
 import { PickListOption } from '@/types/gqlTypes';
@@ -39,6 +39,17 @@ const RadioGroupInputOption: React.FC<Props> = ({
     [onChange, disabled, option]
   );
 
+  const onKeyDown: KeyboardEventHandler<HTMLButtonElement> = useCallback(
+    (e) => {
+      if (e.key === ' ' || e.code === 'Space') {
+        handleClick(e);
+      } else {
+        preventImplicitSubmission(e);
+      }
+    },
+    [handleClick]
+  );
+
   return (
     <>
       <FormControlLabel
@@ -49,7 +60,7 @@ const RadioGroupInputOption: React.FC<Props> = ({
         control={
           <ControlComponent
             disabled={disabled}
-            onKeyDown={preventImplicitSubmission}
+            onKeyDown={onKeyDown}
             data-checked={checked}
             inputProps={{
               'aria-labelledby': helperText

--- a/src/components/elements/input/SsnInput.tsx
+++ b/src/components/elements/input/SsnInput.tsx
@@ -7,6 +7,7 @@ import LabelWithContent from '../LabelWithContent';
 import MultiFieldInput from './MultiFieldInput';
 
 import { DynamicInputCommonProps } from '@/modules/form/types';
+import { preventImplicitSubmission } from '@/utils/forms';
 
 type SsnInputProps = {
   onChange?: (value: string | null) => any;
@@ -34,6 +35,7 @@ const SsnInput = ({
       // FIXME: switch to string input, allow use to type "X" or "x"
       inputMode: 'numeric',
       pattern: '[0-9]+',
+      onKeyDown: preventImplicitSubmission,
       ...inputProps,
     },
     InputProps,

--- a/src/components/elements/input/TextInput.tsx
+++ b/src/components/elements/input/TextInput.tsx
@@ -62,9 +62,6 @@ const TextInput = ({
       id={htmlId}
       fullWidth={fullWidth}
       label={horizontal ? undefined : label} // hide the label if this text input is part of a horizontal group (informally deprecated)
-      onKeyDown={(e) =>
-        !props.multiline && e.key === 'Enter' && e.preventDefault()
-      }
       autoComplete={formAutoCompleteOff}
       value={value === null ? '' : value} // always used as controlled input, so don't pass null or undefined. Note, value may be a number, such as 0, which is falsy
       {...props}

--- a/src/components/elements/input/TextInput.tsx
+++ b/src/components/elements/input/TextInput.tsx
@@ -15,6 +15,7 @@ import { useId } from 'react';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { DynamicInputCommonProps } from '@/modules/form/types';
 import { formAutoCompleteOff } from '@/modules/form/util/formUtil';
+import { preventImplicitSubmission } from '@/utils/forms';
 
 interface Props extends Partial<Omit<TextFieldProps, 'error' | 'variant'>> {
   name?: string;
@@ -62,6 +63,7 @@ const TextInput = ({
       id={htmlId}
       fullWidth={fullWidth}
       label={horizontal ? undefined : label} // hide the label if this text input is part of a horizontal group (informally deprecated)
+      onKeyDown={props.multiline ? undefined : preventImplicitSubmission}
       autoComplete={formAutoCompleteOff}
       value={value === null ? '' : value} // always used as controlled input, so don't pass null or undefined. Note, value may be a number, such as 0, which is falsy
       {...props}

--- a/src/components/layout/dashboard/DashboardContentContainer.tsx
+++ b/src/components/layout/dashboard/DashboardContentContainer.tsx
@@ -1,6 +1,6 @@
 import { Box, Paper } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
-import { ReactNode, useMemo } from 'react';
+import { ReactNode, useMemo, useRef } from 'react';
 
 import {
   DASHBOARD_CONTENT_PX,
@@ -51,6 +51,7 @@ const DashboardContentContainer: React.FC<Props> = ({
 }) => {
   const theme = useTheme();
   const maxPageWidth = useMaxPageWidth();
+  const menuButtonRef = useRef<HTMLButtonElement>(null);
 
   const desktopContainerWidth = desktopNavIsOpen
     ? // FIXME using vw causes horizontal scrollbar when vertical scroll is present
@@ -105,6 +106,7 @@ const DashboardContentContainer: React.FC<Props> = ({
             handleCloseDesktopMenu={handleCloseDesktopMenu}
             label={navLabel}
             skipNavFocusTargetId={FOCUS_TARGET_ID}
+            menuButtonRef={menuButtonRef}
           >
             {sidebar}
           </DashboardContentNav>
@@ -129,6 +131,7 @@ const DashboardContentContainer: React.FC<Props> = ({
               handleOpenMenu={
                 isMobile ? handleOpenMobileMenu : handleOpenDesktopMenu
               }
+              menuButtonRef={menuButtonRef}
             >
               {contextHeader}
             </ContextHeader>

--- a/src/components/layout/dashboard/DashboardContentNav.tsx
+++ b/src/components/layout/dashboard/DashboardContentNav.tsx
@@ -1,6 +1,6 @@
 import MenuOpenIcon from '@mui/icons-material/MenuOpen';
 import { Box, Button, Drawer, Stack, Typography } from '@mui/material';
-import { ReactNode } from 'react';
+import { ReactNode, useCallback } from 'react';
 
 import {
   CONTEXT_HEADER_HEIGHT,
@@ -19,16 +19,19 @@ interface Props {
   handleCloseDesktopMenu: VoidFunction;
   label: string;
   skipNavFocusTargetId: string;
+  menuButtonRef?: React.RefObject<HTMLButtonElement>;
 }
 
 const CloseMenuRow = ({
   onClose,
   label,
   skipNavFocusTargetId,
+  closeButtonRef,
 }: {
   onClose: VoidFunction;
   skipNavFocusTargetId: string;
   label: string;
+  closeButtonRef?: React.Ref<HTMLButtonElement>;
 }) => (
   <Stack
     justifyContent='space-between'
@@ -50,6 +53,7 @@ const CloseMenuRow = ({
       Skip {label} navigation
     </SkipToContentButton>
     <Button
+      ref={closeButtonRef}
       variant='text'
       color='grayscale'
       onClick={onClose}
@@ -69,9 +73,30 @@ const DashboardContentNav: React.FC<Props> = ({
   handleCloseDesktopMenu,
   label,
   skipNavFocusTargetId,
+  menuButtonRef,
 }) => {
   const headerHeight = `${STICKY_BAR_HEIGHT}px`;
   const height = `calc(100vh - ${headerHeight})`;
+
+  // Callback ref that focuses the close button when drawer is open
+  const closeButtonRef = useCallback(
+    (node: HTMLButtonElement | null) => {
+      if (node && desktopNavIsOpen) {
+        // Use requestAnimationFrame to ensure element is painted and focusable
+        requestAnimationFrame(() => {
+          node.focus();
+        });
+      }
+    },
+    [desktopNavIsOpen]
+  );
+
+  // Return focus to menu button when closing
+  const handleCloseWithFocus = () => {
+    handleCloseDesktopMenu();
+    // Wait .25s for drawer animation to complete (matches CSS transition duration)
+    setTimeout(() => menuButtonRef?.current?.focus(), 250);
+  };
 
   return (
     <Box
@@ -115,9 +140,10 @@ const DashboardContentNav: React.FC<Props> = ({
       >
         <Box component='nav' aria-label='sidebar-nav'>
           <CloseMenuRow
-            onClose={handleCloseDesktopMenu}
+            onClose={handleCloseWithFocus}
             label={label}
             skipNavFocusTargetId={skipNavFocusTargetId}
+            closeButtonRef={closeButtonRef}
           />
           {navHeader && (
             <Box

--- a/src/components/layout/dashboard/contextHeader/ContextHeader.tsx
+++ b/src/components/layout/dashboard/contextHeader/ContextHeader.tsx
@@ -24,6 +24,7 @@ interface Props {
   children?: ReactNode;
   focusMode?: boolean;
   focusModeDefaultReturnPath?: string;
+  menuButtonRef?: React.RefObject<HTMLButtonElement>;
 }
 
 export const ContextHeaderAppBar: React.FC<{ children: ReactNode }> = ({
@@ -49,6 +50,7 @@ const ContextHeader: React.FC<Props> = ({
   focusModeDefaultReturnPath,
   isOpen,
   handleOpenMenu,
+  menuButtonRef,
 }) => {
   const isMobile = useIsMobile();
   const { clientId, enrollmentId } = useSafeParams();
@@ -131,6 +133,7 @@ const ContextHeader: React.FC<Props> = ({
               }}
             >
               <Button
+                ref={menuButtonRef}
                 startIcon={<MenuIcon />}
                 variant='text'
                 color='grayscale'

--- a/src/hooks/useScrollToHash.tsx
+++ b/src/hooks/useScrollToHash.tsx
@@ -17,6 +17,13 @@ export const scrollToElement = (
   } else {
     element.scrollIntoView();
   }
+
+  // Move focus to the section for keyboard navigation and screen readers
+  // First make the element focusable (same approach as SkipToContentButton)
+  if (!element.hasAttribute('tabindex')) {
+    element.setAttribute('tabindex', '-1');
+  }
+  element.focus({ preventScroll: true }); // We already smooth-scrolled to it
 };
 
 export function useScrollToHash(pageLoading?: boolean, offset?: number) {

--- a/src/modules/auth/components/LoginForm.tsx
+++ b/src/modules/auth/components/LoginForm.tsx
@@ -105,6 +105,7 @@ const LoginForm = () => {
     [handleSuccess, email, password]
   );
 
+  // For the password field, restore html's default implicit form submission behavior, which we override in TextInput
   const onKeyDown: KeyboardEventHandler<HTMLDivElement> = useCallback(
     (e) => {
       if (e.key === 'Enter') {

--- a/src/modules/form/components/client/names/MultiNameInput.tsx
+++ b/src/modules/form/components/client/names/MultiNameInput.tsx
@@ -11,6 +11,7 @@ import { useRenderLastUpdated } from '../useRenderLastUpdated';
 import NameInput from './NameInput';
 
 import { ClientNameObjectFieldsFragmentDoc } from '@/types/gqlTypes';
+import { preventImplicitSubmission } from '@/utils/forms';
 import { PartialPick } from '@/utils/typeUtil';
 
 const generateNewName = (primary = false) => ({
@@ -62,22 +63,7 @@ const MultiNameInput = ({ id, value, onChange, label }: Props) => {
             radioElement={
               <FormControlLabel
                 checked={nameValue.primary || false}
-                control={
-                  <Radio
-                    onKeyDown={(e) => {
-                      // Prevent form submission on Enter. Enter should select the focused option instead.
-                      // (Following the same pattern from RadioGroupInputOption, used in Dynamic Forms)
-                      if (
-                        e.key === 'Enter' ||
-                        e.key === ' ' ||
-                        e.code === 'Space'
-                      ) {
-                        e.preventDefault();
-                        handleChangePrimary(idx);
-                      }
-                    }}
-                  />
-                }
+                control={<Radio onKeyDown={preventImplicitSubmission} />}
                 label={
                   <Typography variant='body2'>Client's Primary Name</Typography>
                 }

--- a/src/modules/form/components/client/names/MultiNameInput.tsx
+++ b/src/modules/form/components/client/names/MultiNameInput.tsx
@@ -34,6 +34,17 @@ const MultiNameInput = ({ id, value, onChange, label }: Props) => {
     'ClientNameObjectFields'
   );
 
+  const handleChangePrimary = useCallback(
+    (idx: number) => {
+      onChange(
+        value.map((val, i) =>
+          i === idx ? { ...val, primary: true } : { ...val, primary: false }
+        )
+      );
+    },
+    [onChange, value]
+  );
+
   return (
     <RepeatedInputContainer
       id={id}
@@ -51,19 +62,26 @@ const MultiNameInput = ({ id, value, onChange, label }: Props) => {
             radioElement={
               <FormControlLabel
                 checked={nameValue.primary || false}
-                control={<Radio />}
+                control={
+                  <Radio
+                    onKeyDown={(e) => {
+                      // Prevent form submission on Enter. Enter should select the focused option instead.
+                      // (Following the same pattern from RadioGroupInputOption, used in Dynamic Forms)
+                      if (
+                        e.key === 'Enter' ||
+                        e.key === ' ' ||
+                        e.code === 'Space'
+                      ) {
+                        e.preventDefault();
+                        handleChangePrimary(idx);
+                      }
+                    }}
+                  />
+                }
                 label={
                   <Typography variant='body2'>Client's Primary Name</Typography>
                 }
-                onChange={() =>
-                  onChange(
-                    value.map((val, i) =>
-                      i === idx
-                        ? { ...val, primary: true }
-                        : { ...val, primary: false }
-                    )
-                  )
-                }
+                onChange={() => handleChangePrimary(idx)}
               />
             }
           />

--- a/src/utils/forms.ts
+++ b/src/utils/forms.ts
@@ -1,0 +1,16 @@
+import { KeyboardEvent } from 'react';
+
+/**
+ * Prevents implicit form submission on Enter key press (HTML's default form behavior.)
+ * We override this since it is unexpected/unintuitive on long forms.
+ */
+export function preventImplicitSubmission(e: KeyboardEvent<HTMLElement>) {
+  if (
+    e.key === 'Enter' &&
+    // Don't override if the event target is a button. This keeps the DatePicker adornment button working correctly, among others
+    e.target instanceof HTMLElement &&
+    e.target.tagName !== 'BUTTON'
+  ) {
+    e.preventDefault();
+  }
+}


### PR DESCRIPTION
## Description

Summary of changes:
- Remove the override of 'enter' on TextInputs. [#117](https://github.com/open-path/hmis-accessibility/issues/117)
  - This was blocking the default MUI behavior that hitting 'enter' on a DatePicker's calendar adornment should open the datepicker popup.
  - This override was not working anyway, as of the RHF refactor. As of release-190, our current behavior is that hitting 'enter' while on a form text input submits the form. [QA example](https://qa-hmis.openpath.host/client/==SmJGR2FsS09FNmdIclVWOC9mRm1XUT09/enrollments/==SENHYjh5NFZaOHNIclVWOC9mRm1XUT09/assessments/==SDBwT3hXYTV5Y05WZnNEZjhHckN1dz09)
  - We can separately discuss whether that behavior should be prevented. We had overridden it in the past, pre-RHF. But fwiw, I think we should keep it, since it is the html standard. [source](https://www.w3.org/TR/2011/WD-html5-20110525/association-of-controls-and-forms.html#implicit-submission), [discussion](https://stackoverflow.com/questions/57064691/is-implicit-submission-submit-on-enter-key-useful-to-people-using-readers-and)
- Maintain focus on the Menu/Close buttons when the left-hand menu is opened/closed [#65](https://github.com/open-path/hmis-accessibility/issues/65)
- In Assessment navigation, as well as scrolling to the right spot on the page, update keyboard focus to the selected element [#114](https://github.com/open-path/hmis-accessibility/issues/114)
- Prevent the Edit Client form from submit-on-enter when radio button is focused. [#116](https://github.com/open-path/hmis-accessibility/issues/116)
  - The update matches our existing override for [Radio Inputs on Dynamic Forms](https://github.com/greenriver/hmis-frontend/blob/release-190/src/components/elements/input/RadioGroupInputOption.tsx#L41-L49).
  - in contrast to the above, this proposed change (and our existing pattern in dynamic forms) is counter to the html standard. I think it's justifiable because having the form submit in this situation is too unintuitive, especially because the form is long and the submit button is below the fold.

How to test: Each of the 4 sub-issues linked above has repro instructions.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
