### PR TITLE
Add projectId local constant for project form

### DIFF
--- a/src/modules/projectAdministration/components/CreateProjectPage.tsx
+++ b/src/modules/projectAdministration/components/CreateProjectPage.tsx
@@ -2,6 +2,7 @@ import { Typography } from '@mui/material';
 import { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 
+import { useLocalConstantsForProjectForm } from '../hooks/useLocalConstantsForProjectForm';
 import { useOrganizationCrumbs } from '../hooks/useOrganizationCrumbs';
 import BasicBreadcrumbPageLayout from '@/components/layout/BasicBreadcrumbPageLayout';
 import NotFound from '@/components/pages/NotFound';
@@ -9,7 +10,7 @@ import useSafeParams from '@/hooks/useSafeParams';
 import EditRecord from '@/modules/form/components/EditRecord';
 import { cache } from '@/providers/apolloClient';
 import { Routes } from '@/routes/routes';
-import { RecordFormRole, ProjectAllFieldsFragment } from '@/types/gqlTypes';
+import { ProjectAllFieldsFragment, RecordFormRole } from '@/types/gqlTypes';
 import { generateSafePath } from '@/utils/pathEncoding';
 
 const CreateProjectPage = () => {
@@ -32,6 +33,8 @@ const CreateProjectPage = () => {
     [navigate, organizationId]
   );
 
+  const localConstants = useLocalConstantsForProjectForm();
+
   if (!crumbs) return <NotFound />;
 
   return (
@@ -40,6 +43,7 @@ const CreateProjectPage = () => {
         formRole={RecordFormRole.Project}
         onCompleted={onCompleted}
         inputVariables={{ organizationId }}
+        localConstants={localConstants}
         FormActionProps={{ submitButtonText: 'Create Project' }}
         title={
           <Typography component='h1' variant='h3' sx={{ mt: 1, mb: 3 }}>

--- a/src/modules/projectAdministration/components/EditProjectPage.tsx
+++ b/src/modules/projectAdministration/components/EditProjectPage.tsx
@@ -5,6 +5,7 @@ import { useNavigate } from 'react-router-dom';
 import DeleteMutationButton from '@/modules/dataFetching/components/DeleteMutationButton';
 import EditRecord from '@/modules/form/components/EditRecord';
 import { ProjectPermissionsFilter } from '@/modules/permissions/PermissionsFilters';
+import { useLocalConstantsForProjectForm } from '@/modules/projectAdministration/hooks/useLocalConstantsForProjectForm';
 import { useProjectDashboardContext } from '@/modules/projects/components/ProjectDashboard';
 import { ProjectFormTitle } from '@/modules/projects/components/ProjectOverviewPage';
 import { cache } from '@/providers/apolloClient';
@@ -50,11 +51,14 @@ const EditProjectPage = () => {
     navigate(generateSafePath(Routes.ORGANIZATION, { organizationId }));
   }, [project, navigate]);
 
+  const localConstants = useLocalConstantsForProjectForm(project);
+
   return (
     <EditRecord<ProjectAllFieldsFragment>
       formRole={RecordFormRole.Project}
       record={project}
       onCompleted={onCompleted}
+      localConstants={localConstants}
       FormActionProps={{
         onDiscard: generateSafePath(Routes.PROJECT, {
           projectId: project?.id,

--- a/src/modules/projectAdministration/hooks/useLocalConstantsForProjectForm.tsx
+++ b/src/modules/projectAdministration/hooks/useLocalConstantsForProjectForm.tsx
@@ -1,0 +1,18 @@
+import { AlwaysPresentLocalConstants } from '@/modules/form/util/formUtil';
+import { ProjectAllFieldsFragment } from '@/types/gqlTypes';
+
+export const useLocalConstantsForProjectForm = (
+  project?: ProjectAllFieldsFragment | null
+) => {
+  if (!project) {
+    // For Project creation, projectId is undefined
+    return {
+      ...AlwaysPresentLocalConstants,
+    };
+  }
+
+  return {
+    projectId: project.id,
+    ...AlwaysPresentLocalConstants,
+  };
+};

--- a/src/modules/projectAdministration/hooks/useLocalConstantsForProjectForm.tsx
+++ b/src/modules/projectAdministration/hooks/useLocalConstantsForProjectForm.tsx
@@ -4,15 +4,8 @@ import { ProjectAllFieldsFragment } from '@/types/gqlTypes';
 export const useLocalConstantsForProjectForm = (
   project?: ProjectAllFieldsFragment | null
 ) => {
-  if (!project) {
-    // For Project creation, projectId is undefined
-    return {
-      ...AlwaysPresentLocalConstants,
-    };
-  }
-
   return {
-    projectId: project.id,
+    projectId: project?.id || undefined, // For Project creation, projectId is undefined
     ...AlwaysPresentLocalConstants,
   };
 };


### PR DESCRIPTION
## Description

Summary of changes:
- Add the `projectId` local constant when rendering the project form.
- This allows the form definition to have dependent conditions that show different items depending on whether we are creating a new project or editing an existing one.
- Inspired by the existing pattern on the [Client form](https://github.com/greenriver/hmis-frontend/blob/c3d9a86509f8a785d25c53a798b0a3b10f366bf1/src/modules/client/hooks/useClientFormDialog.tsx#L13-L34).

[//]: # 'remove if not applicable'
Relates to hmis-warehouse PR: https://github.com/greenriver/hmis-warehouse/pull/6212 (still in draft). This PR should actually be merged in a prior release relative to that PR, so that when those changes to the Project form are deployed, they work correctly with the deployed frontend code in the previous release.

[//]: # 'remove if not applicable'
How to test:
- Update the project form with a condition that depends on the `projectId` local constant. [Example in draft PR linked above](https://github.com/greenriver/hmis-warehouse/pull/6212/changes#diff-18bfb40924e6ad3c2302ed2f0db2403e19ad66318184e7002b2a6557e3ef43c3R7-R12)
- Open the form for creating a new project. The fields should appear
- Open the form for editing a new project. The fields should not appear.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
New feature

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have used Axe DevTools to scan for accessibility issues (or not applicable)
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
