### PR TITLE
Upgrade dompurify

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -5598,9 +5598,9 @@ domhandler@^2.3.0:
     domelementtype "1"
 
 dompurify@^3.1.6:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.3.2.tgz#58c515d0f8508b8749452a028aa589ad80b36325"
-  integrity sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ==
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.0.tgz#b1fc33ebdadb373241621e0a30e4ad81573dfd0b"
+  integrity sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==
   optionalDependencies:
     "@types/trusted-types" "^2.0.7"
 


### PR DESCRIPTION
## Description

Upgrade dompurify to resolve https://github.com/greenriver/hmis-frontend/security/dependabot/198

This vulnerability should not be affecting us because we do not use ADD_TAGS/FORBID_TAGS

Tested by ensuring `CommonHtmlContent` story is happy in storybook

## Type of change
Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have used Axe DevTools to scan for accessibility issues (or not applicable)
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
