### PR TITLE
Use correct heading level for Bulk Services

### DIFF
--- a/src/modules/bulkServices/components/BulkServicesPage.tsx
+++ b/src/modules/bulkServices/components/BulkServicesPage.tsx
@@ -6,7 +6,8 @@ import { useNavigate } from 'react-router-dom';
 import BulkServiceSearchToggle from './BulkServiceSearchToggle';
 import BulkServicesTable from './BulkServicesTable';
 import ServiceDateRangeSelect from './ServiceDateRangeSelect';
-import StepCard, { StepCardTitle } from './StepCard';
+import StepCard from './StepCard';
+import StepCardTitle from './StepCardTitle';
 import DatePicker from '@/components/elements/input/DatePicker';
 import PageTitle from '@/components/layout/PageTitle';
 import useSearchParamsState, {

--- a/src/modules/bulkServices/components/StepCard.tsx
+++ b/src/modules/bulkServices/components/StepCard.tsx
@@ -1,42 +1,7 @@
-import { Box, Paper, Typography } from '@mui/material';
-import { Stack, SxProps } from '@mui/system';
+import { Box, Paper } from '@mui/material';
 import React, { ReactNode } from 'react';
+import StepCardTitle from './StepCardTitle';
 import CommonCard from '@/components/elements/CommonCard';
-
-export const StepCardTitle: React.FC<{
-  step: string;
-  title: string;
-  sx?: SxProps;
-  action?: ReactNode;
-  component?: React.ElementType;
-}> = ({ step, title, action, sx, component = 'h2' }) => (
-  <Stack
-    justifyContent='space-between'
-    direction='row'
-    sx={{ width: '100%', p: 2, ...sx }}
-  >
-    <Stack direction='row' gap={2} alignItems='center'>
-      <Box
-        sx={{
-          backgroundColor: 'primary.main',
-          color: 'white',
-          borderRadius: '50%',
-          width: '26px',
-          height: '26px',
-          lineHeight: '26px',
-          textAlign: 'center',
-          fontWeight: 600,
-        }}
-      >
-        {step}
-      </Box>
-      <Typography variant='h4' component={component}>
-        {title}
-      </Typography>
-    </Stack>
-    {action}
-  </Stack>
-);
 
 const StepCard: React.FC<{
   step: string;

--- a/src/modules/bulkServices/components/StepCard.tsx
+++ b/src/modules/bulkServices/components/StepCard.tsx
@@ -8,7 +8,8 @@ export const StepCardTitle: React.FC<{
   title: string;
   sx?: SxProps;
   action?: ReactNode;
-}> = ({ step, title, action, sx }) => (
+  component?: React.ElementType;
+}> = ({ step, title, action, sx, component = 'h2' }) => (
   <Stack
     justifyContent='space-between'
     direction='row'
@@ -29,7 +30,9 @@ export const StepCardTitle: React.FC<{
       >
         {step}
       </Box>
-      <Typography variant='h4'>{title}</Typography>
+      <Typography variant='h4' component={component}>
+        {title}
+      </Typography>
     </Stack>
     {action}
   </Stack>
@@ -43,14 +46,29 @@ const StepCard: React.FC<{
   action?: ReactNode;
   disabled?: boolean;
   disabledText?: string;
-}> = ({ step, title, children, action, padded, disabled, disabledText }) => (
+  component?: React.ElementType;
+}> = ({
+  step,
+  title,
+  children,
+  action,
+  padded,
+  disabled,
+  disabledText,
+  component = 'h2',
+}) => (
   <Paper
     sx={{
       pr: padded && !disabled ? 6 : undefined,
       pb: padded && !disabled ? 3 : 0,
     }}
   >
-    <StepCardTitle step={step} title={title} action={action} />
+    <StepCardTitle
+      step={step}
+      title={title}
+      action={action}
+      component={component}
+    />
 
     {disabled ? (
       <CommonCard

--- a/src/modules/bulkServices/components/StepCardTitle.tsx
+++ b/src/modules/bulkServices/components/StepCardTitle.tsx
@@ -1,0 +1,40 @@
+import { Box, Typography } from '@mui/material';
+import { Stack, SxProps } from '@mui/system';
+import React, { ReactNode } from 'react';
+
+export const StepCardTitle: React.FC<{
+  step: string;
+  title: string;
+  sx?: SxProps;
+  action?: ReactNode;
+  component?: React.ElementType;
+}> = ({ step, title, action, sx, component = 'h2' }) => (
+  <Stack
+    justifyContent='space-between'
+    direction='row'
+    sx={{ width: '100%', p: 2, ...sx }}
+  >
+    <Stack direction='row' gap={2} alignItems='center'>
+      <Box
+        sx={{
+          backgroundColor: 'primary.main',
+          color: 'white',
+          borderRadius: '50%',
+          width: '26px',
+          height: '26px',
+          lineHeight: '26px',
+          textAlign: 'center',
+          fontWeight: 600,
+        }}
+      >
+        {step}
+      </Box>
+      <Typography variant='h4' component={component}>
+        {title}
+      </Typography>
+    </Stack>
+    {action}
+  </Stack>
+);
+
+export default StepCardTitle;


### PR DESCRIPTION
## Description

Summary of changes:
- Use `h2` component, keeping `h4` variant, for `StepCardTitle`s in Bulk Services
- Move `StepCardTitle` to own file

[//]: # 'remove if not applicable'
How to test: I tested using the headingsmap extension
<img width="1824" height="1712" alt="Screenshot 2026-02-13 at 3 07 01 PM" src="https://github.com/user-attachments/assets/7ded6578-7ad9-4c1c-b9e7-4abd7fbaba85" />

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
a11y improvement

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have used Axe DevTools to scan for accessibility issues (or not applicable)
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue