### PR TITLE
Add breadcrumbs for Referral navigation

### DIFF
--- a/src/components/layout/dashboard/contextHeader/useDashboardBreadcrumbs.tsx
+++ b/src/components/layout/dashboard/contextHeader/useDashboardBreadcrumbs.tsx
@@ -13,6 +13,8 @@ import {
   ClientDashboardRoutes,
   EnrollmentDashboardRoutes,
   ProjectDashboardRoutes,
+  ReferralRoutes,
+  Routes,
 } from '@/routes/routes';
 
 type CrumbConfig = {
@@ -142,8 +144,8 @@ export const useProjectBreadcrumbConfig = (
         parent: ProjectDashboardRoutes.CE,
       },
       [ProjectDashboardRoutes.REFERRAL_STEP]: {
-        title: 'Referral',
-        parent: ProjectDashboardRoutes.CE,
+        title: 'Step',
+        parent: ProjectDashboardRoutes.REFERRAL,
       },
       [ProjectDashboardRoutes.SEND_REFERRAL]: {
         title: 'Send Referral',
@@ -165,6 +167,22 @@ export const useProjectBreadcrumbConfig = (
     const projectRoot = ProjectDashboardRoutes.OVERVIEW;
     return buildDefaultCrumbs(ProjectDashboardRoutes, overrides, projectRoot);
   }, [context]);
+};
+
+export const useReferralBreadcrumbConfig = (): CrumbConfig => {
+  return useMemo(() => {
+    return {
+      [Routes.REFERRALS]: { title: 'Referrals' },
+      [ReferralRoutes.REFERRAL]: {
+        title: 'Referral',
+        parent: Routes.REFERRALS,
+      },
+      [ReferralRoutes.REFERRAL_STEP]: {
+        title: 'Step',
+        parent: ReferralRoutes.REFERRAL,
+      },
+    };
+  }, []);
 };
 
 export const useClientBreadcrumbConfig = (

--- a/src/modules/ce/components/referral/ProjectReferralPage.tsx
+++ b/src/modules/ce/components/referral/ProjectReferralPage.tsx
@@ -4,19 +4,21 @@ import ReferralContent from './ReferralContent';
 import Loading from '@/components/elements/Loading';
 import NotFound from '@/components/pages/NotFound';
 import useSafeParams from '@/hooks/useSafeParams';
-import { useReferralDashboardContext } from '@/modules/ce/components/referral/ReferralDashboard';
-import { ReferralRoutes } from '@/routes/routes';
+import { useProjectDashboardContext } from '@/modules/projects/components/ProjectDashboard';
+import { ProjectDashboardRoutes } from '@/routes/routes';
 import { useGetCeReferralQuery } from '@/types/gqlTypes';
 import { generateSafePath } from '@/utils/pathEncoding';
 
 /**
- * Thin wrapper around ReferralContent for Referrals rendered in the Referral context
- * (what we previously called "floating referrals").
+ * Thin wrapper around ReferralContent for Referrals rendered within a ProjectDashboard.
+ * The project can be the referral's target project, or its source project (for direct referrals).
+ *
+ * Referrals can also be rendered in the Referral context (what we previously called "floating referrals"); see ReferralPage
  */
-const ReferralPage: React.FC = () => {
+const ProjectReferralPage: React.FC = () => {
   const { referralId } = useSafeParams() as { referralId: string };
 
-  const { overrideBreadcrumbTitles } = useReferralDashboardContext();
+  const { project, overrideBreadcrumbTitles } = useProjectDashboardContext();
 
   const {
     data: { ceReferral: referral } = {},
@@ -31,14 +33,16 @@ const ReferralPage: React.FC = () => {
   useEffect(() => {
     if (!referral) return;
     overrideBreadcrumbTitles({
-      [ReferralRoutes.REFERRAL]: `${referral.targetProjectName} - ${referral.clientName}`,
+      [ProjectDashboardRoutes.REFERRAL]: referral.clientName,
     });
   }, [referral, overrideBreadcrumbTitles]);
 
   const overrideStepTitle = useCallback(
     (name: string | undefined) => {
       if (name === undefined) return;
-      overrideBreadcrumbTitles({ [ReferralRoutes.REFERRAL_STEP]: name });
+      overrideBreadcrumbTitles({
+        [ProjectDashboardRoutes.REFERRAL_STEP]: name,
+      });
     },
     [overrideBreadcrumbTitles]
   );
@@ -50,23 +54,22 @@ const ReferralPage: React.FC = () => {
   return (
     <ReferralContent
       referral={referral}
-      referralPath={generateSafePath(ReferralRoutes.REFERRAL, {
+      referralPath={generateSafePath(ProjectDashboardRoutes.REFERRAL, {
         referralId: referral.id,
+        projectId: project.id,
       })}
       generateReferralStepPath={(stepId) =>
-        generateSafePath(ReferralRoutes.REFERRAL_STEP, {
+        generateSafePath(ProjectDashboardRoutes.REFERRAL_STEP, {
           referralId: referral.id,
           stepId,
+          projectId: project.id,
         })
       }
       overrideStepTitle={overrideStepTitle}
-      linkToProject
+      // Link to the target project if we are in the source project context
+      linkToProject={project.id !== referral.targetProjectId}
     />
   );
 };
 
-export {
-  type ReferralContext,
-  useReferralContext,
-} from './referralOutletContext';
-export default ReferralPage;
+export default ProjectReferralPage;

--- a/src/modules/ce/components/referral/ReferralContent.tsx
+++ b/src/modules/ce/components/referral/ReferralContent.tsx
@@ -1,0 +1,129 @@
+import FolderRoundedIcon from '@mui/icons-material/FolderRounded';
+import { Badge, Container, Stack, Typography } from '@mui/material';
+import { Box } from '@mui/system';
+import React, { useMemo } from 'react';
+import { Outlet } from 'react-router-dom';
+
+import ReferralDetailContent from './ReferralDetailContent';
+import { ReferralContext } from './referralOutletContext';
+import CommonButtonDrawer from '@/components/elements/CommonButtonDrawer';
+import {
+  ActivityIcon,
+  ContactsIcon,
+} from '@/components/elements/SemanticIcons';
+import CommonStickyBar from '@/components/layout/CommonStickyBar';
+import {
+  CONTEXT_HEADER_HEIGHT,
+  STICKY_BAR_HEIGHT,
+} from '@/components/layout/layoutConstants';
+import { useIsMobile } from '@/hooks/useIsMobile';
+import AssignContactsForm from '@/modules/ce/components/referral/AssignContactsForm';
+import ReferralTimeline from '@/modules/ce/components/referral/ReferralTimeline';
+import { CeReferralFieldsFragment } from '@/types/gqlTypes';
+
+export interface ReferralContentProps {
+  referral: CeReferralFieldsFragment;
+  referralPath: string;
+  generateReferralStepPath: (stepId: string) => string;
+  overrideStepTitle?: (name: string | undefined) => void;
+  linkToProject: boolean;
+}
+
+/**
+ * Renders a single Referral. Uses react router outlet to render sub-pages (steps).
+ *
+ * Can be rendered in the Project context or in the Referral context.
+ */
+const ReferralContent: React.FC<ReferralContentProps> = ({
+  referral,
+  referralPath,
+  generateReferralStepPath,
+  overrideStepTitle,
+  linkToProject,
+}) => {
+  const outletContext: ReferralContext = useMemo(
+    () => ({
+      referral,
+      referralPath,
+      generateReferralStepPath,
+      overrideStepTitle,
+    }),
+    [referral, referralPath, generateReferralStepPath, overrideStepTitle]
+  );
+
+  const isMobile = useIsMobile();
+
+  const showContactsDrawer =
+    referral.swimlanes &&
+    referral.swimlanes.length > 0 &&
+    referral.access.canAssignReferralTasks;
+
+  const unassignedSwimlanesCount = referral.swimlanes?.filter(
+    (s) => s.participants.length === 0
+  ).length;
+
+  return (
+    <>
+      <CommonStickyBar
+        top={STICKY_BAR_HEIGHT + CONTEXT_HEADER_HEIGHT}
+        sx={{ pb: 0, pt: isMobile ? 1 : 0 }}
+      >
+        <Container maxWidth='md'>
+          <Stack
+            direction={isMobile ? 'column' : 'row'}
+            alignItems={isMobile ? '' : 'center'}
+            columnGap={2}
+            rowGap={0}
+            justifyContent='space-between'
+          >
+            <Box sx={{ overflow: 'hidden', textWrap: 'nowrap' }}>
+              <Typography
+                variant='h5'
+                component='h1'
+                sx={{ textOverflow: 'ellipsis', overflow: 'hidden' }}
+              >
+                Referral for {referral.clientName}
+              </Typography>
+            </Box>
+            <Stack sx={{ py: 1 }} direction='row' alignItems='center' gap={0.5}>
+              <CommonButtonDrawer
+                title='Details'
+                ButtonProps={{ startIcon: <FolderRoundedIcon /> }}
+              >
+                <ReferralDetailContent
+                  referral={referral}
+                  linkToProject={linkToProject}
+                />
+              </CommonButtonDrawer>
+              {showContactsDrawer && (
+                // MUI badge auto-hides when count is 0
+                <Badge badgeContent={unassignedSwimlanesCount}>
+                  <CommonButtonDrawer
+                    title='Contacts'
+                    ButtonProps={{ startIcon: <ContactsIcon /> }}
+                  >
+                    <AssignContactsForm
+                      referral={referral}
+                      projectId={referral.targetProjectId}
+                    />
+                  </CommonButtonDrawer>
+                </Badge>
+              )}
+              <CommonButtonDrawer
+                title={'Activity'}
+                ButtonProps={{ startIcon: <ActivityIcon /> }}
+              >
+                <ReferralTimeline referral={referral} />
+              </CommonButtonDrawer>
+            </Stack>
+          </Stack>
+        </Container>
+      </CommonStickyBar>
+      <Container maxWidth='md' sx={{ py: 4 }}>
+        <Outlet context={outletContext} />
+      </Container>
+    </>
+  );
+};
+
+export default ReferralContent;

--- a/src/modules/ce/components/referral/ReferralDashboard.tsx
+++ b/src/modules/ce/components/referral/ReferralDashboard.tsx
@@ -1,0 +1,51 @@
+import { Container } from '@mui/material';
+import type { FC } from 'react';
+import { useCallback, useMemo, useState } from 'react';
+import { Outlet, useOutletContext } from 'react-router-dom';
+
+import { ContextHeaderAppBar } from '@/components/layout/dashboard/contextHeader/ContextHeader';
+import ContextHeaderContent from '@/components/layout/dashboard/contextHeader/ContextHeaderContent';
+import {
+  useDashboardBreadcrumbs,
+  useReferralBreadcrumbConfig,
+} from '@/components/layout/dashboard/contextHeader/useDashboardBreadcrumbs';
+
+const ReferralDashboard: FC = () => {
+  const [breadcrumbOverrides, setBreadcrumbOverrides] = useState<
+    Record<string, string> | undefined
+  >();
+  // Merge each partial update into previous overrides, so that
+  // nested pages (ReferralPage and ReferralStep) can each call overrideBreadcrumbTitles
+  // for a different route template key.
+  const overrideBreadcrumbTitles = useCallback(
+    (crumbs: Record<string, string>) =>
+      setBreadcrumbOverrides((prev) => ({ ...prev, ...crumbs })),
+    []
+  );
+  const crumbConfig = useReferralBreadcrumbConfig();
+  const breadcrumbs = useDashboardBreadcrumbs(crumbConfig, breadcrumbOverrides);
+  const outletContext = useMemo(
+    () => ({ overrideBreadcrumbTitles }),
+    [overrideBreadcrumbTitles]
+  );
+
+  return (
+    <>
+      <ContextHeaderAppBar>
+        <Container maxWidth='md'>
+          <ContextHeaderContent breadcrumbs={breadcrumbs} />
+        </Container>
+      </ContextHeaderAppBar>
+      <Outlet context={outletContext} />
+    </>
+  );
+};
+
+export type ReferralDashboardContext = {
+  overrideBreadcrumbTitles: (crumbs: Record<string, string>) => void;
+};
+
+export const useReferralDashboardContext = () =>
+  useOutletContext<ReferralDashboardContext>();
+
+export default ReferralDashboard;

--- a/src/modules/ce/components/referral/ReferralStep.tsx
+++ b/src/modules/ce/components/referral/ReferralStep.tsx
@@ -1,5 +1,5 @@
 import { Box, Divider, Stack } from '@mui/material';
-import React from 'react';
+import React, { useEffect } from 'react';
 import ReferralStepDetails from './ReferralStepDetails';
 import ButtonLink from '@/components/elements/ButtonLink';
 import CommonCard from '@/components/elements/CommonCard';
@@ -15,7 +15,7 @@ import {
 } from '@/types/gqlTypes';
 
 const ReferralStep: React.FC = ({}) => {
-  const { referral, referralPath } = useReferralContext();
+  const { referral, referralPath, overrideStepTitle } = useReferralContext();
   const { stepId } = useSafeParams() as {
     stepId: string;
   };
@@ -31,6 +31,10 @@ const ReferralStep: React.FC = ({}) => {
   });
 
   const stepSummary = referral.steps?.find((s) => s.stepId === stepId);
+
+  useEffect(() => {
+    if (stepSummary?.name) overrideStepTitle?.(stepSummary.name);
+  }, [overrideStepTitle, stepSummary?.name]);
 
   if (fetchError) throw fetchError;
   if (!stepSummary) return <NotFound />;

--- a/src/modules/ce/components/referral/referralOutletContext.tsx
+++ b/src/modules/ce/components/referral/referralOutletContext.tsx
@@ -1,0 +1,13 @@
+import { useOutletContext } from 'react-router-dom';
+
+import { CeReferralFieldsFragment } from '@/types/gqlTypes';
+
+export type ReferralContext = {
+  referral: CeReferralFieldsFragment;
+  referralPath: string;
+  unitPath?: string;
+  generateReferralStepPath: (stepId: string) => string;
+  overrideStepTitle?: (name: string | undefined) => void;
+};
+
+export const useReferralContext = () => useOutletContext<ReferralContext>();

--- a/src/modules/projects/components/ProjectDashboard.tsx
+++ b/src/modules/projects/components/ProjectDashboard.tsx
@@ -1,5 +1,5 @@
 import { Container, Stack, Typography } from '@mui/material';
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { Outlet, useOutletContext } from 'react-router-dom';
 
 import { useDetailedProject } from '../hooks/useDetailedProject';
@@ -76,13 +76,18 @@ const ProjectDashboard: React.FC = () => {
   const navItems = useProjectDashboardNavItems(project);
   const { noPadding, ...dashboardState } = useDashboardState();
   // allow pages to "override" the default breadcrumb text
-  const [breadcrumbOverrides, overrideBreadcrumbTitles] = useState<
+  const [breadcrumbOverrides, setBreadcrumbOverrides] = useState<
     Record<string, string> | undefined
   >();
+  const overrideBreadcrumbTitles = useCallback(
+    (crumbs: Record<string, string>) =>
+      setBreadcrumbOverrides((prev) => ({ ...prev, ...crumbs })),
+    []
+  );
 
   const outletContext: ProjectDashboardContext | undefined = useMemo(
     () => (project ? { project, overrideBreadcrumbTitles } : undefined),
-    [project]
+    [project, overrideBreadcrumbTitles]
   );
 
   const breadCrumbConfig = useProjectBreadcrumbConfig(outletContext);

--- a/src/routes/protected.tsx
+++ b/src/routes/protected.tsx
@@ -59,6 +59,8 @@ import AdminDefaultContactsPage from '@/modules/ce/components/defaultContacts/Ad
 
 import SendReferralPage from '@/modules/ce/components/directReferral/SendReferralPage';
 import ProjectReferralsPage from '@/modules/ce/components/project/ProjectReferralsPage';
+import ProjectReferralPage from '@/modules/ce/components/referral/ProjectReferralPage';
+import ReferralDashboard from '@/modules/ce/components/referral/ReferralDashboard';
 import ReferralPage from '@/modules/ce/components/referral/ReferralPage';
 import ReferralStep from '@/modules/ce/components/referral/ReferralStep';
 import ReferralSteps from '@/modules/ce/components/referral/ReferralSteps';
@@ -211,16 +213,20 @@ export const protectedRoutes: RouteNode[] = [
       },
       {
         path: ReferralRoutes.REFERRAL,
-        // todo @martha - is this going to have /referrals/referral/...?
-        // Doesn't need a permission filter wrapper; internally it will just return NotFound if the client doesn't have access to view the referral.
-        element: <ReferralPage />,
+        element: <ReferralDashboard />,
         children: [
           {
-            path: ReferralRoutes.REFERRAL_STEP,
-            element: <ReferralStep />,
+            path: '',
+            element: <ReferralPage />,
+            children: [
+              {
+                path: 'tasks/:stepId',
+                element: <ReferralStep />,
+              },
+              { path: '', element: <ReferralSteps /> },
+              { path: '*', element: <Navigate to='' replace /> },
+            ],
           },
-          { path: '', element: <ReferralSteps /> },
-          { path: '*', element: <Navigate to='' replace /> },
         ],
       },
       {
@@ -513,7 +519,7 @@ export const protectedRoutes: RouteNode[] = [
             ),
           },
           {
-            // ReferralPage can be rendered in the Target project context,
+            // ProjectReferralPage can be rendered in the Target project context,
             // or in the Source project context (for direct referrals)
             path: ProjectDashboardRoutes.REFERRAL,
             element: (
@@ -533,7 +539,7 @@ export const protectedRoutes: RouteNode[] = [
                   'sendsDirectReferrals',
                 ]}
               >
-                <ReferralPage />
+                <ProjectReferralPage />
               </ProjectRoute>
             ),
             children: [


### PR DESCRIPTION
## Description

**Leaving this PR as a draft for now**, pending design feedback.

Summary of changes:
- Add a new `ReferralDashboard` that renders the top-level-nav referral context with a react router outlet, so that the sub-pages (Referrals, Steps) can reuse the same breadcrumb components. This is based on how we do it today for Project and other dashboards' breadcrumbs. 
- Refactor most of what was previously `ReferralPage` into a new `ReferralContent`
- Refactor `ReferralPage` and add a new `ProjectReferralPage`, both thin wrappers around `ReferralContent`. This lets them separately control breadcrumbs

This PR is split out from https://github.com/greenriver/hmis-frontend/pull/1456 for ease of review, but they should be released at the same time.

[//]: # 'remove if not applicable'
How to test: Click around referral breadcrumbs in the Referral and Project contexts. Confirm the text makes sense and the links go where you expect.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
New feature

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have used Axe DevTools to scan for accessibility issues (or not applicable)
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
