### PR TITLE
Fix bugs with new Project initial fields

### DIFF
--- a/src/modules/form/components/ViewRecord.tsx
+++ b/src/modules/form/components/ViewRecord.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 
 import useFormDefinition from '../hooks/useFormDefinition';
-import { PickListArgs, SubmitFormAllowedTypes } from '../types';
+import { LocalConstants, PickListArgs, SubmitFormAllowedTypes } from '../types';
 import { createInitialValuesFromRecord } from '../util/formUtil';
 
 import DynamicView from './viewable/DynamicView';
@@ -14,6 +14,7 @@ export interface ViewRecordProps<RecordType> {
   formRole: RecordFormRole;
   pickListArgs?: PickListArgs;
   projectId?: string; // Project context for fetching form definition
+  localConstants?: LocalConstants; // Local constants for displaying the form view
 }
 
 /**
@@ -25,6 +26,7 @@ const ViewRecord = <RecordType extends SubmitFormAllowedTypes>({
   formRole,
   pickListArgs,
   projectId,
+  localConstants,
 }: ViewRecordProps<RecordType>): JSX.Element => {
   const { formDefinition, itemMap, loading } = useFormDefinition({
     role: formRole,
@@ -50,6 +52,7 @@ const ViewRecord = <RecordType extends SubmitFormAllowedTypes>({
       values={values}
       definition={formDefinition.definition}
       pickListArgs={pickListArgs}
+      localConstants={localConstants}
     />
   );
 };

--- a/src/modules/form/util/formUtil.ts
+++ b/src/modules/form/util/formUtil.ts
@@ -1363,11 +1363,29 @@ const getMappedValue = (
     const value = get(record, keys); // lodash's `get` will return undefined if the field doesn't exist
 
     // Special cases where we DON'T want to alert Sentry if the field can't be resolved on the record.
-    // - imageBlobId and fileBlobId: we pass these fields when first saving a file, but they aren't persisted on the file or returned on a saved file record.
-    // - mciId: similarly, we pass this field to save an MCI ID or indicate that a new one would be created, but it's resolved on `externalIds` on the client record
-    const specialCaseFieldNames = ['fileBlobId', 'imageBlobId', 'mciId'];
+    const specialCaseFieldNames = [
+      // imageBlobId and fileBlobId: we pass these fields when first saving a file, but they aren't persisted on the file or returned on a saved file record.
+      'fileBlobId',
+      'imageBlobId',
+      // mciId: similarly, we pass this field to save an MCI ID or indicate that a new one would be created, but it's resolved on `externalIds` on the client record
+      'mciId',
+      // initial* fields on project: these are persisted on project related records when creating a new project
+      'initialCocCode',
+      'initialGeocode',
+      'initialFunder',
+      'initialOtherFunder',
+      'initialFunderGrantId',
+      'initialHmisParticipationType',
+      'initialCeAccessPoint',
+      'initialCePreventionAssessment',
+      'initialCeCrisisAssessment',
+      'initialCeHousingAssessment',
+      'initialCeDirectServices',
+      'initialCeReceivesReferrals',
+    ];
+
     if (!specialCaseFieldNames.includes(mapping.fieldName)) {
-      // In general, we do want to alert Sentry if the key is missing, to prevent silently swallowing developer errors.
+      // Besides the special cases above, we generally do want to alert Sentry if the key is missing, to prevent silently swallowing developer errors.
       // This would indicate we're not resolving a field that we should be resolving.
       if (isMissingField(record, keys)) {
         handleMissingField(

--- a/src/modules/projects/components/ProjectOverviewPage.tsx
+++ b/src/modules/projects/components/ProjectOverviewPage.tsx
@@ -14,6 +14,7 @@ import {
   parseHmisDateString,
 } from '@/modules/hmis/hmisUtil';
 import { ProjectPermissionsFilter } from '@/modules/permissions/PermissionsFilters';
+import { useLocalConstantsForProjectForm } from '@/modules/projectAdministration/hooks/useLocalConstantsForProjectForm';
 import { ProjectDashboardRoutes } from '@/routes/routes';
 import { ProjectAllFieldsFragment, RecordFormRole } from '@/types/gqlTypes';
 import { generateSafePath } from '@/utils/pathEncoding';
@@ -99,6 +100,7 @@ const ProjectOverviewPage = () => {
   const { project } = useProjectDashboardContext();
   const showDefaultContactCard =
     project.coordinatedEntryFeatures?.supportsReferrals;
+  const localConstants = useLocalConstantsForProjectForm(project);
 
   return (
     <>
@@ -127,7 +129,11 @@ const ProjectOverviewPage = () => {
           <InactiveBanner project={project} />
         </Grid>
         <Grid item xs={12} lg={showDefaultContactCard ? 8 : 12}>
-          <ViewRecord record={project} formRole={RecordFormRole.Project} />
+          <ViewRecord
+            record={project}
+            formRole={RecordFormRole.Project}
+            localConstants={localConstants}
+          />
         </Grid>
         {showDefaultContactCard && (
           <Grid item xs={12} lg={4}>


### PR DESCRIPTION
## Description

Summary of changes:
- Pass project local constants to `ViewRecord` when displaying an existing project in the Project Overview, so it knows not to display the Funding and Participation section.
- Add initial* project fields to the special cases list in `getMappedValue` so we don't alert to Sentry when we can't find those fields on the Project record.
  - I was wondering whether it would be possible to solve this instead with an update to `getItemMap` so that it wouldn't attempt to get a mapped value for a form item that isn't shown, but that seemed like a bigger refactor that would require a lot of testing to verify no regressions in behavior. 

**Targets release-199** because it should go into the release prior to https://github.com/greenriver/hmis-warehouse/pull/6212.

[//]: # 'remove if not applicable'
How to test:
- View a Project Overview, you should not see the "initial" fields in the Funding and Participation section
- View or edit a Project and check the console. You should not see warnings about unresolved fields (and once this is deployed to QA, we should not get a lot of alerts to sentry)

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have used Axe DevTools to scan for accessibility issues (or not applicable)
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [ ] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
