### PR TITLE
Fix bug with numeric form field in DynamicForm

### DIFF
--- a/src/modules/form/components/DynamicFormFields.tsx
+++ b/src/modules/form/components/DynamicFormFields.tsx
@@ -27,11 +27,15 @@ const DynamicFormFields: React.FC<Props> = ({ handlers, ...props }) => {
     ({ linkId, value: baseValue, type }) => {
       const item = handlers.itemMap[linkId];
       let value = baseValue;
-      // Convert string values to appropriate number types
-      if (item) {
-        if (item.type === ItemType.Integer) value = parseInt(value) || 0;
-        if (item.type === ItemType.Currency) value = parseFloat(value) || 0;
+
+      // If item type is a number, parse the string value as the appropriate number type.
+      if ([ItemType.Integer, ItemType.Currency].includes(item?.type)) {
+        const parsed =
+          item.type === ItemType.Integer ? parseInt(value) : parseFloat(value);
+        // Set value to null if it is not parseable as a number, such as null/empty string.
+        value = isNaN(parsed) ? null : parsed;
       }
+
       handlers.methods.setValue(linkId, value, {
         shouldDirty: type === ChangeType.User,
       });


### PR DESCRIPTION
## Description

Summary of changes: In the `itemChanged` Dynamic Form handler, instead of falling back to 0 when parsing a numerical value returns `NaN`, explicitly check for `NaN` and return `null`.

[//]: # 'remove if not applicable'
How to test: Ensure bug described in ticket is no longer reproducible.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have used Axe DevTools to scan for accessibility issues (or not applicable)
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [ ] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
