### PR TITLE
Upgrade dompurify for CVE-2026-0540

### DIFF
--- a/src/components/elements/CommonHtmlContent.stories.tsx
+++ b/src/components/elements/CommonHtmlContent.stories.tsx
@@ -1,0 +1,31 @@
+import { Meta, StoryObj } from '@storybook/react';
+
+import CommonHtmlContent from './CommonHtmlContent';
+
+export default {
+  component: CommonHtmlContent,
+} as Meta<typeof CommonHtmlContent>;
+
+type Story = StoryObj<typeof CommonHtmlContent>;
+
+export const Default: Story = {
+  args: {
+    children:
+      '<p>Plain <strong>HTML</strong> content is sanitized and rendered safely.</p><ul><li>List item one</li><li>List item two</li></ul>',
+  },
+};
+
+export const WithTypographyVariant: Story = {
+  args: {
+    children: '<span>Rendered with <b><code>variant="body2"</code></b>.</span>',
+    variant: 'body2',
+  },
+};
+
+export const AsSpan: Story = {
+  args: {
+    children: 'Inline content as a <b><code>span</code></b> (e.g. for labels).',
+    component: 'span',
+    variant: 'body2',
+  },
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -5599,9 +5599,9 @@ domhandler@^2.3.0:
     domelementtype "1"
 
 dompurify@^3.1.6:
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.2.4.tgz#af5a5a11407524431456cf18836c55d13441cd8e"
-  integrity sha512-ysFSFEDVduQpyhzAob/kkuJjf5zWkZD8/A9ywSp1byueyuCfHamrCBa14/Oc2iiB0e51B+NpxSl5gmzn+Ms/mg==
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.3.2.tgz#58c515d0f8508b8749452a028aa589ad80b36325"
+  integrity sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ==
   optionalDependencies:
     "@types/trusted-types" "^2.0.7"
 


### PR DESCRIPTION
## Description

* Upgrade dompurify to resolve CVE-2026-0540 and CVE-2025-15599
* Add story for CommonHtmlContent (component that uses dompurify to sanitize html) for easy review/testing

## Type of change
Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have used Axe DevTools to scan for accessibility issues (or not applicable)
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
