### PR TITLE
Pass additional fields when requesting AHA score

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -37616,6 +37616,38 @@
                 "defaultValue": null,
                 "isDeprecated": false,
                 "deprecationReason": null
+              },
+              {
+                "name": "lookupCatalyst",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "lookupReason",
+                "description": null,
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
               }
             ],
             "type": {

--- a/src/api/operations/aha.graphql
+++ b/src/api/operations/aha.graphql
@@ -1,5 +1,13 @@
-mutation FetchAhaScore($clientId: ID!) {
-  fetchAhaScore(clientId: $clientId) {
+mutation FetchAhaScore(
+  $clientId: ID!
+  $lookupCatalyst: String
+  $lookupReason: [String!]
+) {
+  fetchAhaScore(
+    clientId: $clientId
+    lookupCatalyst: $lookupCatalyst
+    lookupReason: $lookupReason
+  ) {
     score
     mciQualityIndicator
     dwClientId

--- a/src/modules/external/aha/components/AhaScore.tsx
+++ b/src/modules/external/aha/components/AhaScore.tsx
@@ -8,8 +8,17 @@ import ErrorAlert from '@/modules/errors/components/ErrorAlert';
 import { emptyErrorState, ErrorState, hasErrors } from '@/modules/errors/util';
 import RequiredLabel from '@/modules/form/components/RequiredLabel';
 import { useDynamicFieldWatchValues } from '@/modules/form/hooks/rhf/useDynamicFieldWatchValues';
-import { ChangeType, GroupItemComponentProps } from '@/modules/form/types';
-import { AhaFailedReason, useFetchAhaScoreMutation } from '@/types/gqlTypes';
+import {
+  ChangeType,
+  GroupItemComponentProps,
+  isPickListOption,
+  isPickListOptionArray,
+} from '@/modules/form/types';
+import {
+  AhaFailedReason,
+  PickListOption,
+  useFetchAhaScoreMutation,
+} from '@/types/gqlTypes';
 
 /**
  * AHA Score Component
@@ -64,6 +73,11 @@ const DW_CLIENT_LINK_ID = 'aha_dw_client_id';
 // Generator of the score, always 'AHA'. Only present if the API call was successful.
 const GENERATOR_LINK_ID = 'aha_generator';
 
+// Optional fields, from elsewhere in the form.
+// If present, pass these form values to the backend when calculating the score.
+const LOOKUP_CATALYST_LINK_ID = 'lookup_catalyst';
+const LOOKUP_REASON_LINK_ID = 'reason_for_aha_lookup';
+
 const EXPECTED_LINK_IDS = [
   SCORE_LINK_ID,
   MCI_QUALITY_INDICATOR_LINK_ID,
@@ -89,10 +103,39 @@ const AhaScore = ({
   const [ahaFailedReason, setAhaFailedReason] = useState<
     AhaFailedReason | undefined | null
   >();
-  // Use RHF to watch the current value of the score field.
-  // This is to disable the fetch button after unlocking an assessment that's already fetched the score.
-  const values = useDynamicFieldWatchValues([SCORE_LINK_ID]);
+
+  // Use RHF to watch the current value of the following fields:
+  // - score: to disable the fetch button after unlocking an assessment that's already fetched the score.
+  // - lookup reason/lookup catalyst: to disable fetch when these haven't been provided yet, and to pass the values to the backend when calculating the score.
+  const values = useDynamicFieldWatchValues([
+    SCORE_LINK_ID,
+    LOOKUP_REASON_LINK_ID,
+    LOOKUP_CATALYST_LINK_ID,
+  ]);
   const scoreValue = values[SCORE_LINK_ID];
+  const { lookupCatalyst, lookupReason, requireCatalystAndReason } =
+    useMemo(() => {
+      const linkIds = Object.keys(handlers?.itemMap || {});
+      const formHasCatalystAndReason =
+        linkIds.includes(LOOKUP_CATALYST_LINK_ID) &&
+        linkIds.includes(LOOKUP_REASON_LINK_ID);
+
+      const catalystPickListOption = values[LOOKUP_CATALYST_LINK_ID];
+      const lookupCatalyst = isPickListOption(catalystPickListOption)
+        ? catalystPickListOption?.code
+        : undefined;
+
+      const reasonPickListOptions = values[LOOKUP_REASON_LINK_ID]; // reason is multi select, so expect an array of pick list options
+      const lookupReason = isPickListOptionArray(reasonPickListOptions)
+        ? reasonPickListOptions?.map((o: PickListOption) => o.code)
+        : undefined;
+
+      return {
+        lookupCatalyst,
+        lookupReason,
+        requireCatalystAndReason: formHasCatalystAndReason,
+      };
+    }, [values, handlers?.itemMap]);
 
   // If client has no score (-1 is returned), hasScore is false and the button stays enabled
   const hasScore =
@@ -105,6 +148,8 @@ const AhaScore = ({
   const [fetchAha, { loading }] = useFetchAhaScoreMutation({
     variables: {
       clientId: clientId,
+      lookupCatalyst: lookupCatalyst,
+      lookupReason: lookupReason,
     },
     onCompleted: (data) => {
       const errors = data.fetchAhaScore?.errors || [];
@@ -136,7 +181,14 @@ const AhaScore = ({
     },
   });
 
-  const hasRequiredContext = !!clientId && clientId !== DUMMY_CLIENT_ID;
+  // Disable the fetch button if:
+  // - we don't have a client ID,
+  // - this is a preview env with a dummy client ID,
+  // - or this form requires lookup catalyst and reason, and they are not filled out yet
+  const hasRequiredContext =
+    !!clientId &&
+    clientId !== DUMMY_CLIENT_ID &&
+    (requireCatalystAndReason ? lookupCatalyst && lookupReason : true);
 
   const handleFetch = useCallback(() => {
     if (hasRequiredContext) {

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -5246,6 +5246,8 @@ export type MutationDeleteUnitsArgs = {
 
 export type MutationFetchAhaScoreArgs = {
   clientId: Scalars['ID']['input'];
+  lookupCatalyst?: InputMaybe<Scalars['String']['input']>;
+  lookupReason?: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
 export type MutationJoinHouseholdArgs = {
@@ -9394,6 +9396,10 @@ export type GetRootPermissionsQuery = {
 
 export type FetchAhaScoreMutationVariables = Exact<{
   clientId: Scalars['ID']['input'];
+  lookupCatalyst?: InputMaybe<Scalars['String']['input']>;
+  lookupReason?: InputMaybe<
+    Array<Scalars['String']['input']> | Scalars['String']['input']
+  >;
 }>;
 
 export type FetchAhaScoreMutation = {
@@ -52125,8 +52131,16 @@ export type GetRootPermissionsQueryResult = Apollo.QueryResult<
   GetRootPermissionsQueryVariables
 >;
 export const FetchAhaScoreDocument = gql`
-  mutation FetchAhaScore($clientId: ID!) {
-    fetchAhaScore(clientId: $clientId) {
+  mutation FetchAhaScore(
+    $clientId: ID!
+    $lookupCatalyst: String
+    $lookupReason: [String!]
+  ) {
+    fetchAhaScore(
+      clientId: $clientId
+      lookupCatalyst: $lookupCatalyst
+      lookupReason: $lookupReason
+    ) {
       score
       mciQualityIndicator
       dwClientId
@@ -52158,6 +52172,8 @@ export type FetchAhaScoreMutationFn = Apollo.MutationFunction<
  * const [fetchAhaScoreMutation, { data, loading, error }] = useFetchAhaScoreMutation({
  *   variables: {
  *      clientId: // value for 'clientId'
+ *      lookupCatalyst: // value for 'lookupCatalyst'
+ *      lookupReason: // value for 'lookupReason'
  *   },
  * });
  */


### PR DESCRIPTION
## Description

Summary of changes: Update the custom `AhaScore` form component to pass additional fields when fetching the score.

[//]: # 'remove if not applicable'
Depends on hmis-warehouse PR: https://github.com/greenriver/hmis-warehouse/pull/6166

[//]: # 'remove if not applicable'
How to test: See linked ticket

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have used Axe DevTools to scan for accessibility issues (or not applicable)
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
