### PR TITLE
Normalize initial value for boolean checkbox display

### DIFF
--- a/src/modules/form/hooks/rhf/useEnrichedFormData.tsx
+++ b/src/modules/form/hooks/rhf/useEnrichedFormData.tsx
@@ -10,6 +10,7 @@ import {
   getEnrichedValueForChoiceItem,
   getInitialValues,
   getItemMap,
+  normalizeBooleanCheckboxValues,
 } from '@/modules/form/util/formUtil';
 import { FormDefinitionJson } from '@/types/gqlTypes';
 
@@ -50,10 +51,12 @@ export const useEnrichedFormData = <T extends FieldValues>({
   });
 
   const [defaultValues] = useState<DefaultValues<T>>(() => {
+    // 1. Start with baseline values: form definition defaults (from "initial" attribute) + previously submitted data (from initialValues prop)
     const newValues: Record<string, any> = {
       ...getInitialValues(definition, localConstants),
       ...cloneDeep(initialValues),
     };
+    // 2. Layer on values that are calculated by "autofill_values" attribute on form items
     Object.keys(itemMap).forEach((linkId) => {
       const change = autofillValues({
         item: itemMap[linkId],
@@ -65,6 +68,9 @@ export const useEnrichedFormData = <T extends FieldValues>({
       //console.info('form init autofill', linkId, change)
       if (change) newValues[linkId] = change.value;
     });
+    // 3. Normalize boolean checkbox fields to be bi-state (true/false only)
+    normalizeBooleanCheckboxValues(newValues, itemMap);
+
     return newValues as DefaultValues<T>;
   });
 

--- a/src/modules/form/hooks/rhf/useEnrichedFormData.tsx
+++ b/src/modules/form/hooks/rhf/useEnrichedFormData.tsx
@@ -68,7 +68,7 @@ export const useEnrichedFormData = <T extends FieldValues>({
       //console.info('form init autofill', linkId, change)
       if (change) newValues[linkId] = change.value;
     });
-    // 3. Normalize boolean checkbox fields to be bi-state (true/false only)
+    // 3. Normalize boolean checkbox fields to be bi-state (true/false only) as opposed to tri-state (true/false/null)
     normalizeBooleanCheckboxValues(newValues, itemMap);
 
     return newValues as DefaultValues<T>;

--- a/src/modules/form/util/formUtil.normalizeBooleanCheckboxValues.test.ts
+++ b/src/modules/form/util/formUtil.normalizeBooleanCheckboxValues.test.ts
@@ -5,11 +5,13 @@ import { normalizeBooleanCheckboxValues } from './formUtil';
 import { Component, ItemType } from '@/types/gqlTypes';
 
 describe('normalizeBooleanCheckboxValues', () => {
-  it('sets undefined boolean checkbox values to false', () => {
+  it('sets undefined/null boolean checkbox values to false and leaves existing values unchanged', () => {
     const values = {
-      checkbox1: undefined,
-      checkbox2: null,
-      textField: 'some value',
+      checkbox1: undefined, // should be set to false
+      checkbox2: true, // should remain true
+      checkbox3: null, // should be set to false
+      checkbox4: false, // should remain false
+      textField: undefined, // should remain undefined
     };
 
     const itemMap: ItemMap = {
@@ -20,6 +22,16 @@ describe('normalizeBooleanCheckboxValues', () => {
       },
       checkbox2: {
         linkId: 'checkbox2',
+        type: ItemType.Boolean,
+        component: Component.Checkbox,
+      },
+      checkbox3: {
+        linkId: 'checkbox3',
+        type: ItemType.Boolean,
+        component: Component.Checkbox,
+      },
+      checkbox4: {
+        linkId: 'checkbox4',
         type: ItemType.Boolean,
         component: Component.Checkbox,
       },
@@ -34,8 +46,10 @@ describe('normalizeBooleanCheckboxValues', () => {
 
     expect(result).toBe(values); // mutates in place
     expect(result.checkbox1).toBe(false);
-    expect(result.checkbox2).toBe(false);
-    expect(result.textField).toBe('some value');
+    expect(result.checkbox2).toBe(true);
+    expect(result.checkbox3).toBe(false);
+    expect(result.checkbox4).toBe(false);
+    expect(result.textField).toBeUndefined();
   });
 
   it('leaves existing boolean checkbox values unchanged', () => {
@@ -84,66 +98,6 @@ describe('normalizeBooleanCheckboxValues', () => {
 
     expect(result.checkbox1).toBe(false);
     expect(Object.keys(result)).toHaveLength(1);
-  });
-
-  it('handles empty itemMap', () => {
-    const values = {
-      field1: undefined,
-      field2: 'value',
-    };
-    const itemMap: ItemMap = {};
-
-    const result = normalizeBooleanCheckboxValues(values, itemMap);
-
-    expect(result).toEqual(values);
-    expect(result.field1).toBeUndefined();
-    expect(result.field2).toBe('value');
-  });
-
-  it('only modifies boolean checkbox fields that are nil', () => {
-    const values = {
-      checkbox1: undefined, // should be set to false
-      checkbox2: true, // should remain true
-      checkbox3: null, // should be set to false
-      checkbox4: false, // should remain false
-      textField: undefined, // should remain undefined
-    };
-
-    const itemMap: ItemMap = {
-      checkbox1: {
-        linkId: 'checkbox1',
-        type: ItemType.Boolean,
-        component: Component.Checkbox,
-      },
-      checkbox2: {
-        linkId: 'checkbox2',
-        type: ItemType.Boolean,
-        component: Component.Checkbox,
-      },
-      checkbox3: {
-        linkId: 'checkbox3',
-        type: ItemType.Boolean,
-        component: Component.Checkbox,
-      },
-      checkbox4: {
-        linkId: 'checkbox4',
-        type: ItemType.Boolean,
-        component: Component.Checkbox,
-      },
-      textField: {
-        linkId: 'textField',
-        type: ItemType.String,
-        component: Component.Dropdown,
-      },
-    };
-
-    const result = normalizeBooleanCheckboxValues(values, itemMap);
-
-    expect(result.checkbox1).toBe(false);
-    expect(result.checkbox2).toBe(true);
-    expect(result.checkbox3).toBe(false);
-    expect(result.checkbox4).toBe(false);
-    expect(result.textField).toBeUndefined();
   });
 
   it('leaves non-checkbox boolean items unchanged', () => {

--- a/src/modules/form/util/formUtil.normalizeBooleanCheckboxValues.test.ts
+++ b/src/modules/form/util/formUtil.normalizeBooleanCheckboxValues.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from 'vitest';
+import { ItemMap } from '../types';
+import { normalizeBooleanCheckboxValues } from './formUtil';
+
+import { Component, ItemType } from '@/types/gqlTypes';
+
+describe('normalizeBooleanCheckboxValues', () => {
+  it('sets undefined boolean checkbox values to false', () => {
+    const values = {
+      checkbox1: undefined,
+      checkbox2: null,
+      textField: 'some value',
+    };
+
+    const itemMap: ItemMap = {
+      checkbox1: {
+        linkId: 'checkbox1',
+        type: ItemType.Boolean,
+        component: Component.Checkbox,
+      },
+      checkbox2: {
+        linkId: 'checkbox2',
+        type: ItemType.Boolean,
+        component: Component.Checkbox,
+      },
+      textField: {
+        linkId: 'textField',
+        type: ItemType.String,
+        component: Component.Dropdown,
+      },
+    };
+
+    const result = normalizeBooleanCheckboxValues(values, itemMap);
+
+    expect(result).toBe(values); // mutates in place
+    expect(result.checkbox1).toBe(false);
+    expect(result.checkbox2).toBe(false);
+    expect(result.textField).toBe('some value');
+  });
+
+  it('leaves existing boolean checkbox values unchanged', () => {
+    const values = {
+      checkbox1: true,
+      checkbox2: false,
+      checkbox3: undefined,
+    };
+
+    const itemMap: ItemMap = {
+      checkbox1: {
+        linkId: 'checkbox1',
+        type: ItemType.Boolean,
+        component: Component.Checkbox,
+      },
+      checkbox2: {
+        linkId: 'checkbox2',
+        type: ItemType.Boolean,
+        component: Component.Checkbox,
+      },
+      checkbox3: {
+        linkId: 'checkbox3',
+        type: ItemType.Boolean,
+        component: Component.Checkbox,
+      },
+    };
+
+    const result = normalizeBooleanCheckboxValues(values, itemMap);
+
+    expect(result.checkbox1).toBe(true);
+    expect(result.checkbox2).toBe(false);
+    expect(result.checkbox3).toBe(false);
+  });
+
+  it('handles empty values object', () => {
+    const values = {};
+    const itemMap: ItemMap = {
+      checkbox1: {
+        linkId: 'checkbox1',
+        type: ItemType.Boolean,
+        component: Component.Checkbox,
+      },
+    };
+
+    const result = normalizeBooleanCheckboxValues(values, itemMap);
+
+    expect(result.checkbox1).toBe(false);
+    expect(Object.keys(result)).toHaveLength(1);
+  });
+
+  it('handles empty itemMap', () => {
+    const values = {
+      field1: undefined,
+      field2: 'value',
+    };
+    const itemMap: ItemMap = {};
+
+    const result = normalizeBooleanCheckboxValues(values, itemMap);
+
+    expect(result).toEqual(values);
+    expect(result.field1).toBeUndefined();
+    expect(result.field2).toBe('value');
+  });
+
+  it('only modifies boolean checkbox fields that are nil', () => {
+    const values = {
+      checkbox1: undefined, // should be set to false
+      checkbox2: true, // should remain true
+      checkbox3: null, // should be set to false
+      checkbox4: false, // should remain false
+      textField: undefined, // should remain undefined
+    };
+
+    const itemMap: ItemMap = {
+      checkbox1: {
+        linkId: 'checkbox1',
+        type: ItemType.Boolean,
+        component: Component.Checkbox,
+      },
+      checkbox2: {
+        linkId: 'checkbox2',
+        type: ItemType.Boolean,
+        component: Component.Checkbox,
+      },
+      checkbox3: {
+        linkId: 'checkbox3',
+        type: ItemType.Boolean,
+        component: Component.Checkbox,
+      },
+      checkbox4: {
+        linkId: 'checkbox4',
+        type: ItemType.Boolean,
+        component: Component.Checkbox,
+      },
+      textField: {
+        linkId: 'textField',
+        type: ItemType.String,
+        component: Component.Dropdown,
+      },
+    };
+
+    const result = normalizeBooleanCheckboxValues(values, itemMap);
+
+    expect(result.checkbox1).toBe(false);
+    expect(result.checkbox2).toBe(true);
+    expect(result.checkbox3).toBe(false);
+    expect(result.checkbox4).toBe(false);
+    expect(result.textField).toBeUndefined();
+  });
+
+  it('leaves non-checkbox boolean items unchanged', () => {
+    const values = {
+      booleanCheckbox: undefined,
+      booleanRadio: undefined,
+      booleanDefault: undefined,
+    };
+
+    const itemMap: ItemMap = {
+      booleanCheckbox: {
+        linkId: 'booleanCheckbox',
+        type: ItemType.Boolean,
+        component: Component.Checkbox,
+      },
+      booleanRadio: {
+        linkId: 'booleanRadio',
+        type: ItemType.Boolean,
+        component: Component.RadioButtons,
+      },
+      booleanDefault: {
+        linkId: 'booleanDefault',
+        type: ItemType.Boolean,
+      },
+    };
+
+    const result = normalizeBooleanCheckboxValues(values, itemMap);
+
+    expect(result.booleanCheckbox).toBe(false);
+    expect(result.booleanRadio).toBeUndefined();
+    expect(result.booleanDefault).toBeUndefined();
+  });
+});

--- a/src/modules/form/util/formUtil.ts
+++ b/src/modules/form/util/formUtil.ts
@@ -1709,3 +1709,26 @@ export const getEnrichedValueForChoiceItem = ({
   }
   return { enrichedValue: found };
 };
+
+// Normalize boolean checkbox fields to be bi-state (true/false only)
+//
+// Context: Boolean items default to the YesNoRadio component, which is tri-state (true/false/null).
+// When the Checkbox component is specified, the frontend is responsible for enforcing bi-state behavior (true/false only).
+// Without this, users  would see inconsistent behavior when viewing checkbox responses, seeing "Data Not Collected" instead of "No".
+// See GH#7239 for more details.
+export const normalizeBooleanCheckboxValues = (
+  values: Record<string, any>,
+  itemMap: ItemMap
+) => {
+  Object.entries(itemMap)
+    .filter(
+      ([linkId, item]) =>
+        item.type === ItemType.Boolean &&
+        item.component === Component.Checkbox &&
+        isNil(values[linkId])
+    )
+    .forEach(([linkId]) => {
+      values[linkId] = false;
+    });
+  return values;
+};


### PR DESCRIPTION
## Description

Issue: https://github.com/open-path/Green-River/issues/7239


#### Buggy behavior:
* A boolean checkbox field would have value 'undefined' if untouched, and would be saved as null (or not saved at all, in the case of custom fields). When form reopened, it displayed as "data not collected".
* If user checked and then unchecked it, it would save as false, and displays as "No" when reopened.

#### Updated behavior
* Boolean checkbox fields are always initialized to `false` if empty. When form is reopened for viewing, the value always shows as "No" if false or null.
* This also results in a response being recorded where there previously was none, specifically for CDEs. No CDE would be created if a checkbox was untouched, whereas now it will be created with value "false".



#### How to test:
1. **Testing backwards compatibility:** save or submit a form using the old code with a checkbox left untouched. Reopen, you should see "data not collected". Now switch to this branch and reopen the same assessment. It should now show "No"
2. **Testing new behavior:** save or submit a form with checkbox unchecked
3. **Testing default booleans**: boolean items that do NOT specify `"component": "CHECKBOX"` should be unchanged. Confirm they still support tri-state if the "yes no radio" component is left empty. 

### Screenshots
for reference:

Item `"type": "BOOLEAN"` (is actually tri-state)
<img width="161" alt="Image" src="https://github.com/user-attachments/assets/fc24923e-25dc-441c-870f-7281c72da7f2" />


Item `"type": "BOOLEAN", "component": "CHECKBOX"` SHOULD be bi-state, but was tri-state. (untouched = null, check and uncheck = false, check = true)

<img width="316" alt="Image" src="https://github.com/user-attachments/assets/179fcf92-14a3-4cdb-bd6e-03fd54d5668f" />


## Type of change
Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have used Axe DevTools to scan for accessibility issues (or not applicable)
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
