### PR TITLE
Hide optional demographics fields when blank

### DIFF
--- a/src/modules/client/components/ClientProfileCard.tsx
+++ b/src/modules/client/components/ClientProfileCard.tsx
@@ -25,6 +25,7 @@ import SimpleAccordion from '@/components/elements/SimpleAccordion';
 import SimpleTable from '@/components/elements/SimpleTable';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import ClientForceRefetchButton from '@/modules/client/components/ClientForceRefetchButton';
+import { isDataNotCollected } from '@/modules/form/util/formUtil';
 import ClientDobAge from '@/modules/hmis/components/ClientDobAge';
 import { ClientSafeSsn } from '@/modules/hmis/components/ClientSsn';
 import HmisEnum, { MultiHmisEnum } from '@/modules/hmis/components/HmisEnum';
@@ -208,47 +209,57 @@ const ClientProfileCardAccordion = ({ client }: Props): JSX.Element => {
             defaultExpanded: true,
             content: (
               <ClientProfileCardTextTable
-                content={{
-                  Race: (
-                    <MultiHmisEnum
-                      values={client.race}
-                      enumMap={HmisEnums.Race}
-                      noData={HmisEnums.NoYesMissing.DATA_NOT_COLLECTED}
-                      oneRowPerValue
-                    />
-                  ),
-                  Gender: (
-                    <>
+                content={Object.fromEntries(
+                  [
+                    [
+                      'Race',
                       <MultiHmisEnum
-                        values={client.gender}
-                        enumMap={HmisEnums.Gender}
+                        values={client.race}
+                        enumMap={HmisEnums.Race}
                         noData={HmisEnums.NoYesMissing.DATA_NOT_COLLECTED}
                         oneRowPerValue
-                      >
-                        {client.differentIdentityText && (
-                          <Typography variant='body2'>
-                            {client.differentIdentityText}
-                          </Typography>
-                        )}{' '}
-                      </MultiHmisEnum>
-                    </>
-                  ),
-                  Sex: (
-                    <HmisEnum
-                      value={client.sex}
-                      enumMap={HmisEnums.Sex}
-                      noData={HmisEnums.NoYesMissing.DATA_NOT_COLLECTED}
-                    />
-                  ),
-                  Pronouns: pronouns(client) || <NotCollectedText />,
-                  'Veteran Status': (
-                    <HmisEnum
-                      value={client.veteranStatus}
-                      enumMap={HmisEnums.NoYesReasonsForMissingData}
-                      noData={HmisEnums.NoYesMissing.DATA_NOT_COLLECTED}
-                    />
-                  ),
-                }}
+                      />,
+                    ],
+                    [
+                      'Gender',
+                      client.gender.some(
+                        (gender) => !isDataNotCollected(gender)
+                      ) && (
+                        <>
+                          <MultiHmisEnum
+                            values={client.gender}
+                            enumMap={HmisEnums.Gender}
+                            noData={HmisEnums.NoYesMissing.DATA_NOT_COLLECTED}
+                            oneRowPerValue
+                          >
+                            {client.differentIdentityText && (
+                              <Typography variant='body2'>
+                                {client.differentIdentityText}
+                              </Typography>
+                            )}{' '}
+                          </MultiHmisEnum>
+                        </>
+                      ),
+                    ],
+                    [
+                      'Sex',
+                      <HmisEnum
+                        value={client.sex}
+                        enumMap={HmisEnums.Sex}
+                        noData={HmisEnums.NoYesMissing.DATA_NOT_COLLECTED}
+                      />,
+                    ],
+                    ['Pronouns', pronouns(client)],
+                    [
+                      'Veteran Status',
+                      <HmisEnum
+                        value={client.veteranStatus}
+                        enumMap={HmisEnums.NoYesReasonsForMissingData}
+                        noData={HmisEnums.NoYesMissing.DATA_NOT_COLLECTED}
+                      />,
+                    ],
+                  ].filter(([, value]) => value)
+                )}
               />
             ),
           },


### PR DESCRIPTION
## Description

Ticket: https://github.com/open-path/Green-River/issues/8118

Updated behavior for the demographics accordion:
* Race: always show (no change)
* Gender: hide if no value / DNC, since this is now an optional field on the client form and not all installations may have it
* Sex: always show (no change)
* Pronouns: hide if no value, not all installations may have this on client form
* Veteran status: always show (no change)

with values:
<img width="457" height="340" alt="Screenshot 2025-12-30 at 4 19 52 PM" src="https://github.com/user-attachments/assets/5dfddd31-9e72-4420-b822-e5d1f420cd53" />

with no data (HUD fields only shown by default)
<img width="459" height="183" alt="Screenshot 2025-12-30 at 4 20 31 PM" src="https://github.com/user-attachments/assets/7b9890a4-0a07-4ce1-bab9-77d735640c14" />


## Type of change
Feature change

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have used Axe DevTools to scan for accessibility issues (or not applicable)
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
