### PR TITLE
Use new cacheKey to fix swimlane cache bug

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -8912,8 +8912,24 @@
         "isOneOf": null,
         "fields": [
           {
+            "name": "cacheKey",
+            "description": "Referral-scoped key for Apollo cache to avoid collisions across referrals.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "id",
-            "description": null,
+            "description": "Same as swimlaneId (unchanged for backwards compatibility). Can be updated to\nresolve cacheKey value once frontend is updated to send swimlaneId to\nassignReferralParticipants.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -8929,7 +8945,7 @@
           },
           {
             "name": "name",
-            "description": null,
+            "description": "Swimlane name",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -8945,7 +8961,7 @@
           },
           {
             "name": "participants",
-            "description": null,
+            "description": "Assigned users for this swimlane on this referral",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -8962,6 +8978,22 @@
                     "ofType": null
                   }
                 }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "swimlaneId",
+            "description": "Template swimlane id; same as id. Use as assignReferralParticipants.swimlaneId.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
               }
             },
             "isDeprecated": false,

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -8913,7 +8913,7 @@
         "fields": [
           {
             "name": "cacheKey",
-            "description": "Referral-scoped key for Apollo cache to avoid collisions across referrals.",
+            "description": "Referral-scoped key for Apollo cache to avoid collisions across referrals",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -8929,7 +8929,7 @@
           },
           {
             "name": "id",
-            "description": "Same as swimlaneId (unchanged for backwards compatibility). Can be updated to\nresolve cacheKey value once frontend is updated to send swimlaneId to\nassignReferralParticipants.",
+            "description": "Swimlane id; client should pass this as assignReferralParticipants.swimlaneId",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -8978,22 +8978,6 @@
                     "ofType": null
                   }
                 }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "swimlaneId",
-            "description": "Template swimlane id; same as id. Use as assignReferralParticipants.swimlaneId.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
               }
             },
             "isDeprecated": false,

