### PR TITLE
Warn when deleting HoH's enrollment

### DIFF
--- a/src/modules/assessments/components/AssessmentFormActions.tsx
+++ b/src/modules/assessments/components/AssessmentFormActions.tsx
@@ -6,12 +6,12 @@ import DeleteAssessmentButton from './DeleteAssessmentButton';
 import PrintViewButton from '@/components/layout/PrintViewButton';
 import AssessmentAutofillButton from '@/modules/assessments/components/AssessmentAutofillButton';
 
+import { isHeadOfMultiMemberHousehold } from '@/modules/hmis/hmisUtil';
 import { EnrollmentDashboardRoutes } from '@/routes/routes';
 import {
   AssessmentRole,
   EnrollmentFieldsFragment,
   FullAssessmentFragment,
-  RelationshipToHoH,
 } from '@/types/gqlTypes';
 import { generateSafePath } from '@/utils/pathEncoding';
 
@@ -68,10 +68,8 @@ const AssessmentFormActions: React.FC<Props> = ({
 
   const showPrintViewButton = !isPrintView && locked && assessment;
 
-  const isHeadOfMultiMemberHousehold = useMemo(
-    () =>
-      enrollment.householdSize > 1 &&
-      enrollment.relationshipToHoH === RelationshipToHoH.SelfHeadOfHousehold,
+  const isHoHInMultiMemberHousehold = useMemo(
+    () => isHeadOfMultiMemberHousehold(enrollment),
     [enrollment]
   );
 
@@ -98,7 +96,7 @@ const AssessmentFormActions: React.FC<Props> = ({
               clientId={enrollment.client.id}
               enrollmentId={enrollment.id}
               onSuccess={navigateToEnrollment}
-              isHeadOfMultiMemberHousehold={isHeadOfMultiMemberHousehold}
+              isHeadOfMultiMemberHousehold={isHoHInMultiMemberHousehold}
             />
           )}
         </Stack>

--- a/src/modules/assessments/components/AssessmentFormActions.tsx
+++ b/src/modules/assessments/components/AssessmentFormActions.tsx
@@ -11,6 +11,7 @@ import {
   AssessmentRole,
   EnrollmentFieldsFragment,
   FullAssessmentFragment,
+  RelationshipToHoH,
 } from '@/types/gqlTypes';
 import { generateSafePath } from '@/utils/pathEncoding';
 
@@ -67,6 +68,13 @@ const AssessmentFormActions: React.FC<Props> = ({
 
   const showPrintViewButton = !isPrintView && locked && assessment;
 
+  const isHeadOfMultiMemberHousehold = useMemo(
+    () =>
+      enrollment.householdSize > 1 &&
+      enrollment.relationshipToHoH === RelationshipToHoH.SelfHeadOfHousehold,
+    [enrollment]
+  );
+
   if (showAutofill || showPrintViewButton || showDeleteAssessmentButton) {
     return (
       <>
@@ -90,6 +98,7 @@ const AssessmentFormActions: React.FC<Props> = ({
               clientId={enrollment.client.id}
               enrollmentId={enrollment.id}
               onSuccess={navigateToEnrollment}
+              isHeadOfMultiMemberHousehold={isHeadOfMultiMemberHousehold}
             />
           )}
         </Stack>

--- a/src/modules/assessments/components/DeleteAssessmentButton.tsx
+++ b/src/modules/assessments/components/DeleteAssessmentButton.tsx
@@ -65,7 +65,7 @@ const DeleteAssessmentButton = ({
         deletesEnrollment
           ? {
               title: 'Delete Enrollment',
-              confirmText: 'Yes, delete enrollment',
+              confirmText: `Yes, delete enrollment${isHeadOfMultiMemberHousehold ? 's' : ''}`,
               color: 'error',
             }
           : undefined
@@ -78,11 +78,11 @@ const DeleteAssessmentButton = ({
           {assessment.role === AssessmentRole.Intake && (
             <>
               <Typography fontWeight={600}>
-                This will delete the enrollment{' '}
-                {isHeadOfMultiMemberHousehold && (
-                  <>and the enrollments of all household members.</>
+                {isHeadOfMultiMemberHousehold ? (
+                  <>This will delete all enrollments in the household.</>
+                ) : (
+                  <>This will delete the enrollment.</>
                 )}
-                .
               </Typography>
             </>
           )}

--- a/src/modules/assessments/components/DeleteAssessmentButton.tsx
+++ b/src/modules/assessments/components/DeleteAssessmentButton.tsx
@@ -1,13 +1,9 @@
 import { Stack, Typography } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 
-import RouterLink from '@/components/elements/RouterLink';
 import DeleteMutationButton from '@/modules/dataFetching/components/DeleteMutationButton';
 import { cache } from '@/providers/apolloClient';
-import {
-  ClientDashboardRoutes,
-  EnrollmentDashboardRoutes,
-} from '@/routes/routes';
+import { ClientDashboardRoutes } from '@/routes/routes';
 import {
   AssessmentRole,
   DeleteAssessmentDocument,
@@ -23,11 +19,13 @@ const DeleteAssessmentButton = ({
   clientId,
   onSuccess,
   enrollmentId,
+  isHeadOfMultiMemberHousehold,
 }: {
   assessment: FullAssessmentFragment;
   clientId: string;
   enrollmentId: string;
   onSuccess?: VoidFunction;
+  isHeadOfMultiMemberHousehold: boolean;
 }) => {
   const navigate = useNavigate();
   const deletesEnrollment = assessment.role === AssessmentRole.Intake;
@@ -80,24 +78,11 @@ const DeleteAssessmentButton = ({
           {assessment.role === AssessmentRole.Intake && (
             <>
               <Typography fontWeight={600}>
-                This will delete the enrollment.
-              </Typography>
-
-              <Typography>
-                If there are other household members, you may need to{' '}
-                <RouterLink
-                  to={generateSafePath(
-                    EnrollmentDashboardRoutes.EDIT_HOUSEHOLD,
-                    {
-                      clientId,
-                      enrollmentId,
-                    }
-                  )}
-                  variant='inherit'
-                >
-                  change the Head of Household
-                </RouterLink>{' '}
-                before taking this action.
+                This will delete the enrollment{' '}
+                {isHeadOfMultiMemberHousehold && (
+                  <>and the enrollments of all household members.</>
+                )}
+                .
               </Typography>
             </>
           )}

--- a/src/modules/enrollment/components/pages/EnrollmentOverview.tsx
+++ b/src/modules/enrollment/components/pages/EnrollmentOverview.tsx
@@ -1,5 +1,5 @@
-import { Grid, Stack } from '@mui/material';
-import { useCallback } from 'react';
+import { Grid, Stack, Typography } from '@mui/material';
+import { useCallback, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import EnrollmentDetails from '../EnrollmentDetails';
@@ -13,7 +13,10 @@ import { ClientAlertHouseholdWrapper } from '@/modules/clientAlerts/components/C
 import DeleteMutationButton from '@/modules/dataFetching/components/DeleteMutationButton';
 import EnrollmentQuickActions from '@/modules/enrollment/components/EnrollmentQuickActions';
 import useEnrollmentDashboardContext from '@/modules/enrollment/hooks/useEnrollmentDashboardContext';
-import { clientBriefName } from '@/modules/hmis/hmisUtil';
+import {
+  clientBriefName,
+  isHeadOfMultiMemberHousehold,
+} from '@/modules/hmis/hmisUtil';
 import HouseholdOverviewTable from '@/modules/household/components/HouseholdOverviewTable';
 import StaffAssignmentCard from '@/modules/staffAssignment/components/StaffAssignmentCard';
 import { ClientDashboardRoutes } from '@/routes/routes';
@@ -39,6 +42,11 @@ const EnrollmentOverview = () => {
       generateSafePath(ClientDashboardRoutes.CLIENT_ENROLLMENTS, { clientId })
     );
   }, [navigate, clientId, enrollmentId]);
+
+  const isHoHInMultiMemberHousehold = useMemo(
+    () => (enrollment ? isHeadOfMultiMemberHousehold(enrollment) : false),
+    [enrollment]
+  );
 
   if (!enrollment) return <NotFound />;
 
@@ -101,6 +109,19 @@ const EnrollmentOverview = () => {
                     size: 'small',
                   }}
                   deleteIcon
+                  confirmationDialogContent={
+                    <Stack gap={1}>
+                      <Typography>
+                        Are you sure you want to delete this enrollment?
+                      </Typography>
+                      {isHoHInMultiMemberHousehold && (
+                        <Typography fontWeight={600}>
+                          This will delete the enrollments of all household
+                          members.
+                        </Typography>
+                      )}
+                    </Stack>
+                  }
                 >
                   Delete Enrollment
                 </DeleteMutationButton>

--- a/src/modules/enrollment/components/pages/EnrollmentOverview.tsx
+++ b/src/modules/enrollment/components/pages/EnrollmentOverview.tsx
@@ -116,8 +116,7 @@ const EnrollmentOverview = () => {
                       </Typography>
                       {isHoHInMultiMemberHousehold && (
                         <Typography fontWeight={600}>
-                          This will delete the enrollments of all household
-                          members.
+                          This will delete all enrollments in the household.
                         </Typography>
                       )}
                     </Stack>

--- a/src/modules/hmis/hmisUtil.ts
+++ b/src/modules/hmis/hmisUtil.ts
@@ -368,6 +368,13 @@ export const entryExitRange = (
   );
 };
 
+export const isHeadOfMultiMemberHousehold = (enrollment: {
+  householdSize: number;
+  relationshipToHoH: RelationshipToHoH;
+}): boolean =>
+  enrollment.householdSize > 1 &&
+  enrollment.relationshipToHoH === RelationshipToHoH.SelfHeadOfHousehold;
+
 // Open, or closed within the last X days
 export const isRecentEnrollment = (
   enrollment: EnrollmentFieldsFragment | ClientEnrollmentFieldsFragment,


### PR DESCRIPTION
## Description

Summary of changes:
- Warn when deleting the HoH's enrollment that this will delete all household members' enrollments:
  - On the Assessment deletion confirmation, when deleting an intake
  - On the Enrollment deletion confirmation, when deleting a WIP enrollment
- Add a new shared helper method `isHeadOfMultiMemberHousehold` for determining whether to show the warning.

[//]: # 'remove if not applicable'
Depends on hmis-warehouse PR: https://github.com/greenriver/hmis-warehouse/pull/6443

[//]: # 'remove if not applicable'
How to test: See QA steps on the issue

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
New feature

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have used Axe DevTools to scan for accessibility issues (or not applicable)
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] My code follows the style guidelines of this project (eslint)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
