### PR TITLE
Prevent console warnings when changing referral contacts

### DIFF
--- a/src/providers/apolloClient.tsx
+++ b/src/providers/apolloClient.tsx
@@ -113,6 +113,16 @@ export const cache = new InMemoryCache({
     // CeReferralSwimlane uses 'cacheKey' because 'id' was non-unique and changing it would be backwards-incompatible, so new cacheKey was added.
     CeReferralSwimlane: {
       keyFields: ['cacheKey'],
+      fields: {
+        // Opt in to default behavior to prevent console warnings. Incoming participants should replace existing participants.
+        participants: { merge: false },
+      },
+    },
+    CeReferralStep: {
+      fields: {
+        // Opt in to default behavior to prevent console warnings. Incoming assignees should replace existing assignees.
+        assignees: { merge: false },
+      },
     },
     ValueBound: { keyFields: false },
     ValidationError: { keyFields: false },


### PR DESCRIPTION
## Description

Prevent these console warnings from appearing when changing/removing contacts on a referral:

> Cache data may be lost when replacing the participants field of a CeReferralSwimlane object.
This could cause additional (usually avoidable) network requests to fetch data that were otherwise cached.
To address this problem (which is not a bug in Apollo Client), define a custom merge function for the CeReferralSwimlane.participants field, so InMemoryCache can safely merge these objects:

> Cache data may be lost when replacing the assignees field of a CeReferralStep object.
This could cause additional (usually avoidable) network requests to fetch data that were otherwise cached.
To address this problem (which is not a bug in Apollo Client), define a custom merge function for the CeReferralStep.assignees field, so InMemoryCache can safely merge these objects:

https://www.apollographql.com/docs/react/caching/cache-field-behavior#opting-in-to-the-default-behavior-for-non-normalized-fields contains an explanation of the problem and fix

## Type of change
Code clean-up

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have used Axe DevTools to scan for accessibility issues (or not applicable)
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
