### PR TITLE
Bug fix: don't show action to close Opportunity if it is locked

### DIFF
--- a/src/modules/units/components/UnitOverview.tsx
+++ b/src/modules/units/components/UnitOverview.tsx
@@ -79,26 +79,27 @@ const UnitOverview: React.FC<Props> = ({ unit }) => {
           </Paper>
         </Grid>
       )}
-      {opportunity?.active && opportunity?.stale && (
-        <Grid item xs={12}>
-          <Alert
-            severity='warning'
-            action={
-              <LoadingButton
-                loading={unavailableLoading}
-                color={'warning'}
-                variant={'outlined'}
-                onClick={() => markUnitUnavailable()}
-              >
-                Stop Accepting Referrals
-              </LoadingButton>
-            }
-          >
-            The requirements below may be outdated. To refresh them, stop and
-            re-start accepting referrals for this unit.
-          </Alert>
-        </Grid>
-      )}
+      {opportunity?.status === CeOpportunityStatus.Open &&
+        opportunity?.stale && (
+          <Grid item xs={12}>
+            <Alert
+              severity='warning'
+              action={
+                <LoadingButton
+                  loading={unavailableLoading}
+                  color={'warning'}
+                  variant={'outlined'}
+                  onClick={() => markUnitUnavailable()}
+                >
+                  Stop Accepting Referrals
+                </LoadingButton>
+              }
+            >
+              The requirements below may be outdated. To refresh them, stop and
+              re-start accepting referrals for this unit.
+            </Alert>
+          </Grid>
+        )}
       <Grid item xs={12} md={6}>
         <MatchRuleCard
           title='Eligibility Requirements'

--- a/src/modules/units/components/UnitOverview.tsx
+++ b/src/modules/units/components/UnitOverview.tsx
@@ -79,6 +79,7 @@ const UnitOverview: React.FC<Props> = ({ unit }) => {
           </Paper>
         </Grid>
       )}
+      {/* If the opportunity is open and stale, show a warning and allow user to refresh the opportunity */}
       {opportunity?.status === CeOpportunityStatus.Open &&
         opportunity?.stale && (
           <Grid item xs={12}>


### PR DESCRIPTION
## Description

Issue: https://github.com/open-path/Green-River/issues/8703

Follow-up to https://github.com/greenriver/hmis-frontend/pull/1320 which introduced a new banner to let the user know that an opportunity is stale. It also has a button to close the opportunity, which throws an error if the opportunity has an active referral

This PR hides the banner if the opportunity has an active referral (aka is locked). The stale-ness of eligibility requirements is irrelevant if there is already an active referral.

## Type of change
Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have used Axe DevTools to scan for accessibility issues (or not applicable)
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
