### PR TITLE
Remove deprecated field otherHouseholdMemberNames from schema

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -8032,30 +8032,6 @@
             "deprecationReason": null
           },
           {
-            "name": "otherHouseholdMemberNames",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": true,
-            "deprecationReason": "Use household_members field instead"
-          },
-          {
             "name": "projectName",
             "description": null,
             "args": [],

--- a/src/types/gqlObjects.ts
+++ b/src/types/gqlObjects.ts
@@ -1376,22 +1376,6 @@ export const HmisObjectSchemas: GqlSchema[] = [
         },
       },
       {
-        name: 'otherHouseholdMemberNames',
-        type: {
-          kind: 'NON_NULL',
-          name: null,
-          ofType: {
-            kind: 'LIST',
-            name: null,
-            ofType: {
-              kind: 'NON_NULL',
-              name: null,
-              ofType: { kind: 'SCALAR', name: 'String', ofType: null },
-            },
-          },
-        },
-      },
-      {
         name: 'projectName',
         type: {
           kind: 'NON_NULL',

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -1037,8 +1037,6 @@ export type CeReferralSourceEnrollment = {
   householdSize: Scalars['Int']['output'];
   id: Scalars['ID']['output'];
   inProgress: Scalars['Boolean']['output'];
-  /** @deprecated Use household_members field instead */
-  otherHouseholdMemberNames: Array<Scalars['String']['output']>;
   projectName: Scalars['String']['output'];
   projectType: ProjectType;
   relationshipToHoH: RelationshipToHoH;


### PR DESCRIPTION
## Description

Summary of changes: Fully remove from schema field that was removed from use in 198.

[//]: # 'remove if not applicable'
Depends on hmis-warehouse PR: https://github.com/greenriver/hmis-warehouse/pull/6200

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Code clean-up

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have used Axe DevTools to scan for accessibility issues (or not applicable)
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (eslint)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
