### PR TITLE
Update behavior of useSearchParamState setter to match SetState

### DIFF
--- a/src/hooks/useSearchParamState.ts
+++ b/src/hooks/useSearchParamState.ts
@@ -164,7 +164,6 @@ const useSearchParamsState = ({
     const currentParams = getAllCurrentParams(searchParams);
     populateParams(currentParams, accumulator);
 
-    // `navigate` instead of `useSearchParams` as workaround for https://github.com/remix-run/react-router/issues/8393
     navigate(
       {
         pathname,
@@ -233,6 +232,7 @@ const useSearchParamsState = ({
 
       const accumulator = new URLSearchParams();
       populateParams(currentParams, accumulator);
+      // `navigate` instead of `useSearchParams` as workaround for https://github.com/remix-run/react-router/issues/8393
       navigate({
         pathname,
         hash,

--- a/src/hooks/useSearchParamState.ts
+++ b/src/hooks/useSearchParamState.ts
@@ -164,6 +164,7 @@ const useSearchParamsState = ({
     const currentParams = getAllCurrentParams(searchParams);
     populateParams(currentParams, accumulator);
 
+    // `navigate` instead of `useSearchParams` as workaround for https://github.com/remix-run/react-router/issues/8393
     navigate(
       {
         pathname,
@@ -213,11 +214,9 @@ const useSearchParamsState = ({
         const hasKey = Object.prototype.hasOwnProperty.call(nextValues, key);
         let value = hasKey ? nextValues[key] : undefined;
 
-        if (hasKey && value !== undefined && paramsDefinition[key]) {
-          if (paramsDefinition[key].type === 'date' && isDate(value)) {
-            // serialize date. if it is invalid, it will be null
-            value = formatDateForGql(value);
-          }
+        if (hasKey && paramsDefinition[key]?.type === 'date' && isDate(value)) {
+          // Try to serialize date. If it is invalid, it will be set to null.
+          value = formatDateForGql(value);
         }
 
         const isEmpty =

--- a/src/hooks/useSearchParamState.ts
+++ b/src/hooks/useSearchParamState.ts
@@ -1,5 +1,4 @@
 import { isDate } from 'date-fns';
-import { isNil } from 'lodash-es';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import { formatDateForGql, parseHmisDateString } from '@/modules/hmis/hmisUtil';
@@ -127,8 +126,9 @@ type Args = {
   initial?: ValueType;
 };
 
-// Returns state and setState function
-type ReturnType = [ValueType, (value: ValueType) => void];
+// Returns state and setState function (supports updater: setValues(prev => ({ ...prev, key: val })))
+type SetStateAction = ValueType | ((prev: ValueType) => ValueType);
+type ReturnType = [ValueType, (value: SetStateAction) => void];
 
 const useSearchParamsState = ({
   paramsDefinition,
@@ -186,31 +186,54 @@ const useSearchParamsState = ({
     return getValues(paramsDefinition, searchParams);
   }, [initial, mounted, paramsDefinition, searchParams]);
 
+  /**
+   * Updates URL search params (same keys as paramsDefinition). Behaves like React setState:
+   * - Pass an object to set/replace: keys present are updated, keys in paramsDefinition but
+   * not in the object are cleared. setValues({}) clears all defined params.
+   * - Pass an updater function to merge with current values: setValues(prev => ({ ...prev, page: 2 })).
+   *
+   * Any keys not present in paramsDefinition are ignored.
+   *
+   * @example
+   * setValues({ page: 1, limit: 25 });           // set these, clear other defined params
+   * setValues({});                               // clear all params in paramsDefinition
+   * setValues(prev => ({ ...prev, page: prev.page + 1 }));  // merge: increment page only
+   */
   const setValues = useCallback(
-    (newValues: Record<string, any>) => {
+    (newValuesOrUpdater: SetStateAction) => {
       const currentParams = getAllCurrentParams(searchParams);
-      for (const key in newValues) {
-        if (Object.prototype.hasOwnProperty.call(newValues, key)) {
-          let value = newValues[key];
+      const currentValues = getValues(paramsDefinition, searchParams);
+      const nextValues =
+        typeof newValuesOrUpdater === 'function'
+          ? newValuesOrUpdater(currentValues)
+          : newValuesOrUpdater;
 
+      // Iterate paramsDefinition so setValues({}) clears all defined params
+      for (const key of Object.keys(paramsDefinition)) {
+        const hasKey = Object.prototype.hasOwnProperty.call(nextValues, key);
+        let value = hasKey ? nextValues[key] : undefined;
+
+        if (hasKey && value !== undefined && paramsDefinition[key]) {
           if (paramsDefinition[key].type === 'date' && isDate(value)) {
             // serialize date. if it is invalid, it will be null
-            value = newValues[key] = formatDateForGql(value);
-          }
-
-          if (
-            isNil(value) ||
-            value === '' ||
-            (Array.isArray(value) && value.length === 0)
-          ) {
-            delete currentParams[key];
-            delete newValues[key];
+            value = formatDateForGql(value);
           }
         }
+
+        const isEmpty =
+          value === undefined ||
+          value === null ||
+          value === '' ||
+          (Array.isArray(value) && value.length === 0);
+        if (isEmpty) {
+          delete currentParams[key];
+        } else {
+          currentParams[key] = value;
+        }
       }
-      // `navigate` instead of `useSearchParams` as workaround for https://github.com/remix-run/react-router/issues/8393
+
       const accumulator = new URLSearchParams();
-      populateParams({ ...currentParams, ...newValues }, accumulator);
+      populateParams(currentParams, accumulator);
       navigate({
         pathname,
         hash,

--- a/src/modules/bulkServices/components/BulkServicesPage.tsx
+++ b/src/modules/bulkServices/components/BulkServicesPage.tsx
@@ -111,7 +111,7 @@ const BulkServicesPage: React.FC<Props> = ({
         <AddNewClientMenu
           projectId={project.id}
           onClientAdded={(data) =>
-            setFilterParams({ searchTerm: data.client.id })
+            setFilterParams((prev) => ({ ...prev, searchTerm: data.client.id }))
           }
           navigateToHousehold={() =>
             navigate(
@@ -155,7 +155,10 @@ const BulkServicesPage: React.FC<Props> = ({
                     // ServiceTypeSelect's internal effect causes `onChange` to be called even when option value is not changing.
                     // To avoid unneeded rerenders, only setFilterParams if the value is changing
                     if (option?.code !== serviceTypeId) {
-                      setFilterParams({ serviceTypeId: option?.code });
+                      setFilterParams((prev) => ({
+                        ...prev,
+                        serviceTypeId: option?.code,
+                      }));
                     }
                   }}
                   label='Service Type'
@@ -164,7 +167,9 @@ const BulkServicesPage: React.FC<Props> = ({
               )}
               <DatePicker
                 value={serviceDate}
-                onChange={(date) => setFilterParams({ serviceDate: date })}
+                onChange={(date) =>
+                  setFilterParams((prev) => ({ ...prev, serviceDate: date }))
+                }
                 max={new Date()}
                 sx={{ width: '200px' }}
                 label={
@@ -179,7 +184,9 @@ const BulkServicesPage: React.FC<Props> = ({
                 <CocPicker
                   project={project}
                   value={coc ? { code: coc } : null}
-                  onChange={(option) => setFilterParams({ coc: option?.code })}
+                  onChange={(option) =>
+                    setFilterParams((prev) => ({ ...prev, coc: option?.code }))
+                  }
                   label='CoC Code'
                   helperText='CoC to use when enrolling new clients'
                 />
@@ -199,20 +206,25 @@ const BulkServicesPage: React.FC<Props> = ({
               value={lookupMode}
               serviceTypeName={serviceTypeName}
               onChange={(mode) => {
-                setFilterParams({
+                setFilterParams((prev) => ({
+                  ...prev, // Preserve selected CoC, Service Date, and Service Type
                   mode,
                   searchTerm: null,
                   servicePeriodStart: null,
                   servicePeriodEnd: null,
-                });
+                }));
               }}
             />
             <Box sx={{ mt: 2 }} maxWidth='800px'>
               {lookupMode === 'search' && (
                 <ClientTextSearchForm
                   initialValue={searchTerm}
-                  onSearch={(value) => setFilterParams({ searchTerm: value })}
-                  onClearSearch={() => setFilterParams({ searchTerm: null })}
+                  onSearch={(value) =>
+                    setFilterParams((prev) => ({ ...prev, searchTerm: value }))
+                  }
+                  onClearSearch={() =>
+                    setFilterParams((prev) => ({ ...prev, searchTerm: null }))
+                  }
                   label={null}
                   placeholder='Client Name, DOB, SSN or ID'
                   helperText='Search includes all of HMIS'
@@ -230,10 +242,11 @@ const BulkServicesPage: React.FC<Props> = ({
                 <ServiceDateRangeSelect
                   initialValue={servicePeriod}
                   onChange={(servicePeriod) =>
-                    setFilterParams({
+                    setFilterParams((prev) => ({
+                      ...prev,
                       servicePeriodStart: servicePeriod?.start,
                       servicePeriodEnd: servicePeriod?.end,
-                    })
+                    }))
                   }
                 />
               )}


### PR DESCRIPTION
## Description

Update useSearchParamState `setFilterParams` behavior to match behavior of React `SetStateAction`. This is more useful and predictable. Previously, it wasn't possible to clear out the state by passing `{}` for example.

Pulled in for use in https://github.com/greenriver/hmis-frontend/pull/1406 which uses this hook to store Filter state in search params.



**How to test**: test bed night workflow and other workflows that use useSearchParamState. No changes expected.

## Type of change
New feature

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have used Axe DevTools to scan for accessibility issues (or not applicable)
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
