### PR TITLE
Disable changing 'repeats' value on form item

### DIFF
--- a/src/modules/formBuilder/components/itemEditor/FormItemEditor.tsx
+++ b/src/modules/formBuilder/components/itemEditor/FormItemEditor.tsx
@@ -216,6 +216,17 @@ const FormItemEditor: React.FC<Props> = ({
     );
   }, [itemTypeValue]);
 
+  // Disable the "Allow multiple" checkbox if the item already has a custom field mapping
+  const disableRepeats = useMemo(
+    () => !!initialItem.mapping?.customFieldKey,
+    [initialItem.mapping?.customFieldKey]
+  );
+  const repeatsHelperText = useMemo(() => {
+    if (!disableRepeats) return undefined;
+    const action = initialItem.repeats ? 'disable' : 'enable';
+    return `This cannot be changed, because the item is already mapped to a custom field. To ${action} multiple responses, delete and re-create the item.`;
+  }, [disableRepeats, initialItem.repeats]);
+
   // Picklist for users to power the editorUserIds multi-select (super admin only UI)
   const {
     data: { pickList: userOptions } = {},
@@ -368,6 +379,8 @@ const FormItemEditor: React.FC<Props> = ({
                 name='repeats'
                 label='Allow multiple responses'
                 control={control}
+                disabled={disableRepeats}
+                helperText={repeatsHelperText}
               />
             )}
           </Section>


### PR DESCRIPTION
## Description

Summary of changes: Prevent Form Builder users from changing the "repeats" value for a form item ("Allow multiple responses") once the item corresponds with a CDED on the backend. 

[//]: # 'remove if not applicable'
How to test: See ticket QA instructions

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
UX improvement

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have used Axe DevTools to scan for accessibility issues (or not applicable)
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
