### PR TITLE
Support passing keys to clientAttributes

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -3971,8 +3971,29 @@
         "fields": [
           {
             "name": "clientAttributes",
-            "description": "Most recent snapshot of client attributes",
-            "args": [],
+            "description": "Current values for the given expression keys",
+            "args": [
+              {
+                "name": "keys",
+                "description": "Keys whose values should be returned. Same format as TableColumnConfig keys.",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -4244,8 +4265,29 @@
         "fields": [
           {
             "name": "clientAttributes",
-            "description": "Aggregation of most recent snapshots from all candidate pools this client belongs to",
-            "args": [],
+            "description": "Current values for the given expression keys",
+            "args": [
+              {
+                "name": "keys",
+                "description": "Keys whose values should be returned. Same format as TableColumnConfig keys.",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
             "type": {
               "kind": "NON_NULL",
               "name": null,

--- a/src/api/operations/ce.fragments.graphql
+++ b/src/api/operations/ce.fragments.graphql
@@ -58,7 +58,7 @@ fragment CeCandidateFields on CeCandidate {
   id
   priorityScores
   clientName
-  clientAttributes
+  clientAttributes(keys: $clientAttributeKeys)
 }
 
 fragment CeReferralSummaryFields on CeReferral {
@@ -378,12 +378,13 @@ fragment CeReferralSourceEnrollmentFields on CeReferralSourceEnrollment {
 }
 
 # CE Client (backed by Client Proxy) is used on the global eligible clients list
+# $clientAttributeKeys is supplied by GetCeClients when requesting live expression values.
 fragment CeClientFields on CeClient {
   id
   destinationClientId
   viewableSourceClientIds
   clientName
-  clientAttributes
+  clientAttributes(keys: $clientAttributeKeys)
   externalIds {
     ...ClientIdentifierFields
   }

--- a/src/api/operations/ce.queries.graphql
+++ b/src/api/operations/ce.queries.graphql
@@ -41,6 +41,7 @@ query GetCeOpportunityCandidates(
   $limit: Int = 25
   $offset: Int = 0
   $filters: CeOpportunityCandidatesFilterOptions
+  $clientAttributeKeys: [String!]! = []
 ) {
   ceOpportunity(id: $opportunityId) {
     id
@@ -169,6 +170,7 @@ query GetCeClients(
   $limit: Int = 25
   $offset: Int = 0
   $filters: CeClientFilterOptions = null
+  $clientAttributeKeys: [String!]! = []
 ) {
   ceClients(limit: $limit, offset: $offset, filters: $filters) {
     offset

--- a/src/api/operations/units.queries.graphql
+++ b/src/api/operations/units.queries.graphql
@@ -40,7 +40,11 @@ query GetUnitGroup($id: ID!) {
   }
 }
 
-query GetUnit($id: ID!, $includeCeFields: Boolean = false) {
+query GetUnit(
+  $id: ID!
+  $includeCeFields: Boolean = false
+  $clientAttributeKeys: [String!]! = []
+) {
   unit(id: $id) {
     ...UnitDetailFields
   }

--- a/src/modules/ce/components/admin/AdminCeClientsTable.tsx
+++ b/src/modules/ce/components/admin/AdminCeClientsTable.tsx
@@ -38,14 +38,6 @@ const COLUMNS: DataColumnDef<
   },
 ];
 
-const configurableColumnValue = (
-  row: CeClientFieldsFragment | CeCandidateFieldsFragment,
-  key: string
-) => {
-  if ('clientAttributes' in row && row.clientAttributes)
-    return row.clientAttributes[key];
-};
-
 export const configurableCeColumns = (
   columns: TableColumnConfigFieldsFragment[]
 ) => {
@@ -53,7 +45,8 @@ export const configurableCeColumns = (
     key: key,
     header: label,
     render: (row: CeClientFieldsFragment | CeCandidateFieldsFragment) => {
-      const value = configurableColumnValue(row, key);
+      if (!row.clientAttributes) return null;
+      const value = row.clientAttributes[key];
       if (!value) return null;
       let values = ensureArray(value);
       if (type === TableColumnConfigType.Date) {
@@ -79,19 +72,21 @@ const AdminCeClientsTable: React.FC = () => {
   const [selectedRow, setSelectedRow] =
     React.useState<CeClientFieldsFragment | null>(null);
 
-  // Define table columns (Default + MCI + Custom configured)
-  const clientAttributeKeys = useMemo(
-    () =>
-      (tableConfigLookup?.ceClientsGlobalConfig?.columns || []).map(
-        (c) => c.key
-      ),
-    [tableConfigLookup?.ceClientsGlobalConfig?.columns]
+  const tableColumnConfig = useMemo(
+    () => tableConfigLookup?.ceClientsGlobalConfig?.columns,
+    [tableConfigLookup]
   );
 
+  // Keys to resolve for client attributes (based on column configuration)
+  const clientAttributeKeys = useMemo(
+    () => (tableColumnConfig || []).map((c) => c.key),
+    [tableColumnConfig]
+  );
+
+  // Define table columns (Default + MCI + Custom configured)
   const columnsWithCustom = useMemo(() => {
-    const columnConfig = tableConfigLookup?.ceClientsGlobalConfig?.columns;
-    const customColumns = columnConfig
-      ? configurableCeColumns(columnConfig)
+    const customColumns = tableColumnConfig
+      ? configurableCeColumns(tableColumnConfig)
       : [];
     return [
       ...COLUMNS,
@@ -100,7 +95,7 @@ const AdminCeClientsTable: React.FC = () => {
         : []),
       ...(customColumns || []),
     ];
-  }, [tableConfigLookup, mciIdEnabled]);
+  }, [tableColumnConfig, mciIdEnabled]);
 
   const { filters, filterValues, setFilterValues } = useTableFilters({
     type: 'CeClientFilterOptions',

--- a/src/modules/ce/components/admin/AdminCeClientsTable.tsx
+++ b/src/modules/ce/components/admin/AdminCeClientsTable.tsx
@@ -38,6 +38,14 @@ const COLUMNS: DataColumnDef<
   },
 ];
 
+const configurableColumnValue = (
+  row: CeClientFieldsFragment | CeCandidateFieldsFragment,
+  key: string
+) => {
+  if ('clientAttributes' in row && row.clientAttributes)
+    return row.clientAttributes[key];
+};
+
 export const configurableCeColumns = (
   columns: TableColumnConfigFieldsFragment[]
 ) => {
@@ -45,8 +53,7 @@ export const configurableCeColumns = (
     key: key,
     header: label,
     render: (row: CeClientFieldsFragment | CeCandidateFieldsFragment) => {
-      if (!row.clientAttributes) return null;
-      const value = row.clientAttributes[key];
+      const value = configurableColumnValue(row, key);
       if (!value) return null;
       let values = ensureArray(value);
       if (type === TableColumnConfigType.Date) {
@@ -73,6 +80,14 @@ const AdminCeClientsTable: React.FC = () => {
     React.useState<CeClientFieldsFragment | null>(null);
 
   // Define table columns (Default + MCI + Custom configured)
+  const clientAttributeKeys = useMemo(
+    () =>
+      (tableConfigLookup?.ceClientsGlobalConfig?.columns || []).map(
+        (c) => c.key
+      ),
+    [tableConfigLookup?.ceClientsGlobalConfig?.columns]
+  );
+
   const columnsWithCustom = useMemo(() => {
     const columnConfig = tableConfigLookup?.ceClientsGlobalConfig?.columns;
     const customColumns = columnConfig
@@ -137,6 +152,7 @@ const AdminCeClientsTable: React.FC = () => {
           columns={columnsWithCustom}
           queryVariables={{
             filters: { searchTerm: debouncedSearch || undefined },
+            clientAttributeKeys,
           }}
           queryDocument={GetCeClientsDocument}
           pagePath='ceClients'

--- a/src/modules/ce/components/unit/PrioritizedClientsTable.tsx
+++ b/src/modules/ce/components/unit/PrioritizedClientsTable.tsx
@@ -63,22 +63,24 @@ const PrioritizedClientsTable: React.FC<Props> = ({
     skip: !unitGroupId,
   });
 
-  // Define table columns (Default + MCI + Custom configured + Action)
-  const clientAttributeKeys = useMemo(
-    () =>
-      (tableConfigLookup?.ceClientsUnitGroupConfig?.columns || []).map(
-        (c) => c.key
-      ),
-    [tableConfigLookup?.ceClientsUnitGroupConfig?.columns]
+  const tableColumnConfig = useMemo(
+    () => tableConfigLookup?.ceClientsUnitGroupConfig?.columns,
+    [tableConfigLookup]
   );
 
+  // Keys to resolve for client attributes (based on column configuration)
+  const clientAttributeKeys = useMemo(
+    () => (tableColumnConfig || []).map((c) => c.key),
+    [tableColumnConfig]
+  );
+
+  // Define table columns (Default + MCI + Custom configured + Action)
   const columns: ColumnDef<CeCandidateFieldsFragment>[] = useMemo(() => {
     const canStartReferrals =
       project.access.canStartReferrals && project.access.canViewReferrals;
 
-    const columnConfig = tableConfigLookup?.ceClientsUnitGroupConfig?.columns;
     const customColumns = (
-      columnConfig ? configurableCeColumns(columnConfig) : []
+      tableColumnConfig ? configurableCeColumns(tableColumnConfig) : []
     ) as ColumnDef<CeCandidateFieldsFragment>[];
 
     return [
@@ -103,7 +105,7 @@ const PrioritizedClientsTable: React.FC<Props> = ({
         ),
       },
     ];
-  }, [project.access, tableConfigLookup, status, opportunity]);
+  }, [project.access, tableColumnConfig, status, opportunity]);
 
   const { filters, filterValues, setFilterValues } = useTableFilters({
     type: 'CeOpportunityCandidatesFilterOptions',

--- a/src/modules/ce/components/unit/PrioritizedClientsTable.tsx
+++ b/src/modules/ce/components/unit/PrioritizedClientsTable.tsx
@@ -64,6 +64,14 @@ const PrioritizedClientsTable: React.FC<Props> = ({
   });
 
   // Define table columns (Default + MCI + Custom configured + Action)
+  const clientAttributeKeys = useMemo(
+    () =>
+      (tableConfigLookup?.ceClientsUnitGroupConfig?.columns || []).map(
+        (c) => c.key
+      ),
+    [tableConfigLookup?.ceClientsUnitGroupConfig?.columns]
+  );
+
   const columns: ColumnDef<CeCandidateFieldsFragment>[] = useMemo(() => {
     const canStartReferrals =
       project.access.canStartReferrals && project.access.canViewReferrals;
@@ -156,6 +164,7 @@ const PrioritizedClientsTable: React.FC<Props> = ({
           queryVariables={{
             opportunityId: opportunity.id,
             filters: { searchTerm: debouncedSearch || undefined },
+            clientAttributeKeys,
           }}
           queryDocument={GetCeOpportunityCandidatesDocument}
           pagePath='ceOpportunity.candidates'

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -590,7 +590,7 @@ export type CeAssessmentsPaginated = {
 
 export type CeCandidate = {
   __typename?: 'CeCandidate';
-  /** Most recent snapshot of client attributes */
+  /** Current values for the given expression keys */
   clientAttributes: Scalars['JSON']['output'];
   /** Masked as "Candidate 123" unless the user has permission to view */
   clientName: Scalars['String']['output'];
@@ -598,6 +598,10 @@ export type CeCandidate = {
   enrollments: CeReferralSourceEnrollmentsPaginated;
   id: Scalars['ID']['output'];
   priorityScores: Array<Scalars['Int']['output']>;
+};
+
+export type CeCandidateClientAttributesArgs = {
+  keys?: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
 export type CeCandidateEnrollmentsArgs = {
@@ -622,7 +626,7 @@ export type CeCandidatesPaginated = {
  */
 export type CeClient = {
   __typename?: 'CeClient';
-  /** Aggregation of most recent snapshots from all candidate pools this client belongs to */
+  /** Current values for the given expression keys */
   clientAttributes: Scalars['JSON']['output'];
   clientName: Scalars['String']['output'];
   destinationClientId: Scalars['ID']['output'];
@@ -636,6 +640,14 @@ export type CeClient = {
    * data source and are viewable by the current user
    */
   viewableSourceClientIds: Array<Scalars['ID']['output']>;
+};
+
+/**
+ * A client who is eligible for Coordinated Entry (CE), represented by a
+ * ClientProxy. Underlying client record is Destination Client.
+ */
+export type CeClientClientAttributesArgs = {
+  keys?: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
 /**
@@ -20677,6 +20689,9 @@ export type GetCeOpportunityCandidatesQueryVariables = Exact<{
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   filters?: InputMaybe<CeOpportunityCandidatesFilterOptions>;
+  clientAttributeKeys?:
+    | Array<Scalars['String']['input']>
+    | Scalars['String']['input'];
 }>;
 
 export type GetCeOpportunityCandidatesQuery = {
@@ -21847,6 +21862,9 @@ export type GetCeClientsQueryVariables = Exact<{
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   filters?: InputMaybe<CeClientFilterOptions>;
+  clientAttributeKeys?:
+    | Array<Scalars['String']['input']>
+    | Scalars['String']['input'];
 }>;
 
 export type GetCeClientsQuery = {
@@ -48332,6 +48350,9 @@ export type GetUnitGroupQuery = {
 export type GetUnitQueryVariables = Exact<{
   id: Scalars['ID']['input'];
   includeCeFields?: InputMaybe<Scalars['Boolean']['input']>;
+  clientAttributeKeys?:
+    | Array<Scalars['String']['input']>
+    | Scalars['String']['input'];
 }>;
 
 export type GetUnitQuery = {
@@ -50518,7 +50539,7 @@ export const CeClientFieldsFragmentDoc = gql`
     destinationClientId
     viewableSourceClientIds
     clientName
-    clientAttributes
+    clientAttributes(keys: $clientAttributeKeys)
     externalIds {
       ...ClientIdentifierFields
     }
@@ -52093,7 +52114,7 @@ export const CeCandidateFieldsFragmentDoc = gql`
     id
     priorityScores
     clientName
-    clientAttributes
+    clientAttributes(keys: $clientAttributeKeys)
   }
 `;
 export const UnitDetailFieldsFragmentDoc = gql`
@@ -55186,6 +55207,7 @@ export const GetCeOpportunityCandidatesDocument = gql`
     $limit: Int = 25
     $offset: Int = 0
     $filters: CeOpportunityCandidatesFilterOptions
+    $clientAttributeKeys: [String!]! = []
   ) {
     ceOpportunity(id: $opportunityId) {
       id
@@ -55219,6 +55241,7 @@ export const GetCeOpportunityCandidatesDocument = gql`
  *      limit: // value for 'limit'
  *      offset: // value for 'offset'
  *      filters: // value for 'filters'
+ *      clientAttributeKeys: // value for 'clientAttributeKeys'
  *   },
  * });
  */
@@ -56118,6 +56141,7 @@ export const GetCeClientsDocument = gql`
     $limit: Int = 25
     $offset: Int = 0
     $filters: CeClientFilterOptions = null
+    $clientAttributeKeys: [String!]! = []
   ) {
     ceClients(limit: $limit, offset: $offset, filters: $filters) {
       offset
@@ -56146,6 +56170,7 @@ export const GetCeClientsDocument = gql`
  *      limit: // value for 'limit'
  *      offset: // value for 'offset'
  *      filters: // value for 'filters'
+ *      clientAttributeKeys: // value for 'clientAttributeKeys'
  *   },
  * });
  */
@@ -69815,7 +69840,11 @@ export type GetUnitGroupQueryResult = Apollo.QueryResult<
   GetUnitGroupQueryVariables
 >;
 export const GetUnitDocument = gql`
-  query GetUnit($id: ID!, $includeCeFields: Boolean = false) {
+  query GetUnit(
+    $id: ID!
+    $includeCeFields: Boolean = false
+    $clientAttributeKeys: [String!]! = []
+  ) {
     unit(id: $id) {
       ...UnitDetailFields
     }
@@ -69837,6 +69866,7 @@ export const GetUnitDocument = gql`
  *   variables: {
  *      id: // value for 'id'
  *      includeCeFields: // value for 'includeCeFields'
+ *      clientAttributeKeys: // value for 'clientAttributeKeys'
  *   },
  * });
  */


### PR DESCRIPTION
## Description

Issue: https://github.com/open-path/Green-River/issues/9111
Backend: https://github.com/greenriver/hmis-warehouse/pull/6399 (Release-210)

Start requesting specific keys, so we can remove the backend default behavior of resolve-everything-you-might-need.

How to test: set up a table column config locally, view global and unit-level waitlists


## Type of change
New feature

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have used Axe DevTools to scan for accessibility issues (or not applicable)
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
