### PR TITLE
Make form rules fetch more standard

### DIFF
--- a/src/api/operations/config.queries.graphql
+++ b/src/api/operations/config.queries.graphql
@@ -1,20 +1,25 @@
 query GetFormRules(
+  $id: ID!
   $limit: Int = 25
   $offset: Int = 0
   $filters: FormRuleFilterOptions
   $sortOrder: FormRuleSortOption
 ) {
-  formRules(
-    limit: $limit
-    offset: $offset
-    filters: $filters
-    sortOrder: $sortOrder
-  ) {
-    offset
-    limit
-    nodesCount
-    nodes {
-      ...FormRuleFields
+  formDefinition(id: $id) {
+    id
+    cacheKey
+    formRules(
+      limit: $limit
+      offset: $offset
+      filters: $filters
+      sortOrder: $sortOrder
+    ) {
+      offset
+      limit
+      nodesCount
+      nodes {
+        ...FormRuleFields
+      }
     }
   }
 }

--- a/src/modules/admin/components/formRules/FormRuleTable.tsx
+++ b/src/modules/admin/components/formRules/FormRuleTable.tsx
@@ -4,7 +4,6 @@ import React from 'react';
 import ButtonTooltipContainer from '@/components/elements/ButtonTooltipContainer';
 import { FormRule } from '@/modules/admin/components/formRules/FormRule';
 import GenericTableWithData from '@/modules/dataFetching/components/GenericTableWithData';
-import { cache } from '@/providers/apolloClient';
 import {
   ActiveStatus,
   FormRole,
@@ -14,27 +13,18 @@ import {
   GetFormRulesQueryVariables,
   useDeactivateFormRuleMutation,
 } from '@/types/gqlTypes';
-import { evictQuery } from '@/utils/cacheUtil';
 
 type RowType = FormRuleFieldsFragment;
 
 interface Props {
   formId: string;
   formRole: FormRole;
-  formCacheKey: string;
 }
 
-const FormRuleTable: React.FC<Props> = ({ formId, formRole, formCacheKey }) => {
+const FormRuleTable: React.FC<Props> = ({ formId, formRole }) => {
   const [deactivate, { loading, error }] = useDeactivateFormRuleMutation({
-    onCompleted: (data) => {
-      if (data.deleteFormRule?.formRule) {
-        evictQuery('formRules');
-        cache.evict({
-          id: `FormDefinition:{"cacheKey":"${formCacheKey}"}`,
-          fieldName: 'projectMatches',
-        });
-      }
-    },
+    awaitRefetchQueries: true,
+    refetchQueries: ['GetFormRules', 'GetFormProjectMatches'],
   });
 
   if (error) throw error;
@@ -46,11 +36,11 @@ const FormRuleTable: React.FC<Props> = ({ formId, formRole, formCacheKey }) => {
         GetFormRulesQueryVariables,
         RowType
       >
-        queryVariables={{ filters: { definition: formId } }}
+        queryVariables={{ id: formId }}
         defaultFilterValues={{ activeStatus: ActiveStatus.Active }}
         queryDocument={GetFormRulesDocument}
         columns={[]}
-        pagePath='formRules'
+        pagePath='formDefinition.formRules'
         noData='No form rules'
         recordType='FormRule'
         paginationItemName='rule'

--- a/src/modules/admin/components/formRules/FormRulesCard.tsx
+++ b/src/modules/admin/components/formRules/FormRulesCard.tsx
@@ -12,14 +12,8 @@ interface Props {
   formId: string;
   formTitle: string;
   formRole: FormRole;
-  formCacheKey: string;
 }
-const FormRulesCard: React.FC<Props> = ({
-  formId,
-  formTitle,
-  formRole,
-  formCacheKey,
-}) => {
+const FormRulesCard: React.FC<Props> = ({ formId, formTitle, formRole }) => {
   const [dialogOpen, setDialogOpen] = useState<boolean>(false);
 
   // Fetch here in order to display the total number of project matches outside of the table.
@@ -54,11 +48,7 @@ const FormRulesCard: React.FC<Props> = ({
           </Typography>
         </Box>
         <Divider sx={{ borderWidth: 'inherit' }} />
-        <FormRuleTable
-          formId={formId}
-          formRole={formRole}
-          formCacheKey={formCacheKey}
-        />
+        <FormRuleTable formId={formId} formRole={formRole} />
         <Box padding={2}>
           <Typography variant='h6' component='h3' sx={{ pb: 1 }}>
             Projects
@@ -75,7 +65,6 @@ const FormRulesCard: React.FC<Props> = ({
         formId={formId}
         formTitle={formTitle}
         formRole={formRole}
-        formCacheKey={formCacheKey}
         open={dialogOpen}
         onClose={() => setDialogOpen(false)}
       />

--- a/src/modules/admin/components/formRules/NewFormRuleDialog.tsx
+++ b/src/modules/admin/components/formRules/NewFormRuleDialog.tsx
@@ -21,7 +21,6 @@ import { localResolvePickList } from '@/modules/form/util/formUtil';
 import CardGroup, {
   RemovableCard,
 } from '@/modules/formBuilder/components/itemEditor/conditionals/CardGroup';
-import { cache } from '@/providers/apolloClient';
 import {
   DataCollectedAbout,
   FormRole,
@@ -60,7 +59,6 @@ interface Props {
   formId: string;
   formTitle: string;
   formRole: FormRole;
-  formCacheKey: string;
 }
 
 const NewFormRuleDialog: React.FC<Props> = ({
@@ -69,7 +67,6 @@ const NewFormRuleDialog: React.FC<Props> = ({
   formId,
   formTitle,
   formRole,
-  formCacheKey,
 }) => {
   // Form state for the rule
   const [dataCollectedAbout, setDataCollectedAbout] =
@@ -120,32 +117,12 @@ const NewFormRuleDialog: React.FC<Props> = ({
   }, [onClose]);
 
   const [createFormRule, { loading, error }] = useCreateFormRuleMutation({
+    awaitRefetchQueries: true,
+    // Refetch this form's rules and projectMatches, so both tables reflect the new rule
+    refetchQueries: ['GetFormRules', 'GetFormProjectMatches'],
     onCompleted: (data) => {
       if (data.createFormRule?.formRule) {
         onCloseDialog();
-
-        // Apollo has now already added the new rule to the cache, but here we add it to the cached result of the
-        // `formRules` query (by reference), so that it's reflected in the FormRuleTable
-        cache.modify({
-          fields: {
-            formRules(existingRules = {}) {
-              return {
-                ...existingRules,
-                nodesCount: existingRules.nodesCount + 1, // this isn't used, but update it anyway to avoid inconsistency
-                nodes: [
-                  ...existingRules.nodes,
-                  { __ref: `FormRule:${data.createFormRule?.formRule?.id}` },
-                ],
-              };
-            },
-          },
-        });
-
-        // Evict the existing `projectMatches` for this form, so that they are re-fetched and reflect the new rule
-        cache.evict({
-          id: `FormDefinition:{"cacheKey":"${formCacheKey}"}`,
-          fieldName: 'projectMatches',
-        });
       } else if (data.createFormRule?.errors?.length) {
         setValidationError(data.createFormRule.errors[0].fullMessage);
       }

--- a/src/modules/admin/components/forms/FormDefinitionDetailPage.tsx
+++ b/src/modules/admin/components/forms/FormDefinitionDetailPage.tsx
@@ -91,7 +91,6 @@ const FormDefinitionDetailPage = () => {
           formId={formIdentifier.displayVersion.id}
           formTitle={formIdentifier.displayVersion.title}
           formRole={formIdentifier.displayVersion.role}
-          formCacheKey={formIdentifier.displayVersion.cacheKey}
         />
         <CommonCard
           title='Version History'

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -24818,6 +24818,7 @@ export type UpdateServiceTypeMutation = {
 };
 
 export type GetFormRulesQueryVariables = Exact<{
+  id: Scalars['ID']['input'];
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   filters?: InputMaybe<FormRuleFilterOptions>;
@@ -24826,59 +24827,64 @@ export type GetFormRulesQueryVariables = Exact<{
 
 export type GetFormRulesQuery = {
   __typename?: 'Query';
-  formRules: {
-    __typename?: 'FormRulesPaginated';
-    offset: number;
-    limit: number;
-    nodesCount: number;
-    nodes: Array<{
-      __typename?: 'FormRule';
-      id: string;
-      active: boolean;
-      activeStatus: ActiveStatus;
-      system: boolean;
-      definitionIdentifier: string;
-      definitionId?: string | null;
-      definitionTitle?: string | null;
-      definitionRole?: FormRole | null;
-      dataCollectedAbout?: DataCollectedAbout | null;
-      funder?: FundingSource | null;
-      otherFunder?: string | null;
-      projectType?: ProjectType | null;
-      projectId?: string | null;
-      projectName?: string | null;
-      organizationId?: string | null;
-      createdAt: string;
-      updatedAt: string;
-      organization?: {
-        __typename?: 'Organization';
+  formDefinition?: {
+    __typename?: 'FormDefinition';
+    id: string;
+    cacheKey: string;
+    formRules: {
+      __typename?: 'FormRulesPaginated';
+      offset: number;
+      limit: number;
+      nodesCount: number;
+      nodes: Array<{
+        __typename?: 'FormRule';
         id: string;
-        hudId: string;
-        organizationName: string;
-      } | null;
-      serviceCategory?: {
-        __typename?: 'ServiceCategory';
-        id: string;
-        name: string;
-      } | null;
-      serviceType?: {
-        __typename?: 'ServiceType';
-        id: string;
-        name: string;
-        hud: boolean;
-        hudRecordType?: RecordType | null;
-        hudTypeProvided?: ServiceTypeProvided | null;
-        dateCreated?: string | null;
-        dateUpdated?: string | null;
-        supportsBulkAssignment: boolean;
-        serviceCategory: {
+        active: boolean;
+        activeStatus: ActiveStatus;
+        system: boolean;
+        definitionIdentifier: string;
+        definitionId?: string | null;
+        definitionTitle?: string | null;
+        definitionRole?: FormRole | null;
+        dataCollectedAbout?: DataCollectedAbout | null;
+        funder?: FundingSource | null;
+        otherFunder?: string | null;
+        projectType?: ProjectType | null;
+        projectId?: string | null;
+        projectName?: string | null;
+        organizationId?: string | null;
+        createdAt: string;
+        updatedAt: string;
+        organization?: {
+          __typename?: 'Organization';
+          id: string;
+          hudId: string;
+          organizationName: string;
+        } | null;
+        serviceCategory?: {
           __typename?: 'ServiceCategory';
           id: string;
           name: string;
-        };
-      } | null;
-    }>;
-  };
+        } | null;
+        serviceType?: {
+          __typename?: 'ServiceType';
+          id: string;
+          name: string;
+          hud: boolean;
+          hudRecordType?: RecordType | null;
+          hudTypeProvided?: ServiceTypeProvided | null;
+          dateCreated?: string | null;
+          dateUpdated?: string | null;
+          supportsBulkAssignment: boolean;
+          serviceCategory: {
+            __typename?: 'ServiceCategory';
+            id: string;
+            name: string;
+          };
+        } | null;
+      }>;
+    };
+  } | null;
 };
 
 export type GetFormProjectMatchesQueryVariables = Exact<{
@@ -57370,22 +57376,27 @@ export type UpdateServiceTypeMutationOptions = Apollo.BaseMutationOptions<
 >;
 export const GetFormRulesDocument = gql`
   query GetFormRules(
+    $id: ID!
     $limit: Int = 25
     $offset: Int = 0
     $filters: FormRuleFilterOptions
     $sortOrder: FormRuleSortOption
   ) {
-    formRules(
-      limit: $limit
-      offset: $offset
-      filters: $filters
-      sortOrder: $sortOrder
-    ) {
-      offset
-      limit
-      nodesCount
-      nodes {
-        ...FormRuleFields
+    formDefinition(id: $id) {
+      id
+      cacheKey
+      formRules(
+        limit: $limit
+        offset: $offset
+        filters: $filters
+        sortOrder: $sortOrder
+      ) {
+        offset
+        limit
+        nodesCount
+        nodes {
+          ...FormRuleFields
+        }
       }
     }
   }
@@ -57404,6 +57415,7 @@ export const GetFormRulesDocument = gql`
  * @example
  * const { data, loading, error } = useGetFormRulesQuery({
  *   variables: {
+ *      id: // value for 'id'
  *      limit: // value for 'limit'
  *      offset: // value for 'offset'
  *      filters: // value for 'filters'
@@ -57412,10 +57424,14 @@ export const GetFormRulesDocument = gql`
  * });
  */
 export function useGetFormRulesQuery(
-  baseOptions?: Apollo.QueryHookOptions<
+  baseOptions: Apollo.QueryHookOptions<
     GetFormRulesQuery,
     GetFormRulesQueryVariables
-  >
+  > &
+    (
+      | { variables: GetFormRulesQueryVariables; skip?: boolean }
+      | { skip: boolean }
+    )
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<GetFormRulesQuery, GetFormRulesQueryVariables>(


### PR DESCRIPTION
## Description

[low priority] We're currently fetching Form Rules with a global Form Rules query, that is filtered by form definition ID, which I think is a non-standard pattern for us; see `FormProjectMatchTable` for comparison, for example. (I think this might be a historical relic since there used to just be one table of all form rules across the app?) And this seems to have required some caching acrobatics that I think can be simplified a lot if we take an approach that looks more like our usual.

This is a code cleanup, and isn't actually the fix to the bug in the linked ticket (that's [here](https://github.com/greenriver/hmis-warehouse/pull/6058)) -- so if we consider it too much churn, I'm fine with closing this without merge.

Summary of changes: 
- Update the `GetFormRules` query to accept a form definition ID and query for that definition's rules
- Update both `FormRuleTable` and `NewFormRuleDialog` to simplify the cache clearing
- No need to continue passing `formCacheKey` around

[//]: # 'remove if not applicable'
How to test:
- Open form definition detail page; confirm rules are fetched and displayed successfully
- Play with adding/removing form rules. Confirm that both the rules table and the project match table update automatically when changes are made.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Code cleanup

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