--- a/src/api/operations/ce.fragments.graphql
+++ b/src/api/operations/ce.fragments.graphql
@@ -276,7 +276,6 @@ fragment CeReferralWithNotesAndAuditEvents on CeReferral {
 fragment CeReferralSwimlaneFields on CeReferralSwimlane {
   id
   cacheKey
-  swimlaneId
   name
   participants {
     id

--- a/src/api/operations/ce.fragments.graphql
+++ b/src/api/operations/ce.fragments.graphql
@@ -275,6 +275,8 @@ fragment CeReferralWithNotesAndAuditEvents on CeReferral {
 
 fragment CeReferralSwimlaneFields on CeReferralSwimlane {
   id
+  cacheKey
+  swimlaneId
   name
   participants {
     id

--- a/src/modules/ce/components/referral/AssignContactsForm.tsx
+++ b/src/modules/ce/components/referral/AssignContactsForm.tsx
@@ -71,9 +71,9 @@ const AssignContactsForm: React.FC<Props> = ({
             <AssignContactFormItem
               key={swimlane.id}
               swimlane={swimlane}
-              users={values[swimlane.id] || []}
+              users={values[swimlane.swimlaneId] || []}
               setUsers={(userIds) => {
-                handleChangeValue(swimlane.id, userIds);
+                handleChangeValue(swimlane.swimlaneId, userIds);
               }}
               projectId={projectId}
             />

--- a/src/modules/ce/components/referral/AssignContactsForm.tsx
+++ b/src/modules/ce/components/referral/AssignContactsForm.tsx
@@ -71,9 +71,9 @@ const AssignContactsForm: React.FC<Props> = ({
             <AssignContactFormItem
               key={swimlane.id}
               swimlane={swimlane}
-              users={values[swimlane.swimlaneId] || []}
+              users={values[swimlane.id] || []}
               setUsers={(userIds) => {
-                handleChangeValue(swimlane.swimlaneId, userIds);
+                handleChangeValue(swimlane.id, userIds);
               }}
               projectId={projectId}
             />

--- a/src/providers/apolloClient.tsx
+++ b/src/providers/apolloClient.tsx
@@ -110,6 +110,10 @@ export const cache = new InMemoryCache({
     FormDefinition: {
       keyFields: ['cacheKey'],
     },
+    // CeReferralSwimlane uses 'cacheKey' because 'id' was non-unique and changing it would be backwards-incompatible, so new cacheKey was added.
+    CeReferralSwimlane: {
+      keyFields: ['cacheKey'],
+    },
     ValueBound: { keyFields: false },
     ValidationError: { keyFields: false },
   },

--- a/src/types/gqlObjects.ts
+++ b/src/types/gqlObjects.ts
@@ -1567,6 +1567,14 @@ export const HmisObjectSchemas: GqlSchema[] = [
     name: 'CeReferralSwimlane',
     fields: [
       {
+        name: 'cacheKey',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'ID', ofType: null },
+        },
+      },
+      {
         name: 'id',
         type: {
           kind: 'NON_NULL',
@@ -1580,6 +1588,14 @@ export const HmisObjectSchemas: GqlSchema[] = [
           kind: 'NON_NULL',
           name: null,
           ofType: { kind: 'SCALAR', name: 'String', ofType: null },
+        },
+      },
+      {
+        name: 'swimlaneId',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'ID', ofType: null },
         },
       },
     ],

--- a/src/types/gqlObjects.ts
+++ b/src/types/gqlObjects.ts
@@ -1590,14 +1590,6 @@ export const HmisObjectSchemas: GqlSchema[] = [
           ofType: { kind: 'SCALAR', name: 'String', ofType: null },
         },
       },
-      {
-        name: 'swimlaneId',
-        type: {
-          kind: 'NON_NULL',
-          name: null,
-          ofType: { kind: 'SCALAR', name: 'ID', ofType: null },
-        },
-      },
     ],
   },
   {

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -1153,20 +1153,14 @@ export type CeReferralStepsPaginated = {
 
 export type CeReferralSwimlane = {
   __typename?: 'CeReferralSwimlane';
-  /** Referral-scoped key for Apollo cache to avoid collisions across referrals. */
+  /** Referral-scoped key for Apollo cache to avoid collisions across referrals */
   cacheKey: Scalars['ID']['output'];
-  /**
-   * Same as swimlaneId (unchanged for backwards compatibility). Can be updated to
-   * resolve cacheKey value once frontend is updated to send swimlaneId to
-   * assignReferralParticipants.
-   */
+  /** Swimlane id; client should pass this as assignReferralParticipants.swimlaneId */
   id: Scalars['ID']['output'];
   /** Swimlane name */
   name: Scalars['String']['output'];
   /** Assigned users for this swimlane on this referral */
   participants: Array<ApplicationUser>;
-  /** Template swimlane id; same as id. Use as assignReferralParticipants.swimlaneId. */
-  swimlaneId: Scalars['ID']['output'];
 };
 
 export type CeReferralsPaginated = {
@@ -17748,7 +17742,6 @@ export type CeReferralFieldsFragment = {
     __typename?: 'CeReferralSwimlane';
     id: string;
     cacheKey: string;
-    swimlaneId: string;
     name: string;
     participants: Array<{
       __typename?: 'ApplicationUser';
@@ -17875,7 +17868,6 @@ export type CeReferralSwimlaneFieldsFragment = {
   __typename?: 'CeReferralSwimlane';
   id: string;
   cacheKey: string;
-  swimlaneId: string;
   name: string;
   participants: Array<{
     __typename?: 'ApplicationUser';
@@ -17891,7 +17883,6 @@ export type CeReferralWithSwimlanesFragment = {
     __typename?: 'CeReferralSwimlane';
     id: string;
     cacheKey: string;
-    swimlaneId: string;
     name: string;
     participants: Array<{
       __typename?: 'ApplicationUser';
@@ -20186,7 +20177,6 @@ export type SubmitCeReferralStepMutation = {
         __typename?: 'CeReferralSwimlane';
         id: string;
         cacheKey: string;
-        swimlaneId: string;
         name: string;
         participants: Array<{
           __typename?: 'ApplicationUser';
@@ -20527,7 +20517,6 @@ export type AssignParticipantsMutation = {
         __typename?: 'CeReferralSwimlane';
         id: string;
         cacheKey: string;
-        swimlaneId: string;
         name: string;
         participants: Array<{
           __typename?: 'ApplicationUser';
@@ -20898,7 +20887,6 @@ export type GetCeReferralQuery = {
       __typename?: 'CeReferralSwimlane';
       id: string;
       cacheKey: string;
-      swimlaneId: string;
       name: string;
       participants: Array<{
         __typename?: 'ApplicationUser';
@@ -50374,7 +50362,6 @@ export const CeReferralSwimlaneFieldsFragmentDoc = gql`
   fragment CeReferralSwimlaneFields on CeReferralSwimlane {
     id
     cacheKey
-    swimlaneId
     name
     participants {
       id

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -1153,9 +1153,20 @@ export type CeReferralStepsPaginated = {
 
 export type CeReferralSwimlane = {
   __typename?: 'CeReferralSwimlane';
+  /** Referral-scoped key for Apollo cache to avoid collisions across referrals. */
+  cacheKey: Scalars['ID']['output'];
+  /**
+   * Same as swimlaneId (unchanged for backwards compatibility). Can be updated to
+   * resolve cacheKey value once frontend is updated to send swimlaneId to
+   * assignReferralParticipants.
+   */
   id: Scalars['ID']['output'];
+  /** Swimlane name */
   name: Scalars['String']['output'];
+  /** Assigned users for this swimlane on this referral */
   participants: Array<ApplicationUser>;
+  /** Template swimlane id; same as id. Use as assignReferralParticipants.swimlaneId. */
+  swimlaneId: Scalars['ID']['output'];
 };
 
 export type CeReferralsPaginated = {
@@ -17736,6 +17747,8 @@ export type CeReferralFieldsFragment = {
   swimlanes?: Array<{
     __typename?: 'CeReferralSwimlane';
     id: string;
+    cacheKey: string;
+    swimlaneId: string;
     name: string;
     participants: Array<{
       __typename?: 'ApplicationUser';
@@ -17861,6 +17874,8 @@ export type CeReferralWithNotesAndAuditEventsFragment = {
 export type CeReferralSwimlaneFieldsFragment = {
   __typename?: 'CeReferralSwimlane';
   id: string;
+  cacheKey: string;
+  swimlaneId: string;
   name: string;
   participants: Array<{
     __typename?: 'ApplicationUser';
@@ -17875,6 +17890,8 @@ export type CeReferralWithSwimlanesFragment = {
   swimlanes?: Array<{
     __typename?: 'CeReferralSwimlane';
     id: string;
+    cacheKey: string;
+    swimlaneId: string;
     name: string;
     participants: Array<{
       __typename?: 'ApplicationUser';
@@ -20168,6 +20185,8 @@ export type SubmitCeReferralStepMutation = {
       swimlanes?: Array<{
         __typename?: 'CeReferralSwimlane';
         id: string;
+        cacheKey: string;
+        swimlaneId: string;
         name: string;
         participants: Array<{
           __typename?: 'ApplicationUser';
@@ -20507,6 +20526,8 @@ export type AssignParticipantsMutation = {
       swimlanes?: Array<{
         __typename?: 'CeReferralSwimlane';
         id: string;
+        cacheKey: string;
+        swimlaneId: string;
         name: string;
         participants: Array<{
           __typename?: 'ApplicationUser';
@@ -20876,6 +20897,8 @@ export type GetCeReferralQuery = {
     swimlanes?: Array<{
       __typename?: 'CeReferralSwimlane';
       id: string;
+      cacheKey: string;
+      swimlaneId: string;
       name: string;
       participants: Array<{
         __typename?: 'ApplicationUser';
@@ -50350,6 +50373,8 @@ export const ClientCeReferralTableFieldsFragmentDoc = gql`
 export const CeReferralSwimlaneFieldsFragmentDoc = gql`
   fragment CeReferralSwimlaneFields on CeReferralSwimlane {
     id
+    cacheKey
+    swimlaneId
     name
     participants {
       id


### PR DESCRIPTION
## Description

Issue: https://github.com/open-path/Green-River/issues/9092

Use new `cacheKey` to fix cache bug for referral swimlanes. We were previously caching with `id` (the Apollo default) which had collisions across referrals.

Depends on hmis-warehouse PR: https://github.com/greenriver/hmis-warehouse/pull/6381

**How to test:** See issue for repro. You can also use Apollo dev tools to inspect the cache and see that `CeReferralSwimlane` is cached with a unique ID, and new records are populated in the cache when you navigate to a new referral. (As opposed to existing cached records being updated, like before).

## Type of change
Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have used Axe DevTools to scan for accessibility issues (or not applicable)
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
