### PR TITLE
Allow CommonLabeledTextBlock to render '0' value

### DIFF
--- a/src/components/elements/CommonLabeledTextBlock.tsx
+++ b/src/components/elements/CommonLabeledTextBlock.tsx
@@ -2,6 +2,7 @@ import { Box, Typography, TypographyProps } from '@mui/material';
 import { ReactNode } from 'react';
 
 import NotCollectedText from '@/components/elements/NotCollectedText';
+import { hasMeaningfulValue } from '@/modules/form/util/formUtil';
 
 interface Props {
   children: ReactNode | string | null | undefined;
@@ -33,7 +34,11 @@ export const CommonLabeledTextBlock: React.FC<Props> = ({
       {title}
     </Box>
     <Box sx={{ whiteSpace: 'pre-wrap', overflowWrap: 'break-word' }}>
-      {children ? children : <NotCollectedText variant={variant} />}
+      {hasMeaningfulValue(children) ? (
+        children
+      ) : (
+        <NotCollectedText variant={variant} />
+      )}
     </Box>
   </Typography>
 );


### PR DESCRIPTION
## Description

Update CommonLabeledTextBlock to only render "data not collected" if the child passed is null/undefined/empty string or empty array. Support rendering the value if it is zero.

Before:
<img width="422" height="239" alt="Screenshot 2025-12-30 at 4 00 50 PM" src="https://github.com/user-attachments/assets/66afa2d7-6b82-4eac-95d7-b6c6b12c780b" />

After:
<img width="310" height="245" alt="Screenshot 2025-12-30 at 4 00 54 PM" src="https://github.com/user-attachments/assets/12a991a8-28e0-4ee2-afb8-e075ffcc5265" />


## Type of change
Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have used Axe DevTools to scan for accessibility issues (or not applicable)
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
