### PR TITLE
Use ceParticipationServices field for displaying ce participation services provided

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -6254,6 +6254,30 @@
             "deprecationReason": null
           },
           {
+            "name": "ceParticipationServices",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "CeParticipationServices",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "ceParticipationStatusEndDate",
             "description": null,
             "args": [],
@@ -6298,8 +6322,8 @@
               "name": "NoYes",
               "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "Use ceParticipationServices instead"
           },
           {
             "name": "dateCreated",
@@ -6346,8 +6370,8 @@
               "name": "NoYes",
               "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "Use ceParticipationServices instead"
           },
           {
             "name": "housingAssessment",
@@ -6358,8 +6382,8 @@
               "name": "NoYes",
               "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "Use ceParticipationServices instead"
           },
           {
             "name": "id",
@@ -6386,8 +6410,8 @@
               "name": "NoYes",
               "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "Use ceParticipationServices instead"
           },
           {
             "name": "receivesReferrals",
@@ -6417,6 +6441,42 @@
         "inputFields": null,
         "interfaces": [],
         "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "CeParticipationServices",
+        "description": null,
+        "isOneOf": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "CRISIS_ASSESSMENT",
+            "description": "Shelter Assessment, Screening, and/or Referral",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "DIRECT_SERVICES",
+            "description": "Direct Services (search and/or placement support)",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "HOUSING_ASSESSMENT",
+            "description": "Housing Assessment, Screening, and/or Referral",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "PREVENTION_ASSESSMENT",
+            "description": "Homelessness Prevention Assessment, Screening, and/or Referral",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
         "possibleTypes": null
       },
       {

--- a/src/api/operations/project.fragments.graphql
+++ b/src/api/operations/project.fragments.graphql
@@ -118,10 +118,7 @@ fragment CeParticipationFields on CeParticipation {
   accessPoint
   ceParticipationStatusStartDate
   ceParticipationStatusEndDate
-  crisisAssessment
-  directServices
-  housingAssessment
-  preventionAssessment
+  ceParticipationServices
   receivesReferrals
   dateCreated
   dateUpdated

--- a/src/modules/projectAdministration/components/CeParticipationsPage.tsx
+++ b/src/modules/projectAdministration/components/CeParticipationsPage.tsx
@@ -12,6 +12,7 @@ import { HudRecordMetadataHistoryColumn } from '@/modules/hmis/components/HudRec
 import { parseAndFormatDateRange, yesNo } from '@/modules/hmis/hmisUtil';
 import { useProjectDashboardContext } from '@/modules/projects/components/ProjectDashboard';
 import { cache } from '@/providers/apolloClient';
+import { HmisEnums } from '@/types/gqlEnums';
 import {
   CeParticipationFieldsFragment,
   DeleteCeParticipationDocument,
@@ -40,41 +41,23 @@ const columns: ColumnDef<CeParticipationFieldsFragment>[] = [
       yesNo(accessPoint),
   },
   {
-    header: 'Assessments',
-    key: 'assessments',
+    header: 'Provided by Project',
+    key: 'servicesProvided',
     render: ({
       accessPoint,
-      preventionAssessment,
-      crisisAssessment,
-      housingAssessment,
+      ceParticipationServices,
     }: CeParticipationFieldsFragment) => {
-      const assmts = [];
-      if (preventionAssessment === NoYes.Yes) {
-        assmts.push('Prevention Assessment');
-      }
-      if (crisisAssessment === NoYes.Yes) {
-        assmts.push('Crisis Assessment');
-      }
-      if (housingAssessment === NoYes.Yes) {
-        assmts.push('Housing Assessment');
-      }
-      if (assmts.length === 0) {
-        return accessPoint === NoYes.Yes ? 'No Assessments' : 'N/A';
+      if (ceParticipationServices.length === 0) {
+        return accessPoint === NoYes.Yes ? 'Not Specified' : 'N/A';
       }
       return (
         <Stack direction='column'>
-          {assmts.map((str) => (
-            <span>{str}</span>
+          {ceParticipationServices.map((str) => (
+            <span>{HmisEnums.CeParticipationServices[str]}</span>
           ))}
         </Stack>
       );
     },
-  },
-  {
-    header: 'Direct Services',
-    key: 'directServices',
-    render: ({ accessPoint, directServices }: CeParticipationFieldsFragment) =>
-      yesNo(directServices, accessPoint === NoYes.Yes ? 'Unknown' : 'N/A'),
   },
   {
     header: 'Receives Referrals',

--- a/src/types/gqlEnums.ts
+++ b/src/types/gqlEnums.ts
@@ -90,6 +90,13 @@ export const HmisEnums = {
     DATE_AVAILABLE_LATEST_FIRST: 'Date Available, latest first',
   },
   CeOpportunityStatus: { closed: 'Closed', locked: 'Locked', open: 'Open' },
+  CeParticipationServices: {
+    CRISIS_ASSESSMENT: 'Shelter Assessment, Screening, and/or Referral',
+    DIRECT_SERVICES: 'Direct Services (search and/or placement support)',
+    HOUSING_ASSESSMENT: 'Housing Assessment, Screening, and/or Referral',
+    PREVENTION_ASSESSMENT:
+      'Homelessness Prevention Assessment, Screening, and/or Referral',
+  },
   CeReferralAuditEventType: {
     ACCEPT_REFERRAL: 'Accepted Referral',
     COMPLETE_STEP: 'Completed Task',

--- a/src/types/gqlObjects.ts
+++ b/src/types/gqlObjects.ts
@@ -1043,6 +1043,26 @@ export const HmisObjectSchemas: GqlSchema[] = [
         type: { kind: 'ENUM', name: 'NoYes', ofType: null },
       },
       {
+        name: 'ceParticipationServices',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: {
+            kind: 'LIST',
+            name: null,
+            ofType: {
+              kind: 'NON_NULL',
+              name: null,
+              ofType: {
+                kind: 'ENUM',
+                name: 'CeParticipationServices',
+                ofType: null,
+              },
+            },
+          },
+        },
+      },
+      {
         name: 'ceParticipationStatusEndDate',
         type: { kind: 'SCALAR', name: 'ISO8601Date', ofType: null },
       },

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -853,20 +853,36 @@ export enum CeOpportunityStatus {
 export type CeParticipation = {
   __typename?: 'CeParticipation';
   accessPoint?: Maybe<NoYes>;
+  ceParticipationServices: Array<CeParticipationServices>;
   ceParticipationStatusEndDate?: Maybe<Scalars['ISO8601Date']['output']>;
   ceParticipationStatusStartDate?: Maybe<Scalars['ISO8601Date']['output']>;
   createdBy?: Maybe<ApplicationUser>;
+  /** @deprecated Use ceParticipationServices instead */
   crisisAssessment?: Maybe<NoYes>;
   dateCreated?: Maybe<Scalars['ISO8601DateTime']['output']>;
   dateDeleted?: Maybe<Scalars['ISO8601DateTime']['output']>;
   dateUpdated?: Maybe<Scalars['ISO8601DateTime']['output']>;
+  /** @deprecated Use ceParticipationServices instead */
   directServices?: Maybe<NoYes>;
+  /** @deprecated Use ceParticipationServices instead */
   housingAssessment?: Maybe<NoYes>;
   id: Scalars['ID']['output'];
+  /** @deprecated Use ceParticipationServices instead */
   preventionAssessment?: Maybe<NoYes>;
   receivesReferrals?: Maybe<NoYes>;
   user?: Maybe<ApplicationUser>;
 };
+
+export enum CeParticipationServices {
+  /** Shelter Assessment, Screening, and/or Referral */
+  CrisisAssessment = 'CRISIS_ASSESSMENT',
+  /** Direct Services (search and/or placement support) */
+  DirectServices = 'DIRECT_SERVICES',
+  /** Housing Assessment, Screening, and/or Referral */
+  HousingAssessment = 'HOUSING_ASSESSMENT',
+  /** Homelessness Prevention Assessment, Screening, and/or Referral */
+  PreventionAssessment = 'PREVENTION_ASSESSMENT',
+}
 
 export type CeParticipationsPaginated = {
   __typename?: 'CeParticipationsPaginated';
@@ -37916,10 +37932,7 @@ export type SubmitFormMutation = {
           accessPoint?: NoYes | null;
           ceParticipationStatusStartDate?: string | null;
           ceParticipationStatusEndDate?: string | null;
-          crisisAssessment?: NoYes | null;
-          directServices?: NoYes | null;
-          housingAssessment?: NoYes | null;
-          preventionAssessment?: NoYes | null;
+          ceParticipationServices: Array<CeParticipationServices>;
           receivesReferrals?: NoYes | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
@@ -43708,10 +43721,7 @@ export type CeParticipationFieldsFragment = {
   accessPoint?: NoYes | null;
   ceParticipationStatusStartDate?: string | null;
   ceParticipationStatusEndDate?: string | null;
-  crisisAssessment?: NoYes | null;
-  directServices?: NoYes | null;
-  housingAssessment?: NoYes | null;
-  preventionAssessment?: NoYes | null;
+  ceParticipationServices: Array<CeParticipationServices>;
   receivesReferrals?: NoYes | null;
   dateCreated?: string | null;
   dateUpdated?: string | null;
@@ -45153,10 +45163,7 @@ export type GetProjectCeParticipationsQuery = {
         accessPoint?: NoYes | null;
         ceParticipationStatusStartDate?: string | null;
         ceParticipationStatusEndDate?: string | null;
-        crisisAssessment?: NoYes | null;
-        directServices?: NoYes | null;
-        housingAssessment?: NoYes | null;
-        preventionAssessment?: NoYes | null;
+        ceParticipationServices: Array<CeParticipationServices>;
         receivesReferrals?: NoYes | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
@@ -52051,10 +52058,7 @@ export const CeParticipationFieldsFragmentDoc = gql`
     accessPoint
     ceParticipationStatusStartDate
     ceParticipationStatusEndDate
-    crisisAssessment
-    directServices
-    housingAssessment
-    preventionAssessment
+    ceParticipationServices
     receivesReferrals
     dateCreated
     dateUpdated


### PR DESCRIPTION
## Description

Summary of changes: use new ceParticipationServices for collection and display of CE Participation fields.

Depends on hmis-warehouse PR: https://github.com/greenriver/hmis-warehouse/pull/6224

<img width="628" height="662" alt="Screenshot 2026-02-09 at 5 27 56 PM" src="https://github.com/user-attachments/assets/a1432770-d538-493f-a8b3-0ceafca84474" />
<img width="1182" height="508" alt="Screenshot 2026-02-09 at 5 27 50 PM" src="https://github.com/user-attachments/assets/36703e12-e12f-433d-95e3-d57537d243e8" />

## Type of change
hud compliance

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have used Axe DevTools to scan for accessibility issues (or not applicable)
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
