### PR TITLE
Add breadcrumb for send referral

### DIFF
--- a/src/components/layout/dashboard/contextHeader/useDashboardBreadcrumbs.tsx
+++ b/src/components/layout/dashboard/contextHeader/useDashboardBreadcrumbs.tsx
@@ -96,6 +96,7 @@ export const useProjectBreadcrumbConfig = (
         title: 'ESG Funding Report',
         parent: ProjectDashboardRoutes.REFERRALS,
       },
+      // TODO(#8142) remove legacy referral routes
       [ProjectDashboardRoutes.NEW_OUTGOING_REFERRAL]: {
         title: 'Create Referral',
         parent: ProjectDashboardRoutes.REFERRALS,
@@ -151,6 +152,10 @@ export const useProjectBreadcrumbConfig = (
       [ProjectDashboardRoutes.REFERRAL_STEP]: {
         title: 'Referral',
         parent: ProjectDashboardRoutes.CE,
+      },
+      [ProjectDashboardRoutes.SEND_REFERRAL]: {
+        title: 'Send Referral',
+        parent: ProjectDashboardRoutes.REFERRALS,
       },
       [ProjectDashboardRoutes.UNIT_GROUP]: {
         title: 'Unit Group',


### PR DESCRIPTION
## Description

Fix issue where the new "Send Referral" page didn't have a breadcrumb "parent", so you couldn't navigate back to the referral page using the breadcrumbs.

## Type of change
bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
