### PR TITLE
Rename prop for clarity

### DIFF
--- a/src/modules/dataFetching/components/GenericTableWithData.tsx
+++ b/src/modules/dataFetching/components/GenericTableWithData.tsx
@@ -81,7 +81,8 @@ export interface Props<
     TableFilterType<FilterOptionsType>,
     SortOptionsType
   >['tableDisplayOptionButtons'];
-  onCompleted?: (data: Query) => void;
+  /** Fires when data is available (network or cache). Use to gate actions until results are shown, e.g. to reduce duplicate client record creation. */
+  onDataReady?: (data: Query) => void;
   filterRows?: (rows: RowDataType) => boolean; // Client-side row filtering
   loading?: boolean;
 }
@@ -127,7 +128,7 @@ const GenericTableWithData = <
   noData,
   rowsPerPageOptions,
   tableDisplayOptionButtons,
-  onCompleted,
+  onDataReady,
   paginationItemName,
   filterRows,
   vertical,
@@ -202,10 +203,12 @@ const GenericTableWithData = <
 
   const hasRefetched = useHasRefetched(networkStatus);
 
-  // workaround to fire "onCompleted" even if data was fetched from cache
+  // Fire onDataReady when data is available (from network or cache). Apollo's onCompleted
+  // only runs for network completions, so we use this effect to run the callback whenever
+  // the table has data to show.
   useEffect(() => {
-    if (onCompleted && data) onCompleted(data);
-  }, [data, onCompleted]);
+    if (onDataReady && data) onDataReady(data);
+  }, [onDataReady, data]);
 
   useEffect(() => {
     if (!isEqual(previousQueryVariables, queryVariables)) {

--- a/src/modules/household/components/ManageHousehold.tsx
+++ b/src/modules/household/components/ManageHousehold.tsx
@@ -65,6 +65,9 @@ const ManageHousehold = ({
   const { globalFeatureFlags } = useGlobalFeatureFlags();
 
   const [searchInput, setSearchInput] = useState<ClientSearchInput>();
+  // Whether the user has searched for clients (and the results are visible).
+  // Visibility of "Add New Client" button is gated on this, to prevent user from adding
+  // duplicate clients before completing a search.
   const [hasSearched, setHasSearched] = useState(false);
   // Search is expanded by default only if this is a new household (no members yet)
   const [searchOpen, setSearchOpen] = useState(!householdId);
@@ -252,7 +255,7 @@ const ManageHousehold = ({
                   filters={filters}
                   recordType='Client'
                   defaultSortOption={ClientSortOption.BestMatch}
-                  onCompleted={() => setHasSearched(true)}
+                  onDataReady={() => setHasSearched(true)}
                   rowSecondaryActionConfigs={(row) => [
                     getViewClientMenuItem(row),
                   ]}

--- a/src/modules/search/components/ClientSearch.tsx
+++ b/src/modules/search/components/ClientSearch.tsx
@@ -126,7 +126,9 @@ const ClientSearch = () => {
     useState<boolean>(false);
   // initial form state derived from the SearchParams
   const [initialValues, setInitialValues] = useState<ClientSearchInputType>();
-  // whether search has occurred
+  // Whether the user has searched for clients (and the results are visible).
+  // Visibility of "Add New Client" button is gated on this, to prevent user from adding
+  // duplicate clients before completing a search.
   const [hasSearched, setHasSearched] = useState(false);
 
   const isMobile = useIsMobile();
@@ -265,7 +267,7 @@ const ClientSearch = () => {
           >
             queryVariables={{ input: searchInput }}
             queryDocument={SearchClientsDocument}
-            onCompleted={() => setHasSearched(true)}
+            onDataReady={() => setHasSearched(true)}
             columns={columns}
             rowLinkTo={(client) => getViewClientMenuItem(client).to}
             rowName={(row) => clientBriefName(row)}


### PR DESCRIPTION
## Description

Rename prop for clarity, since we usually use `onCompleted` for apollo callbacks.
Add comments explaining usage.

No change in behavior.

Relates to https://github.com/greenriver/hmis-warehouse/pull/6300 because we may want to add a true onCompleted hook for that.


**How to test:**
- Perform a client search for string "TEST". "Add new client" button should appear when results are returned. This is a desired lag (afaik) to prevent duplicate record creation.
- Hit "clear search". ( "Add new client" button disappears)
- Perform a client search for string "TEST" again (hits the cache and returns immediately). "Add new client" button should reappear immediately.

## Type of change
Code cleanup

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have used Axe DevTools to scan for accessibility issues (or not applicable)
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
