### PR TITLE
Expand persistent table filters to remaining tables

### DIFF
--- a/src/hooks/useTableFilters.ts
+++ b/src/hooks/useTableFilters.ts
@@ -117,12 +117,3 @@ export default function useTableFilters<K extends keyof FilterOptionsByName>({
     ) => void,
   };
 }
-
-// LEGACY: For backwards compatibility, re-export useTableFilters with old signature.
-// New code should use useTableFilters directly.
-export function useFilters<K extends keyof FilterOptionsByName>(
-  args: Omit<Args<K>, 'syncToUrl' | 'initialFilterValues'>
-): TableFilterType<FilterOptionsByName[K]> {
-  const { filters } = useTableFilters<K>({ ...args, syncToUrl: false });
-  return filters;
-}

--- a/src/modules/admin/components/formRules/FormRuleTable.tsx
+++ b/src/modules/admin/components/formRules/FormRuleTable.tsx
@@ -36,8 +36,10 @@ const FormRuleTable: React.FC<Props> = ({ formId, formRole }) => {
         GetFormRulesQueryVariables,
         RowType
       >
-        queryVariables={{ id: formId }}
-        defaultFilterValues={{ activeStatus: ActiveStatus.Active }}
+        queryVariables={{
+          id: formId,
+          filters: { activeStatus: [ActiveStatus.Active] },
+        }}
         queryDocument={GetFormRulesDocument}
         columns={[]}
         pagePath='formDefinition.formRules'

--- a/src/modules/admin/components/users/ClientAccessSummaryTable.tsx
+++ b/src/modules/admin/components/users/ClientAccessSummaryTable.tsx
@@ -36,12 +36,10 @@ const columns: ColumnDef<ClientAccessSummaryFieldsFragment>[] = [
 
 interface Props {
   userId: string;
-  startDate?: string;
   searchTerm?: string;
 }
 const ClientAccessSummaryTable: React.FC<Props> = ({
   userId,
-  startDate,
   searchTerm = '',
 }) => {
   const { filters, filterValues, setFilterValues } = useTableFilters({
@@ -59,9 +57,6 @@ const ClientAccessSummaryTable: React.FC<Props> = ({
         filters: { searchTerm },
       }}
       queryDocument={GetUserClientSummariesDocument}
-      defaultFilterValues={{
-        onOrAfter: startDate,
-      }}
       columns={columns}
       pagePath='user.clientAccessSummaries'
       noData='No access history'

--- a/src/modules/admin/components/users/EnrollmentAccessSummaryTable.tsx
+++ b/src/modules/admin/components/users/EnrollmentAccessSummaryTable.tsx
@@ -44,12 +44,10 @@ const columns: ColumnDef<EnrollmentAccessSummaryFieldsFragment>[] = [
 
 interface Props {
   userId: string;
-  startDate?: string;
   searchTerm?: string;
 }
 const EnrollmentAccessSummaryTable: React.FC<Props> = ({
   userId,
-  startDate,
   searchTerm,
 }) => {
   const { filters, filterValues, setFilterValues } = useTableFilters({
@@ -66,7 +64,6 @@ const EnrollmentAccessSummaryTable: React.FC<Props> = ({
         id: userId,
         filters: { searchTerm },
       }}
-      defaultFilterValues={{ onOrAfter: startDate }}
       queryDocument={GetUserEnrollmentSummariesDocument}
       columns={columns}
       pagePath='user.enrollmentAccessSummaries'

--- a/src/modules/admin/components/users/UserAccessHistory.tsx
+++ b/src/modules/admin/components/users/UserAccessHistory.tsx
@@ -112,14 +112,12 @@ const UserAccessHistory = ({ accessEntityType }: Props) => {
         {accessEntityType === 'clients' && (
           <ClientAccessSummaryTable
             userId={userId}
-            // startDate={defaultStartDate}
             searchTerm={debouncedSearch}
           />
         )}
         {accessEntityType === 'enrollments' && (
           <EnrollmentAccessSummaryTable
             userId={userId}
-            // startDate={defaultStartDate}
             searchTerm={debouncedSearch}
           />
         )}

--- a/src/modules/assessments/components/pages/ClientAssessmentsPage.tsx
+++ b/src/modules/assessments/components/pages/ClientAssessmentsPage.tsx
@@ -3,7 +3,7 @@ import { useCallback } from 'react';
 import { getViewEnrollmentMenuItem } from '@/components/elements/table/tableRowActionUtil';
 import PageTitle from '@/components/layout/PageTitle';
 import useSafeParams from '@/hooks/useSafeParams';
-import { useFilters } from '@/hooks/useTableFilters';
+import useTableFilters from '@/hooks/useTableFilters';
 import { ClientAssessmentType } from '@/modules/assessments/assessmentTypes';
 import {
   ASSESSMENT_COLUMNS,
@@ -50,7 +50,7 @@ const ClientAssessmentsPage = () => {
   const { clientId } = useSafeParams() as { clientId: string };
   const { client } = useClientDashboardContext();
 
-  const filters = useFilters({
+  const { filters, filterValues, setFilterValues } = useTableFilters({
     type: 'AssessmentFilterOptions',
   });
 
@@ -86,6 +86,8 @@ const ClientAssessmentsPage = () => {
           ClientAssessmentType
         >
           filters={filters}
+          filterValues={filterValues}
+          onFilterChange={setFilterValues}
           queryVariables={{ id: clientId }}
           queryDocument={GetClientAssessmentsDocument}
           columns={COLUMNS}

--- a/src/modules/audit/components/ClientAuditHistory.tsx
+++ b/src/modules/audit/components/ClientAuditHistory.tsx
@@ -3,7 +3,7 @@ import { ContextualCollapsibleListsProvider } from '@/components/elements/Collap
 import { ColumnDef } from '@/components/elements/table/types';
 import PageTitle from '@/components/layout/PageTitle';
 import useSafeParams from '@/hooks/useSafeParams';
-import { useFilters } from '@/hooks/useTableFilters';
+import useTableFilters from '@/hooks/useTableFilters';
 import {
   AUDIT_HISTORY_COLUMNS,
   AUDIT_HISTORY_USER_COLUMNS,
@@ -30,7 +30,7 @@ const columns: ColumnDef<AuditHistoryType>[] = [
 
 const ClientAuditHistory = () => {
   const { clientId } = useSafeParams() as { clientId: string };
-  const filters = useFilters({
+  const { filters, filterValues, setFilterValues } = useTableFilters({
     type: 'ClientAuditEventFilterOptions',
   });
 
@@ -57,6 +57,8 @@ const ClientAuditHistory = () => {
           queryVariables={{ id: clientId }}
           recordType='ClientAuditEvent'
           filters={filters}
+          filterValues={filterValues}
+          onFilterChange={setFilterValues}
         />
       </Paper>
     </ContextualCollapsibleListsProvider>

--- a/src/modules/audit/components/EnrollmentAuditHistory.tsx
+++ b/src/modules/audit/components/EnrollmentAuditHistory.tsx
@@ -3,7 +3,7 @@ import { ContextualCollapsibleListsProvider } from '@/components/elements/Collap
 import { ColumnDef } from '@/components/elements/table/types';
 import PageTitle from '@/components/layout/PageTitle';
 import useSafeParams from '@/hooks/useSafeParams';
-import { useFilters } from '@/hooks/useTableFilters';
+import useTableFilters from '@/hooks/useTableFilters';
 import {
   AUDIT_HISTORY_COLUMNS,
   AUDIT_HISTORY_USER_COLUMNS,
@@ -30,7 +30,7 @@ const columns: ColumnDef<AuditHistoryType>[] = [
 
 const EnrollmentAuditHistory = () => {
   const { enrollmentId } = useSafeParams() as { enrollmentId: string };
-  const filters = useFilters({
+  const { filters, filterValues, setFilterValues } = useTableFilters({
     type: 'EnrollmentAuditEventFilterOptions',
   });
 
@@ -57,6 +57,8 @@ const EnrollmentAuditHistory = () => {
           queryVariables={{ id: enrollmentId }}
           recordType='EnrollmentAuditEvent'
           filters={filters}
+          filterValues={filterValues}
+          onFilterChange={setFilterValues}
         />
       </Paper>
     </ContextualCollapsibleListsProvider>

--- a/src/modules/ce/components/client/ClientOpportunitiesTable.tsx
+++ b/src/modules/ce/components/client/ClientOpportunitiesTable.tsx
@@ -2,7 +2,7 @@ import { Paper, Typography } from '@mui/material';
 import React from 'react';
 import DateWithRelativeTooltip from '@/components/elements/DateWithRelativeTooltip';
 import { ColumnDef } from '@/components/elements/table/types';
-import { useFilters } from '@/hooks/useTableFilters';
+import useTableFilters from '@/hooks/useTableFilters';
 import useClientDashboardContext from '@/modules/client/hooks/useClientDashboardContext';
 import GenericTableWithData from '@/modules/dataFetching/components/GenericTableWithData';
 import ProjectTypeChip from '@/modules/hmis/components/ProjectTypeChip';
@@ -62,7 +62,7 @@ const ClientOpportunitiesTable: React.FC = () => {
   const { id: clientId } = client;
   const clientName = clientBriefName(client);
 
-  const filters = useFilters({
+  const { filters, filterValues, setFilterValues } = useTableFilters({
     type: 'ClientEligibleCeOpportunityFilterOptions',
   });
 
@@ -89,6 +89,8 @@ const ClientOpportunitiesTable: React.FC = () => {
             id: clientId,
           }}
           filters={filters}
+          filterValues={filterValues}
+          onFilterChange={setFilterValues}
           queryDocument={GetClientEligibleOpportunitiesDocument}
           pagePath='client.eligibleCeOpportunities'
           noData='No units'

--- a/src/modules/ce/components/client/ClientReferralsTable.tsx
+++ b/src/modules/ce/components/client/ClientReferralsTable.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { ColumnDef } from '@/components/elements/table/types';
 import useSafeParams from '@/hooks/useSafeParams';
 
-import { useFilters } from '@/hooks/useTableFilters';
+import useTableFilters from '@/hooks/useTableFilters';
 import {
   REFERRAL_COLUMNS,
   REFERRAL_WITH_PROJECT_COLUMNS,
@@ -32,7 +32,9 @@ const ClientReferralsTable: React.FC = () => {
     clientId: string;
   };
 
-  const filters = useFilters({ type: 'ClientCeReferralFilterOptions' });
+  const { filters, filterValues, setFilterValues } = useTableFilters({
+    type: 'ClientCeReferralFilterOptions',
+  });
 
   return (
     <Paper>
@@ -56,6 +58,8 @@ const ClientReferralsTable: React.FC = () => {
         }
         rowActionTitle='View Referral'
         filters={filters}
+        filterValues={filterValues}
+        onFilterChange={setFilterValues}
       />
     </Paper>
   );

--- a/src/modules/ce/components/defaultContacts/AdminDefaultContactsTable.tsx
+++ b/src/modules/ce/components/defaultContacts/AdminDefaultContactsTable.tsx
@@ -5,7 +5,7 @@ import SwimlaneLabel from './SwimlaneLabel';
 import Loading from '@/components/elements/Loading';
 import NotCollectedText from '@/components/elements/NotCollectedText';
 import useDebouncedState from '@/hooks/useDebouncedState';
-import { useFilters } from '@/hooks/useTableFilters';
+import useTableFilters from '@/hooks/useTableFilters';
 import EditProjectCeDefaultContactsModal from '@/modules/ce/components/defaultContacts/EditProjectCeDefaultContactsModal';
 import GenericTableWithData from '@/modules/dataFetching/components/GenericTableWithData';
 import { DataColumnDef } from '@/modules/dataFetching/types';
@@ -50,7 +50,7 @@ const AdminDefaultContactsTable: React.FC<Props> = ({}) => {
 
   const [search, setSearch, debouncedSearch] = useDebouncedState<string>('');
 
-  const filters = useFilters({
+  const { filters, filterValues, setFilterValues } = useTableFilters({
     type: 'ProjectFilterOptions',
     omit: ['status', 'funder', 'ceEnabled', 'searchTerm'],
   });
@@ -123,6 +123,8 @@ const AdminDefaultContactsTable: React.FC<Props> = ({}) => {
             }}
             defaultSortOption={ProjectSortOption.OrganizationAndName}
             filters={filters}
+            filterValues={filterValues}
+            onFilterChange={setFilterValues}
             queryDocument={GetDefaultContactsDocument}
             pagePath='projects'
             paginationItemName='coordinated entry project'

--- a/src/modules/ce/components/directReferral/ProjectOutgoingReferralsTable.tsx
+++ b/src/modules/ce/components/directReferral/ProjectOutgoingReferralsTable.tsx
@@ -2,7 +2,7 @@ import { Paper } from '@mui/material';
 import React from 'react';
 import DateWithRelativeTooltip from '@/components/elements/DateWithRelativeTooltip';
 import { getViewClientMenuItem } from '@/components/elements/table/tableRowActionUtil';
-import { useFilters } from '@/hooks/useTableFilters';
+import useTableFilters from '@/hooks/useTableFilters';
 import ReferralStatusChip from '@/modules/ce/components/referral/ReferralStatusChip';
 import GenericTableWithData from '@/modules/dataFetching/components/GenericTableWithData';
 import { DataColumnDef } from '@/modules/dataFetching/types';
@@ -65,7 +65,7 @@ interface Props {
  * Table showing outgoing referrals from a project.
  */
 const ProjectOutgoingReferralsTable: React.FC<Props> = ({ projectId }) => {
-  const filters = useFilters({
+  const { filters, filterValues, setFilterValues } = useTableFilters({
     type: 'ProjectOutgoingCeReferralFilterOptions',
     omit: ['searchTerm'],
   });
@@ -82,6 +82,8 @@ const ProjectOutgoingReferralsTable: React.FC<Props> = ({ projectId }) => {
           id: projectId,
         }}
         filters={filters}
+        filterValues={filterValues}
+        onFilterChange={setFilterValues}
         queryDocument={GetProjectOutgoingDirectCeReferralsDocument}
         pagePath='project.outgoingDirectCeReferrals'
         noData='No referrals'

--- a/src/modules/ce/components/project/ProjectReferralsTable.tsx
+++ b/src/modules/ce/components/project/ProjectReferralsTable.tsx
@@ -1,7 +1,7 @@
 import { Paper } from '@mui/material';
 import React from 'react';
 import { ColumnDef } from '@/components/elements/table/types';
-import { useFilters } from '@/hooks/useTableFilters';
+import useTableFilters from '@/hooks/useTableFilters';
 import { REFERRAL_COLUMNS } from '@/modules/ce/referralColumns';
 import GenericTableWithData from '@/modules/dataFetching/components/GenericTableWithData';
 import { ProjectDashboardRoutes } from '@/routes/routes';
@@ -34,7 +34,7 @@ interface Props {
  * If user has "canViewOwnReferrals", then they will only be able to see referrals that have an available task assigned to them.
  */
 const ProjectReferralsTable: React.FC<Props> = ({ projectId }) => {
-  const filters = useFilters({
+  const { filters, filterValues, setFilterValues } = useTableFilters({
     type: 'ProjectCeReferralFilterOptions',
     omit: ['searchTerm'],
   });
@@ -51,6 +51,8 @@ const ProjectReferralsTable: React.FC<Props> = ({ projectId }) => {
           id: projectId,
         }}
         filters={filters}
+        filterValues={filterValues}
+        onFilterChange={setFilterValues}
         queryDocument={GetProjectCeReferralsDocument}
         pagePath='project.ceReferrals'
         noData='No referrals'

--- a/src/modules/ce/components/unit/PrioritizedClientsTable.tsx
+++ b/src/modules/ce/components/unit/PrioritizedClientsTable.tsx
@@ -6,7 +6,7 @@ import TableRowActions from '@/components/elements/table/TableRowActions';
 import { BASE_ACTION_COLUMN_DEF } from '@/components/elements/table/tableRowActionUtil';
 import { ColumnDef } from '@/components/elements/table/types';
 import useDebouncedState from '@/hooks/useDebouncedState';
-import { useFilters } from '@/hooks/useTableFilters';
+import useTableFilters from '@/hooks/useTableFilters';
 import { configurableCeColumns } from '@/modules/ce/components/admin/AdminCeClientsTable';
 import StartReferralButton from '@/modules/ce/components/unit/StartReferralButton';
 import GenericTableWithData from '@/modules/dataFetching/components/GenericTableWithData';
@@ -97,9 +97,10 @@ const PrioritizedClientsTable: React.FC<Props> = ({
     ];
   }, [project.access, tableConfigLookup, status, opportunity]);
 
-  const filters = useFilters({
+  const { filters, filterValues, setFilterValues } = useTableFilters({
     type: 'CeOpportunityCandidatesFilterOptions',
     omit: ['searchTerm'],
+    initialFilterValues: { excludeDeclinedClients: true },
   });
 
   const [search, setSearch, debouncedSearch] = useDebouncedState<string>('');
@@ -161,9 +162,8 @@ const PrioritizedClientsTable: React.FC<Props> = ({
           paginationItemName='client'
           noData={'No clients are currently eligible for this unit.'}
           filters={filters}
-          defaultFilterValues={{
-            excludeDeclinedClients: true,
-          }}
+          filterValues={filterValues}
+          onFilterChange={setFilterValues}
         />
       </Paper>
     </Stack>

--- a/src/modules/clientMerge/components/admin/GlobalClientMergeHistory.tsx
+++ b/src/modules/clientMerge/components/admin/GlobalClientMergeHistory.tsx
@@ -4,7 +4,7 @@ import ButtonLink from '@/components/elements/ButtonLink';
 import { getViewClientMenuItem } from '@/components/elements/table/tableRowActionUtil';
 import { ColumnDef } from '@/components/elements/table/types';
 import PageTitle from '@/components/layout/PageTitle';
-import { useFilters } from '@/hooks/useTableFilters';
+import useTableFilters from '@/hooks/useTableFilters';
 import ClientName from '@/modules/client/components/ClientName';
 import GenericTableWithData from '@/modules/dataFetching/components/GenericTableWithData';
 import { AdminDashboardRoutes } from '@/routes/routes';
@@ -32,7 +32,7 @@ const GlobalClientMergeHistory = () => {
   const pathToMerge = generateSafePath(
     AdminDashboardRoutes.PERFORM_CLIENT_MERGES
   );
-  const filters = useFilters({
+  const { filters, filterValues, setFilterValues } = useTableFilters({
     type: 'MergeAuditEventFilterOptions',
   });
 
@@ -56,6 +56,8 @@ const GlobalClientMergeHistory = () => {
           pagePath='mergeAuditHistory'
           noData='No merge history'
           filters={filters}
+          filterValues={filterValues}
+          onFilterChange={setFilterValues}
           recordType='MergeAuditEvent'
           paginationItemName='merge event'
           noSort

--- a/src/modules/clientMerge/components/client/NewClientMerge.tsx
+++ b/src/modules/clientMerge/components/client/NewClientMerge.tsx
@@ -10,7 +10,7 @@ import { getViewClientMenuItem } from '@/components/elements/table/tableRowActio
 import { ColumnDef } from '@/components/elements/table/types';
 import TitleCard from '@/components/elements/TitleCard';
 import PageTitle from '@/components/layout/PageTitle';
-import { useFilters } from '@/hooks/useTableFilters';
+import useTableFilters from '@/hooks/useTableFilters';
 import useClientDashboardContext from '@/modules/client/hooks/useClientDashboardContext';
 import {
   ContextualClientSsn,
@@ -104,7 +104,7 @@ const NewClientMerge = () => {
     []
   );
 
-  const filters = useFilters({
+  const { filters, filterValues, setFilterValues } = useTableFilters({
     type: 'ClientFilterOptions',
   });
 
@@ -179,6 +179,8 @@ const NewClientMerge = () => {
                   // that no longer exists (e.g. has already been merged in)
                   fetchPolicy='network-only'
                   filters={filters}
+                  filterValues={filterValues}
+                  onFilterChange={setFilterValues}
                   recordType='Client'
                   defaultSortOption={ClientSortOption.BestMatch}
                   rowSecondaryActionConfigs={(row) => [

--- a/src/modules/dataFetching/components/GenericTableWithData.tsx
+++ b/src/modules/dataFetching/components/GenericTableWithData.tsx
@@ -56,7 +56,7 @@ export interface Props<
     rows: RowDataType[],
     loading?: boolean
   ) => DataColumnDef<RowDataType, QueryVariables>[]; // dynamically define column defs based on current data
-  /** Filter config (which filters exist, their type/labels). From useFilters() or useTableFilters(). */
+  /** Filter config (which filters exist, their type/labels). From useTableFilters(). */
   filters?: TableFilterType<FilterOptionsType>;
   sortOptions?: SortOptionsType;
   defaultSortOption?: keyof SortOptionsType;

--- a/src/modules/enrollment/components/EnrollmentAssessmentsTable.tsx
+++ b/src/modules/enrollment/components/EnrollmentAssessmentsTable.tsx
@@ -1,5 +1,5 @@
 import { ColumnDef } from '@/components/elements/table/types';
-import { useFilters } from '@/hooks/useTableFilters';
+import useTableFilters from '@/hooks/useTableFilters';
 import {
   ASSESSMENT_COLUMNS,
   ASSESSMENT_DETAILS_COL,
@@ -32,7 +32,7 @@ const EnrollmentAssessmentsTable: React.FC<Props> = ({
   enrollmentId,
   projectId,
 }) => {
-  const filters = useFilters({
+  const { filters, filterValues, setFilterValues } = useTableFilters({
     type: 'AssessmentsForEnrollmentFilterOptions',
     pickListArgs: { projectId },
   });
@@ -44,6 +44,8 @@ const EnrollmentAssessmentsTable: React.FC<Props> = ({
       AssessmentFieldsFragment
     >
       filters={filters}
+      filterValues={filterValues}
+      onFilterChange={setFilterValues}
       queryVariables={{ id: enrollmentId }}
       queryDocument={GetEnrollmentAssessmentsDocument}
       columns={COLUMNS}

--- a/src/modules/enrollment/components/HouseholdAssessmentsTable.tsx
+++ b/src/modules/enrollment/components/HouseholdAssessmentsTable.tsx
@@ -1,5 +1,5 @@
 import { ColumnDef } from '@/components/elements/table/types';
-import { useFilters } from '@/hooks/useTableFilters';
+import useTableFilters from '@/hooks/useTableFilters';
 import {
   ASSESSMENT_CLIENT_NAME_COL,
   ASSESSMENT_COLUMNS,
@@ -38,7 +38,7 @@ const HouseholdAssessmentsTable: React.FC<Props> = ({
   householdId,
   projectId,
 }) => {
-  const filters = useFilters({
+  const { filters, filterValues, setFilterValues } = useTableFilters({
     type: 'AssessmentsForHouseholdFilterOptions',
     pickListArgs: { projectId },
   });
@@ -50,6 +50,8 @@ const HouseholdAssessmentsTable: React.FC<Props> = ({
       HhmAssessmentType
     >
       filters={filters}
+      filterValues={filterValues}
+      onFilterChange={setFilterValues}
       queryVariables={{ id: householdId }}
       queryDocument={GetHouseholdAssessmentsDocument}
       columns={COLUMNS}

--- a/src/modules/enrollment/components/pages/ClientEnrollmentsPage.tsx
+++ b/src/modules/enrollment/components/pages/ClientEnrollmentsPage.tsx
@@ -4,7 +4,7 @@ import { ReactNode, useCallback } from 'react';
 import NotCollectedText from '@/components/elements/NotCollectedText';
 import { ColumnDef } from '@/components/elements/table/types';
 import PageTitle from '@/components/layout/PageTitle';
-import { useFilters } from '@/hooks/useTableFilters';
+import useTableFilters from '@/hooks/useTableFilters';
 import useClientDashboardContext from '@/modules/client/hooks/useClientDashboardContext';
 import GenericTableWithData from '@/modules/dataFetching/components/GenericTableWithData';
 import { ENROLLMENT_COLUMNS } from '@/modules/enrollment/columns/enrollmentColumns';
@@ -122,7 +122,7 @@ const COLUMNS: ColumnDef<ClientEnrollmentFieldsFragment>[] = [
 const ClientEnrollmentsPage = () => {
   const { client } = useClientDashboardContext();
 
-  const filters = useFilters({
+  const { filters, filterValues, setFilterValues } = useTableFilters({
     type: 'EnrollmentsForClientFilterOptions',
   });
 
@@ -155,6 +155,8 @@ const ClientEnrollmentsPage = () => {
           rowActionTitle='View Enrollment'
           pagePath='client.enrollments'
           filters={filters}
+          filterValues={filterValues}
+          onFilterChange={setFilterValues}
           recordType='Enrollment'
           noSort
           defaultSortOption={EnrollmentSortOption.MostRecent}

--- a/src/modules/household/components/ManageHousehold.tsx
+++ b/src/modules/household/components/ManageHousehold.tsx
@@ -18,7 +18,7 @@ import { ColumnDef } from '@/components/elements/table/types';
 import NotFound from '@/components/pages/NotFound';
 import { useGlobalFeatureFlags } from '@/hooks/useGlobalFeatureFlags';
 import { useIsMobile } from '@/hooks/useIsMobile';
-import { useFilters } from '@/hooks/useTableFilters';
+import useTableFilters from '@/hooks/useTableFilters';
 import { SsnDobShowContextProvider } from '@/modules/client/providers/ClientSsnDobVisibility';
 import GenericTableWithData from '@/modules/dataFetching/components/GenericTableWithData';
 import AssociatedHouseholdMembers from '@/modules/household/components/AssociatedHouseholdMembers';
@@ -120,7 +120,7 @@ const ManageHousehold = ({
     ];
   }, [addToEnrollmentColumns, globalFeatureFlags, isMobile]);
 
-  const filters = useFilters({
+  const { filters, filterValues, setFilterValues } = useTableFilters({
     type: 'ClientFilterOptions',
   });
 
@@ -253,6 +253,8 @@ const ManageHousehold = ({
                   pagePath='clientSearch'
                   fetchPolicy='cache-and-network'
                   filters={filters}
+                  filterValues={filterValues}
+                  onFilterChange={setFilterValues}
                   recordType='Client'
                   defaultSortOption={ClientSortOption.BestMatch}
                   onDataReady={() => setHasSearched(true)}

--- a/src/modules/projectAdministration/components/OrganizationProjectsTable.tsx
+++ b/src/modules/projectAdministration/components/OrganizationProjectsTable.tsx
@@ -3,7 +3,7 @@ import { useCallback } from 'react';
 import TextInput from '@/components/elements/input/TextInput';
 import { ColumnDef } from '@/components/elements/table/types';
 import useDebouncedState from '@/hooks/useDebouncedState';
-import { useFilters } from '@/hooks/useTableFilters';
+import useTableFilters from '@/hooks/useTableFilters';
 import GenericTableWithData from '@/modules/dataFetching/components/GenericTableWithData';
 import ProjectTypeChip from '@/modules/hmis/components/ProjectTypeChip';
 import { parseAndFormatDateRange } from '@/modules/hmis/hmisUtil';
@@ -62,9 +62,10 @@ const OrganizationProjectsTable = ({
     []
   );
 
-  const filters = useFilters({
+  const { filters, filterValues, setFilterValues } = useTableFilters({
     type: 'ProjectsForEnrollmentFilterOptions',
     omit: ['searchTerm'],
+    initialFilterValues: { status: [ProjectFilterOptionStatus.Open] },
   });
 
   return (
@@ -97,10 +98,9 @@ const OrganizationProjectsTable = ({
       noData='No projects'
       pagePath='organization.projects'
       filters={hideFilters ? undefined : filters}
+      filterValues={hideFilters ? undefined : filterValues}
+      onFilterChange={hideFilters ? undefined : setFilterValues}
       recordType='Project'
-      defaultFilterValues={
-        hideFilters ? undefined : { status: [ProjectFilterOptionStatus.Open] }
-      }
       noSort
     />
   );

--- a/src/modules/projects/components/ProjectAssessments.tsx
+++ b/src/modules/projects/components/ProjectAssessments.tsx
@@ -4,7 +4,7 @@ import { getViewEnrollmentMenuItem } from '@/components/elements/table/tableRowA
 import { ColumnDef } from '@/components/elements/table/types';
 import PageTitle from '@/components/layout/PageTitle';
 import useSafeParams from '@/hooks/useSafeParams';
-import { useFilters } from '@/hooks/useTableFilters';
+import useTableFilters from '@/hooks/useTableFilters';
 import {
   ASSESSMENT_CLIENT_NAME_COL,
   ASSESSMENT_COLUMNS,
@@ -43,7 +43,7 @@ const ProjectAssessments = () => {
   };
   const { project } = useProjectDashboardContext();
 
-  const filters = useFilters({
+  const { filters, filterValues, setFilterValues } = useTableFilters({
     type: 'AssessmentsForProjectFilterOptions',
     pickListArgs: { projectId },
   });
@@ -80,6 +80,8 @@ const ProjectAssessments = () => {
           pagePath='project.assessments'
           recordType='Assessment'
           filters={filters}
+          filterValues={filterValues}
+          onFilterChange={setFilterValues}
           defaultSortOption={AssessmentSortOption.AssessmentDate}
         />
       </Paper>

--- a/src/modules/projects/components/tables/ProjectExternalSubmissionsTable.tsx
+++ b/src/modules/projects/components/tables/ProjectExternalSubmissionsTable.tsx
@@ -4,7 +4,7 @@ import { useCallback, useState } from 'react';
 import LoadingButton from '@/components/elements/LoadingButton';
 import { ColumnDef } from '@/components/elements/table/types';
 import theme from '@/config/theme';
-import { useFilters } from '@/hooks/useTableFilters';
+import useTableFilters from '@/hooks/useTableFilters';
 import GenericTableWithData from '@/modules/dataFetching/components/GenericTableWithData';
 import ApolloErrorAlert from '@/modules/errors/components/ApolloErrorAlert';
 import RelativeDateTableCellContents from '@/modules/hmis/components/RelativeDateTableCellContents';
@@ -107,7 +107,7 @@ const ProjectExternalSubmissionsTable = ({
     []
   );
 
-  const filters = useFilters({
+  const { filters, filterValues, setFilterValues } = useTableFilters({
     type: 'ExternalFormSubmissionFilterOptions',
   });
 
@@ -138,6 +138,8 @@ const ProjectExternalSubmissionsTable = ({
         recordType='ExternalFormSubmission'
         paginationItemName='submission'
         filters={filters}
+        filterValues={filterValues}
+        onFilterChange={setFilterValues}
         EnhancedTableToolbarProps={{
           title: (
             <Stack

--- a/src/modules/search/components/ClientSearch.tsx
+++ b/src/modules/search/components/ClientSearch.tsx
@@ -24,7 +24,7 @@ import { useGlobalFeatureFlags } from '@/hooks/useGlobalFeatureFlags';
 import { useIsMobile } from '@/hooks/useIsMobile';
 
 import useSearchParamsState from '@/hooks/useSearchParamState';
-import { useFilters } from '@/hooks/useTableFilters';
+import useTableFilters from '@/hooks/useTableFilters';
 import ClientName from '@/modules/client/components/ClientName';
 import ClientSearchResultCard from '@/modules/client/components/searchResultCard/ClientSearchResultCard';
 import {
@@ -273,7 +273,7 @@ const ClientSearch: React.FC<ClientSearchProps> = ({ searchType }) => {
     ]
   );
 
-  const filters = useFilters({
+  const { filters, filterValues, setFilterValues } = useTableFilters({
     type: 'ClientFilterOptions',
   });
 
@@ -346,6 +346,8 @@ const ClientSearch: React.FC<ClientSearchProps> = ({ searchType }) => {
             pagePath='clientSearch'
             fetchPolicy='cache-and-network'
             filters={filters}
+            filterValues={filterValues}
+            onFilterChange={setFilterValues}
             recordType='Client'
             defaultSortOption={
               searchType === 'broad'

--- a/src/modules/services/components/ClientServicesPage.tsx
+++ b/src/modules/services/components/ClientServicesPage.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { getViewEnrollmentMenuItem } from '@/components/elements/table/tableRowActionUtil';
 import PageTitle from '@/components/layout/PageTitle';
 import useSafeParams from '@/hooks/useSafeParams';
-import { useFilters } from '@/hooks/useTableFilters';
+import useTableFilters from '@/hooks/useTableFilters';
 import useClientDashboardContext from '@/modules/client/hooks/useClientDashboardContext';
 import GenericTableWithData from '@/modules/dataFetching/components/GenericTableWithData';
 
@@ -57,7 +57,7 @@ const ClientServicesPage: React.FC = () => {
   const { clientId } = useSafeParams() as { clientId: string };
   const { client } = useClientDashboardContext();
 
-  const filters = useFilters({
+  const { filters, filterValues, setFilterValues } = useTableFilters({
     type: 'ServiceFilterOptions',
   });
 
@@ -71,6 +71,8 @@ const ClientServicesPage: React.FC = () => {
           ServiceType
         >
           filters={filters}
+          filterValues={filterValues}
+          onFilterChange={setFilterValues}
           queryVariables={{ id: clientId }}
           queryDocument={GetClientServicesDocument}
           columns={columns}

--- a/src/modules/services/components/EnrollmentServicesPage.tsx
+++ b/src/modules/services/components/EnrollmentServicesPage.tsx
@@ -4,7 +4,7 @@ import { useCallback, useState } from 'react';
 import { ColumnDef } from '@/components/elements/table/types';
 import TitleCard from '@/components/elements/TitleCard';
 import NotFound from '@/components/pages/NotFound';
-import { useFilters } from '@/hooks/useTableFilters';
+import useTableFilters from '@/hooks/useTableFilters';
 import GenericTableWithData from '@/modules/dataFetching/components/GenericTableWithData';
 import useEnrollmentDashboardContext from '@/modules/enrollment/hooks/useEnrollmentDashboardContext';
 import { parseAndFormatDate } from '@/modules/hmis/hmisUtil';
@@ -43,7 +43,7 @@ const EnrollmentServicesPage = () => {
     onClose: () => setViewingRecord(undefined),
   });
 
-  const filters = useFilters({
+  const { filters, filterValues, setFilterValues } = useTableFilters({
     type: 'ServicesForEnrollmentFilterOptions',
   });
 
@@ -103,6 +103,8 @@ const EnrollmentServicesPage = () => {
           noData='No services'
           recordType='Service'
           filters={filters}
+          filterValues={filterValues}
+          onFilterChange={setFilterValues}
           noSort
         />
       </TitleCard>

--- a/src/modules/services/components/ProjectServicesTable.tsx
+++ b/src/modules/services/components/ProjectServicesTable.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { getViewEnrollmentMenuItem } from '@/components/elements/table/tableRowActionUtil';
 import { ColumnDef } from '@/components/elements/table/types';
-import { useFilters } from '@/hooks/useTableFilters';
+import useTableFilters from '@/hooks/useTableFilters';
 import ClientName from '@/modules/client/components/ClientName';
 import GenericTableWithData from '@/modules/dataFetching/components/GenericTableWithData';
 
@@ -49,7 +49,7 @@ const ProjectServicesTable = ({
     ];
   }, [columns]);
 
-  const filters = useFilters({
+  const { filters, filterValues, setFilterValues } = useTableFilters({
     type: 'ServicesForProjectFilterOptions',
   });
 
@@ -82,6 +82,8 @@ const ProjectServicesTable = ({
       pagePath='project.services'
       recordType='Service'
       filters={filters}
+      filterValues={filterValues}
+      onFilterChange={setFilterValues}
     />
   );
 };

--- a/src/modules/units/components/UnitManagementTable.tsx
+++ b/src/modules/units/components/UnitManagementTable.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from 'react';
 import { ColumnDef } from '@/components/elements/table/types';
-import { useFilters } from '@/hooks/useTableFilters';
+import useTableFilters from '@/hooks/useTableFilters';
 import GenericTableWithData from '@/modules/dataFetching/components/GenericTableWithData';
 
 import { useProjectDashboardContext } from '@/modules/projects/components/ProjectDashboard';
@@ -59,7 +59,7 @@ const UnitManagementTable: React.FC<Props> = ({
     ];
   }, [coordinatedEntryFeatures.supportsReferrals, unitGroupId]);
 
-  const filters = useFilters({
+  const { filters, filterValues, setFilterValues } = useTableFilters({
     type: 'UnitFilterOptions',
     omit: unitGroupId ? ['unitType'] : [], // if looking at units in one group, no need to show this filter
     pickListArgs: { projectId },
@@ -127,6 +127,7 @@ const UnitManagementTable: React.FC<Props> = ({
         queryVariables={{
           id: projectId,
           includeCeFields: coordinatedEntryFeatures.supportsReferrals || false,
+          filters: { unitGroup: unitGroupId ? [unitGroupId] : undefined },
         }}
         queryDocument={GetUnitsDocument}
         columns={columns}
@@ -140,8 +141,9 @@ const UnitManagementTable: React.FC<Props> = ({
             row.canBeMarkedUnavailable
           )
         }
-        defaultFilterValues={{ unitGroup: unitGroupId }}
         filters={filters}
+        filterValues={filterValues}
+        onFilterChange={setFilterValues}
         recordType='Unit'
         EnhancedTableToolbarProps={{
           title: canDoAnyUnitActions ? 'Manage Units' : 'Units',


### PR DESCRIPTION
## Description

Update remaining tables and remove legacy `useFilters`. This is a follow-up to https://github.com/greenriver/hmis-frontend/pull/1406.

Proposing this into release-207 so we can do QA for all tables in one sweep.

**Impact:** the affected tables will now have their applied filters reflected in URL search params

## Type of change
New feature

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have used Axe DevTools to scan for accessibility issues (or not applicable)
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
