### PR TITLE
Use correct heading levels for Client and Enrollment dashboards

### DIFF
--- a/src/modules/client/components/ClientCustomDataElementsCard.tsx
+++ b/src/modules/client/components/ClientCustomDataElementsCard.tsx
@@ -46,7 +46,11 @@ const ClientCustomDataElementsCard: React.FC<Props> = ({ client }) => {
   if (rows.length === 0) return null;
 
   return (
-    <TitleCard title='Custom Fields' headerVariant='border'>
+    <TitleCard
+      title='Custom Fields'
+      headerVariant='border'
+      headerComponent='h2'
+    >
       <CommonDetailGridContainer>
         {rows.map(({ id, label, value }) => (
           <CommonDetailGridItem label={label} key={id}>

--- a/src/modules/client/components/ClientEnrollmentCard.tsx
+++ b/src/modules/client/components/ClientEnrollmentCard.tsx
@@ -94,7 +94,11 @@ interface Props {
 
 const ClientEnrollmentCard: React.FC<Props> = ({ client }) => {
   return (
-    <TitleCard title='Recent Enrollments' headerVariant='border'>
+    <TitleCard
+      title='Recent Enrollments'
+      headerVariant='border'
+      headerComponent='h2'
+    >
       <RecentEnrollments clientId={client.id} />
     </TitleCard>
   );

--- a/src/modules/clientAlerts/components/ClientAlertCard.tsx
+++ b/src/modules/clientAlerts/components/ClientAlertCard.tsx
@@ -1,5 +1,5 @@
 import { Box, Stack, Typography } from '@mui/material';
-import { ReactNode, useMemo } from 'react';
+import { ElementType, ReactNode, useMemo } from 'react';
 import { ClientAlertType } from './ClientAlert';
 import ClientAlertStack from './ClientAlertStack';
 import Loading from '@/components/elements/Loading';
@@ -15,12 +15,14 @@ interface ClientAlertCardProps {
   clientAlerts: ClientAlertType[];
   children?: ReactNode;
   loading?: boolean;
+  headerComponent?: ElementType<any>;
 }
 const ClientAlertCard: React.FC<ClientAlertCardProps> = ({
   alertContext = AlertContext.Client,
   clientAlerts,
   children,
   loading = false,
+  headerComponent = 'h2',
 }) => {
   const title = useMemo(() => {
     const cardTitle = `${alertContext} Alerts`;
@@ -29,7 +31,11 @@ const ClientAlertCard: React.FC<ClientAlertCardProps> = ({
   }, [alertContext, clientAlerts.length, loading]);
 
   return (
-    <TitleCard title={title} headerVariant='border'>
+    <TitleCard
+      title={title}
+      headerVariant='border'
+      headerComponent={headerComponent}
+    >
       {loading && <Loading />}
       {!loading && (
         <Box sx={{ m: 2 }}>

--- a/src/modules/enrollment/components/EnrollmentQuickActions.tsx
+++ b/src/modules/enrollment/components/EnrollmentQuickActions.tsx
@@ -55,7 +55,7 @@ const EnrollmentQuickActions = ({
   }
 
   return (
-    <TitleCard title='Quick Actions'>
+    <TitleCard title='Quick Actions' headerComponent='h2'>
       <Stack spacing={2} sx={{ px: 2, pb: 2, textAlign: 'center' }}>
         {/* Record a Service */}
         {canRecordService && (

--- a/src/modules/enrollment/components/EnrollmentReminders.tsx
+++ b/src/modules/enrollment/components/EnrollmentReminders.tsx
@@ -266,6 +266,7 @@ const EnrollmentReminders: React.FC<Props> = ({ enrollmentId }) => {
           : `Household Tasks (${displayReminders.length})`
       }
       headerVariant='border'
+      headerComponent='h2'
     >
       {loading && !data ? (
         <Loading />

--- a/src/modules/enrollment/components/pages/EnrollmentOverview.tsx
+++ b/src/modules/enrollment/components/pages/EnrollmentOverview.tsx
@@ -50,7 +50,11 @@ const EnrollmentOverview = () => {
       <Grid container spacing={4}>
         <Grid item md={8} xs={12}>
           <Stack spacing={4}>
-            <TitleCard title='Household' headerVariant='border'>
+            <TitleCard
+              title='Household'
+              headerVariant='border'
+              headerComponent='h2'
+            >
               <HouseholdOverviewTable enrollmentId={enrollmentId} />
             </TitleCard>
             <TitleCard
@@ -59,6 +63,7 @@ const EnrollmentOverview = () => {
                   ? clientBriefName(enrollment.client)
                   : ''
               } Enrollment Details`}
+              headerComponent='h2'
             >
               <EnrollmentDetails enrollment={enrollment} />
             </TitleCard>

--- a/src/modules/staffAssignment/components/StaffAssignmentCard.tsx
+++ b/src/modules/staffAssignment/components/StaffAssignmentCard.tsx
@@ -74,6 +74,7 @@ const StaffAssignmentCard: React.FC<StaffAssignmentCardProps> = ({
       )}
       <TitleCard
         title='Staff Assignment'
+        headerComponent='h2'
         stackOnMobile={false}
         actions={
           enrollment.relationshipToHoH ===


### PR DESCRIPTION
## Description

Summary of changes:
- Use `headerComponent='h2'` for `TitleCard`s that are displayed on the Client and Enrollment dashboards.
- I considered making this the default, which is a similar approach to `PageTitle`, which defaults to `variant='h1', component='h3'`. I decided against that because we use so many `TitleCard`s across the app, and it didn't seem worthwhile to make and test such a wide-ranging change.

[//]: # 'remove if not applicable'
How to test: I used the headingsmap extn.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
A11y improvement

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have used Axe DevTools to scan for accessibility issues (or not applicable)
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
