### PR TITLE
Set numeric form field that can't be parsed to undefined, not null

### DIFF
--- a/src/modules/form/components/DynamicFormFields.tsx
+++ b/src/modules/form/components/DynamicFormFields.tsx
@@ -32,8 +32,8 @@ const DynamicFormFields: React.FC<Props> = ({ handlers, ...props }) => {
       if ([ItemType.Integer, ItemType.Currency].includes(item?.type)) {
         const parsed =
           item.type === ItemType.Integer ? parseInt(value) : parseFloat(value);
-        // Set value to null if it is not parseable as a number, such as null/empty string.
-        value = isNaN(parsed) ? null : parsed;
+        // Set value to undefined if it is not parseable as a number, such as null/empty string.
+        value = isNaN(parsed) ? undefined : parsed;
       }
 
       handlers.methods.setValue(linkId, value, {


### PR DESCRIPTION
## Description

Summary of changes:
- Fixes bug described here: https://github.com/open-path/Green-River/issues/8133#issuecomment-4000059372
- Root cause: https://github.com/greenriver/hmis-frontend/blob/a27dc4212fd62ba4e15c1e999ca830cfa5a4bf99/src/modules/form/util/formUtil.ts#L516
  - Originally when the form is loaded: value is `undefined`. `Number(undefined)` evaluates to `NaN`
  - After the value is filled in and then cleared: value was `null`. `Number(null)` evaluates to `0` 😮
  - Solution: when value is filled and cleared, it should be `undefined` to match the state on initial load when no values had been filled in yet.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have used Axe DevTools to scan for accessibility issues (or not applicable)
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [ ] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
