### PR TITLE
Don't autofill assessment date

### DIFF
--- a/src/modules/assessments/components/AssessmentForm.tsx
+++ b/src/modules/assessments/components/AssessmentForm.tsx
@@ -199,6 +199,18 @@ const AssessmentForm: React.FC<Props> = ({
     if (source) {
       // Overlay with values from Assessment
       const initFromAssessment = initialValuesFromAssessment(itemMap, source);
+
+      if (sourceAssessment) {
+        // If we are autofilling from another assessment, don't autofill the assessment date.
+        const noAutofillLinkIds = Object.values(itemMap)
+          .filter((item) => !!item.assessmentDate)
+          .map((item) => item.linkId);
+
+        noAutofillLinkIds.forEach((linkId) => {
+          delete initFromAssessment[linkId];
+        });
+      }
+
       assign(init, initFromAssessment);
 
       // Overlay initial values that have "OVERWRITE" specification type ("linked" fields)


### PR DESCRIPTION
## Description

Summary of changes: When autofilling an assessment from another assessment, don't populate the assessment date.

How to test: See ticket

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Fix to unintuitive behavior

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have used Axe DevTools to scan for accessibility issues (or not applicable)
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
