### PR TITLE
Bump alpine image to 3.23

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@
 # build container
 #####################################################################
 ARG NODE_VERSION
-FROM node:${NODE_VERSION}-alpine AS builder
+FROM node:${NODE_VERSION}-alpine3.23 AS builder
 
 ARG GITHASH
 ARG FULL_GITHASH
@@ -34,7 +34,7 @@ RUN --mount=type=cache,target=/app/node_modules \
 #####################################################################
 # nginx container
 #####################################################################
-FROM nginx:1.25-alpine
+FROM nginx:1.28-alpine3.23
 ARG USERID=${USERID:-10000}
 ARG GROUPID=${GROUPID:-10001}
 


### PR DESCRIPTION
## Description
Issue: https://github.com/open-path/Green-River/issues/8987

We were at 3.19 which is EOL. Bump to 3.23 and pin the version.

* NODE_VERSION is currently on 24.14.1 (set in `.nvmrc). Verified this tag exists on docker hub
* NGINX version had to be bumped from 1.25 to 1.28 because `1.25-alpine3.23` is not published

Testing: I built the image locally, haven't done testing beyond that

## Type of change
Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
