### PR TITLE
Update schema to deprecate AUDITABLE_USERS picklist

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -40201,6 +40201,12 @@
             "deprecationReason": null
           },
           {
+            "name": "CE_ACCESS_POINT_PROJECT_NAMES",
+            "description": "Projects with an active CE Participation record with Access Point = Yes",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "CE_EVENTS",
             "description": "Grouped HUD CE Event types",
             "isDeprecated": false,
@@ -40436,7 +40442,7 @@
           },
           {
             "name": "USERS",
-            "description": "User accounts",
+            "description": "User accounts. Returns all users, for use when filtering audit events",
             "isDeprecated": false,
             "deprecationReason": null
           }

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -40167,8 +40167,8 @@
           {
             "name": "AUDITABLE_USERS",
             "description": "Current and historical user accounts",
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "No longer used"
           },
           {
             "name": "AVAILABLE_BULK_SERVICE_TYPES",
@@ -40436,7 +40436,7 @@
           },
           {
             "name": "USERS",
-            "description": "User accounts. Deprecated in favor of AUDITABLE_USERS",
+            "description": "User accounts",
             "isDeprecated": false,
             "deprecationReason": null
           }

--- a/src/types/gqlEnums.ts
+++ b/src/types/gqlEnums.ts
@@ -998,6 +998,8 @@ export const HmisEnums = {
       'Units available for the given Enrollment at the given project. List is limited to units with the same unit type currently occupied by the household, if any.',
     AVAILABLE_UNIT_TYPES:
       'Unit types that have unoccupied units in the specified project',
+    CE_ACCESS_POINT_PROJECT_NAMES:
+      'Projects with an active CE Participation record with Access Point = Yes',
     CE_EVENTS: 'Grouped HUD CE Event types',
     CE_REFERRAL_STATUSES: 'CE_REFERRAL_STATUSES',
     CE_WORKFLOW_TEMPLATE_IDENTIFIERS: 'Templates for CE workflow definitions',
@@ -1044,7 +1046,8 @@ export const HmisEnums = {
     SUB_TYPE_PROVIDED_5: 'SUB_TYPE_PROVIDED_5',
     UNIT_GROUPS_FOR_PROJECT_DIRECT_CE_REFERRAL:
       'Unit groups for the given project that can receive CE referrals',
-    USERS: 'User accounts',
+    USERS:
+      'User accounts. Returns all users, for use when filtering audit events',
   },
   PreferredLanguage: {
     INVALID: 'Invalid Value',

--- a/src/types/gqlEnums.ts
+++ b/src/types/gqlEnums.ts
@@ -1044,7 +1044,7 @@ export const HmisEnums = {
     SUB_TYPE_PROVIDED_5: 'SUB_TYPE_PROVIDED_5',
     UNIT_GROUPS_FOR_PROJECT_DIRECT_CE_REFERRAL:
       'Unit groups for the given project that can receive CE referrals',
-    USERS: 'User accounts. Deprecated in favor of AUDITABLE_USERS',
+    USERS: 'User accounts',
   },
   PreferredLanguage: {
     INVALID: 'Invalid Value',

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -5651,6 +5651,8 @@ export enum PickListType {
   AvailableUnitsForEnrollment = 'AVAILABLE_UNITS_FOR_ENROLLMENT',
   /** Unit types that have unoccupied units in the specified project */
   AvailableUnitTypes = 'AVAILABLE_UNIT_TYPES',
+  /** Projects with an active CE Participation record with Access Point = Yes */
+  CeAccessPointProjectNames = 'CE_ACCESS_POINT_PROJECT_NAMES',
   /** Grouped HUD CE Event types */
   CeEvents = 'CE_EVENTS',
   CeReferralStatuses = 'CE_REFERRAL_STATUSES',
@@ -5711,7 +5713,7 @@ export enum PickListType {
   SubTypeProvided_5 = 'SUB_TYPE_PROVIDED_5',
   /** Unit groups for the given project that can receive CE referrals */
   UnitGroupsForProjectDirectCeReferral = 'UNIT_GROUPS_FOR_PROJECT_DIRECT_CE_REFERRAL',
-  /** User accounts */
+  /** User accounts. Returns all users, for use when filtering audit events */
   Users = 'USERS',
 }
 

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -5636,7 +5636,10 @@ export enum PickListType {
    * exist in the project (both active and inactive).
    */
   AssessmentNames = 'ASSESSMENT_NAMES',
-  /** Current and historical user accounts */
+  /**
+   * Current and historical user accounts
+   * @deprecated No longer used
+   */
   AuditableUsers = 'AUDITABLE_USERS',
   AvailableBulkServiceTypes = 'AVAILABLE_BULK_SERVICE_TYPES',
   AvailableFileTypes = 'AVAILABLE_FILE_TYPES',
@@ -5708,7 +5711,7 @@ export enum PickListType {
   SubTypeProvided_5 = 'SUB_TYPE_PROVIDED_5',
   /** Unit groups for the given project that can receive CE referrals */
   UnitGroupsForProjectDirectCeReferral = 'UNIT_GROUPS_FOR_PROJECT_DIRECT_CE_REFERRAL',
-  /** User accounts. Deprecated in favor of AUDITABLE_USERS */
+  /** User accounts */
   Users = 'USERS',
 }
 


### PR DESCRIPTION
## Description

Summary of changes:
- Deprecate no-longer-used picklist AUDITABLE_USERS
  - It's no longer used anywhere on the frontend, but removing it carries some risk if there are form definitions referencing it. I'm pretty sure there won't be any; it sounds like this was previously used on the admin User Audit screens, which now present a table of users instead.
- Remove deprecation notice in comment on USERS picklist
  - This previously said "Deprecated in favor of AUDITABLE_USERS", but I believe that comment is out-of-date; the Users picklist is now still used in a few places.

[//]: # 'remove if not applicable'
Depends on hmis-warehouse PR: https://github.com/greenriver/hmis-warehouse/pull/6333

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Schema update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have used Axe DevTools to scan for accessibility issues (or not applicable)
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] My code follows the style guidelines of this project (eslint)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
