### PR TITLE
Expose external form object key

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -26862,6 +26862,18 @@
             "deprecationReason": null
           },
           {
+            "name": "externalFormObjectKey",
+            "description": "External object key, only present for External Form role",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "formRules",
             "description": null,
             "args": [

--- a/src/api/operations/form.fragments.graphql
+++ b/src/api/operations/form.fragments.graphql
@@ -175,6 +175,7 @@ fragment FormIdentifierDetails on FormIdentifier {
     canDuplicateForm
   }
   displayVersion {
+    externalFormObjectKey
     ...FormDefinitionMetadata
   }
   draftVersion {

--- a/src/modules/admin/components/forms/FormDefinitionActionsCard.tsx
+++ b/src/modules/admin/components/forms/FormDefinitionActionsCard.tsx
@@ -37,6 +37,7 @@ const FormDefinitionActionsCard: React.FC<Props> = ({ formIdentifier }) => {
     ? parseHmisDateString(formIdentifier.draftVersion?.dateUpdated)
     : undefined;
 
+  const { externalFormObjectKey } = formIdentifier.displayVersion;
   const { managedInVersionControl, access } = formIdentifier;
   const { canManageForm, canPublishForm, canDuplicateForm } = access;
 
@@ -54,6 +55,18 @@ const FormDefinitionActionsCard: React.FC<Props> = ({ formIdentifier }) => {
         >
           View Published Form
         </ButtonLink>
+        {externalFormObjectKey && (
+          <ButtonLink
+            // TODO: DEV ONLY
+            to={`https://hmis-warehouse.dev.test/hmis_external_api/external_forms/${externalFormObjectKey}`}
+            // variant={hasDraft ? 'outlined' : 'contained'}
+            openInNew
+            fullWidth
+            disabled={!isPublished}
+          >
+            View External Form Preview
+          </ButtonLink>
+        )}
         {isPublished && (
           <Typography variant='caption'>
             Published {publishedOn ? formatRelativeDateTime(publishedOn) : ''}{' '}

--- a/src/modules/admin/components/forms/FormDefinitionActionsCard.tsx
+++ b/src/modules/admin/components/forms/FormDefinitionActionsCard.tsx
@@ -5,6 +5,7 @@ import { generatePath } from 'react-router-dom';
 import ButtonLink from '@/components/elements/ButtonLink';
 import CommonCard from '@/components/elements/CommonCard';
 
+import { OpenInNewIcon } from '@/components/elements/SemanticIcons';
 import DuplicateFormButton from '@/modules/admin/components/forms/DuplicateFormButton';
 import EditFormButton from '@/modules/admin/components/forms/EditFormButton';
 import {
@@ -55,16 +56,16 @@ const FormDefinitionActionsCard: React.FC<Props> = ({ formIdentifier }) => {
         >
           View Published Form
         </ButtonLink>
-        {externalFormObjectKey && (
+        {/* In Dev only, expose link to external form preview. This is not available in non-dev environments. */}
+        {externalFormObjectKey && import.meta.env.MODE === 'development' && (
           <ButtonLink
-            // TODO: DEV ONLY
-            to={`https://hmis-warehouse.dev.test/hmis_external_api/external_forms/${externalFormObjectKey}`}
-            // variant={hasDraft ? 'outlined' : 'contained'}
+            to={`/hmis_external_api/external_forms/${externalFormObjectKey}`}
             openInNew
             fullWidth
+            Icon={OpenInNewIcon}
             disabled={!isPublished}
           >
-            View External Form Preview
+            External Form Preview
           </ButtonLink>
         )}
         {isPublished && (

--- a/src/modules/admin/components/forms/FormDefinitionDetailPage.tsx
+++ b/src/modules/admin/components/forms/FormDefinitionDetailPage.tsx
@@ -65,6 +65,11 @@ const FormDefinitionDetailPage = () => {
                 <CommonLabeledTextBlock title='Form ID'>
                   {formIdentifier.identifier}
                 </CommonLabeledTextBlock>
+                {formIdentifier.displayVersion?.externalFormObjectKey && (
+                  <CommonLabeledTextBlock title='External Form Key'>
+                    {formIdentifier.displayVersion.externalFormObjectKey}
+                  </CommonLabeledTextBlock>
+                )}
                 <CommonLabeledTextBlock title='Form Type'>
                   <Chip
                     size='small'

--- a/src/modules/admin/components/forms/FormDefinitionDetailPage.tsx
+++ b/src/modules/admin/components/forms/FormDefinitionDetailPage.tsx
@@ -13,7 +13,7 @@ import FormDefinitionActionsCard from '@/modules/admin/components/forms/FormDefi
 import FormStatusText from '@/modules/admin/components/forms/FormStatusText';
 import HmisEnum from '@/modules/hmis/components/HmisEnum';
 import { HmisEnums } from '@/types/gqlEnums';
-import { useGetFormIdentifierDetailsQuery } from '@/types/gqlTypes';
+import { FormRole, useGetFormIdentifierDetailsQuery } from '@/types/gqlTypes';
 
 const FormDefinitionDetailPage = () => {
   const { identifier } = useSafeParams() as {
@@ -65,11 +65,6 @@ const FormDefinitionDetailPage = () => {
                 <CommonLabeledTextBlock title='Form ID'>
                   {formIdentifier.identifier}
                 </CommonLabeledTextBlock>
-                {formIdentifier.displayVersion?.externalFormObjectKey && (
-                  <CommonLabeledTextBlock title='External Form Key'>
-                    {formIdentifier.displayVersion.externalFormObjectKey}
-                  </CommonLabeledTextBlock>
-                )}
                 <CommonLabeledTextBlock title='Form Type'>
                   <Chip
                     size='small'
@@ -85,6 +80,18 @@ const FormDefinitionDetailPage = () => {
                 <CommonLabeledTextBlock title='Form Status'>
                   <FormStatusText identifier={formIdentifier} />
                 </CommonLabeledTextBlock>
+                {formIdentifier.displayVersion.role ===
+                  FormRole.ExternalForm && (
+                  <CommonLabeledTextBlock title='External Form Key'>
+                    {formIdentifier.displayVersion.externalFormObjectKey ? (
+                      formIdentifier.displayVersion.externalFormObjectKey
+                    ) : (
+                      <Typography variant='body2' color='error.dark'>
+                        Contact support to configure
+                      </Typography>
+                    )}
+                  </CommonLabeledTextBlock>
+                )}
               </Stack>
             </CommonCard>
           </Grid>

--- a/src/modules/admin/components/forms/FormDefinitionDetailPage.tsx
+++ b/src/modules/admin/components/forms/FormDefinitionDetailPage.tsx
@@ -32,12 +32,13 @@ const FormDefinitionDetailPage = () => {
   if (!formIdentifier && loading) return <Loading />;
   if (!formIdentifier) return <NotFound />;
 
+  // FormDefinition used for "display" in configuration tool,
+  // which is either the published version or the most recent version (if no published version exists)
+  const { displayVersion } = formIdentifier;
+
   return (
     <>
-      <PageTitle
-        overlineText='Selected Form'
-        title={formIdentifier.displayVersion.title}
-      />
+      <PageTitle overlineText='Selected Form' title={displayVersion.title} />
       <Stack gap={2}>
         <Grid container spacing={2}>
           <Grid item xs={12} md={8}>
@@ -72,7 +73,7 @@ const FormDefinitionDetailPage = () => {
                     label={
                       <HmisEnum
                         enumMap={HmisEnums.FormRole}
-                        value={formIdentifier.displayVersion.role}
+                        value={displayVersion.role}
                       />
                     }
                   />
@@ -80,11 +81,10 @@ const FormDefinitionDetailPage = () => {
                 <CommonLabeledTextBlock title='Form Status'>
                   <FormStatusText identifier={formIdentifier} />
                 </CommonLabeledTextBlock>
-                {formIdentifier.displayVersion.role ===
-                  FormRole.ExternalForm && (
+                {displayVersion.role === FormRole.ExternalForm && (
                   <CommonLabeledTextBlock title='External Form Key'>
-                    {formIdentifier.displayVersion.externalFormObjectKey ? (
-                      formIdentifier.displayVersion.externalFormObjectKey
+                    {displayVersion.externalFormObjectKey ? (
+                      displayVersion.externalFormObjectKey
                     ) : (
                       <Typography variant='body2' color='error.dark'>
                         Contact support to configure
@@ -100,9 +100,9 @@ const FormDefinitionDetailPage = () => {
           </Grid>
         </Grid>
         <FormRulesCard
-          formId={formIdentifier.displayVersion.id}
-          formTitle={formIdentifier.displayVersion.title}
-          formRole={formIdentifier.displayVersion.role}
+          formId={displayVersion.id}
+          formTitle={displayVersion.title}
+          formRole={displayVersion.role}
           managedInVersionControl={formIdentifier.managedInVersionControl}
         />
         <CommonCard

--- a/src/types/gqlObjects.ts
+++ b/src/types/gqlObjects.ts
@@ -4371,6 +4371,10 @@ export const HmisObjectSchemas: GqlSchema[] = [
         },
       },
       {
+        name: 'externalFormObjectKey',
+        type: { kind: 'SCALAR', name: 'String', ofType: null },
+      },
+      {
         name: 'id',
         type: {
           kind: 'NON_NULL',

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -3616,6 +3616,8 @@ export type FormDefinition = {
   dateCreated: Scalars['ISO8601DateTime']['output'];
   dateUpdated: Scalars['ISO8601DateTime']['output'];
   definition: FormDefinitionJson;
+  /** External object key, only present for External Form role */
+  externalFormObjectKey?: Maybe<Scalars['String']['output']>;
   formRules: FormRulesPaginated;
   id: Scalars['ID']['output'];
   identifier: Scalars['String']['output'];
@@ -33847,6 +33849,7 @@ export type FormIdentifierDetailsFragment = {
   };
   displayVersion: {
     __typename?: 'FormDefinition';
+    externalFormObjectKey?: string | null;
     id: string;
     role: FormRole;
     title: string;
@@ -35112,6 +35115,7 @@ export type PublishFormDefinitionMutation = {
       };
       displayVersion: {
         __typename?: 'FormDefinition';
+        externalFormObjectKey?: string | null;
         id: string;
         role: FormRole;
         title: string;
@@ -37361,6 +37365,7 @@ export type GetFormIdentifierDetailsQuery = {
     };
     displayVersion: {
       __typename?: 'FormDefinition';
+      externalFormObjectKey?: string | null;
       id: string;
       role: FormRole;
       title: string;
@@ -51161,6 +51166,7 @@ export const FormIdentifierDetailsFragmentDoc = gql`
       canDuplicateForm
     }
     displayVersion {
+      externalFormObjectKey
       ...FormDefinitionMetadata
     }
     draftVersion {


### PR DESCRIPTION
## Description

Summary of changes:
* display external object key for External Form roles
* in development, link to preview page

<img width="1178" height="413" alt="Screenshot 2026-01-06 at 11 06 44 AM" src="https://github.com/user-attachments/assets/5da6629c-9b58-4b36-8abd-3af9d9a664bd" />

Depends on hmis-warehouse PR: https://github.com/greenriver/hmis-warehouse/pull/6138

How to test: create an external form, publish it, set external form object key in DB, and preview

Ticket for future work to support _setting_ the object key: https://github.com/open-path/Green-River/issues/6550


## Type of change
new feature

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have used Axe DevTools to scan for accessibility issues (or not applicable)
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
