### PR TITLE
Remove empty group items when all child items are filtered out from Data Collected About rule

### DIFF
--- a/src/modules/form/components/group/QuestionGroup.tsx
+++ b/src/modules/form/components/group/QuestionGroup.tsx
@@ -21,7 +21,7 @@ const QuestionGroup = ({
   const hasTitle = !!item.text;
   const isConditionalGroup =
     !!item.item &&
-    (!!item.enableWhen || !!item.item[0].enableWhen) &&
+    (!!item.enableWhen || !!item.item[0]?.enableWhen) &&
     // Don't indent InfoGroup because it already has visual distinction
     item.component !== Component.InfoGroup;
 

--- a/src/modules/form/types.ts
+++ b/src/modules/form/types.ts
@@ -6,6 +6,7 @@ import { RegisterOptions } from 'react-hook-form';
 import { FormDefinitionHandlers } from '@/modules/form/hooks/useFormDefinitionHandlers';
 import { HmisEnums } from '@/types/gqlEnums';
 import {
+  FormDefinitionJsonFieldsFragment,
   FormItem,
   GetAssessmentsForPopulationQuery,
   ItemType,
@@ -205,3 +206,5 @@ export type RhfRules = Omit<
   RegisterOptions,
   'valueAsNumber' | 'valueAsDate' | 'setValueAs' | 'disabled'
 >;
+
+export type FormItemType = FormDefinitionJsonFieldsFragment['item'][number];

--- a/src/modules/form/util/formUtil.applyDataCollectedAbout.test.ts
+++ b/src/modules/form/util/formUtil.applyDataCollectedAbout.test.ts
@@ -4,6 +4,7 @@ import { applyDataCollectedAbout } from './formUtil';
 import {
   DataCollectedAbout,
   FormDefinitionFieldsFragment,
+  ItemType,
   NoYesReasonsForMissingData,
   RelationshipToHoH,
 } from '@/types/gqlTypes';
@@ -179,5 +180,59 @@ describe('applyDataCollectedAbout', () => {
         RelationshipToHoH.SelfHeadOfHousehold
       )
     ).toHaveLength(0);
+  });
+
+  it('removes groups when all child items are filtered out', () => {
+    const items = [
+      {
+        linkId: 'group1',
+        type: ItemType.Group,
+        item: [
+          {
+            linkId: 'child1',
+            dataCollectedAbout: DataCollectedAbout.Hoh,
+          },
+          {
+            linkId: 'child2',
+            dataCollectedAbout: DataCollectedAbout.Hoh,
+          },
+        ],
+      },
+      {
+        linkId: 'group2',
+        type: ItemType.Group,
+        item: [
+          {
+            linkId: 'child3',
+            // No dataCollectedAbout, so it should remain
+          },
+          {
+            linkId: 'child4',
+            dataCollectedAbout: DataCollectedAbout.Hoh,
+          },
+        ],
+      },
+    ];
+
+    // When client is not HOH, all HOH items should be filtered out
+    // group1 should be removed entirely since all children are filtered
+    // group2 should remain but only contain child3
+    expect(
+      applyDataCollectedAbout(
+        items as FormDefinitionFieldsFragment['definition']['item'],
+        client,
+        RelationshipToHoH.OtherRelative
+      )
+    ).toMatchObject([
+      {
+        linkId: 'group2',
+        type: ItemType.Group,
+        item: [
+          {
+            linkId: 'child3',
+          },
+        ],
+      },
+    ]);
   });
 });

--- a/src/modules/form/util/formUtil.ts
+++ b/src/modules/form/util/formUtil.ts
@@ -28,6 +28,7 @@ import {
 import {
   AssessmentForPopulation,
   DynamicInputCommonProps,
+  FormItemType,
   FormValues,
   HIDDEN_VALUE,
   isHmisEnum,
@@ -1112,12 +1113,16 @@ export type ClientNameDobVeteranFields = {
 /**
  * Recursively filters out any items where "data collected about" does not apply.
  * Returns a modified copy of the definition.
+ *
+ * Note: logic is similar to Hmis::Form::DefinitionItemFilter on the backend, which handles
+ * filtering out items based on Project applicability. Client applicability ("data collected about") is handled
+ * on the frontend, so that household members can use the same shared form definition returned from the API.
  */
 export const applyDataCollectedAbout = (
-  items: FormDefinitionFieldsFragment['definition']['item'],
+  items: FormItemType[],
   client: ClientNameDobVeteranFields,
   relationshipToHoH: RelationshipToHoH
-): FormDefinitionFieldsFragment['definition']['item'] => {
+): FormItemType[] => {
   function isApplicable(item: FormItem) {
     if (!item.dataCollectedAbout) return true;
 
@@ -1128,18 +1133,27 @@ export const applyDataCollectedAbout = (
     );
   }
 
-  function recur(item: (typeof items)[0]) {
+  function recur(item: FormItemType) {
     if (!item.item) return item;
+
     const { item: childItems, ...rest } = item;
-    const filteredItems: typeof items = childItems
+    const filteredItems: FormItemType[] = childItems
       .filter((child) => isApplicable(child))
-      .map((child) => recur(child));
+      .map((child) => recur(child))
+      .filter((child) => child !== null);
+
+    // If the group is empty, return null so it is filtered out
+    if (rest.type === ItemType.Group && filteredItems.length === 0) {
+      return null;
+    }
+
     return { ...rest, item: filteredItems };
   }
 
   return items
     .filter((child) => isApplicable(child))
-    .map((child) => recur(child));
+    .map((child) => recur(child))
+    .filter((child) => child !== null);
 };
 
 // Apply DataCollectedAbout to a FormDefinition. Return cloned definition.


### PR DESCRIPTION
## Description

Issue: https://github.com/open-path/Green-River/issues/8472

* Update `applyDataCollectedAbout` such that it filters out `GROUP` items  when all child items were filtered out.
  * This mirrors logic on the backend which filters out groups when all child items are filtered out due to project applicability: https://github.com/greenriver/hmis-warehouse/blob/ef351980650f5ffb2583abd669b87193abd3e617/drivers/hmis/app/models/hmis/form/definition_item_filter.rb#L58-L59
  * Client applicability form filtering is currently handled on the frontend so that clients in the same household can use the same form definition (as opposed to each household member needing to fetch the FD separately to get their own client filtering).

**How to test**: render a form where there is a group and all children are not applicable due to `data_collected_about` value. The bug only presented when the child item _also_ had enable_when, due to [this unsafe accessor](https://github.com/greenriver/hmis-frontend/blob/1b528db5bb52587b41cbdef491cc864704df3e8d/src/modules/form/components/group/QuestionGroup.tsx#L24).

## Type of change
Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
