### PR TITLE
Make table filtering type-safe with generated types

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "storybook": "storybook dev -p 6006 --no-open",
     "build-storybook": "storybook build",
     "test-storybook": "test-storybook",
-    "graphql:codegen": "graphql-codegen --config codegen.yml && node scripts/generateEnumDescriptions.js && prettier --write ./src/types/* graphql.schema.json"
+    "graphql:codegen": "graphql-codegen --config codegen.yml && node scripts/generateEnumDescriptions.js && node scripts/generateGqlFilterOptionsTypes.js && prettier --write ./src/types/* graphql.schema.json"
   },
   "lint-staged": {
     "*.{js,ts,jsx,tsx}": [

--- a/scripts/generateGqlFilterOptionsTypes.js
+++ b/scripts/generateGqlFilterOptionsTypes.js
@@ -1,0 +1,53 @@
+'use strict';
+
+/**
+ * Reads graphql.schema.json (from graphql-codegen introspection) and emits
+ * src/types/gqlFilterOptionsTypes.generated.ts with all input object types
+ * whose name ends with `FilterOptions`.
+ *
+ * This is used to make table filtering type-safe (see useTableFilters.ts).
+ */
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.join(__dirname, '..');
+
+const generatedFileHeader =
+  '// **** THIS FILE IS GENERATED, DO NOT EDIT DIRECTLY ****\n\n';
+
+const schemaPath = path.join(repoRoot, 'graphql.schema.json');
+const outPath = path.join(
+  repoRoot,
+  'src/types/gqlFilterOptionsTypes.generated.ts'
+);
+
+const raw = fs.readFileSync(schemaPath, 'utf8');
+const schema = JSON.parse(raw);
+
+const types = schema.__schema?.types ?? [];
+const names = types
+  .filter(
+    (t) =>
+      t.kind === 'INPUT_OBJECT' &&
+      typeof t.name === 'string' &&
+      t.name.endsWith('FilterOptions')
+  )
+  .map((t) => t.name)
+  .sort((a, b) => a.localeCompare(b));
+
+if (names.length === 0) {
+  console.error(
+    'generateGqlFilterOptionsTypes: no *FilterOptions INPUT_OBJECT types found'
+  );
+  process.exit(1);
+}
+
+const importLine = `import type {\n${names.map((n) => `  ${n}`).join(',\n')},\n} from './gqlTypes';\n\n`;
+
+const mapEntries = names.map((n) => `  ${n}: ${n};`).join('\n');
+
+const output = `${generatedFileHeader}${importLine}export type FilterOptionsByName = {\n${mapEntries}\n};\n\nexport type FilterOptionsGraphqlTypeName = keyof FilterOptionsByName;\n\nexport const FILTER_OPTIONS_GRAPHQL_TYPE_NAMES = [\n${names.map((n) => `  '${n}'`).join(',\n')},\n] as const;\n`;
+
+fs.writeFileSync(outPath, output, 'utf8');

--- a/src/hooks/useTableFilters.ts
+++ b/src/hooks/useTableFilters.ts
@@ -1,10 +1,9 @@
 import { useMemo } from 'react';
 
-import useSearchParamsState, {
-  SearchParamsStateType,
-} from '@/hooks/useSearchParamState';
+import useSearchParamsState from '@/hooks/useSearchParamState';
 
 import { PickListArgs } from '@/modules/form/types';
+import type { FilterOptionsByName } from '@/types/gqlFilterOptionsTypes.generated';
 import { TableFilterConfigFieldsFragment } from '@/types/gqlTypes';
 import { FilterType, TableFilterType } from '@/types/tableFilterTypes';
 import {
@@ -12,21 +11,21 @@ import {
   buildUrlParamsDefinition,
 } from '@/utils/tableFilterUtil';
 
-interface Args<T = Record<string, unknown>> {
-  /** GraphQL type to use for inferring filters (e.g. 'ClientFilterOptions') */
-  type: string;
+type Args<K extends keyof FilterOptionsByName> = {
+  /** GraphQL input type name for filter fields (must match a generated *FilterOptions type). */
+  type: K;
   /** (Optional) Pick list args to be applied to all PickList filter items */
   pickListArgs?: PickListArgs;
   /** (Optional) Keys to skip when inferring filters. Filters that are text-based are always skipped
    * because they are not supported in the filter widget (due to limiting PII in URL). */
-  omit?: Array<string>;
+  omit?: Array<keyof FilterOptionsByName[K]>;
   /** (Optional) Dynamic filters to include (e.g. from HMIS Table Configuration) */
   dynamicFilters?: TableFilterConfigFieldsFragment[];
   /** (Optional) Whether to sync filter values to URL. If true, filterValues are reflected as URL search params. (Default: true) */
   syncToUrl?: boolean;
   /** (Optional) Initial filter values to set when URL has no params. Ignored if syncToUrl is false. */
-  initialFilterValues?: Partial<T>;
-}
+  initialFilterValues?: Partial<FilterOptionsByName[K]>;
+};
 
 /**
  * Builds a table filter configuration from a GraphQL filter input type (e.g. `ClientFilterOptions`)
@@ -44,56 +43,56 @@ interface Args<T = Record<string, unknown>> {
  * - Unlike Optional Table Columns (which similarly have logic to sync to URL),
  * filter values do not persist to localStorage. This was an intentional design choice.
  **/
-export default function useTableFilters<T = Record<string, unknown>>(
-  args: Args<T> & { syncToUrl?: true }
+export default function useTableFilters<K extends keyof FilterOptionsByName>(
+  args: Args<K> & { syncToUrl?: true }
 ): {
-  filters: TableFilterType<T>;
-  filterValues: Partial<T>;
-  setFilterValues: (values: Partial<T>) => void;
+  filters: TableFilterType<FilterOptionsByName[K]>;
+  filterValues: Partial<FilterOptionsByName[K]>;
+  setFilterValues: (values: Partial<FilterOptionsByName[K]>) => void;
 };
-export default function useTableFilters<T = Record<string, unknown>>(
-  args: Args<T> & { syncToUrl: false }
-): { filters: TableFilterType<T> };
+export default function useTableFilters<K extends keyof FilterOptionsByName>(
+  args: Args<K> & { syncToUrl: false }
+): { filters: TableFilterType<FilterOptionsByName[K]> };
 
-export default function useTableFilters<T = Record<string, unknown>>({
+export default function useTableFilters<K extends keyof FilterOptionsByName>({
   type, // Filter type, e.g. 'ClientFilterOptions'
-  initialFilterValues = {} as Partial<T>,
+  initialFilterValues = {} as Partial<FilterOptionsByName[K]>,
   pickListArgs = {},
   omit = [],
   dynamicFilters,
   syncToUrl = true,
-}: Args<T>):
+}: Args<K>):
   | {
-      filters: TableFilterType<T>; // filter configuration
-      filterValues: Partial<T>; // filter values (if syncToUrl is true)
-      setFilterValues: (values: Partial<T>) => void; // set filter values (if syncToUrl is true)
+      filters: TableFilterType<FilterOptionsByName[K]>; // filter configuration
+      filterValues: Partial<FilterOptionsByName[K]>; // filter values (if syncToUrl is true)
+      setFilterValues: (values: Partial<FilterOptionsByName[K]>) => void; // set filter values (if syncToUrl is true)
     }
-  | { filters: TableFilterType<T> } {
+  | { filters: TableFilterType<FilterOptionsByName[K]> } {
   // Build TableFilterType filter configuration by introspecting on the GraphQL schema for the given filter type.
   // If dynamicFilters are provided, add them to the filter configuration.
   const filters = useMemo(() => {
-    const result: TableFilterType<T> = buildTableFilterType<T>(
+    const result = buildTableFilterType<FilterOptionsByName[K]>(
       type,
       omit,
       pickListArgs
     );
     // Add dynamic filters if provided
     (dynamicFilters || []).forEach(({ key, label, options }) => {
-      result[key as keyof T] = {
+      result[key as keyof FilterOptionsByName[K]] = {
         key,
         label,
         multi: true,
         type: 'local_picklist', // Dynamic filters must have picklist options defined on them
         isDynamic: true,
         pickListOptions: options,
-      } as FilterType<T>;
+      } as FilterType<FilterOptionsByName[K]>;
     });
 
     return result;
   }, [type, dynamicFilters, omit, pickListArgs]);
 
   // Build URL param definition from filter configuration; if syncing filter state to URL.
-  const urlParamsDefinition: SearchParamsStateType = useMemo(() => {
+  const urlParamsDefinition = useMemo(() => {
     if (!syncToUrl || !filters || Object.keys(filters).length === 0) {
       return {};
     }
@@ -112,16 +111,18 @@ export default function useTableFilters<T = Record<string, unknown>>({
 
   return {
     filters,
-    filterValues: urlFilterValues as Partial<T>,
-    setFilterValues: setUrlFilterValues as (values: Partial<T>) => void,
+    filterValues: urlFilterValues as Partial<FilterOptionsByName[K]>,
+    setFilterValues: setUrlFilterValues as (
+      values: Partial<FilterOptionsByName[K]>
+    ) => void,
   };
 }
 
 // LEGACY: For backwards compatibility, re-export useTableFilters with old signature.
 // New code should use useTableFilters directly.
-export function useFilters<T = Record<string, unknown>>(
-  args: Omit<Args<T>, 'syncToUrl' | 'initialFilterValues'>
-): TableFilterType<T> {
-  const { filters } = useTableFilters<T>({ ...args, syncToUrl: false });
+export function useFilters<K extends keyof FilterOptionsByName>(
+  args: Omit<Args<K>, 'syncToUrl' | 'initialFilterValues'>
+): TableFilterType<FilterOptionsByName[K]> {
+  const { filters } = useTableFilters<K>({ ...args, syncToUrl: false });
   return filters;
 }

--- a/src/modules/admin/components/projectConfig/ProjectConfigTable.tsx
+++ b/src/modules/admin/components/projectConfig/ProjectConfigTable.tsx
@@ -20,7 +20,6 @@ import {
   GetProjectConfigsQuery,
   GetProjectConfigsQueryVariables,
   ProjectConfigFieldsFragment,
-  ProjectConfigFilterOptions,
   ProjectConfigType,
 } from '@/types/gqlTypes';
 import { evictProjectConfigs } from '@/utils/cacheUtil';
@@ -87,10 +86,9 @@ const ProjectConfigTable = ({
     []
   );
 
-  const { filters, filterValues, setFilterValues } =
-    useTableFilters<ProjectConfigFilterOptions>({
-      type: 'ProjectConfigFilterOptions',
-    });
+  const { filters, filterValues, setFilterValues } = useTableFilters({
+    type: 'ProjectConfigFilterOptions',
+  });
 
   return (
     <>

--- a/src/modules/admin/components/services/ServiceTypeTable.tsx
+++ b/src/modules/admin/components/services/ServiceTypeTable.tsx
@@ -9,7 +9,6 @@ import {
   GetServiceTypesQuery,
   GetServiceTypesQueryVariables,
   ServiceTypeConfigFieldsFragment,
-  ServiceTypeFilterOptions,
 } from '@/types/gqlTypes';
 import { generateSafePath } from '@/utils/pathEncoding';
 
@@ -48,10 +47,9 @@ const COLUMNS: ColumnDef<ServiceTypeConfigFieldsFragment>[] = [
 ];
 
 const ServiceTypeTable = () => {
-  const { filters, filterValues, setFilterValues } =
-    useTableFilters<ServiceTypeFilterOptions>({
-      type: 'ServiceTypeFilterOptions',
-    });
+  const { filters, filterValues, setFilterValues } = useTableFilters({
+    type: 'ServiceTypeFilterOptions',
+  });
 
   return (
     <>

--- a/src/modules/admin/components/users/ClientAccessSummaryTable.tsx
+++ b/src/modules/admin/components/users/ClientAccessSummaryTable.tsx
@@ -6,7 +6,6 @@ import GenericTableWithData from '@/modules/dataFetching/components/GenericTable
 import RelativeDateTableCellContents from '@/modules/hmis/components/RelativeDateTableCellContents';
 import {
   ClientAccessSummaryFieldsFragment,
-  ClientAccessSummaryFilterOptions,
   GetUserClientSummariesDocument,
   GetUserClientSummariesQuery,
   GetUserClientSummariesQueryVariables,
@@ -45,10 +44,9 @@ const ClientAccessSummaryTable: React.FC<Props> = ({
   startDate,
   searchTerm = '',
 }) => {
-  const { filters, filterValues, setFilterValues } =
-    useTableFilters<ClientAccessSummaryFilterOptions>({
-      type: 'ClientAccessSummaryFilterOptions',
-    });
+  const { filters, filterValues, setFilterValues } = useTableFilters({
+    type: 'ClientAccessSummaryFilterOptions',
+  });
 
   return (
     <GenericTableWithData<

--- a/src/modules/admin/components/users/EnrollmentAccessSummaryTable.tsx
+++ b/src/modules/admin/components/users/EnrollmentAccessSummaryTable.tsx
@@ -4,7 +4,6 @@ import GenericTableWithData from '@/modules/dataFetching/components/GenericTable
 import RelativeDateTableCellContents from '@/modules/hmis/components/RelativeDateTableCellContents';
 import {
   EnrollmentAccessSummaryFieldsFragment,
-  EnrollmentAccessSummaryFilterOptions,
   GetUserEnrollmentSummariesDocument,
   GetUserEnrollmentSummariesQuery,
   GetUserEnrollmentSummariesQueryVariables,
@@ -53,10 +52,9 @@ const EnrollmentAccessSummaryTable: React.FC<Props> = ({
   startDate,
   searchTerm,
 }) => {
-  const { filters, filterValues, setFilterValues } =
-    useTableFilters<EnrollmentAccessSummaryFilterOptions>({
-      type: 'EnrollmentAccessSummaryFilterOptions',
-    });
+  const { filters, filterValues, setFilterValues } = useTableFilters({
+    type: 'EnrollmentAccessSummaryFilterOptions',
+  });
 
   return (
     <GenericTableWithData<

--- a/src/modules/admin/components/users/UserAuditHistory.tsx
+++ b/src/modules/admin/components/users/UserAuditHistory.tsx
@@ -44,10 +44,9 @@ const columns: ColumnDef<UserAuditEventFieldsFragment>[] = [
 
 const UserAuditHistory = () => {
   const { userId } = useSafeParams() as { userId: string };
-  const { filters, filterValues, setFilterValues } =
-    useTableFilters<UserAuditEventFilterOptions>({
-      type: 'UserAuditEventFilterOptions',
-    });
+  const { filters, filterValues, setFilterValues } = useTableFilters({
+    type: 'UserAuditEventFilterOptions',
+  });
 
   const rowSecondaryActionConfigs = useCallback(
     ({

--- a/src/modules/ce/components/admin/AdminCeClientsTable.tsx
+++ b/src/modules/ce/components/admin/AdminCeClientsTable.tsx
@@ -16,7 +16,6 @@ import { ClientDashboardRoutes } from '@/routes/routes';
 import {
   CeCandidateFieldsFragment,
   CeClientFieldsFragment,
-  CeClientFilterOptions,
   ExternalIdentifierType,
   GetCeClientsDocument,
   GetCeClientsQuery,
@@ -88,11 +87,10 @@ const AdminCeClientsTable: React.FC = () => {
     ];
   }, [tableConfigLookup, mciIdEnabled]);
 
-  const { filters, filterValues, setFilterValues } =
-    useTableFilters<CeClientFilterOptions>({
-      type: 'CeClientFilterOptions',
-      dynamicFilters: tableConfigLookup?.ceClientsGlobalConfig?.filters,
-    });
+  const { filters, filterValues, setFilterValues } = useTableFilters({
+    type: 'CeClientFilterOptions',
+    dynamicFilters: tableConfigLookup?.ceClientsGlobalConfig?.filters,
+  });
 
   const rowSecondaryActionConfigs = useCallback(
     (row: CeClientFieldsFragment) => {

--- a/src/modules/ce/components/admin/AdminOpportunitiesTable.tsx
+++ b/src/modules/ce/components/admin/AdminOpportunitiesTable.tsx
@@ -8,7 +8,6 @@ import ProjectTypeChip from '@/modules/hmis/components/ProjectTypeChip';
 import { ProjectDashboardRoutes } from '@/routes/routes';
 import {
   CeOpportunityAdminFieldsFragment,
-  CeOpportunityFilterOptions,
   CeOpportunitySortOption,
   CeOpportunityStatus,
   GetAdminCeOpportunitiesDocument,
@@ -57,14 +56,13 @@ const COLUMNS: DataColumnDef<
 
 interface Props {}
 const AdminOpportunitiesTable: React.FC<Props> = ({}) => {
-  const { filters, filterValues, setFilterValues } =
-    useTableFilters<CeOpportunityFilterOptions>({
-      type: 'CeOpportunityFilterOptions',
-      omit: [
-        'status', // omitted because only 'open' opportunities are queried
-        'availableOnDate', // omitted because filter is not implemented on the backend #7537
-      ],
-    });
+  const { filters, filterValues, setFilterValues } = useTableFilters({
+    type: 'CeOpportunityFilterOptions',
+    omit: [
+      'status', // omitted because only 'open' opportunities are queried
+      'availableOnDate', // omitted because filter is not implemented on the backend #7537
+    ],
+  });
 
   return (
     <Paper>

--- a/src/modules/ce/components/admin/AdminReferralsTable.tsx
+++ b/src/modules/ce/components/admin/AdminReferralsTable.tsx
@@ -19,7 +19,6 @@ import {
 import { HmisEnums } from '@/types/gqlEnums';
 import {
   CeReferralAdminFieldsFragment,
-  CeReferralFilterOptions,
   GetAdminCeReferralsDocument,
   GetAdminCeReferralsQuery,
   GetAdminCeReferralsQueryVariables,
@@ -91,10 +90,9 @@ interface Props {}
 const AdminReferralsTable: React.FC<Props> = ({}) => {
   const [search, setSearch, debouncedSearch] = useDebouncedState<string>('');
 
-  const { filters, filterValues, setFilterValues } =
-    useTableFilters<CeReferralFilterOptions>({
-      type: 'CeReferralFilterOptions',
-    });
+  const { filters, filterValues, setFilterValues } = useTableFilters({
+    type: 'CeReferralFilterOptions',
+  });
 
   const rowSecondaryActions = useCallback(
     (row: CeReferralAdminFieldsFragment) => {

--- a/src/modules/ce/components/client/ClientReferralsTable.tsx
+++ b/src/modules/ce/components/client/ClientReferralsTable.tsx
@@ -32,10 +32,7 @@ const ClientReferralsTable: React.FC = () => {
     clientId: string;
   };
 
-  const filters = useFilters({
-    type: 'ClientCeReferralFilterOptions',
-    omit: ['workflowTemplate'],
-  });
+  const filters = useFilters({ type: 'ClientCeReferralFilterOptions' });
 
   return (
     <Paper>

--- a/src/modules/projectAdministration/components/AllProjectsPage.tsx
+++ b/src/modules/projectAdministration/components/AllProjectsPage.tsx
@@ -25,7 +25,6 @@ import {
   GetProjectsQuery,
   GetProjectsQueryVariables,
   ProjectAllFieldsFragment,
-  ProjectFilterOptions,
   ProjectFilterOptionStatus,
   ProjectSortOption,
 } from '@/types/gqlTypes';
@@ -106,7 +105,7 @@ const ProjectsTable = ({
     filters: projectFilters,
     filterValues,
     setFilterValues,
-  } = useTableFilters<ProjectFilterOptions>({
+  } = useTableFilters({
     type: 'ProjectFilterOptions',
     omit: ['ceEnabled'],
     // Initially, filter to only open projects

--- a/src/modules/projects/components/tables/ProjectClientEnrollmentsTable.tsx
+++ b/src/modules/projects/components/tables/ProjectClientEnrollmentsTable.tsx
@@ -53,15 +53,14 @@ const ProjectClientEnrollmentsTable = ({
       ];
     }, [projectType, staffAssignmentsEnabled]);
 
-  const { filters, filterValues, setFilterValues } =
-    useTableFilters<EnrollmentsForProjectFilterOptions>({
-      type: 'EnrollmentsForProjectFilterOptions',
-      omit: [
-        'bedNightOnDate', // Not applicable, this filter is available via bed night workflow
-        staffAssignmentsEnabled ? '' : 'assignedStaff',
-      ],
-      pickListArgs: { projectId: projectId },
-    });
+  const { filters, filterValues, setFilterValues } = useTableFilters({
+    type: 'EnrollmentsForProjectFilterOptions',
+    omit: [
+      'bedNightOnDate', // Not applicable, this filter is available via bed night workflow
+      ...(staffAssignmentsEnabled ? [] : ['assignedStaff']),
+    ] as (keyof EnrollmentsForProjectFilterOptions)[],
+    pickListArgs: { projectId: projectId },
+  });
 
   return (
     <GenericTableWithData<

--- a/src/modules/projects/components/tables/ProjectClientEnrollmentsTable.tsx
+++ b/src/modules/projects/components/tables/ProjectClientEnrollmentsTable.tsx
@@ -55,11 +55,12 @@ const ProjectClientEnrollmentsTable = ({
 
   const { filters, filterValues, setFilterValues } = useTableFilters({
     type: 'EnrollmentsForProjectFilterOptions',
-    omit: [
-      'bedNightOnDate', // Not applicable, this filter is available via bed night workflow
-      ...(staffAssignmentsEnabled ? [] : ['assignedStaff']),
-    ] as (keyof EnrollmentsForProjectFilterOptions)[],
-    pickListArgs: { projectId: projectId },
+    // Always exclude bedNightOnDate filter, it is only applicable to bed night workflow.
+    // Exclude assignedStaff filter if staff assignments are not enabled for this project.
+    omit: staffAssignmentsEnabled
+      ? ['bedNightOnDate']
+      : ['bedNightOnDate', 'assignedStaff'],
+    pickListArgs: { projectId },
   });
 
   return (

--- a/src/modules/projects/components/tables/ProjectHouseholdsTable.tsx
+++ b/src/modules/projects/components/tables/ProjectHouseholdsTable.tsx
@@ -206,12 +206,11 @@ const ProjectHouseholdsTable: React.FC<Props> = ({ projectId, searchTerm }) => {
     }));
   }, [projectType, staffAssignmentsEnabled]);
 
-  const { filters, filterValues, setFilterValues } =
-    useTableFilters<HouseholdFilterOptions>({
-      type: 'HouseholdFilterOptions',
-      omit: staffAssignmentsEnabled ? undefined : ['assignedStaff'],
-      pickListArgs: { projectId: projectId },
-    });
+  const { filters, filterValues, setFilterValues } = useTableFilters({
+    type: 'HouseholdFilterOptions',
+    omit: staffAssignmentsEnabled ? undefined : ['assignedStaff'],
+    pickListArgs: { projectId: projectId },
+  });
 
   return (
     <GenericTableWithData<

--- a/src/modules/search/components/ClientSearch.tsx
+++ b/src/modules/search/components/ClientSearch.tsx
@@ -216,7 +216,6 @@ const ClientSearch: React.FC<ClientSearchProps> = ({ searchType }) => {
 
   const filters = useFilters({
     type: 'ClientFilterOptions',
-    omit: ['searchTerm'],
   });
 
   const isTiny = useIsMobile('sm');

--- a/src/modules/units/components/UnitManagementTable.tsx
+++ b/src/modules/units/components/UnitManagementTable.tsx
@@ -61,10 +61,7 @@ const UnitManagementTable: React.FC<Props> = ({
 
   const filters = useFilters({
     type: 'UnitFilterOptions',
-    omit: [
-      'status', // deprecated filter option, remove
-      ...(unitGroupId ? ['unitType'] : []), // if looking at units in one group, no need to show this filter
-    ],
+    omit: unitGroupId ? ['unitType'] : [], // if looking at units in one group, no need to show this filter
     pickListArgs: { projectId },
   });
 

--- a/src/types/gqlFilterOptionsTypes.generated.ts
+++ b/src/types/gqlFilterOptionsTypes.generated.ts
@@ -1,0 +1,126 @@
+// **** THIS FILE IS GENERATED, DO NOT EDIT DIRECTLY ****
+
+import type {
+  ApplicationUserFilterOptions,
+  AssessmentFilterOptions,
+  AssessmentsForEnrollmentFilterOptions,
+  AssessmentsForHouseholdFilterOptions,
+  AssessmentsForProjectFilterOptions,
+  CeClientFilterOptions,
+  CeEligibleUnitGroupFilterOptions,
+  CeOpportunityCandidatesFilterOptions,
+  CeOpportunityFilterOptions,
+  CeReferralFilterOptions,
+  ClientAccessSummaryFilterOptions,
+  ClientAuditEventFilterOptions,
+  ClientCeReferralFilterOptions,
+  ClientEligibleCeOpportunityFilterOptions,
+  ClientFilterOptions,
+  EnrollmentAccessSummaryFilterOptions,
+  EnrollmentAuditEventFilterOptions,
+  EnrollmentsForClientFilterOptions,
+  EnrollmentsForProjectFilterOptions,
+  ExternalFormSubmissionFilterOptions,
+  FormIdentifierFilterOptions,
+  FormRuleFilterOptions,
+  HouseholdFilterOptions,
+  MergeAuditEventFilterOptions,
+  OrganizationFilterOptions,
+  ProjectCeOpportunityFilterOptions,
+  ProjectCeReferralFilterOptions,
+  ProjectConfigFilterOptions,
+  ProjectFilterOptions,
+  ProjectOutgoingCeReferralFilterOptions,
+  ProjectsForEnrollmentFilterOptions,
+  ReferralPostingFilterOptions,
+  ServiceFilterOptions,
+  ServicesForEnrollmentFilterOptions,
+  ServicesForProjectFilterOptions,
+  ServiceTypeFilterOptions,
+  UnitFilterOptions,
+  UserAuditEventFilterOptions,
+} from './gqlTypes';
+
+export type FilterOptionsByName = {
+  ApplicationUserFilterOptions: ApplicationUserFilterOptions;
+  AssessmentFilterOptions: AssessmentFilterOptions;
+  AssessmentsForEnrollmentFilterOptions: AssessmentsForEnrollmentFilterOptions;
+  AssessmentsForHouseholdFilterOptions: AssessmentsForHouseholdFilterOptions;
+  AssessmentsForProjectFilterOptions: AssessmentsForProjectFilterOptions;
+  CeClientFilterOptions: CeClientFilterOptions;
+  CeEligibleUnitGroupFilterOptions: CeEligibleUnitGroupFilterOptions;
+  CeOpportunityCandidatesFilterOptions: CeOpportunityCandidatesFilterOptions;
+  CeOpportunityFilterOptions: CeOpportunityFilterOptions;
+  CeReferralFilterOptions: CeReferralFilterOptions;
+  ClientAccessSummaryFilterOptions: ClientAccessSummaryFilterOptions;
+  ClientAuditEventFilterOptions: ClientAuditEventFilterOptions;
+  ClientCeReferralFilterOptions: ClientCeReferralFilterOptions;
+  ClientEligibleCeOpportunityFilterOptions: ClientEligibleCeOpportunityFilterOptions;
+  ClientFilterOptions: ClientFilterOptions;
+  EnrollmentAccessSummaryFilterOptions: EnrollmentAccessSummaryFilterOptions;
+  EnrollmentAuditEventFilterOptions: EnrollmentAuditEventFilterOptions;
+  EnrollmentsForClientFilterOptions: EnrollmentsForClientFilterOptions;
+  EnrollmentsForProjectFilterOptions: EnrollmentsForProjectFilterOptions;
+  ExternalFormSubmissionFilterOptions: ExternalFormSubmissionFilterOptions;
+  FormIdentifierFilterOptions: FormIdentifierFilterOptions;
+  FormRuleFilterOptions: FormRuleFilterOptions;
+  HouseholdFilterOptions: HouseholdFilterOptions;
+  MergeAuditEventFilterOptions: MergeAuditEventFilterOptions;
+  OrganizationFilterOptions: OrganizationFilterOptions;
+  ProjectCeOpportunityFilterOptions: ProjectCeOpportunityFilterOptions;
+  ProjectCeReferralFilterOptions: ProjectCeReferralFilterOptions;
+  ProjectConfigFilterOptions: ProjectConfigFilterOptions;
+  ProjectFilterOptions: ProjectFilterOptions;
+  ProjectOutgoingCeReferralFilterOptions: ProjectOutgoingCeReferralFilterOptions;
+  ProjectsForEnrollmentFilterOptions: ProjectsForEnrollmentFilterOptions;
+  ReferralPostingFilterOptions: ReferralPostingFilterOptions;
+  ServiceFilterOptions: ServiceFilterOptions;
+  ServicesForEnrollmentFilterOptions: ServicesForEnrollmentFilterOptions;
+  ServicesForProjectFilterOptions: ServicesForProjectFilterOptions;
+  ServiceTypeFilterOptions: ServiceTypeFilterOptions;
+  UnitFilterOptions: UnitFilterOptions;
+  UserAuditEventFilterOptions: UserAuditEventFilterOptions;
+};
+
+export type FilterOptionsGraphqlTypeName = keyof FilterOptionsByName;
+
+export const FILTER_OPTIONS_GRAPHQL_TYPE_NAMES = [
+  'ApplicationUserFilterOptions',
+  'AssessmentFilterOptions',
+  'AssessmentsForEnrollmentFilterOptions',
+  'AssessmentsForHouseholdFilterOptions',
+  'AssessmentsForProjectFilterOptions',
+  'CeClientFilterOptions',
+  'CeEligibleUnitGroupFilterOptions',
+  'CeOpportunityCandidatesFilterOptions',
+  'CeOpportunityFilterOptions',
+  'CeReferralFilterOptions',
+  'ClientAccessSummaryFilterOptions',
+  'ClientAuditEventFilterOptions',
+  'ClientCeReferralFilterOptions',
+  'ClientEligibleCeOpportunityFilterOptions',
+  'ClientFilterOptions',
+  'EnrollmentAccessSummaryFilterOptions',
+  'EnrollmentAuditEventFilterOptions',
+  'EnrollmentsForClientFilterOptions',
+  'EnrollmentsForProjectFilterOptions',
+  'ExternalFormSubmissionFilterOptions',
+  'FormIdentifierFilterOptions',
+  'FormRuleFilterOptions',
+  'HouseholdFilterOptions',
+  'MergeAuditEventFilterOptions',
+  'OrganizationFilterOptions',
+  'ProjectCeOpportunityFilterOptions',
+  'ProjectCeReferralFilterOptions',
+  'ProjectConfigFilterOptions',
+  'ProjectFilterOptions',
+  'ProjectOutgoingCeReferralFilterOptions',
+  'ProjectsForEnrollmentFilterOptions',
+  'ReferralPostingFilterOptions',
+  'ServiceFilterOptions',
+  'ServicesForEnrollmentFilterOptions',
+  'ServicesForProjectFilterOptions',
+  'ServiceTypeFilterOptions',
+  'UnitFilterOptions',
+  'UserAuditEventFilterOptions',
+] as const;

--- a/src/utils/tableFilterUtil.ts
+++ b/src/utils/tableFilterUtil.ts
@@ -108,7 +108,7 @@ const getFilter = (
 // by introspecting the GraphQL schema.
 export function buildTableFilterType<T>(
   type?: string | null,
-  omit: string[] = [],
+  omit: Array<keyof T> = [],
   pickListArgs?: PickListArgs
 ): TableFilterType<T> {
   if (!type) return {};
@@ -119,7 +119,7 @@ export function buildTableFilterType<T>(
   const result: Partial<Record<keyof T, FilterType<T>>> = {};
 
   schema.args.forEach(({ name }) => {
-    if (omit.includes(name)) return;
+    if (omit.includes(name as keyof T)) return;
 
     const filter = getFilter(type, name, pickListArgs);
     if (filter) {
@@ -173,11 +173,11 @@ export const transformDynamicFilters = <FilterOptionsType>(
 /** Build URL param definition from filter config; only includes non–free-text filters (no PII in URL). */
 export function buildUrlParamsDefinition<T>(
   filters: TableFilterType<T>,
-  omit: string[] = []
+  omit: Array<keyof T> = []
 ): SearchParamsStateType {
   const def: SearchParamsStateType = {};
   Object.entries(filters).forEach(([key, filter]) => {
-    if (omit.includes(key)) return;
+    if (omit.includes(key as keyof T)) return;
     const f = filter as FilterType<any>;
     if (f.type === 'text') return; // never put free-text in URL (PII)
     if (f.type === 'date') {


### PR DESCRIPTION
## Description

Follow-up to https://github.com/greenriver/hmis-frontend/pull/1406 to make table-filtering typesafe.
Related issue: https://github.com/open-path/Green-River/issues/149


## What changed

- **Codegen / scripts**
  - Added `scripts/generateGqlFilterOptionsTypes.js`, run after GraphQL codegen
  - Emits `src/types/gqlFilterOptionsTypes.generated.ts`: imports each `*FilterOptions` type from `gqlTypes`, exports **`FilterOptionsByName`**, **`FilterOptionsGraphqlTypeName`** (`keyof` that map), and **`FILTER_OPTIONS_GRAPHQL_TYPE_NAMES`** (`as const` list).
- **`useTableFilters` / `useFilters`**
  - `Args` uses **`type: K`** where **`K extends keyof FilterOptionsByName`**, so invalid `type` strings are rejected.
  - **`omit`**, **`initialFilterValues`**, and return types use **`FilterOptionsByName[K]`** instead of a free generic or plain `string` for `type`.
  - Call sites **no longer pass** `useTableFilters<SomeFilterOptions>` / `useFilters<SomeFilterOptions>` (the old generic was the **model** type, not the GraphQL type name); behavior is unchanged, with **inference from `type: '…FilterOptions'`**.
  - Type-checking will fail if callers pass values to `omit` that are not part of the generated filters. There were a few places where we did this, which I removed.


## How to verify

- `yarn graphql:codegen` — regenerates `gqlFilterOptionsTypes.generated.ts` when the schema changes.
- `yarn tsc` — should pass; new filter inputs in the schema require a codegen run so the registry stays aligned.
- No expected change in behavior for any tables, including dynamic filters


## Type of change
Code cleanup

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have used Axe DevTools to scan for accessibility issues (or not applicable)
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
