### PR TITLE
Move broad and specific client search to separate routes

### DIFF
--- a/src/modules/search/components/ClientSearch.tsx
+++ b/src/modules/search/components/ClientSearch.tsx
@@ -111,12 +111,25 @@ export const SEARCH_RESULT_COLUMNS: ColumnDef<ClientSearchResultFieldsFragment>[
 export const MOBILE_SEARCH_RESULT_COLUMNS: ColumnDef<ClientSearchResultFieldsFragment>[] =
   [CLIENT_COLUMNS.name, CLIENT_COLUMNS.id, CLIENT_COLUMNS.dobAge];
 
+interface ClientSearchProps {
+  searchType: SearchType;
+}
+
 /**
- * Client Search page
+ * Main client search UI
+ *
+ * This component renders:
+ * - "Search Type" toggle for switching between 'broad' and 'specific' search modes
+ * - Input form for text search or advanced search, depending on the search type
+ * - Paginated search results table, which can be displayed as cards or table (state tracked internally)
+ *
+ * Special logic:
+ * - Tracks whether or not a search has occurred, and displays an "Add New Client" button if it has.
+ *   This is a guard to prevent users from client duplicate clients without searching first.
+ * - Depending on global feature flags, the table may include an "MCI ID" column.
+ * - Search parameters are synced with the URL (TODO: update when changed to searchQueryId approach)
  */
-const ClientSearch = () => {
-  // type of search (broad or specific)
-  const [searchType, setSearchType] = useState<SearchType>('broad');
+const ClientSearch: React.FC<ClientSearchProps> = ({ searchType }) => {
   // type of display (table or cards)
   const [displayType, setDisplayType] = useState<DisplayType>('table');
   // URL search parameters
@@ -174,7 +187,6 @@ const ClientSearch = () => {
       const initState = searchParamsToState(searchParams);
       setInitialValues(initState);
       setSearchInput(initState);
-      if (!initState.textSearch) setSearchType('specific');
     }
   }, [derivedSearchParams, searchParams]);
 
@@ -216,7 +228,7 @@ const ClientSearch = () => {
         justifyContent='space-between'
         alignItems={isTiny ? undefined : 'flex-end'}
       >
-        <ClientSearchTypeToggle value={searchType} onChange={setSearchType} />
+        <ClientSearchTypeToggle value={searchType} />
         {hasSearched && (
           <RootPermissionsFilter permissions='canEditClients'>
             <Box sx={{ height: 'fit-content' }}>

--- a/src/modules/search/components/ClientSearchPage.tsx
+++ b/src/modules/search/components/ClientSearchPage.tsx
@@ -1,10 +1,22 @@
 import PageContainer from '@/components/layout/PageContainer';
 import ClientSearch from '@/modules/search/components/ClientSearch';
+import { SearchType } from '@/modules/search/components/ClientSearchTypeToggle';
 
-const ClientSearchPage = () => {
+interface ClientSearchPageProps {
+  searchType: SearchType;
+}
+
+/**
+ * Page wrapper for client search: layout, title, and routing-derived search type
+ * (broad vs specific) passed into ClientSearch.
+ */
+const ClientSearchPage: React.FC<ClientSearchPageProps> = ({ searchType }) => {
   return (
     <PageContainer title='Clients'>
-      <ClientSearch />
+      <ClientSearch
+        key={searchType} // force re-mount when search type changes
+        searchType={searchType}
+      />
     </PageContainer>
   );
 };

--- a/src/modules/search/components/ClientSearchTypeToggle.tsx
+++ b/src/modules/search/components/ClientSearchTypeToggle.tsx
@@ -1,50 +1,70 @@
 import LocationSearchingIcon from '@mui/icons-material/LocationSearching';
 import SearchIcon from '@mui/icons-material/Search';
 
-import CommonToggle, {
-  CommonToggleProps,
-} from '@/components/elements/CommonToggle';
+import { useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import CommonToggle from '@/components/elements/CommonToggle';
 import LabelWithContent from '@/components/elements/LabelWithContent';
+import { Routes } from '@/routes/routes';
 
 export type SearchType = 'broad' | 'specific';
 
 interface ClientSearchTypeToggleProps {
   value: SearchType;
-  onChange: CommonToggleProps<SearchType>['onChange'];
 }
 
+/**
+ * Toggle between broad (text) and specific (advanced) client search modes.
+ * Uses React Router navigation to switch between "broad" and "specific" client search routes.
+ */
 const ClientSearchTypeToggle: React.FC<ClientSearchTypeToggleProps> = ({
   value,
-  onChange,
-}) => (
-  <LabelWithContent
-    label='Search Type'
-    LabelProps={{ sx: { fontSize: 16 } }}
-    labelId='search-type-label'
-    renderChildren={(labelElement) => (
-      <CommonToggle
-        value={value}
-        onChange={onChange}
-        aria-labelledby={
-          (labelElement && labelElement.getAttribute('id')) || undefined
-        }
-        items={[
-          {
-            value: 'broad',
-            label: 'Broad Search',
-            testId: 'broadSearchToggleButton',
-            Icon: SearchIcon,
-          },
-          {
-            value: 'specific',
-            label: 'Specific Search',
-            testId: 'specificSearchToggleButton',
-            Icon: LocationSearchingIcon,
-          },
-        ]}
-      />
-    )}
-  />
-);
+}) => {
+  const navigate = useNavigate();
+  const handleChange = useCallback(
+    (newValue: SearchType) => {
+      switch (newValue) {
+        case 'broad':
+          navigate(Routes.CLIENT_SEARCH);
+          break;
+        case 'specific':
+          navigate(Routes.CLIENT_SEARCH_ADVANCED);
+          break;
+      }
+    },
+    [navigate]
+  );
+
+  return (
+    <LabelWithContent
+      label='Search Type'
+      LabelProps={{ sx: { fontSize: 16 } }}
+      labelId='search-type-label'
+      renderChildren={(labelElement) => (
+        <CommonToggle
+          value={value}
+          onChange={handleChange}
+          aria-labelledby={
+            (labelElement && labelElement.getAttribute('id')) || undefined
+          }
+          items={[
+            {
+              value: 'broad',
+              label: 'Broad Search',
+              testId: 'broadSearchToggleButton',
+              Icon: SearchIcon,
+            },
+            {
+              value: 'specific',
+              label: 'Specific Search',
+              testId: 'specificSearchToggleButton',
+              Icon: LocationSearchingIcon,
+            },
+          ]}
+        />
+      )}
+    />
+  );
+};
 
 export default ClientSearchTypeToggle;

--- a/src/routes/protected.tsx
+++ b/src/routes/protected.tsx
@@ -1072,7 +1072,14 @@ export const protectedRoutes: RouteNode[] = [
           },
         ],
       },
-      { path: '/', element: <ClientSearchPage /> },
+      {
+        path: Routes.CLIENT_SEARCH_ADVANCED,
+        element: <ClientSearchPage searchType='specific' />,
+      },
+      {
+        path: Routes.CLIENT_SEARCH,
+        element: <ClientSearchPage searchType='broad' />,
+      },
       {
         path: '*',
         element: (

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -5,6 +5,7 @@ const ReferralSubRoutes = {
 
 export const Routes = {
   CLIENT_SEARCH: '/',
+  CLIENT_SEARCH_ADVANCED: '/advanced-search',
   CREATE_CLIENT: '/client/new',
   CLIENT_DASHBOARD: '/client/:clientId',
   ENROLLMENT_DASHBOARD: '/client/:clientId/enrollments/:enrollmentId',


### PR DESCRIPTION
## Description

This change moves the client search type (broad vs. specific) from React state inside ClientSearch into the router by giving each mode its own route (`/` for broad, `/advanced` for specific).

This matches the pattern we already use for the toggle between "Clients" and "Households" on the Project Enrollments page.

This change is intended to reduce local state and branching in ClientSearch, to reduce state management changes in https://github.com/greenriver/hmis-frontend/pull/1405. Each route renders a separate instance of the search UI so the two modes don’t share in-memory state and there’s no “bleed” (e.g. advanced form values or results appearing in broad mode or vice versa).

In addition, the URL now encodes the selected search mode, so users can bookmark or share a link that opens client search in the correct mode (broad or specific/advanced).

## Type of change
Refactor

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have used Axe DevTools to scan for accessibility issues (or not applicable)
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
