### PR TITLE
Add accessible markup to OpenInNew icon

### DIFF
--- a/src/components/elements/ButtonLink.tsx
+++ b/src/components/elements/ButtonLink.tsx
@@ -1,6 +1,5 @@
-import { SvgIconComponent } from '@mui/icons-material';
-import { Button, ButtonProps } from '@mui/material';
-import { forwardRef, Ref } from 'react';
+import { Button, ButtonProps, SvgIconProps } from '@mui/material';
+import { ComponentType, forwardRef, Ref } from 'react';
 import { Link, LinkProps } from 'react-router-dom';
 
 export type ButtonLinkProps = Omit<
@@ -9,7 +8,7 @@ export type ButtonLinkProps = Omit<
 > &
   LinkProps & {
     leftAlign?: boolean;
-    Icon?: SvgIconComponent;
+    Icon?: ComponentType<SvgIconProps>;
     openInNew?: boolean;
   };
 

--- a/src/components/elements/CommonMenuButton.tsx
+++ b/src/components/elements/CommonMenuButton.tsx
@@ -1,4 +1,3 @@
-import { SvgIconComponent } from '@mui/icons-material';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import {
   Button,
@@ -9,10 +8,11 @@ import {
   Menu,
   MenuItem,
   MenuProps,
+  SvgIconProps,
   Stack,
   Typography,
 } from '@mui/material';
-import { ReactNode, useState } from 'react';
+import { ComponentType, ReactNode, useState } from 'react';
 import { To } from 'react-router-dom';
 
 import RouterLink from './RouterLink';
@@ -22,7 +22,7 @@ import { LocationState } from '@/routes/routeUtil';
 export type CommonMenuItem = {
   key: string;
   title: ReactNode;
-  Icon?: SvgIconComponent;
+  Icon?: ComponentType<SvgIconProps>;
   to?: To;
   onClick?: VoidFunction;
   divider?: boolean;

--- a/src/components/elements/ExternalLink.tsx
+++ b/src/components/elements/ExternalLink.tsx
@@ -1,6 +1,6 @@
 import { Link, LinkProps, Typography } from '@mui/material';
 import React from 'react';
-import { OpenInNewIcon } from '@/components/elements/SemanticIcons';
+import NewTabIcon from '@/components/elements/NewTabIcon';
 
 const ExternalLink: React.FC<LinkProps> = ({ children, ...props }) => {
   return (
@@ -14,7 +14,7 @@ const ExternalLink: React.FC<LinkProps> = ({ children, ...props }) => {
           textDecoration: 'inherit',
         }}
       >
-        {children} <OpenInNewIcon fontSize='inherit' />
+        {children} <NewTabIcon />
       </Typography>
     </Link>
   );

--- a/src/components/elements/NewTabIcon.tsx
+++ b/src/components/elements/NewTabIcon.tsx
@@ -1,0 +1,20 @@
+import { Box, SvgIconProps } from '@mui/material';
+import React from 'react';
+import { OpenInNewIcon } from '@/components/elements/SemanticIcons';
+import { customVisuallyHidden } from '@/config/theme';
+
+/**
+ * OpenInNewIcon with visually hidden "(opens in new tab)" text for accessibility.
+ * Use wherever a link or button opens in a new tab.
+ */
+const NewTabIcon: React.FC<SvgIconProps> = (props) => (
+  <>
+    <OpenInNewIcon fontSize='inherit' {...props} />
+    <Box component='span' sx={customVisuallyHidden}>
+      {' '}
+      (opens in new tab)
+    </Box>
+  </>
+);
+
+export default NewTabIcon;

--- a/src/components/elements/RouterLink.tsx
+++ b/src/components/elements/RouterLink.tsx
@@ -1,17 +1,16 @@
-import { SvgIconComponent } from '@mui/icons-material';
-import OpenInNewIcon from '@mui/icons-material/OpenInNew';
-import { Link, LinkProps, Stack } from '@mui/material';
-import { forwardRef } from 'react';
+import { Link, LinkProps, Stack, SvgIconProps } from '@mui/material';
+import { ComponentType, forwardRef } from 'react';
 import {
   Link as ReactRouterLink,
   LinkProps as ReactRouterLinkProps,
 } from 'react-router-dom';
+import NewTabIcon from '@/components/elements/NewTabIcon';
 
 export type RouterLinkProps = Omit<LinkProps, 'href'> &
   ReactRouterLinkProps & {
     plain?: boolean;
     openInNew?: boolean;
-    Icon?: SvgIconComponent | false; // pass false to omit icon for openInNew
+    Icon?: ComponentType<SvgIconProps> | false; // pass false to omit icon for openInNew
   };
 
 const RouterLink = forwardRef<HTMLLinkElement, RouterLinkProps>(
@@ -39,7 +38,7 @@ const RouterLink = forwardRef<HTMLLinkElement, RouterLinkProps>(
           >
             {children}
             {openInNew && Icon !== false ? (
-              <OpenInNewIcon fontSize='inherit' />
+              <NewTabIcon fontSize='inherit' />
             ) : (
               Icon && <Icon fontSize='inherit' />
             )}

--- a/src/components/layout/nav/UserMenu.tsx
+++ b/src/components/layout/nav/UserMenu.tsx
@@ -18,7 +18,7 @@ import {
   usePopupState,
 } from 'material-ui-popup-state/hooks';
 import React, { ReactNode, useMemo } from 'react';
-import { OpenInNewIcon } from '@/components/elements/SemanticIcons';
+import NewTabIcon from '@/components/elements/NewTabIcon';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import useAuth from '@/modules/auth/hooks/useAuth';
 import { useHmisAppSettings } from '@/modules/hmisAppSettings/useHmisAppSettings';
@@ -52,7 +52,7 @@ const UserMenu: React.FC = () => {
           key='manage account'
         >
           <ListItemIcon>
-            <OpenInNewIcon fontSize='small' />
+            <NewTabIcon fontSize='small' />
           </ListItemIcon>
           <ListItemText>Manage Account</ListItemText>
         </MenuItem>
@@ -68,7 +68,7 @@ const UserMenu: React.FC = () => {
           key='warehouse'
         >
           <ListItemIcon>
-            <OpenInNewIcon fontSize='small' />
+            <NewTabIcon fontSize='small' />
           </ListItemIcon>
           <ListItemText>{warehouseName}</ListItemText>
         </MenuItem>

--- a/src/modules/admin/components/forms/FormDefinitionActionsCard.tsx
+++ b/src/modules/admin/components/forms/FormDefinitionActionsCard.tsx
@@ -5,7 +5,7 @@ import { generatePath } from 'react-router-dom';
 import ButtonLink from '@/components/elements/ButtonLink';
 import CommonCard from '@/components/elements/CommonCard';
 
-import { OpenInNewIcon } from '@/components/elements/SemanticIcons';
+import NewTabIcon from '@/components/elements/NewTabIcon';
 import DuplicateFormButton from '@/modules/admin/components/forms/DuplicateFormButton';
 import EditFormButton from '@/modules/admin/components/forms/EditFormButton';
 import {
@@ -62,7 +62,7 @@ const FormDefinitionActionsCard: React.FC<Props> = ({ formIdentifier }) => {
             to={`/hmis_external_api/external_forms/${externalFormObjectKey}`}
             openInNew
             fullWidth
-            Icon={OpenInNewIcon}
+            Icon={NewTabIcon}
             disabled={!isPublished}
           >
             External Form Preview

--- a/src/modules/admin/components/users/UserActionsMenu.tsx
+++ b/src/modules/admin/components/users/UserActionsMenu.tsx
@@ -53,9 +53,9 @@ const UserActionsMenu: React.FC<Props> = ({
         key: 'edit',
         to: user.manageAccountUrl,
         title: 'Edit Account',
-        Icon: OpenInNewIcon,
+        Icon: OpenInNewIcon, // no need to use accessible NewTabIcon here, because we override the aria label anyway.
         openInNew: true,
-        ariaLabel: `Edit ${user.name}'s Account in the Warehouse`,
+        ariaLabel: `Edit ${user.name}'s Account in the Warehouse (opens in new tab)`,
       });
     }
     return items;

--- a/src/modules/ce/components/unit/SourceEnrollmentCard.tsx
+++ b/src/modules/ce/components/unit/SourceEnrollmentCard.tsx
@@ -4,6 +4,7 @@ import ButtonLink from '@/components/elements/ButtonLink';
 import CommonSelectableCard from '@/components/elements/CommonSelectableCard';
 import CommonTextWithIcon from '@/components/elements/CommonTextWithIcon';
 import CommonTruncatedList from '@/components/elements/CommonTruncatedList';
+import NewTabIcon from '@/components/elements/NewTabIcon';
 import RelativeDateDisplay from '@/components/elements/RelativeDateDisplay';
 import RouterLink from '@/components/elements/RouterLink';
 import {
@@ -138,6 +139,7 @@ const SourceEnrollmentCard: React.FC<Props> = ({
                     variant={'contained'}
                     color={'grayscale'}
                     openInNew={true}
+                    Icon={NewTabIcon}
                   >
                     View Assessment
                   </ButtonLink>

--- a/src/modules/household/hooks/useHouseholdMenuActions.tsx
+++ b/src/modules/household/hooks/useHouseholdMenuActions.tsx
@@ -154,7 +154,7 @@ export function useHouseholdMenuActions({
         {
           key: 'open client profile',
           title: 'Open Client Profile',
-          Icon: OpenInNewIcon,
+          Icon: OpenInNewIcon, // no need to use accessible NewTabIcon here, because we override the aria label anyway.
           to: generateSafePath(ClientDashboardRoutes.PROFILE, { clientId }),
           openInNew: true,
           ariaLabel: `Go to  ${clientBriefName(row.client)}'s Client Profile (opens in new tab)`,

--- a/src/modules/household/hooks/useHouseholdMenuActions.tsx
+++ b/src/modules/household/hooks/useHouseholdMenuActions.tsx
@@ -157,7 +157,7 @@ export function useHouseholdMenuActions({
           Icon: OpenInNewIcon,
           to: generateSafePath(ClientDashboardRoutes.PROFILE, { clientId }),
           openInNew: true,
-          ariaLabel: `Go to  ${clientBriefName(row.client)}'s Client Profile`,
+          ariaLabel: `Go to  ${clientBriefName(row.client)}'s Client Profile (opens in new tab)`,
         },
       ];
 

--- a/src/modules/legacyReferrals/components/ProjectReferralPostingPage.tsx
+++ b/src/modules/legacyReferrals/components/ProjectReferralPostingPage.tsx
@@ -5,7 +5,7 @@ import { ProjectReferralPostingForm } from './ProjectReferralPostingForm';
 import ButtonLink from '@/components/elements/ButtonLink';
 import { CommonLabeledTextBlock } from '@/components/elements/CommonLabeledTextBlock';
 import Loading from '@/components/elements/Loading';
-import { OpenInNewIcon } from '@/components/elements/SemanticIcons';
+import NewTabIcon from '@/components/elements/NewTabIcon';
 import TitleCard from '@/components/elements/TitleCard';
 import PageTitle from '@/components/layout/PageTitle';
 import NotFound from '@/components/pages/NotFound';
@@ -84,7 +84,7 @@ const ProjectReferralPostingPage: React.FC = () => {
                 href={fetchPreventionAssessmentReportUrl(
                   referralPosting.referralIdentifier
                 )}
-                endIcon={<OpenInNewIcon />}
+                endIcon={<NewTabIcon />}
               >
                 LINK Prevention Assessment Report
               </Button>

--- a/src/modules/legacyReferrals/components/admin/ConsumerSummaryReportDialog.tsx
+++ b/src/modules/legacyReferrals/components/admin/ConsumerSummaryReportDialog.tsx
@@ -11,7 +11,7 @@ import React, { useState } from 'react';
 
 import CommonDialog from '@/components/elements/CommonDialog';
 import DatePicker from '@/components/elements/input/DatePicker';
-import { OpenInNewIcon } from '@/components/elements/SemanticIcons';
+import NewTabIcon from '@/components/elements/NewTabIcon';
 import { fetchConsumerSummaryReportUrl } from '@/modules/legacyReferrals/externalReportApi';
 
 export interface ConsumerSummaryReportDialogProps extends DialogProps {
@@ -62,7 +62,7 @@ const ConsumerSummaryReportDialog: React.FC<
             endDate,
           })}
           onClick={(e) => props.onClose && props.onClose(e, 'escapeKeyDown')}
-          endIcon={<OpenInNewIcon />}
+          endIcon={<NewTabIcon />}
         >
           View Consumer Summary Report
         </Button>


### PR DESCRIPTION
## Description

Summary of changes:
- Add a new shared component `NewTabIcon`, which renders the "open in new" icon next to visually-hidden text "opens in new tab" for accessibility.
- Use `NewTabIcon` most places `OpenInNewIcon` was previously used. (Exceptions marked in comments.)

[//]: # 'remove if not applicable'
How to test: See ticket

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
A11y improvement

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have used Axe DevTools to scan for accessibility issues (or not applicable)
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
