### PR TITLE
Patch pagination bug with persistent table filters

### DIFF
--- a/src/hooks/useTableFilters.ts
+++ b/src/hooks/useTableFilters.ts
@@ -27,6 +27,14 @@ type Args<K extends keyof FilterOptionsByName> = {
   initialFilterValues?: Partial<FilterOptionsByName[K]>;
 };
 
+/** Stable references for defaults (to avoid new instances each render, impacting useMemo/useEffect deps) */
+const EMPTY_INITIAL_FILTER_VALUES: Partial<
+  FilterOptionsByName[keyof FilterOptionsByName]
+> = Object.freeze({});
+const EMPTY_PICK_LIST_ARGS: PickListArgs = Object.freeze({});
+const EMPTY_OMIT: Array<keyof FilterOptionsByName[keyof FilterOptionsByName]> =
+  [];
+
 /**
  * Builds a table filter configuration from a GraphQL filter input type (e.g. `ClientFilterOptions`)
  * and optionally mirrors filter values in the URL so they persist on navigation and can be shared.
@@ -56,9 +64,11 @@ export default function useTableFilters<K extends keyof FilterOptionsByName>(
 
 export default function useTableFilters<K extends keyof FilterOptionsByName>({
   type, // Filter type, e.g. 'ClientFilterOptions'
-  initialFilterValues = {} as Partial<FilterOptionsByName[K]>,
-  pickListArgs = {},
-  omit = [],
+  initialFilterValues = EMPTY_INITIAL_FILTER_VALUES as Partial<
+    FilterOptionsByName[K]
+  >,
+  pickListArgs = EMPTY_PICK_LIST_ARGS,
+  omit = EMPTY_OMIT,
   dynamicFilters,
   syncToUrl = true,
 }: Args<K>):

--- a/src/hooks/useTableFilters.ts
+++ b/src/hooks/useTableFilters.ts
@@ -30,8 +30,8 @@ type Args<K extends keyof FilterOptionsByName> = {
 /** Stable references for defaults (to avoid new instances each render, impacting useMemo/useEffect deps) */
 const EMPTY_INITIAL_FILTER_VALUES: Partial<
   FilterOptionsByName[keyof FilterOptionsByName]
-> = Object.freeze({});
-const EMPTY_PICK_LIST_ARGS: PickListArgs = Object.freeze({});
+> = {};
+const EMPTY_PICK_LIST_ARGS: PickListArgs = {};
 const EMPTY_OMIT: Array<keyof FilterOptionsByName[keyof FilterOptionsByName]> =
   [];
 

--- a/src/modules/dataFetching/components/GenericTableWithData.tsx
+++ b/src/modules/dataFetching/components/GenericTableWithData.tsx
@@ -162,6 +162,7 @@ const GenericTableWithData = <
     filterValuesProp !== undefined && onFilterChange
       ? filterValuesProp
       : internalFilterValues;
+  const previousFilterValues = usePrevious(filterValues);
   const setFilterValues =
     filterValuesProp !== undefined && onFilterChange
       ? onFilterChange
@@ -176,10 +177,13 @@ const GenericTableWithData = <
     optionalColumnsMenuProps,
   } = useOptionalColumns<RowDataType, QueryVariables>({ columns: columnsProp });
 
-  // if the filters change, return to the first page
+  // If filters change (by value), return to the first page. Use deep comparison so URL-backed
+  // filter objects that get a new reference each render do not reset pagination.
   useEffect(() => {
-    setPage(0);
-  }, [filterValues]);
+    if (!isEqual(previousFilterValues, filterValues)) {
+      setPage(0);
+    }
+  }, [previousFilterValues, filterValues]);
 
   const filterProps = useMemo(() => {
     if (!filters || Object.keys(filters).length === 0) return;


### PR DESCRIPTION
## Description

Fixes an issue where tables that sync filters to the URL could not move to the next page: the footer looked like it updated, but the list stayed on the first page and flickered.

The cause was twofold: optional hook arguments were using fresh empty objects and arrays on every render, which made URL-backed filter state look “new” every time and broke memoization. Separately, the table reset the current page whenever the filter prop’s identity changed, even when the actual filters were unchanged.

The fix stabilizes those default empty values so they stay the same across renders, and only resets pagination when the meaning of the filters changes, not when the same values are carried in a new object. Together, that restores reliable pagination for URL-backed filters without changing how filters behave for users.



### How to test

Exercise a table that uses URL-backed filters and run through navigation **in mixed orders** (don’t follow a single linear script). Goal: confirm nothing gets stuck, flashes wrongly, or shows the wrong slice of data.

Try combinations such as:

- Open the page, paginate forward and back, then jump with the page control if available.
- Change **rows per page**, then paginate again.
- Apply one or more **filters**, confirm results, then change **page** and **page size**.
- Change **sort** (if available), paginate, then change sort again.
- **Clear / remove filters** partially and fully; paginate after each change.
- Apply filters, go to a later page, then **change a filter** (or apply a new one)—confirm you land on **page 1** with updated results.
- Use **browser back / forward** after changing filters or page. Currently only _filters_ are expected to be maintained (not sort or page number)

**Expected Behavior**

- Pagination, page size, sort, and filters all stay consistent with what’s on screen and in the URL.
- **Whenever filters actually change** (including clearing them in a way that changes the query), the table should **reset to the first page** for the new result set.

## Type of change
Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have used Axe DevTools to scan for accessibility issues (or not applicable)
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
