### PR TITLE
Simplify frontend file permissions

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -10942,7 +10942,7 @@
             "deprecationReason": null
           },
           {
-            "name": "canManageAnyClientFiles",
+            "name": "canIndexFiles",
             "description": null,
             "args": [],
             "type": {
@@ -10956,6 +10956,22 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "canManageAnyClientFiles",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": true,
+            "deprecationReason": "Resolve canManage on individual file access field instead"
           },
           {
             "name": "canManageClientAlerts",
@@ -10986,8 +11002,8 @@
                 "ofType": null
               }
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "Resolve canManage on individual file access field instead"
           },
           {
             "name": "canManageScanCards",
@@ -11066,8 +11082,8 @@
                 "ofType": null
               }
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "Use canIndexFiles"
           },
           {
             "name": "canViewClientAlerts",
@@ -25807,6 +25823,22 @@
         "isOneOf": null,
         "fields": [
           {
+            "name": "access",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "FileAccess",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "confidential",
             "description": null,
             "args": [],
@@ -26034,6 +26066,50 @@
               "kind": "OBJECT",
               "name": "ApplicationUser",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "FileAccess",
+        "description": null,
+        "isOneOf": null,
+        "fields": [
+          {
+            "name": "canManage",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -26155,7 +26155,23 @@
         "isOneOf": null,
         "fields": [
           {
-            "name": "canManage",
+            "name": "canDeleteFile",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "canEditFile",
             "description": null,
             "args": [],
             "type": {

--- a/src/api/operations/access.fragments.graphql
+++ b/src/api/operations/access.fragments.graphql
@@ -52,11 +52,10 @@ fragment ClientAccessFields on ClientAccess {
   canAuditClients
   canManageScanCards
   canMergeClients
-  canViewAnyFiles
+  canIndexFiles
 
   # The below perms could be pulled out and fetched on Client Files tab, for perf improvement
-  canManageAnyClientFiles
-  canManageOwnClientFiles
+  # todo @Martha
   canUploadClientFiles
 
   # Referral-related root permissions, resolved on Client for convenience

--- a/src/api/operations/access.fragments.graphql
+++ b/src/api/operations/access.fragments.graphql
@@ -54,14 +54,16 @@ fragment ClientAccessFields on ClientAccess {
   canMergeClients
   canIndexFiles
 
-  # The below perms could be pulled out and fetched on Client Files tab, for perf improvement
-  # todo @Martha
-  canUploadClientFiles
-
   # Referral-related root permissions, resolved on Client for convenience
   canViewReferrals
   canViewOwnReferrals
   canViewClientEligibleOpportunities
+}
+
+# Resolved only where client file upload UI is shown (not part of ClientAccessFields).
+fragment ClientFileUploadAccessFields on ClientAccess {
+  id
+  canUploadClientFiles
 }
 
 fragment EnrollmentAccessFields on EnrollmentAccess {

--- a/src/api/operations/client.queries.graphql
+++ b/src/api/operations/client.queries.graphql
@@ -46,6 +46,15 @@ query GetClientPermissions($id: ID!) {
   }
 }
 
+query GetClientFileUploadAccess($id: ID!) {
+  client(id: $id) {
+    id
+    access {
+      ...ClientFileUploadAccessFields
+    }
+  }
+}
+
 query GetClientImage($id: ID!) {
   client(id: $id) {
     ...ClientImage

--- a/src/api/operations/file.fragments.graphql
+++ b/src/api/operations/file.fragments.graphql
@@ -7,7 +7,10 @@ fragment FileFields on File {
   name
   url
   tags
-  ownFile
+  ownFile # todo @martha - can remove?
+  access {
+    canManage
+  }
   redacted
   enrollmentId
   enrollment {

--- a/src/api/operations/file.fragments.graphql
+++ b/src/api/operations/file.fragments.graphql
@@ -8,7 +8,8 @@ fragment FileFields on File {
   url
   tags
   access {
-    canManage
+    canEditFile
+    canDeleteFile
   }
   redacted
   enrollmentId

--- a/src/api/operations/file.fragments.graphql
+++ b/src/api/operations/file.fragments.graphql
@@ -7,7 +7,6 @@ fragment FileFields on File {
   name
   url
   tags
-  ownFile # todo @martha - can remove?
   access {
     canManage
   }

--- a/src/components/accessWrappers/FileEditRoute.tsx
+++ b/src/components/accessWrappers/FileEditRoute.tsx
@@ -31,6 +31,7 @@ const FileEditRoute: React.FC<
     skip: !clientId,
   });
   const canUpload = data?.client?.access?.canUploadClientFiles;
+  const canEdit = file.data?.file?.access?.canEditFile;
 
   if (loading) return <Loading />;
   if (!file && !create) {
@@ -41,7 +42,7 @@ const FileEditRoute: React.FC<
   // If uploading, check on the client whether the user can upload files
   if (create && !canUpload) return <NotFound />;
   // If attempting to edit an existing file, check permission on the file
-  if (!create && !file.data?.file?.access?.canManage) return <NotFound />;
+  if (!create && !canEdit) return <NotFound />;
 
   return <>{children}</>;
 };

--- a/src/components/accessWrappers/FileEditRoute.tsx
+++ b/src/components/accessWrappers/FileEditRoute.tsx
@@ -25,18 +25,16 @@ const FileEditRoute: React.FC<
   });
   const [permissions, { loading }] = useClientPermissions(clientId || '');
 
-  const canEdit =
-    permissions?.canManageAnyClientFiles ||
-    permissions?.canManageOwnClientFiles;
-  const canEditAny = permissions?.canManageAnyClientFiles;
-
   if (loading) return <Loading />;
   if (!file && !create) {
     console.error('File not found');
     return <NotFound />;
   }
-  if (!canEdit) return <NotFound />;
-  if (!create && !canEditAny && !file.data?.file?.ownFile) return <NotFound />;
+
+  // If uploading, check on the client whether the user can upload files
+  if (create && !permissions?.canUploadClientFiles) return <NotFound />;
+  // If attempting to edit an existing file, check permission on the file
+  if (!create && !file.data?.file?.access?.canManage) return <NotFound />;
 
   return <>{children}</>;
 };

--- a/src/components/accessWrappers/FileEditRoute.tsx
+++ b/src/components/accessWrappers/FileEditRoute.tsx
@@ -2,8 +2,10 @@ import Loading from '../elements/Loading';
 import NotFound from '../pages/NotFound';
 
 import useSafeParams from '@/hooks/useSafeParams';
-import { useClientPermissions } from '@/modules/permissions/useHasPermissionsHooks';
-import { useGetFileQuery } from '@/types/gqlTypes';
+import {
+  useGetClientFileUploadAccessQuery,
+  useGetFileQuery,
+} from '@/types/gqlTypes';
 
 const FileEditRoute: React.FC<
   React.PropsWithChildren<{
@@ -23,7 +25,12 @@ const FileEditRoute: React.FC<
     variables: { id: fileId || '' },
     skip: !fileId,
   });
-  const [permissions, { loading }] = useClientPermissions(clientId || '');
+
+  const { data, loading } = useGetClientFileUploadAccessQuery({
+    variables: { id: clientId || '' },
+    skip: !clientId,
+  });
+  const canUpload = data?.client?.access?.canUploadClientFiles;
 
   if (loading) return <Loading />;
   if (!file && !create) {
@@ -32,7 +39,7 @@ const FileEditRoute: React.FC<
   }
 
   // If uploading, check on the client whether the user can upload files
-  if (create && !permissions?.canUploadClientFiles) return <NotFound />;
+  if (create && !canUpload) return <NotFound />;
   // If attempting to edit an existing file, check permission on the file
   if (!create && !file.data?.file?.access?.canManage) return <NotFound />;
 

--- a/src/modules/client/hooks/useClientDashboardNavItems.tsx
+++ b/src/modules/client/hooks/useClientDashboardNavItems.tsx
@@ -44,7 +44,7 @@ export const useClientDashboardNavItems = (
             id: 'files',
             title: 'Files',
             path: ClientDashboardRoutes.FILES,
-            permissions: ['canViewAnyFiles'],
+            permissions: ['canIndexFiles'],
             hide: !enabledFeatures.includes(ClientDashboardFeature.File),
           },
           {

--- a/src/modules/clientFiles/components/ClientFilesPage.tsx
+++ b/src/modules/clientFiles/components/ClientFilesPage.tsx
@@ -37,16 +37,13 @@ const FileActions: React.FC<{
     onDeleteFile: () => onDone(file),
   });
 
+  // editButton and deleteButton will be null if the user doesn't have permission
   const { editButton, deleteButton, downloadButton } = getActionsForFile(file);
   return (
     <>
       {!noDownload && downloadButton}
-      {file.access.canManage && (
-        <>
-          {editButton}
-          {deleteButton}
-        </>
-      )}
+      {editButton}
+      {deleteButton}
     </>
   );
 };

--- a/src/modules/clientFiles/components/ClientFilesPage.tsx
+++ b/src/modules/clientFiles/components/ClientFilesPage.tsx
@@ -13,13 +13,13 @@ import { useIsMobile } from '@/hooks/useIsMobile';
 import useSafeParams from '@/hooks/useSafeParams';
 import GenericTableWithData from '@/modules/dataFetching/components/GenericTableWithData';
 import { DataColumnDef } from '@/modules/dataFetching/types';
-import { useHasClientPermissions } from '@/modules/permissions/useHasPermissionsHooks';
 import { ClientDashboardRoutes } from '@/routes/routes';
 import {
   GetClientFilesDocument,
   GetClientFilesQuery,
   GetClientFilesQueryVariables,
   PickListType,
+  useGetClientFileUploadAccessQuery,
   useGetPickListQuery,
 } from '@/types/gqlTypes';
 import { generateSafePath } from '@/utils/pathEncoding';
@@ -55,9 +55,11 @@ const ClientFilesPage = () => {
   const { clientId } = useSafeParams() as { clientId: string };
   const [viewingFile, setViewingFile] = useState<ClientFileType | undefined>();
 
-  const [canUpload] = useHasClientPermissions(clientId, [
-    'canUploadClientFiles',
-  ]);
+  const { data: clientAccessData } = useGetClientFileUploadAccessQuery({
+    variables: { id: clientId },
+  });
+  const canUpload = clientAccessData?.client?.access?.canUploadClientFiles;
+
   const { data: pickListData } = useGetPickListQuery({
     variables: { pickListType: PickListType.AvailableFileTypes },
   });

--- a/src/modules/clientFiles/components/ClientFilesPage.tsx
+++ b/src/modules/clientFiles/components/ClientFilesPage.tsx
@@ -13,10 +13,7 @@ import { useIsMobile } from '@/hooks/useIsMobile';
 import useSafeParams from '@/hooks/useSafeParams';
 import GenericTableWithData from '@/modules/dataFetching/components/GenericTableWithData';
 import { DataColumnDef } from '@/modules/dataFetching/types';
-import {
-  useClientPermissions,
-  useHasClientPermissions,
-} from '@/modules/permissions/useHasPermissionsHooks';
+import { useHasClientPermissions } from '@/modules/permissions/useHasPermissionsHooks';
 import { ClientDashboardRoutes } from '@/routes/routes';
 import {
   GetClientFilesDocument,
@@ -32,25 +29,19 @@ type ClientFileType = NonNullable<
 >['nodes'][0];
 
 const FileActions: React.FC<{
-  clientId: string;
   file: ClientFileType;
   onDone?: (file: ClientFileType) => any;
   noDownload?: boolean;
-}> = ({ clientId, file, onDone = () => {}, noDownload }) => {
+}> = ({ file, onDone = () => {}, noDownload }) => {
   const { getActionsForFile } = useFileActions({
     onDeleteFile: () => onDone(file),
   });
-
-  const [perms] = useClientPermissions(clientId);
-  const { canManageOwnClientFiles, canManageAnyClientFiles } = perms || {};
-  const canManage =
-    canManageAnyClientFiles || (canManageOwnClientFiles && file.ownFile);
 
   const { editButton, deleteButton, downloadButton } = getActionsForFile(file);
   return (
     <>
       {!noDownload && downloadButton}
-      {canManage && (
+      {file.access.canManage && (
         <>
           {editButton}
           {deleteButton}
@@ -193,7 +184,6 @@ const ClientFilesPage = () => {
           file={viewingFile}
           actions={
             <FileActions
-              clientId={clientId}
               file={viewingFile}
               onDone={() => setViewingFile(undefined)}
             />

--- a/src/modules/clientFiles/hooks/useFileActions.tsx
+++ b/src/modules/clientFiles/hooks/useFileActions.tsx
@@ -75,8 +75,8 @@ const useFileActions = ({ onDeleteFile = () => {} }: UseFileActionsArgs) => {
 
       return {
         downloadButton: file.url ? downloadButton : null,
-        editButton: file.access.canManage ? editButton : null,
-        deleteButton: file.access.canManage ? deleteButton : null,
+        editButton: file.access.canEditFile ? editButton : null,
+        deleteButton: file.access.canDeleteFile ? deleteButton : null,
       } as const;
     },
     [clientId, onDeleteFile]

--- a/src/modules/clientFiles/hooks/useFileActions.tsx
+++ b/src/modules/clientFiles/hooks/useFileActions.tsx
@@ -4,7 +4,6 @@ import { Link as ReactRouterLink } from 'react-router-dom';
 
 import useSafeParams from '@/hooks/useSafeParams';
 import DeleteMutationButton from '@/modules/dataFetching/components/DeleteMutationButton';
-import { useHasClientPermissions } from '@/modules/permissions/useHasPermissionsHooks';
 import { cache } from '@/providers/apolloClient';
 import { ClientDashboardRoutes } from '@/routes/routes';
 import {
@@ -21,14 +20,6 @@ export type UseFileActionsArgs = {
 
 const useFileActions = ({ onDeleteFile = () => {} }: UseFileActionsArgs) => {
   const { clientId } = useSafeParams() as { clientId: string };
-
-  const [canEdit] = useHasClientPermissions(clientId, [
-    'canManageAnyClientFiles',
-    'canManageOwnClientFiles',
-  ]);
-  const [canEditAny] = useHasClientPermissions(clientId, [
-    'canManageAnyClientFiles',
-  ]);
 
   const getActionsForFile = useCallback(
     (file: FileFieldsFragment) => {
@@ -84,12 +75,11 @@ const useFileActions = ({ onDeleteFile = () => {} }: UseFileActionsArgs) => {
 
       return {
         downloadButton: file.url ? downloadButton : null,
-        editButton: canEdit || canEditAny || file.ownFile ? editButton : null,
-        deleteButton:
-          canEdit || canEditAny || file.ownFile ? deleteButton : null,
+        editButton: file.access.canManage ? editButton : null,
+        deleteButton: file.access.canManage ? deleteButton : null,
       } as const;
     },
-    [canEditAny, canEdit, clientId, onDeleteFile]
+    [clientId, onDeleteFile]
   );
 
   return useMemo(

--- a/src/routes/protected.tsx
+++ b/src/routes/protected.tsx
@@ -842,7 +842,7 @@ export const protectedRoutes: RouteNode[] = [
             path: ClientDashboardRoutes.FILES,
             element: (
               <ClientRoute
-                permissions='canViewAnyFiles'
+                permissions='canIndexFiles'
                 redirectRoute={ClientDashboardRoutes.PROFILE}
               >
                 <ClientFilesPage />

--- a/src/types/gqlObjects.ts
+++ b/src/types/gqlObjects.ts
@@ -4348,7 +4348,15 @@ export const HmisObjectSchemas: GqlSchema[] = [
     name: 'FileAccess',
     fields: [
       {
-        name: 'canManage',
+        name: 'canDeleteFile',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'Boolean', ofType: null },
+        },
+      },
+      {
+        name: 'canEditFile',
         type: {
           kind: 'NON_NULL',
           name: null,

--- a/src/types/gqlObjects.ts
+++ b/src/types/gqlObjects.ts
@@ -1933,6 +1933,14 @@ export const HmisObjectSchemas: GqlSchema[] = [
         },
       },
       {
+        name: 'canIndexFiles',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'Boolean', ofType: null },
+        },
+      },
+      {
         name: 'canManageAnyClientFiles',
         type: {
           kind: 'NON_NULL',
@@ -4334,6 +4342,27 @@ export const HmisObjectSchemas: GqlSchema[] = [
         },
       },
       { name: 'url', type: { kind: 'SCALAR', name: 'String', ofType: null } },
+    ],
+  },
+  {
+    name: 'FileAccess',
+    fields: [
+      {
+        name: 'canManage',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'Boolean', ofType: null },
+        },
+      },
+      {
+        name: 'id',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'ID', ofType: null },
+        },
+      },
     ],
   },
   {

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -1383,13 +1383,17 @@ export type ClientAccess = {
   canAuditClients: Scalars['Boolean']['output'];
   canDeleteClient: Scalars['Boolean']['output'];
   canEditClient: Scalars['Boolean']['output'];
+  canIndexFiles: Scalars['Boolean']['output'];
+  /** @deprecated Resolve canManage on individual file access field instead */
   canManageAnyClientFiles: Scalars['Boolean']['output'];
   canManageClientAlerts: Scalars['Boolean']['output'];
+  /** @deprecated Resolve canManage on individual file access field instead */
   canManageOwnClientFiles: Scalars['Boolean']['output'];
   canManageScanCards: Scalars['Boolean']['output'];
   canMergeClients: Scalars['Boolean']['output'];
   canPrintClientCaseNotes: Scalars['Boolean']['output'];
   canUploadClientFiles: Scalars['Boolean']['output'];
+  /** @deprecated Use canIndexFiles */
   canViewAnyFiles: Scalars['Boolean']['output'];
   canViewClientAlerts: Scalars['Boolean']['output'];
   canViewClientEligibleOpportunities: Scalars['Boolean']['output'];
@@ -3502,6 +3506,7 @@ export type FieldMapping = {
 /** File */
 export type File = {
   __typename?: 'File';
+  access: FileAccess;
   confidential?: Maybe<Scalars['Boolean']['output']>;
   contentType?: Maybe<Scalars['String']['output']>;
   dateCreated?: Maybe<Scalars['ISO8601DateTime']['output']>;
@@ -3519,6 +3524,12 @@ export type File = {
   uploadedBy?: Maybe<ApplicationUser>;
   url?: Maybe<Scalars['String']['output']>;
   user?: Maybe<ApplicationUser>;
+};
+
+export type FileAccess = {
+  __typename?: 'FileAccess';
+  canManage: Scalars['Boolean']['output'];
+  id: Scalars['ID']['output'];
 };
 
 /** File Sorting Options */
@@ -9118,9 +9129,7 @@ export type ClientAccessFieldsFragment = {
   canAuditClients: boolean;
   canManageScanCards: boolean;
   canMergeClients: boolean;
-  canViewAnyFiles: boolean;
-  canManageAnyClientFiles: boolean;
-  canManageOwnClientFiles: boolean;
+  canIndexFiles: boolean;
   canUploadClientFiles: boolean;
   canViewReferrals: boolean;
   canViewOwnReferrals: boolean;
@@ -9590,6 +9599,7 @@ export type AssessmentWithRecordsFragment = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
+          access: { __typename?: 'FileAccess'; canManage: boolean };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -9646,6 +9656,7 @@ export type AssessmentWithRecordsFragment = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
+          access: { __typename?: 'FileAccess'; canManage: boolean };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -9832,6 +9843,7 @@ export type AssessmentWithRecordsFragment = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
+          access: { __typename?: 'FileAccess'; canManage: boolean };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -9888,6 +9900,7 @@ export type AssessmentWithRecordsFragment = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
+          access: { __typename?: 'FileAccess'; canManage: boolean };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -10034,6 +10047,7 @@ export type AssessmentWithRecordsFragment = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
+          access: { __typename?: 'FileAccess'; canManage: boolean };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -10090,6 +10104,7 @@ export type AssessmentWithRecordsFragment = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
+          access: { __typename?: 'FileAccess'; canManage: boolean };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -10181,6 +10196,7 @@ export type AssessmentWithRecordsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
+        access: { __typename?: 'FileAccess'; canManage: boolean };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -10237,6 +10253,7 @@ export type AssessmentWithRecordsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
+        access: { __typename?: 'FileAccess'; canManage: boolean };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -10458,6 +10475,7 @@ export type FullAssessmentFragment = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
+          access: { __typename?: 'FileAccess'; canManage: boolean };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -10514,6 +10532,7 @@ export type FullAssessmentFragment = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
+          access: { __typename?: 'FileAccess'; canManage: boolean };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -10700,6 +10719,7 @@ export type FullAssessmentFragment = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
+          access: { __typename?: 'FileAccess'; canManage: boolean };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -10756,6 +10776,7 @@ export type FullAssessmentFragment = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
+          access: { __typename?: 'FileAccess'; canManage: boolean };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -10902,6 +10923,7 @@ export type FullAssessmentFragment = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
+          access: { __typename?: 'FileAccess'; canManage: boolean };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -10958,6 +10980,7 @@ export type FullAssessmentFragment = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
+          access: { __typename?: 'FileAccess'; canManage: boolean };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -11049,6 +11072,7 @@ export type FullAssessmentFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
+        access: { __typename?: 'FileAccess'; canManage: boolean };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -11105,6 +11129,7 @@ export type FullAssessmentFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
+        access: { __typename?: 'FileAccess'; canManage: boolean };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -11222,6 +11247,7 @@ export type AssessmentWithCdesFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
+        access: { __typename?: 'FileAccess'; canManage: boolean };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -11278,6 +11304,7 @@ export type AssessmentWithCdesFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
+        access: { __typename?: 'FileAccess'; canManage: boolean };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -12494,6 +12521,7 @@ export type GetAssessmentQuery = {
             enrollmentId?: string | null;
             dateCreated?: string | null;
             dateUpdated?: string | null;
+            access: { __typename?: 'FileAccess'; canManage: boolean };
             enrollment?: { __typename?: 'Enrollment'; id: string } | null;
             uploadedBy?: {
               __typename?: 'ApplicationUser';
@@ -12550,6 +12578,7 @@ export type GetAssessmentQuery = {
             enrollmentId?: string | null;
             dateCreated?: string | null;
             dateUpdated?: string | null;
+            access: { __typename?: 'FileAccess'; canManage: boolean };
             enrollment?: { __typename?: 'Enrollment'; id: string } | null;
             uploadedBy?: {
               __typename?: 'ApplicationUser';
@@ -12736,6 +12765,7 @@ export type GetAssessmentQuery = {
             enrollmentId?: string | null;
             dateCreated?: string | null;
             dateUpdated?: string | null;
+            access: { __typename?: 'FileAccess'; canManage: boolean };
             enrollment?: { __typename?: 'Enrollment'; id: string } | null;
             uploadedBy?: {
               __typename?: 'ApplicationUser';
@@ -12792,6 +12822,7 @@ export type GetAssessmentQuery = {
             enrollmentId?: string | null;
             dateCreated?: string | null;
             dateUpdated?: string | null;
+            access: { __typename?: 'FileAccess'; canManage: boolean };
             enrollment?: { __typename?: 'Enrollment'; id: string } | null;
             uploadedBy?: {
               __typename?: 'ApplicationUser';
@@ -12938,6 +12969,7 @@ export type GetAssessmentQuery = {
             enrollmentId?: string | null;
             dateCreated?: string | null;
             dateUpdated?: string | null;
+            access: { __typename?: 'FileAccess'; canManage: boolean };
             enrollment?: { __typename?: 'Enrollment'; id: string } | null;
             uploadedBy?: {
               __typename?: 'ApplicationUser';
@@ -12994,6 +13026,7 @@ export type GetAssessmentQuery = {
             enrollmentId?: string | null;
             dateCreated?: string | null;
             dateUpdated?: string | null;
+            access: { __typename?: 'FileAccess'; canManage: boolean };
             enrollment?: { __typename?: 'Enrollment'; id: string } | null;
             uploadedBy?: {
               __typename?: 'ApplicationUser';
@@ -13085,6 +13118,7 @@ export type GetAssessmentQuery = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
+          access: { __typename?: 'FileAccess'; canManage: boolean };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -13141,6 +13175,7 @@ export type GetAssessmentQuery = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
+          access: { __typename?: 'FileAccess'; canManage: boolean };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -13293,6 +13328,7 @@ export type GetClientAssessmentsQuery = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
+              access: { __typename?: 'FileAccess'; canManage: boolean };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -13349,6 +13385,7 @@ export type GetClientAssessmentsQuery = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
+              access: { __typename?: 'FileAccess'; canManage: boolean };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -13472,6 +13509,7 @@ export type GetEnrollmentAssessmentsQuery = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
+              access: { __typename?: 'FileAccess'; canManage: boolean };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -13528,6 +13566,7 @@ export type GetEnrollmentAssessmentsQuery = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
+              access: { __typename?: 'FileAccess'; canManage: boolean };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -13665,6 +13704,7 @@ export type GetHouseholdAssessmentsQuery = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
+              access: { __typename?: 'FileAccess'; canManage: boolean };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -13721,6 +13761,7 @@ export type GetHouseholdAssessmentsQuery = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
+              access: { __typename?: 'FileAccess'; canManage: boolean };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -13987,6 +14028,7 @@ export type SubmitAssessmentMutation = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
+              access: { __typename?: 'FileAccess'; canManage: boolean };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -14043,6 +14085,7 @@ export type SubmitAssessmentMutation = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
+              access: { __typename?: 'FileAccess'; canManage: boolean };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -14229,6 +14272,7 @@ export type SubmitAssessmentMutation = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
+              access: { __typename?: 'FileAccess'; canManage: boolean };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -14285,6 +14329,7 @@ export type SubmitAssessmentMutation = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
+              access: { __typename?: 'FileAccess'; canManage: boolean };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -14431,6 +14476,7 @@ export type SubmitAssessmentMutation = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
+              access: { __typename?: 'FileAccess'; canManage: boolean };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -14487,6 +14533,7 @@ export type SubmitAssessmentMutation = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
+              access: { __typename?: 'FileAccess'; canManage: boolean };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -14578,6 +14625,7 @@ export type SubmitAssessmentMutation = {
             enrollmentId?: string | null;
             dateCreated?: string | null;
             dateUpdated?: string | null;
+            access: { __typename?: 'FileAccess'; canManage: boolean };
             enrollment?: { __typename?: 'Enrollment'; id: string } | null;
             uploadedBy?: {
               __typename?: 'ApplicationUser';
@@ -14634,6 +14682,7 @@ export type SubmitAssessmentMutation = {
             enrollmentId?: string | null;
             dateCreated?: string | null;
             dateUpdated?: string | null;
+            access: { __typename?: 'FileAccess'; canManage: boolean };
             enrollment?: { __typename?: 'Enrollment'; id: string } | null;
             uploadedBy?: {
               __typename?: 'ApplicationUser';
@@ -14842,6 +14891,7 @@ export type SubmitHouseholdAssessmentsMutation = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
+              access: { __typename?: 'FileAccess'; canManage: boolean };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -14898,6 +14948,7 @@ export type SubmitHouseholdAssessmentsMutation = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
+              access: { __typename?: 'FileAccess'; canManage: boolean };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -15084,6 +15135,7 @@ export type SubmitHouseholdAssessmentsMutation = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
+              access: { __typename?: 'FileAccess'; canManage: boolean };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -15140,6 +15192,7 @@ export type SubmitHouseholdAssessmentsMutation = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
+              access: { __typename?: 'FileAccess'; canManage: boolean };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -15286,6 +15339,7 @@ export type SubmitHouseholdAssessmentsMutation = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
+              access: { __typename?: 'FileAccess'; canManage: boolean };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -15342,6 +15396,7 @@ export type SubmitHouseholdAssessmentsMutation = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
+              access: { __typename?: 'FileAccess'; canManage: boolean };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -15433,6 +15488,7 @@ export type SubmitHouseholdAssessmentsMutation = {
             enrollmentId?: string | null;
             dateCreated?: string | null;
             dateUpdated?: string | null;
+            access: { __typename?: 'FileAccess'; canManage: boolean };
             enrollment?: { __typename?: 'Enrollment'; id: string } | null;
             uploadedBy?: {
               __typename?: 'ApplicationUser';
@@ -15489,6 +15545,7 @@ export type SubmitHouseholdAssessmentsMutation = {
             enrollmentId?: string | null;
             dateCreated?: string | null;
             dateUpdated?: string | null;
+            access: { __typename?: 'FileAccess'; canManage: boolean };
             enrollment?: { __typename?: 'Enrollment'; id: string } | null;
             uploadedBy?: {
               __typename?: 'ApplicationUser';
@@ -15714,6 +15771,7 @@ export type GetAssessmentsForPopulationQuery = {
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
                 dateUpdated?: string | null;
+                access: { __typename?: 'FileAccess'; canManage: boolean };
                 enrollment?: { __typename?: 'Enrollment'; id: string } | null;
                 uploadedBy?: {
                   __typename?: 'ApplicationUser';
@@ -15770,6 +15828,7 @@ export type GetAssessmentsForPopulationQuery = {
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
                 dateUpdated?: string | null;
+                access: { __typename?: 'FileAccess'; canManage: boolean };
                 enrollment?: { __typename?: 'Enrollment'; id: string } | null;
                 uploadedBy?: {
                   __typename?: 'ApplicationUser';
@@ -15956,6 +16015,7 @@ export type GetAssessmentsForPopulationQuery = {
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
                 dateUpdated?: string | null;
+                access: { __typename?: 'FileAccess'; canManage: boolean };
                 enrollment?: { __typename?: 'Enrollment'; id: string } | null;
                 uploadedBy?: {
                   __typename?: 'ApplicationUser';
@@ -16012,6 +16072,7 @@ export type GetAssessmentsForPopulationQuery = {
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
                 dateUpdated?: string | null;
+                access: { __typename?: 'FileAccess'; canManage: boolean };
                 enrollment?: { __typename?: 'Enrollment'; id: string } | null;
                 uploadedBy?: {
                   __typename?: 'ApplicationUser';
@@ -16158,6 +16219,7 @@ export type GetAssessmentsForPopulationQuery = {
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
                 dateUpdated?: string | null;
+                access: { __typename?: 'FileAccess'; canManage: boolean };
                 enrollment?: { __typename?: 'Enrollment'; id: string } | null;
                 uploadedBy?: {
                   __typename?: 'ApplicationUser';
@@ -16214,6 +16276,7 @@ export type GetAssessmentsForPopulationQuery = {
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
                 dateUpdated?: string | null;
+                access: { __typename?: 'FileAccess'; canManage: boolean };
                 enrollment?: { __typename?: 'Enrollment'; id: string } | null;
                 uploadedBy?: {
                   __typename?: 'ApplicationUser';
@@ -16305,6 +16368,7 @@ export type GetAssessmentsForPopulationQuery = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
+              access: { __typename?: 'FileAccess'; canManage: boolean };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -16361,6 +16425,7 @@ export type GetAssessmentsForPopulationQuery = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
+              access: { __typename?: 'FileAccess'; canManage: boolean };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -18458,6 +18523,7 @@ export type CeReferralStepFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
+        access: { __typename?: 'FileAccess'; canManage: boolean };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -18514,6 +18580,7 @@ export type CeReferralStepFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
+        access: { __typename?: 'FileAccess'; canManage: boolean };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -19265,6 +19332,7 @@ export type StartCeReferralStepMutation = {
             enrollmentId?: string | null;
             dateCreated?: string | null;
             dateUpdated?: string | null;
+            access: { __typename?: 'FileAccess'; canManage: boolean };
             enrollment?: { __typename?: 'Enrollment'; id: string } | null;
             uploadedBy?: {
               __typename?: 'ApplicationUser';
@@ -19321,6 +19389,7 @@ export type StartCeReferralStepMutation = {
             enrollmentId?: string | null;
             dateCreated?: string | null;
             dateUpdated?: string | null;
+            access: { __typename?: 'FileAccess'; canManage: boolean };
             enrollment?: { __typename?: 'Enrollment'; id: string } | null;
             uploadedBy?: {
               __typename?: 'ApplicationUser';
@@ -19958,6 +20027,7 @@ export type SubmitCeReferralStepMutation = {
             enrollmentId?: string | null;
             dateCreated?: string | null;
             dateUpdated?: string | null;
+            access: { __typename?: 'FileAccess'; canManage: boolean };
             enrollment?: { __typename?: 'Enrollment'; id: string } | null;
             uploadedBy?: {
               __typename?: 'ApplicationUser';
@@ -20014,6 +20084,7 @@ export type SubmitCeReferralStepMutation = {
             enrollmentId?: string | null;
             dateCreated?: string | null;
             dateUpdated?: string | null;
+            access: { __typename?: 'FileAccess'; canManage: boolean };
             enrollment?: { __typename?: 'Enrollment'; id: string } | null;
             uploadedBy?: {
               __typename?: 'ApplicationUser';
@@ -21527,6 +21598,7 @@ export type GetCeReferralStepQuery = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
+          access: { __typename?: 'FileAccess'; canManage: boolean };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -21583,6 +21655,7 @@ export type GetCeReferralStepQuery = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
+          access: { __typename?: 'FileAccess'; canManage: boolean };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -22045,9 +22118,7 @@ export type ClientFieldsFragment = {
     canAuditClients: boolean;
     canManageScanCards: boolean;
     canMergeClients: boolean;
-    canViewAnyFiles: boolean;
-    canManageAnyClientFiles: boolean;
-    canManageOwnClientFiles: boolean;
+    canIndexFiles: boolean;
     canUploadClientFiles: boolean;
     canViewReferrals: boolean;
     canViewOwnReferrals: boolean;
@@ -22088,6 +22159,7 @@ export type ClientFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
+        access: { __typename?: 'FileAccess'; canManage: boolean };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -22144,6 +22216,7 @@ export type ClientFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
+        access: { __typename?: 'FileAccess'; canManage: boolean };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -22534,9 +22607,7 @@ export type GetClientQuery = {
       canAuditClients: boolean;
       canManageScanCards: boolean;
       canMergeClients: boolean;
-      canViewAnyFiles: boolean;
-      canManageAnyClientFiles: boolean;
-      canManageOwnClientFiles: boolean;
+      canIndexFiles: boolean;
       canUploadClientFiles: boolean;
       canViewReferrals: boolean;
       canViewOwnReferrals: boolean;
@@ -22577,6 +22648,7 @@ export type GetClientQuery = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
+          access: { __typename?: 'FileAccess'; canManage: boolean };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -22633,6 +22705,7 @@ export type GetClientQuery = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
+          access: { __typename?: 'FileAccess'; canManage: boolean };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -22775,9 +22848,7 @@ export type GetClientPermissionsQuery = {
       canAuditClients: boolean;
       canManageScanCards: boolean;
       canMergeClients: boolean;
-      canViewAnyFiles: boolean;
-      canManageAnyClientFiles: boolean;
-      canManageOwnClientFiles: boolean;
+      canIndexFiles: boolean;
       canUploadClientFiles: boolean;
       canViewReferrals: boolean;
       canViewOwnReferrals: boolean;
@@ -22982,6 +23053,7 @@ export type GetClientServicesQuery = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
+              access: { __typename?: 'FileAccess'; canManage: boolean };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -23038,6 +23110,7 @@ export type GetClientServicesQuery = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
+              access: { __typename?: 'FileAccess'; canManage: boolean };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -23182,6 +23255,7 @@ export type DeleteClientFileMutation = {
       enrollmentId?: string | null;
       dateCreated?: string | null;
       dateUpdated?: string | null;
+      access: { __typename?: 'FileAccess'; canManage: boolean };
       enrollment?: { __typename?: 'Enrollment'; id: string } | null;
       uploadedBy?: {
         __typename?: 'ApplicationUser';
@@ -23311,9 +23385,7 @@ export type GetClientHouseholdMemberCandidatesQuery = {
                 canAuditClients: boolean;
                 canManageScanCards: boolean;
                 canMergeClients: boolean;
-                canViewAnyFiles: boolean;
-                canManageAnyClientFiles: boolean;
-                canManageOwnClientFiles: boolean;
+                canIndexFiles: boolean;
                 canUploadClientFiles: boolean;
                 canViewReferrals: boolean;
                 canViewOwnReferrals: boolean;
@@ -23387,6 +23459,7 @@ export type GetFileQuery = {
     enrollmentId?: string | null;
     dateCreated?: string | null;
     dateUpdated?: string | null;
+    access: { __typename?: 'FileAccess'; canManage: boolean };
     enrollment?: { __typename?: 'Enrollment'; id: string } | null;
     uploadedBy?: {
       __typename?: 'ApplicationUser';
@@ -23461,6 +23534,7 @@ export type GetClientFilesQuery = {
             canViewEnrollmentDetails: boolean;
           };
         } | null;
+        access: { __typename?: 'FileAccess'; canManage: boolean };
         uploadedBy?: {
           __typename?: 'ApplicationUser';
           id: string;
@@ -24223,9 +24297,7 @@ export type MergeClientsMutation = {
         canAuditClients: boolean;
         canManageScanCards: boolean;
         canMergeClients: boolean;
-        canViewAnyFiles: boolean;
-        canManageAnyClientFiles: boolean;
-        canManageOwnClientFiles: boolean;
+        canIndexFiles: boolean;
         canUploadClientFiles: boolean;
         canViewReferrals: boolean;
         canViewOwnReferrals: boolean;
@@ -24266,6 +24338,7 @@ export type MergeClientsMutation = {
             enrollmentId?: string | null;
             dateCreated?: string | null;
             dateUpdated?: string | null;
+            access: { __typename?: 'FileAccess'; canManage: boolean };
             enrollment?: { __typename?: 'Enrollment'; id: string } | null;
             uploadedBy?: {
               __typename?: 'ApplicationUser';
@@ -24322,6 +24395,7 @@ export type MergeClientsMutation = {
             enrollmentId?: string | null;
             dateCreated?: string | null;
             dateUpdated?: string | null;
+            access: { __typename?: 'FileAccess'; canManage: boolean };
             enrollment?: { __typename?: 'Enrollment'; id: string } | null;
             uploadedBy?: {
               __typename?: 'ApplicationUser';
@@ -25002,6 +25076,7 @@ export type CurrentLivingSituationFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
+        access: { __typename?: 'FileAccess'; canManage: boolean };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -25058,6 +25133,7 @@ export type CurrentLivingSituationFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
+        access: { __typename?: 'FileAccess'; canManage: boolean };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -25175,6 +25251,7 @@ export type ProjectCurrentLivingSituationFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
+        access: { __typename?: 'FileAccess'; canManage: boolean };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -25231,6 +25308,7 @@ export type ProjectCurrentLivingSituationFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
+        access: { __typename?: 'FileAccess'; canManage: boolean };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -25348,6 +25426,7 @@ export type GetEnrollmentCurrentLivingSituationsQuery = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
+              access: { __typename?: 'FileAccess'; canManage: boolean };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -25404,6 +25483,7 @@ export type GetEnrollmentCurrentLivingSituationsQuery = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
+              access: { __typename?: 'FileAccess'; canManage: boolean };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -25540,6 +25620,7 @@ export type GetProjectCurrentLivingSituationsQuery = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
+              access: { __typename?: 'FileAccess'; canManage: boolean };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -25596,6 +25677,7 @@ export type GetProjectCurrentLivingSituationsQuery = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
+              access: { __typename?: 'FileAccess'; canManage: boolean };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -25700,6 +25782,7 @@ export type CustomCaseNoteFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
+        access: { __typename?: 'FileAccess'; canManage: boolean };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -25756,6 +25839,7 @@ export type CustomCaseNoteFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
+        access: { __typename?: 'FileAccess'; canManage: boolean };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -25864,6 +25948,7 @@ export type GetEnrollmentCustomCaseNotesQuery = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
+              access: { __typename?: 'FileAccess'; canManage: boolean };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -25920,6 +26005,7 @@ export type GetEnrollmentCustomCaseNotesQuery = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
+              access: { __typename?: 'FileAccess'; canManage: boolean };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -26078,6 +26164,7 @@ export type GetClientCaseNotesQuery = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
+              access: { __typename?: 'FileAccess'; canManage: boolean };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -26134,6 +26221,7 @@ export type GetClientCaseNotesQuery = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
+              access: { __typename?: 'FileAccess'; canManage: boolean };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -26196,6 +26284,7 @@ export type CustomDataElementValueFieldsFragment = {
     enrollmentId?: string | null;
     dateCreated?: string | null;
     dateUpdated?: string | null;
+    access: { __typename?: 'FileAccess'; canManage: boolean };
     enrollment?: { __typename?: 'Enrollment'; id: string } | null;
     uploadedBy?: {
       __typename?: 'ApplicationUser';
@@ -26261,6 +26350,7 @@ export type CustomDataElementFieldsFragment = {
       enrollmentId?: string | null;
       dateCreated?: string | null;
       dateUpdated?: string | null;
+      access: { __typename?: 'FileAccess'; canManage: boolean };
       enrollment?: { __typename?: 'Enrollment'; id: string } | null;
       uploadedBy?: {
         __typename?: 'ApplicationUser';
@@ -26317,6 +26407,7 @@ export type CustomDataElementFieldsFragment = {
       enrollmentId?: string | null;
       dateCreated?: string | null;
       dateUpdated?: string | null;
+      access: { __typename?: 'FileAccess'; canManage: boolean };
       enrollment?: { __typename?: 'Enrollment'; id: string } | null;
       uploadedBy?: {
         __typename?: 'ApplicationUser';
@@ -27498,6 +27589,7 @@ export type EnrolledClientFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
+        access: { __typename?: 'FileAccess'; canManage: boolean };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -27554,6 +27646,7 @@ export type EnrolledClientFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
+        access: { __typename?: 'FileAccess'; canManage: boolean };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -27649,6 +27742,7 @@ export type AllEnrollmentDetailsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
+        access: { __typename?: 'FileAccess'; canManage: boolean };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -27705,6 +27799,7 @@ export type AllEnrollmentDetailsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
+        access: { __typename?: 'FileAccess'; canManage: boolean };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -27783,6 +27878,7 @@ export type AllEnrollmentDetailsFragment = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
+          access: { __typename?: 'FileAccess'; canManage: boolean };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -27839,6 +27935,7 @@ export type AllEnrollmentDetailsFragment = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
+          access: { __typename?: 'FileAccess'; canManage: boolean };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -28636,6 +28733,7 @@ export type SubmittedEnrollmentResultFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
+        access: { __typename?: 'FileAccess'; canManage: boolean };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -28692,6 +28790,7 @@ export type SubmittedEnrollmentResultFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
+        access: { __typename?: 'FileAccess'; canManage: boolean };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -28862,9 +28961,7 @@ export type EnrollmentWithHouseholdFieldsFragment = {
           canAuditClients: boolean;
           canManageScanCards: boolean;
           canMergeClients: boolean;
-          canViewAnyFiles: boolean;
-          canManageAnyClientFiles: boolean;
-          canManageOwnClientFiles: boolean;
+          canIndexFiles: boolean;
           canUploadClientFiles: boolean;
           canViewReferrals: boolean;
           canViewOwnReferrals: boolean;
@@ -29113,6 +29210,7 @@ export type GetEnrollmentDetailsQuery = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
+          access: { __typename?: 'FileAccess'; canManage: boolean };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -29169,6 +29267,7 @@ export type GetEnrollmentDetailsQuery = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
+          access: { __typename?: 'FileAccess'; canManage: boolean };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -29247,6 +29346,7 @@ export type GetEnrollmentDetailsQuery = {
             enrollmentId?: string | null;
             dateCreated?: string | null;
             dateUpdated?: string | null;
+            access: { __typename?: 'FileAccess'; canManage: boolean };
             enrollment?: { __typename?: 'Enrollment'; id: string } | null;
             uploadedBy?: {
               __typename?: 'ApplicationUser';
@@ -29303,6 +29403,7 @@ export type GetEnrollmentDetailsQuery = {
             enrollmentId?: string | null;
             dateCreated?: string | null;
             dateUpdated?: string | null;
+            access: { __typename?: 'FileAccess'; canManage: boolean };
             enrollment?: { __typename?: 'Enrollment'; id: string } | null;
             uploadedBy?: {
               __typename?: 'ApplicationUser';
@@ -30003,9 +30104,7 @@ export type GetEnrollmentWithHouseholdQuery = {
             canAuditClients: boolean;
             canManageScanCards: boolean;
             canMergeClients: boolean;
-            canViewAnyFiles: boolean;
-            canManageAnyClientFiles: boolean;
-            canManageOwnClientFiles: boolean;
+            canIndexFiles: boolean;
             canUploadClientFiles: boolean;
             canViewReferrals: boolean;
             canViewOwnReferrals: boolean;
@@ -31636,6 +31735,7 @@ export type FileFieldsFragment = {
   enrollmentId?: string | null;
   dateCreated?: string | null;
   dateUpdated?: string | null;
+  access: { __typename?: 'FileAccess'; canManage: boolean };
   enrollment?: { __typename?: 'Enrollment'; id: string } | null;
   uploadedBy?: {
     __typename?: 'ApplicationUser';
@@ -37669,9 +37769,7 @@ export type SubmitFormMutation = {
             canAuditClients: boolean;
             canManageScanCards: boolean;
             canMergeClients: boolean;
-            canViewAnyFiles: boolean;
-            canManageAnyClientFiles: boolean;
-            canManageOwnClientFiles: boolean;
+            canIndexFiles: boolean;
             canUploadClientFiles: boolean;
             canViewReferrals: boolean;
             canViewOwnReferrals: boolean;
@@ -37712,6 +37810,7 @@ export type SubmitFormMutation = {
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
                 dateUpdated?: string | null;
+                access: { __typename?: 'FileAccess'; canManage: boolean };
                 enrollment?: { __typename?: 'Enrollment'; id: string } | null;
                 uploadedBy?: {
                   __typename?: 'ApplicationUser';
@@ -37768,6 +37867,7 @@ export type SubmitFormMutation = {
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
                 dateUpdated?: string | null;
+                access: { __typename?: 'FileAccess'; canManage: boolean };
                 enrollment?: { __typename?: 'Enrollment'; id: string } | null;
                 uploadedBy?: {
                   __typename?: 'ApplicationUser';
@@ -37924,6 +38024,7 @@ export type SubmitFormMutation = {
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
                 dateUpdated?: string | null;
+                access: { __typename?: 'FileAccess'; canManage: boolean };
                 enrollment?: { __typename?: 'Enrollment'; id: string } | null;
                 uploadedBy?: {
                   __typename?: 'ApplicationUser';
@@ -37980,6 +38081,7 @@ export type SubmitFormMutation = {
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
                 dateUpdated?: string | null;
+                access: { __typename?: 'FileAccess'; canManage: boolean };
                 enrollment?: { __typename?: 'Enrollment'; id: string } | null;
                 uploadedBy?: {
                   __typename?: 'ApplicationUser';
@@ -38080,6 +38182,7 @@ export type SubmitFormMutation = {
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
                 dateUpdated?: string | null;
+                access: { __typename?: 'FileAccess'; canManage: boolean };
                 enrollment?: { __typename?: 'Enrollment'; id: string } | null;
                 uploadedBy?: {
                   __typename?: 'ApplicationUser';
@@ -38136,6 +38239,7 @@ export type SubmitFormMutation = {
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
                 dateUpdated?: string | null;
+                access: { __typename?: 'FileAccess'; canManage: boolean };
                 enrollment?: { __typename?: 'Enrollment'; id: string } | null;
                 uploadedBy?: {
                   __typename?: 'ApplicationUser';
@@ -38226,6 +38330,7 @@ export type SubmitFormMutation = {
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
                 dateUpdated?: string | null;
+                access: { __typename?: 'FileAccess'; canManage: boolean };
                 enrollment?: { __typename?: 'Enrollment'; id: string } | null;
                 uploadedBy?: {
                   __typename?: 'ApplicationUser';
@@ -38282,6 +38387,7 @@ export type SubmitFormMutation = {
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
                 dateUpdated?: string | null;
+                access: { __typename?: 'FileAccess'; canManage: boolean };
                 enrollment?: { __typename?: 'Enrollment'; id: string } | null;
                 uploadedBy?: {
                   __typename?: 'ApplicationUser';
@@ -38397,6 +38503,7 @@ export type SubmitFormMutation = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
+          access: { __typename?: 'FileAccess'; canManage: boolean };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -38471,6 +38578,7 @@ export type SubmitFormMutation = {
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
                 dateUpdated?: string | null;
+                access: { __typename?: 'FileAccess'; canManage: boolean };
                 enrollment?: { __typename?: 'Enrollment'; id: string } | null;
                 uploadedBy?: {
                   __typename?: 'ApplicationUser';
@@ -38527,6 +38635,7 @@ export type SubmitFormMutation = {
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
                 dateUpdated?: string | null;
+                access: { __typename?: 'FileAccess'; canManage: boolean };
                 enrollment?: { __typename?: 'Enrollment'; id: string } | null;
                 uploadedBy?: {
                   __typename?: 'ApplicationUser';
@@ -38639,6 +38748,7 @@ export type SubmitFormMutation = {
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
                 dateUpdated?: string | null;
+                access: { __typename?: 'FileAccess'; canManage: boolean };
                 enrollment?: { __typename?: 'Enrollment'; id: string } | null;
                 uploadedBy?: {
                   __typename?: 'ApplicationUser';
@@ -38695,6 +38805,7 @@ export type SubmitFormMutation = {
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
                 dateUpdated?: string | null;
+                access: { __typename?: 'FileAccess'; canManage: boolean };
                 enrollment?: { __typename?: 'Enrollment'; id: string } | null;
                 uploadedBy?: {
                   __typename?: 'ApplicationUser';
@@ -38780,6 +38891,7 @@ export type SubmitFormMutation = {
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
                 dateUpdated?: string | null;
+                access: { __typename?: 'FileAccess'; canManage: boolean };
                 enrollment?: { __typename?: 'Enrollment'; id: string } | null;
                 uploadedBy?: {
                   __typename?: 'ApplicationUser';
@@ -38836,6 +38948,7 @@ export type SubmitFormMutation = {
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
                 dateUpdated?: string | null;
+                access: { __typename?: 'FileAccess'; canManage: boolean };
                 enrollment?: { __typename?: 'Enrollment'; id: string } | null;
                 uploadedBy?: {
                   __typename?: 'ApplicationUser';
@@ -38957,6 +39070,7 @@ export type SubmitFormMutation = {
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
                 dateUpdated?: string | null;
+                access: { __typename?: 'FileAccess'; canManage: boolean };
                 enrollment?: { __typename?: 'Enrollment'; id: string } | null;
                 uploadedBy?: {
                   __typename?: 'ApplicationUser';
@@ -39013,6 +39127,7 @@ export type SubmitFormMutation = {
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
                 dateUpdated?: string | null;
+                access: { __typename?: 'FileAccess'; canManage: boolean };
                 enrollment?: { __typename?: 'Enrollment'; id: string } | null;
                 uploadedBy?: {
                   __typename?: 'ApplicationUser';
@@ -39217,6 +39332,7 @@ export type SubmitFormMutation = {
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
                 dateUpdated?: string | null;
+                access: { __typename?: 'FileAccess'; canManage: boolean };
                 enrollment?: { __typename?: 'Enrollment'; id: string } | null;
                 uploadedBy?: {
                   __typename?: 'ApplicationUser';
@@ -39273,6 +39389,7 @@ export type SubmitFormMutation = {
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
                 dateUpdated?: string | null;
+                access: { __typename?: 'FileAccess'; canManage: boolean };
                 enrollment?: { __typename?: 'Enrollment'; id: string } | null;
                 uploadedBy?: {
                   __typename?: 'ApplicationUser';
@@ -41025,9 +41142,7 @@ export type HouseholdFieldsFragment = {
         canAuditClients: boolean;
         canManageScanCards: boolean;
         canMergeClients: boolean;
-        canViewAnyFiles: boolean;
-        canManageAnyClientFiles: boolean;
-        canManageOwnClientFiles: boolean;
+        canIndexFiles: boolean;
         canUploadClientFiles: boolean;
         canViewReferrals: boolean;
         canViewOwnReferrals: boolean;
@@ -41108,9 +41223,7 @@ export type HouseholdClientFieldsFragment = {
       canAuditClients: boolean;
       canManageScanCards: boolean;
       canMergeClients: boolean;
-      canViewAnyFiles: boolean;
-      canManageAnyClientFiles: boolean;
-      canManageOwnClientFiles: boolean;
+      canIndexFiles: boolean;
       canUploadClientFiles: boolean;
       canViewReferrals: boolean;
       canViewOwnReferrals: boolean;
@@ -41288,9 +41401,7 @@ export type JoinHouseholdMutation = {
             canAuditClients: boolean;
             canManageScanCards: boolean;
             canMergeClients: boolean;
-            canViewAnyFiles: boolean;
-            canManageAnyClientFiles: boolean;
-            canManageOwnClientFiles: boolean;
+            canIndexFiles: boolean;
             canUploadClientFiles: boolean;
             canViewReferrals: boolean;
             canViewOwnReferrals: boolean;
@@ -41379,9 +41490,7 @@ export type JoinHouseholdMutation = {
             canAuditClients: boolean;
             canManageScanCards: boolean;
             canMergeClients: boolean;
-            canViewAnyFiles: boolean;
-            canManageAnyClientFiles: boolean;
-            canManageOwnClientFiles: boolean;
+            canIndexFiles: boolean;
             canUploadClientFiles: boolean;
             canViewReferrals: boolean;
             canViewOwnReferrals: boolean;
@@ -41483,9 +41592,7 @@ export type SplitHouseholdMutation = {
             canAuditClients: boolean;
             canManageScanCards: boolean;
             canMergeClients: boolean;
-            canViewAnyFiles: boolean;
-            canManageAnyClientFiles: boolean;
-            canManageOwnClientFiles: boolean;
+            canIndexFiles: boolean;
             canUploadClientFiles: boolean;
             canViewReferrals: boolean;
             canViewOwnReferrals: boolean;
@@ -41574,9 +41681,7 @@ export type SplitHouseholdMutation = {
             canAuditClients: boolean;
             canManageScanCards: boolean;
             canMergeClients: boolean;
-            canViewAnyFiles: boolean;
-            canManageAnyClientFiles: boolean;
-            canManageOwnClientFiles: boolean;
+            canIndexFiles: boolean;
             canUploadClientFiles: boolean;
             canViewReferrals: boolean;
             canViewOwnReferrals: boolean;
@@ -41674,9 +41779,7 @@ export type GetHouseholdQuery = {
           canAuditClients: boolean;
           canManageScanCards: boolean;
           canMergeClients: boolean;
-          canViewAnyFiles: boolean;
-          canManageAnyClientFiles: boolean;
-          canManageOwnClientFiles: boolean;
+          canIndexFiles: boolean;
           canUploadClientFiles: boolean;
           canViewReferrals: boolean;
           canViewOwnReferrals: boolean;
@@ -41832,6 +41935,7 @@ export type InventoryFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
+        access: { __typename?: 'FileAccess'; canManage: boolean };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -41888,6 +41992,7 @@ export type InventoryFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
+        access: { __typename?: 'FileAccess'; canManage: boolean };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -42165,6 +42270,7 @@ export type OrganizationDetailFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
+        access: { __typename?: 'FileAccess'; canManage: boolean };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -42221,6 +42327,7 @@ export type OrganizationDetailFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
+        access: { __typename?: 'FileAccess'; canManage: boolean };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -42307,6 +42414,7 @@ export type OrganizationFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
+        access: { __typename?: 'FileAccess'; canManage: boolean };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -42363,6 +42471,7 @@ export type OrganizationFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
+        access: { __typename?: 'FileAccess'; canManage: boolean };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -42482,6 +42591,7 @@ export type GetOrganizationQuery = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
+          access: { __typename?: 'FileAccess'; canManage: boolean };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -42538,6 +42648,7 @@ export type GetOrganizationQuery = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
+          access: { __typename?: 'FileAccess'; canManage: boolean };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -42737,6 +42848,7 @@ export type ProjectAllFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
+        access: { __typename?: 'FileAccess'; canManage: boolean };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -42793,6 +42905,7 @@ export type ProjectAllFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
+        access: { __typename?: 'FileAccess'; canManage: boolean };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -43523,6 +43636,7 @@ export type FunderFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
+        access: { __typename?: 'FileAccess'; canManage: boolean };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -43579,6 +43693,7 @@ export type FunderFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
+        access: { __typename?: 'FileAccess'; canManage: boolean };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -43819,6 +43934,7 @@ export type GetProjectQuery = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
+          access: { __typename?: 'FileAccess'; canManage: boolean };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -43875,6 +43991,7 @@ export type GetProjectQuery = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
+          access: { __typename?: 'FileAccess'; canManage: boolean };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -44324,6 +44441,7 @@ export type GetProjectAssessmentsQuery = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
+              access: { __typename?: 'FileAccess'; canManage: boolean };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -44380,6 +44498,7 @@ export type GetProjectAssessmentsQuery = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
+              access: { __typename?: 'FileAccess'; canManage: boolean };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -44524,6 +44643,7 @@ export type GetFunderQuery = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
+          access: { __typename?: 'FileAccess'; canManage: boolean };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -44580,6 +44700,7 @@ export type GetFunderQuery = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
+          access: { __typename?: 'FileAccess'; canManage: boolean };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -44683,6 +44804,7 @@ export type GetInventoryQuery = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
+          access: { __typename?: 'FileAccess'; canManage: boolean };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -44739,6 +44861,7 @@ export type GetInventoryQuery = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
+          access: { __typename?: 'FileAccess'; canManage: boolean };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -44883,6 +45006,7 @@ export type GetProjectInventoriesQuery = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
+              access: { __typename?: 'FileAccess'; canManage: boolean };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -44939,6 +45063,7 @@ export type GetProjectInventoriesQuery = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
+              access: { __typename?: 'FileAccess'; canManage: boolean };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -45188,6 +45313,7 @@ export type GetProjectFundersQuery = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
+              access: { __typename?: 'FileAccess'; canManage: boolean };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -45244,6 +45370,7 @@ export type GetProjectFundersQuery = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
+              access: { __typename?: 'FileAccess'; canManage: boolean };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -45800,6 +45927,7 @@ export type UpdateReferralPostingMutation = {
             enrollmentId?: string | null;
             dateCreated?: string | null;
             dateUpdated?: string | null;
+            access: { __typename?: 'FileAccess'; canManage: boolean };
             enrollment?: { __typename?: 'Enrollment'; id: string } | null;
             uploadedBy?: {
               __typename?: 'ApplicationUser';
@@ -45856,6 +45984,7 @@ export type UpdateReferralPostingMutation = {
             enrollmentId?: string | null;
             dateCreated?: string | null;
             dateUpdated?: string | null;
+            access: { __typename?: 'FileAccess'; canManage: boolean };
             enrollment?: { __typename?: 'Enrollment'; id: string } | null;
             uploadedBy?: {
               __typename?: 'ApplicationUser';
@@ -46040,6 +46169,7 @@ export type GetReferralPostingQuery = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
+          access: { __typename?: 'FileAccess'; canManage: boolean };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -46096,6 +46226,7 @@ export type GetReferralPostingQuery = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
+          access: { __typename?: 'FileAccess'; canManage: boolean };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -46319,6 +46450,7 @@ export type ReferralPostingDetailFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
+        access: { __typename?: 'FileAccess'; canManage: boolean };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -46375,6 +46507,7 @@ export type ReferralPostingDetailFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
+        access: { __typename?: 'FileAccess'; canManage: boolean };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -46492,6 +46625,7 @@ export type EsgFundingServiceFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
+        access: { __typename?: 'FileAccess'; canManage: boolean };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -46548,6 +46682,7 @@ export type EsgFundingServiceFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
+        access: { __typename?: 'FileAccess'; canManage: boolean };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -46643,6 +46778,7 @@ export type GetEsgFundingReportQuery = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
+          access: { __typename?: 'FileAccess'; canManage: boolean };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -46699,6 +46835,7 @@ export type GetEsgFundingReportQuery = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
+          access: { __typename?: 'FileAccess'; canManage: boolean };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -47056,6 +47193,7 @@ export type ServiceDetailFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
+        access: { __typename?: 'FileAccess'; canManage: boolean };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -47112,6 +47250,7 @@ export type ServiceDetailFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
+        access: { __typename?: 'FileAccess'; canManage: boolean };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -47218,6 +47357,7 @@ export type ServiceFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
+        access: { __typename?: 'FileAccess'; canManage: boolean };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -47274,6 +47414,7 @@ export type ServiceFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
+        access: { __typename?: 'FileAccess'; canManage: boolean };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -47380,6 +47521,7 @@ export type ClientServiceFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
+        access: { __typename?: 'FileAccess'; canManage: boolean };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -47436,6 +47578,7 @@ export type ClientServiceFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
+        access: { __typename?: 'FileAccess'; canManage: boolean };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -47561,6 +47704,7 @@ export type GetServiceQuery = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
+          access: { __typename?: 'FileAccess'; canManage: boolean };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -47617,6 +47761,7 @@ export type GetServiceQuery = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
+          access: { __typename?: 'FileAccess'; canManage: boolean };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -47757,6 +47902,7 @@ export type DeleteServiceMutation = {
             enrollmentId?: string | null;
             dateCreated?: string | null;
             dateUpdated?: string | null;
+            access: { __typename?: 'FileAccess'; canManage: boolean };
             enrollment?: { __typename?: 'Enrollment'; id: string } | null;
             uploadedBy?: {
               __typename?: 'ApplicationUser';
@@ -47813,6 +47959,7 @@ export type DeleteServiceMutation = {
             enrollmentId?: string | null;
             dateCreated?: string | null;
             dateUpdated?: string | null;
+            access: { __typename?: 'FileAccess'; canManage: boolean };
             enrollment?: { __typename?: 'Enrollment'; id: string } | null;
             uploadedBy?: {
               __typename?: 'ApplicationUser';
@@ -47952,6 +48099,7 @@ export type GetEnrollmentServicesQuery = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
+              access: { __typename?: 'FileAccess'; canManage: boolean };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -48008,6 +48156,7 @@ export type GetEnrollmentServicesQuery = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
+              access: { __typename?: 'FileAccess'; canManage: boolean };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -49911,6 +50060,9 @@ export const FileFieldsFragmentDoc = gql`
     url
     tags
     ownFile
+    access {
+      canManage
+    }
     redacted
     enrollmentId
     enrollment {
@@ -51123,9 +51275,7 @@ export const ClientAccessFieldsFragmentDoc = gql`
     canAuditClients
     canManageScanCards
     canMergeClients
-    canViewAnyFiles
-    canManageAnyClientFiles
-    canManageOwnClientFiles
+    canIndexFiles
     canUploadClientFiles
     canViewReferrals
     canViewOwnReferrals

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -9130,10 +9130,15 @@ export type ClientAccessFieldsFragment = {
   canManageScanCards: boolean;
   canMergeClients: boolean;
   canIndexFiles: boolean;
-  canUploadClientFiles: boolean;
   canViewReferrals: boolean;
   canViewOwnReferrals: boolean;
   canViewClientEligibleOpportunities: boolean;
+};
+
+export type ClientFileUploadAccessFieldsFragment = {
+  __typename?: 'ClientAccess';
+  id: string;
+  canUploadClientFiles: boolean;
 };
 
 export type EnrollmentAccessFieldsFragment = {
@@ -22055,7 +22060,6 @@ export type ClientFieldsFragment = {
     canManageScanCards: boolean;
     canMergeClients: boolean;
     canIndexFiles: boolean;
-    canUploadClientFiles: boolean;
     canViewReferrals: boolean;
     canViewOwnReferrals: boolean;
     canViewClientEligibleOpportunities: boolean;
@@ -22542,7 +22546,6 @@ export type GetClientQuery = {
       canManageScanCards: boolean;
       canMergeClients: boolean;
       canIndexFiles: boolean;
-      canUploadClientFiles: boolean;
       canViewReferrals: boolean;
       canViewOwnReferrals: boolean;
       canViewClientEligibleOpportunities: boolean;
@@ -22781,10 +22784,26 @@ export type GetClientPermissionsQuery = {
       canManageScanCards: boolean;
       canMergeClients: boolean;
       canIndexFiles: boolean;
-      canUploadClientFiles: boolean;
       canViewReferrals: boolean;
       canViewOwnReferrals: boolean;
       canViewClientEligibleOpportunities: boolean;
+    };
+  } | null;
+};
+
+export type GetClientFileUploadAccessQueryVariables = Exact<{
+  id: Scalars['ID']['input'];
+}>;
+
+export type GetClientFileUploadAccessQuery = {
+  __typename?: 'Query';
+  client?: {
+    __typename?: 'Client';
+    id: string;
+    access: {
+      __typename?: 'ClientAccess';
+      id: string;
+      canUploadClientFiles: boolean;
     };
   } | null;
 };
@@ -23315,7 +23334,6 @@ export type GetClientHouseholdMemberCandidatesQuery = {
                 canManageScanCards: boolean;
                 canMergeClients: boolean;
                 canIndexFiles: boolean;
-                canUploadClientFiles: boolean;
                 canViewReferrals: boolean;
                 canViewOwnReferrals: boolean;
                 canViewClientEligibleOpportunities: boolean;
@@ -24225,7 +24243,6 @@ export type MergeClientsMutation = {
         canManageScanCards: boolean;
         canMergeClients: boolean;
         canIndexFiles: boolean;
-        canUploadClientFiles: boolean;
         canViewReferrals: boolean;
         canViewOwnReferrals: boolean;
         canViewClientEligibleOpportunities: boolean;
@@ -28862,7 +28879,6 @@ export type EnrollmentWithHouseholdFieldsFragment = {
           canManageScanCards: boolean;
           canMergeClients: boolean;
           canIndexFiles: boolean;
-          canUploadClientFiles: boolean;
           canViewReferrals: boolean;
           canViewOwnReferrals: boolean;
           canViewClientEligibleOpportunities: boolean;
@@ -30001,7 +30017,6 @@ export type GetEnrollmentWithHouseholdQuery = {
             canManageScanCards: boolean;
             canMergeClients: boolean;
             canIndexFiles: boolean;
-            canUploadClientFiles: boolean;
             canViewReferrals: boolean;
             canViewOwnReferrals: boolean;
             canViewClientEligibleOpportunities: boolean;
@@ -37665,7 +37680,6 @@ export type SubmitFormMutation = {
             canManageScanCards: boolean;
             canMergeClients: boolean;
             canIndexFiles: boolean;
-            canUploadClientFiles: boolean;
             canViewReferrals: boolean;
             canViewOwnReferrals: boolean;
             canViewClientEligibleOpportunities: boolean;
@@ -41019,7 +41033,6 @@ export type HouseholdFieldsFragment = {
         canManageScanCards: boolean;
         canMergeClients: boolean;
         canIndexFiles: boolean;
-        canUploadClientFiles: boolean;
         canViewReferrals: boolean;
         canViewOwnReferrals: boolean;
         canViewClientEligibleOpportunities: boolean;
@@ -41100,7 +41113,6 @@ export type HouseholdClientFieldsFragment = {
       canManageScanCards: boolean;
       canMergeClients: boolean;
       canIndexFiles: boolean;
-      canUploadClientFiles: boolean;
       canViewReferrals: boolean;
       canViewOwnReferrals: boolean;
       canViewClientEligibleOpportunities: boolean;
@@ -41278,7 +41290,6 @@ export type JoinHouseholdMutation = {
             canManageScanCards: boolean;
             canMergeClients: boolean;
             canIndexFiles: boolean;
-            canUploadClientFiles: boolean;
             canViewReferrals: boolean;
             canViewOwnReferrals: boolean;
             canViewClientEligibleOpportunities: boolean;
@@ -41367,7 +41378,6 @@ export type JoinHouseholdMutation = {
             canManageScanCards: boolean;
             canMergeClients: boolean;
             canIndexFiles: boolean;
-            canUploadClientFiles: boolean;
             canViewReferrals: boolean;
             canViewOwnReferrals: boolean;
             canViewClientEligibleOpportunities: boolean;
@@ -41469,7 +41479,6 @@ export type SplitHouseholdMutation = {
             canManageScanCards: boolean;
             canMergeClients: boolean;
             canIndexFiles: boolean;
-            canUploadClientFiles: boolean;
             canViewReferrals: boolean;
             canViewOwnReferrals: boolean;
             canViewClientEligibleOpportunities: boolean;
@@ -41558,7 +41567,6 @@ export type SplitHouseholdMutation = {
             canManageScanCards: boolean;
             canMergeClients: boolean;
             canIndexFiles: boolean;
-            canUploadClientFiles: boolean;
             canViewReferrals: boolean;
             canViewOwnReferrals: boolean;
             canViewClientEligibleOpportunities: boolean;
@@ -41656,7 +41664,6 @@ export type GetHouseholdQuery = {
           canManageScanCards: boolean;
           canMergeClients: boolean;
           canIndexFiles: boolean;
-          canUploadClientFiles: boolean;
           canViewReferrals: boolean;
           canViewOwnReferrals: boolean;
           canViewClientEligibleOpportunities: boolean;
@@ -49726,6 +49733,12 @@ export const RootPermissionsFragmentDoc = gql`
     canIndexReferrals
   }
 `;
+export const ClientFileUploadAccessFieldsFragmentDoc = gql`
+  fragment ClientFileUploadAccessFields on ClientAccess {
+    id
+    canUploadClientFiles
+  }
+`;
 export const OrganizationAccessFieldsFragmentDoc = gql`
   fragment OrganizationAccessFields on OrganizationAccess {
     id
@@ -51105,7 +51118,6 @@ export const ClientAccessFieldsFragmentDoc = gql`
     canManageScanCards
     canMergeClients
     canIndexFiles
-    canUploadClientFiles
     canViewReferrals
     canViewOwnReferrals
     canViewClientEligibleOpportunities
@@ -57267,6 +57279,113 @@ export type GetClientPermissionsSuspenseQueryHookResult = ReturnType<
 export type GetClientPermissionsQueryResult = Apollo.QueryResult<
   GetClientPermissionsQuery,
   GetClientPermissionsQueryVariables
+>;
+export const GetClientFileUploadAccessDocument = gql`
+  query GetClientFileUploadAccess($id: ID!) {
+    client(id: $id) {
+      id
+      access {
+        ...ClientFileUploadAccessFields
+      }
+    }
+  }
+  ${ClientFileUploadAccessFieldsFragmentDoc}
+`;
+
+/**
+ * __useGetClientFileUploadAccessQuery__
+ *
+ * To run a query within a React component, call `useGetClientFileUploadAccessQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetClientFileUploadAccessQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetClientFileUploadAccessQuery({
+ *   variables: {
+ *      id: // value for 'id'
+ *   },
+ * });
+ */
+export function useGetClientFileUploadAccessQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    GetClientFileUploadAccessQuery,
+    GetClientFileUploadAccessQueryVariables
+  > &
+    (
+      | { variables: GetClientFileUploadAccessQueryVariables; skip?: boolean }
+      | { skip: boolean }
+    )
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    GetClientFileUploadAccessQuery,
+    GetClientFileUploadAccessQueryVariables
+  >(GetClientFileUploadAccessDocument, options);
+}
+export function useGetClientFileUploadAccessLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GetClientFileUploadAccessQuery,
+    GetClientFileUploadAccessQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    GetClientFileUploadAccessQuery,
+    GetClientFileUploadAccessQueryVariables
+  >(GetClientFileUploadAccessDocument, options);
+}
+// @ts-ignore
+export function useGetClientFileUploadAccessSuspenseQuery(
+  baseOptions?: Apollo.SuspenseQueryHookOptions<
+    GetClientFileUploadAccessQuery,
+    GetClientFileUploadAccessQueryVariables
+  >
+): Apollo.UseSuspenseQueryResult<
+  GetClientFileUploadAccessQuery,
+  GetClientFileUploadAccessQueryVariables
+>;
+export function useGetClientFileUploadAccessSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        GetClientFileUploadAccessQuery,
+        GetClientFileUploadAccessQueryVariables
+      >
+): Apollo.UseSuspenseQueryResult<
+  GetClientFileUploadAccessQuery | undefined,
+  GetClientFileUploadAccessQueryVariables
+>;
+export function useGetClientFileUploadAccessSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        GetClientFileUploadAccessQuery,
+        GetClientFileUploadAccessQueryVariables
+      >
+) {
+  const options =
+    baseOptions === Apollo.skipToken
+      ? baseOptions
+      : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<
+    GetClientFileUploadAccessQuery,
+    GetClientFileUploadAccessQueryVariables
+  >(GetClientFileUploadAccessDocument, options);
+}
+export type GetClientFileUploadAccessQueryHookResult = ReturnType<
+  typeof useGetClientFileUploadAccessQuery
+>;
+export type GetClientFileUploadAccessLazyQueryHookResult = ReturnType<
+  typeof useGetClientFileUploadAccessLazyQuery
+>;
+export type GetClientFileUploadAccessSuspenseQueryHookResult = ReturnType<
+  typeof useGetClientFileUploadAccessSuspenseQuery
+>;
+export type GetClientFileUploadAccessQueryResult = Apollo.QueryResult<
+  GetClientFileUploadAccessQuery,
+  GetClientFileUploadAccessQueryVariables
 >;
 export const GetClientImageDocument = gql`
   query GetClientImage($id: ID!) {

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -3537,7 +3537,8 @@ export type File = {
 
 export type FileAccess = {
   __typename?: 'FileAccess';
-  canManage: Scalars['Boolean']['output'];
+  canDeleteFile: Scalars['Boolean']['output'];
+  canEditFile: Scalars['Boolean']['output'];
   id: Scalars['ID']['output'];
 };
 
@@ -9630,7 +9631,11 @@ export type AssessmentWithRecordsFragment = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
-          access: { __typename?: 'FileAccess'; canManage: boolean };
+          access: {
+            __typename?: 'FileAccess';
+            canEditFile: boolean;
+            canDeleteFile: boolean;
+          };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -9686,7 +9691,11 @@ export type AssessmentWithRecordsFragment = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
-          access: { __typename?: 'FileAccess'; canManage: boolean };
+          access: {
+            __typename?: 'FileAccess';
+            canEditFile: boolean;
+            canDeleteFile: boolean;
+          };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -9872,7 +9881,11 @@ export type AssessmentWithRecordsFragment = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
-          access: { __typename?: 'FileAccess'; canManage: boolean };
+          access: {
+            __typename?: 'FileAccess';
+            canEditFile: boolean;
+            canDeleteFile: boolean;
+          };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -9928,7 +9941,11 @@ export type AssessmentWithRecordsFragment = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
-          access: { __typename?: 'FileAccess'; canManage: boolean };
+          access: {
+            __typename?: 'FileAccess';
+            canEditFile: boolean;
+            canDeleteFile: boolean;
+          };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -10074,7 +10091,11 @@ export type AssessmentWithRecordsFragment = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
-          access: { __typename?: 'FileAccess'; canManage: boolean };
+          access: {
+            __typename?: 'FileAccess';
+            canEditFile: boolean;
+            canDeleteFile: boolean;
+          };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -10130,7 +10151,11 @@ export type AssessmentWithRecordsFragment = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
-          access: { __typename?: 'FileAccess'; canManage: boolean };
+          access: {
+            __typename?: 'FileAccess';
+            canEditFile: boolean;
+            canDeleteFile: boolean;
+          };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -10221,7 +10246,11 @@ export type AssessmentWithRecordsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
-        access: { __typename?: 'FileAccess'; canManage: boolean };
+        access: {
+          __typename?: 'FileAccess';
+          canEditFile: boolean;
+          canDeleteFile: boolean;
+        };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -10277,7 +10306,11 @@ export type AssessmentWithRecordsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
-        access: { __typename?: 'FileAccess'; canManage: boolean };
+        access: {
+          __typename?: 'FileAccess';
+          canEditFile: boolean;
+          canDeleteFile: boolean;
+        };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -10498,7 +10531,11 @@ export type FullAssessmentFragment = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
-          access: { __typename?: 'FileAccess'; canManage: boolean };
+          access: {
+            __typename?: 'FileAccess';
+            canEditFile: boolean;
+            canDeleteFile: boolean;
+          };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -10554,7 +10591,11 @@ export type FullAssessmentFragment = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
-          access: { __typename?: 'FileAccess'; canManage: boolean };
+          access: {
+            __typename?: 'FileAccess';
+            canEditFile: boolean;
+            canDeleteFile: boolean;
+          };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -10740,7 +10781,11 @@ export type FullAssessmentFragment = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
-          access: { __typename?: 'FileAccess'; canManage: boolean };
+          access: {
+            __typename?: 'FileAccess';
+            canEditFile: boolean;
+            canDeleteFile: boolean;
+          };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -10796,7 +10841,11 @@ export type FullAssessmentFragment = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
-          access: { __typename?: 'FileAccess'; canManage: boolean };
+          access: {
+            __typename?: 'FileAccess';
+            canEditFile: boolean;
+            canDeleteFile: boolean;
+          };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -10942,7 +10991,11 @@ export type FullAssessmentFragment = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
-          access: { __typename?: 'FileAccess'; canManage: boolean };
+          access: {
+            __typename?: 'FileAccess';
+            canEditFile: boolean;
+            canDeleteFile: boolean;
+          };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -10998,7 +11051,11 @@ export type FullAssessmentFragment = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
-          access: { __typename?: 'FileAccess'; canManage: boolean };
+          access: {
+            __typename?: 'FileAccess';
+            canEditFile: boolean;
+            canDeleteFile: boolean;
+          };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -11089,7 +11146,11 @@ export type FullAssessmentFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
-        access: { __typename?: 'FileAccess'; canManage: boolean };
+        access: {
+          __typename?: 'FileAccess';
+          canEditFile: boolean;
+          canDeleteFile: boolean;
+        };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -11145,7 +11206,11 @@ export type FullAssessmentFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
-        access: { __typename?: 'FileAccess'; canManage: boolean };
+        access: {
+          __typename?: 'FileAccess';
+          canEditFile: boolean;
+          canDeleteFile: boolean;
+        };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -11262,7 +11327,11 @@ export type AssessmentWithCdesFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
-        access: { __typename?: 'FileAccess'; canManage: boolean };
+        access: {
+          __typename?: 'FileAccess';
+          canEditFile: boolean;
+          canDeleteFile: boolean;
+        };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -11318,7 +11387,11 @@ export type AssessmentWithCdesFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
-        access: { __typename?: 'FileAccess'; canManage: boolean };
+        access: {
+          __typename?: 'FileAccess';
+          canEditFile: boolean;
+          canDeleteFile: boolean;
+        };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -12534,7 +12607,11 @@ export type GetAssessmentQuery = {
             enrollmentId?: string | null;
             dateCreated?: string | null;
             dateUpdated?: string | null;
-            access: { __typename?: 'FileAccess'; canManage: boolean };
+            access: {
+              __typename?: 'FileAccess';
+              canEditFile: boolean;
+              canDeleteFile: boolean;
+            };
             enrollment?: { __typename?: 'Enrollment'; id: string } | null;
             uploadedBy?: {
               __typename?: 'ApplicationUser';
@@ -12590,7 +12667,11 @@ export type GetAssessmentQuery = {
             enrollmentId?: string | null;
             dateCreated?: string | null;
             dateUpdated?: string | null;
-            access: { __typename?: 'FileAccess'; canManage: boolean };
+            access: {
+              __typename?: 'FileAccess';
+              canEditFile: boolean;
+              canDeleteFile: boolean;
+            };
             enrollment?: { __typename?: 'Enrollment'; id: string } | null;
             uploadedBy?: {
               __typename?: 'ApplicationUser';
@@ -12776,7 +12857,11 @@ export type GetAssessmentQuery = {
             enrollmentId?: string | null;
             dateCreated?: string | null;
             dateUpdated?: string | null;
-            access: { __typename?: 'FileAccess'; canManage: boolean };
+            access: {
+              __typename?: 'FileAccess';
+              canEditFile: boolean;
+              canDeleteFile: boolean;
+            };
             enrollment?: { __typename?: 'Enrollment'; id: string } | null;
             uploadedBy?: {
               __typename?: 'ApplicationUser';
@@ -12832,7 +12917,11 @@ export type GetAssessmentQuery = {
             enrollmentId?: string | null;
             dateCreated?: string | null;
             dateUpdated?: string | null;
-            access: { __typename?: 'FileAccess'; canManage: boolean };
+            access: {
+              __typename?: 'FileAccess';
+              canEditFile: boolean;
+              canDeleteFile: boolean;
+            };
             enrollment?: { __typename?: 'Enrollment'; id: string } | null;
             uploadedBy?: {
               __typename?: 'ApplicationUser';
@@ -12978,7 +13067,11 @@ export type GetAssessmentQuery = {
             enrollmentId?: string | null;
             dateCreated?: string | null;
             dateUpdated?: string | null;
-            access: { __typename?: 'FileAccess'; canManage: boolean };
+            access: {
+              __typename?: 'FileAccess';
+              canEditFile: boolean;
+              canDeleteFile: boolean;
+            };
             enrollment?: { __typename?: 'Enrollment'; id: string } | null;
             uploadedBy?: {
               __typename?: 'ApplicationUser';
@@ -13034,7 +13127,11 @@ export type GetAssessmentQuery = {
             enrollmentId?: string | null;
             dateCreated?: string | null;
             dateUpdated?: string | null;
-            access: { __typename?: 'FileAccess'; canManage: boolean };
+            access: {
+              __typename?: 'FileAccess';
+              canEditFile: boolean;
+              canDeleteFile: boolean;
+            };
             enrollment?: { __typename?: 'Enrollment'; id: string } | null;
             uploadedBy?: {
               __typename?: 'ApplicationUser';
@@ -13125,7 +13222,11 @@ export type GetAssessmentQuery = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
-          access: { __typename?: 'FileAccess'; canManage: boolean };
+          access: {
+            __typename?: 'FileAccess';
+            canEditFile: boolean;
+            canDeleteFile: boolean;
+          };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -13181,7 +13282,11 @@ export type GetAssessmentQuery = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
-          access: { __typename?: 'FileAccess'; canManage: boolean };
+          access: {
+            __typename?: 'FileAccess';
+            canEditFile: boolean;
+            canDeleteFile: boolean;
+          };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -13333,7 +13438,11 @@ export type GetClientAssessmentsQuery = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
-              access: { __typename?: 'FileAccess'; canManage: boolean };
+              access: {
+                __typename?: 'FileAccess';
+                canEditFile: boolean;
+                canDeleteFile: boolean;
+              };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -13389,7 +13498,11 @@ export type GetClientAssessmentsQuery = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
-              access: { __typename?: 'FileAccess'; canManage: boolean };
+              access: {
+                __typename?: 'FileAccess';
+                canEditFile: boolean;
+                canDeleteFile: boolean;
+              };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -13512,7 +13625,11 @@ export type GetEnrollmentAssessmentsQuery = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
-              access: { __typename?: 'FileAccess'; canManage: boolean };
+              access: {
+                __typename?: 'FileAccess';
+                canEditFile: boolean;
+                canDeleteFile: boolean;
+              };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -13568,7 +13685,11 @@ export type GetEnrollmentAssessmentsQuery = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
-              access: { __typename?: 'FileAccess'; canManage: boolean };
+              access: {
+                __typename?: 'FileAccess';
+                canEditFile: boolean;
+                canDeleteFile: boolean;
+              };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -13705,7 +13826,11 @@ export type GetHouseholdAssessmentsQuery = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
-              access: { __typename?: 'FileAccess'; canManage: boolean };
+              access: {
+                __typename?: 'FileAccess';
+                canEditFile: boolean;
+                canDeleteFile: boolean;
+              };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -13761,7 +13886,11 @@ export type GetHouseholdAssessmentsQuery = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
-              access: { __typename?: 'FileAccess'; canManage: boolean };
+              access: {
+                __typename?: 'FileAccess';
+                canEditFile: boolean;
+                canDeleteFile: boolean;
+              };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -14027,7 +14156,11 @@ export type SubmitAssessmentMutation = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
-              access: { __typename?: 'FileAccess'; canManage: boolean };
+              access: {
+                __typename?: 'FileAccess';
+                canEditFile: boolean;
+                canDeleteFile: boolean;
+              };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -14083,7 +14216,11 @@ export type SubmitAssessmentMutation = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
-              access: { __typename?: 'FileAccess'; canManage: boolean };
+              access: {
+                __typename?: 'FileAccess';
+                canEditFile: boolean;
+                canDeleteFile: boolean;
+              };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -14269,7 +14406,11 @@ export type SubmitAssessmentMutation = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
-              access: { __typename?: 'FileAccess'; canManage: boolean };
+              access: {
+                __typename?: 'FileAccess';
+                canEditFile: boolean;
+                canDeleteFile: boolean;
+              };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -14325,7 +14466,11 @@ export type SubmitAssessmentMutation = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
-              access: { __typename?: 'FileAccess'; canManage: boolean };
+              access: {
+                __typename?: 'FileAccess';
+                canEditFile: boolean;
+                canDeleteFile: boolean;
+              };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -14471,7 +14616,11 @@ export type SubmitAssessmentMutation = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
-              access: { __typename?: 'FileAccess'; canManage: boolean };
+              access: {
+                __typename?: 'FileAccess';
+                canEditFile: boolean;
+                canDeleteFile: boolean;
+              };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -14527,7 +14676,11 @@ export type SubmitAssessmentMutation = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
-              access: { __typename?: 'FileAccess'; canManage: boolean };
+              access: {
+                __typename?: 'FileAccess';
+                canEditFile: boolean;
+                canDeleteFile: boolean;
+              };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -14618,7 +14771,11 @@ export type SubmitAssessmentMutation = {
             enrollmentId?: string | null;
             dateCreated?: string | null;
             dateUpdated?: string | null;
-            access: { __typename?: 'FileAccess'; canManage: boolean };
+            access: {
+              __typename?: 'FileAccess';
+              canEditFile: boolean;
+              canDeleteFile: boolean;
+            };
             enrollment?: { __typename?: 'Enrollment'; id: string } | null;
             uploadedBy?: {
               __typename?: 'ApplicationUser';
@@ -14674,7 +14831,11 @@ export type SubmitAssessmentMutation = {
             enrollmentId?: string | null;
             dateCreated?: string | null;
             dateUpdated?: string | null;
-            access: { __typename?: 'FileAccess'; canManage: boolean };
+            access: {
+              __typename?: 'FileAccess';
+              canEditFile: boolean;
+              canDeleteFile: boolean;
+            };
             enrollment?: { __typename?: 'Enrollment'; id: string } | null;
             uploadedBy?: {
               __typename?: 'ApplicationUser';
@@ -14882,7 +15043,11 @@ export type SubmitHouseholdAssessmentsMutation = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
-              access: { __typename?: 'FileAccess'; canManage: boolean };
+              access: {
+                __typename?: 'FileAccess';
+                canEditFile: boolean;
+                canDeleteFile: boolean;
+              };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -14938,7 +15103,11 @@ export type SubmitHouseholdAssessmentsMutation = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
-              access: { __typename?: 'FileAccess'; canManage: boolean };
+              access: {
+                __typename?: 'FileAccess';
+                canEditFile: boolean;
+                canDeleteFile: boolean;
+              };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -15124,7 +15293,11 @@ export type SubmitHouseholdAssessmentsMutation = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
-              access: { __typename?: 'FileAccess'; canManage: boolean };
+              access: {
+                __typename?: 'FileAccess';
+                canEditFile: boolean;
+                canDeleteFile: boolean;
+              };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -15180,7 +15353,11 @@ export type SubmitHouseholdAssessmentsMutation = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
-              access: { __typename?: 'FileAccess'; canManage: boolean };
+              access: {
+                __typename?: 'FileAccess';
+                canEditFile: boolean;
+                canDeleteFile: boolean;
+              };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -15326,7 +15503,11 @@ export type SubmitHouseholdAssessmentsMutation = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
-              access: { __typename?: 'FileAccess'; canManage: boolean };
+              access: {
+                __typename?: 'FileAccess';
+                canEditFile: boolean;
+                canDeleteFile: boolean;
+              };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -15382,7 +15563,11 @@ export type SubmitHouseholdAssessmentsMutation = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
-              access: { __typename?: 'FileAccess'; canManage: boolean };
+              access: {
+                __typename?: 'FileAccess';
+                canEditFile: boolean;
+                canDeleteFile: boolean;
+              };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -15473,7 +15658,11 @@ export type SubmitHouseholdAssessmentsMutation = {
             enrollmentId?: string | null;
             dateCreated?: string | null;
             dateUpdated?: string | null;
-            access: { __typename?: 'FileAccess'; canManage: boolean };
+            access: {
+              __typename?: 'FileAccess';
+              canEditFile: boolean;
+              canDeleteFile: boolean;
+            };
             enrollment?: { __typename?: 'Enrollment'; id: string } | null;
             uploadedBy?: {
               __typename?: 'ApplicationUser';
@@ -15529,7 +15718,11 @@ export type SubmitHouseholdAssessmentsMutation = {
             enrollmentId?: string | null;
             dateCreated?: string | null;
             dateUpdated?: string | null;
-            access: { __typename?: 'FileAccess'; canManage: boolean };
+            access: {
+              __typename?: 'FileAccess';
+              canEditFile: boolean;
+              canDeleteFile: boolean;
+            };
             enrollment?: { __typename?: 'Enrollment'; id: string } | null;
             uploadedBy?: {
               __typename?: 'ApplicationUser';
@@ -15754,7 +15947,11 @@ export type GetAssessmentsForPopulationQuery = {
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
                 dateUpdated?: string | null;
-                access: { __typename?: 'FileAccess'; canManage: boolean };
+                access: {
+                  __typename?: 'FileAccess';
+                  canEditFile: boolean;
+                  canDeleteFile: boolean;
+                };
                 enrollment?: { __typename?: 'Enrollment'; id: string } | null;
                 uploadedBy?: {
                   __typename?: 'ApplicationUser';
@@ -15810,7 +16007,11 @@ export type GetAssessmentsForPopulationQuery = {
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
                 dateUpdated?: string | null;
-                access: { __typename?: 'FileAccess'; canManage: boolean };
+                access: {
+                  __typename?: 'FileAccess';
+                  canEditFile: boolean;
+                  canDeleteFile: boolean;
+                };
                 enrollment?: { __typename?: 'Enrollment'; id: string } | null;
                 uploadedBy?: {
                   __typename?: 'ApplicationUser';
@@ -15996,7 +16197,11 @@ export type GetAssessmentsForPopulationQuery = {
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
                 dateUpdated?: string | null;
-                access: { __typename?: 'FileAccess'; canManage: boolean };
+                access: {
+                  __typename?: 'FileAccess';
+                  canEditFile: boolean;
+                  canDeleteFile: boolean;
+                };
                 enrollment?: { __typename?: 'Enrollment'; id: string } | null;
                 uploadedBy?: {
                   __typename?: 'ApplicationUser';
@@ -16052,7 +16257,11 @@ export type GetAssessmentsForPopulationQuery = {
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
                 dateUpdated?: string | null;
-                access: { __typename?: 'FileAccess'; canManage: boolean };
+                access: {
+                  __typename?: 'FileAccess';
+                  canEditFile: boolean;
+                  canDeleteFile: boolean;
+                };
                 enrollment?: { __typename?: 'Enrollment'; id: string } | null;
                 uploadedBy?: {
                   __typename?: 'ApplicationUser';
@@ -16198,7 +16407,11 @@ export type GetAssessmentsForPopulationQuery = {
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
                 dateUpdated?: string | null;
-                access: { __typename?: 'FileAccess'; canManage: boolean };
+                access: {
+                  __typename?: 'FileAccess';
+                  canEditFile: boolean;
+                  canDeleteFile: boolean;
+                };
                 enrollment?: { __typename?: 'Enrollment'; id: string } | null;
                 uploadedBy?: {
                   __typename?: 'ApplicationUser';
@@ -16254,7 +16467,11 @@ export type GetAssessmentsForPopulationQuery = {
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
                 dateUpdated?: string | null;
-                access: { __typename?: 'FileAccess'; canManage: boolean };
+                access: {
+                  __typename?: 'FileAccess';
+                  canEditFile: boolean;
+                  canDeleteFile: boolean;
+                };
                 enrollment?: { __typename?: 'Enrollment'; id: string } | null;
                 uploadedBy?: {
                   __typename?: 'ApplicationUser';
@@ -16345,7 +16562,11 @@ export type GetAssessmentsForPopulationQuery = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
-              access: { __typename?: 'FileAccess'; canManage: boolean };
+              access: {
+                __typename?: 'FileAccess';
+                canEditFile: boolean;
+                canDeleteFile: boolean;
+              };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -16401,7 +16622,11 @@ export type GetAssessmentsForPopulationQuery = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
-              access: { __typename?: 'FileAccess'; canManage: boolean };
+              access: {
+                __typename?: 'FileAccess';
+                canEditFile: boolean;
+                canDeleteFile: boolean;
+              };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -18498,7 +18723,11 @@ export type CeReferralStepFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
-        access: { __typename?: 'FileAccess'; canManage: boolean };
+        access: {
+          __typename?: 'FileAccess';
+          canEditFile: boolean;
+          canDeleteFile: boolean;
+        };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -18554,7 +18783,11 @@ export type CeReferralStepFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
-        access: { __typename?: 'FileAccess'; canManage: boolean };
+        access: {
+          __typename?: 'FileAccess';
+          canEditFile: boolean;
+          canDeleteFile: boolean;
+        };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -19305,7 +19538,11 @@ export type StartCeReferralStepMutation = {
             enrollmentId?: string | null;
             dateCreated?: string | null;
             dateUpdated?: string | null;
-            access: { __typename?: 'FileAccess'; canManage: boolean };
+            access: {
+              __typename?: 'FileAccess';
+              canEditFile: boolean;
+              canDeleteFile: boolean;
+            };
             enrollment?: { __typename?: 'Enrollment'; id: string } | null;
             uploadedBy?: {
               __typename?: 'ApplicationUser';
@@ -19361,7 +19598,11 @@ export type StartCeReferralStepMutation = {
             enrollmentId?: string | null;
             dateCreated?: string | null;
             dateUpdated?: string | null;
-            access: { __typename?: 'FileAccess'; canManage: boolean };
+            access: {
+              __typename?: 'FileAccess';
+              canEditFile: boolean;
+              canDeleteFile: boolean;
+            };
             enrollment?: { __typename?: 'Enrollment'; id: string } | null;
             uploadedBy?: {
               __typename?: 'ApplicationUser';
@@ -19998,7 +20239,11 @@ export type SubmitCeReferralStepMutation = {
             enrollmentId?: string | null;
             dateCreated?: string | null;
             dateUpdated?: string | null;
-            access: { __typename?: 'FileAccess'; canManage: boolean };
+            access: {
+              __typename?: 'FileAccess';
+              canEditFile: boolean;
+              canDeleteFile: boolean;
+            };
             enrollment?: { __typename?: 'Enrollment'; id: string } | null;
             uploadedBy?: {
               __typename?: 'ApplicationUser';
@@ -20054,7 +20299,11 @@ export type SubmitCeReferralStepMutation = {
             enrollmentId?: string | null;
             dateCreated?: string | null;
             dateUpdated?: string | null;
-            access: { __typename?: 'FileAccess'; canManage: boolean };
+            access: {
+              __typename?: 'FileAccess';
+              canEditFile: boolean;
+              canDeleteFile: boolean;
+            };
             enrollment?: { __typename?: 'Enrollment'; id: string } | null;
             uploadedBy?: {
               __typename?: 'ApplicationUser';
@@ -21567,7 +21816,11 @@ export type GetCeReferralStepQuery = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
-          access: { __typename?: 'FileAccess'; canManage: boolean };
+          access: {
+            __typename?: 'FileAccess';
+            canEditFile: boolean;
+            canDeleteFile: boolean;
+          };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -21623,7 +21876,11 @@ export type GetCeReferralStepQuery = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
-          access: { __typename?: 'FileAccess'; canManage: boolean };
+          access: {
+            __typename?: 'FileAccess';
+            canEditFile: boolean;
+            canDeleteFile: boolean;
+          };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -22125,7 +22382,11 @@ export type ClientFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
-        access: { __typename?: 'FileAccess'; canManage: boolean };
+        access: {
+          __typename?: 'FileAccess';
+          canEditFile: boolean;
+          canDeleteFile: boolean;
+        };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -22181,7 +22442,11 @@ export type ClientFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
-        access: { __typename?: 'FileAccess'; canManage: boolean };
+        access: {
+          __typename?: 'FileAccess';
+          canEditFile: boolean;
+          canDeleteFile: boolean;
+        };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -22611,7 +22876,11 @@ export type GetClientQuery = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
-          access: { __typename?: 'FileAccess'; canManage: boolean };
+          access: {
+            __typename?: 'FileAccess';
+            canEditFile: boolean;
+            canDeleteFile: boolean;
+          };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -22667,7 +22936,11 @@ export type GetClientQuery = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
-          access: { __typename?: 'FileAccess'; canManage: boolean };
+          access: {
+            __typename?: 'FileAccess';
+            canEditFile: boolean;
+            canDeleteFile: boolean;
+          };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -23030,7 +23303,11 @@ export type GetClientServicesQuery = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
-              access: { __typename?: 'FileAccess'; canManage: boolean };
+              access: {
+                __typename?: 'FileAccess';
+                canEditFile: boolean;
+                canDeleteFile: boolean;
+              };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -23086,7 +23363,11 @@ export type GetClientServicesQuery = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
-              access: { __typename?: 'FileAccess'; canManage: boolean };
+              access: {
+                __typename?: 'FileAccess';
+                canEditFile: boolean;
+                canDeleteFile: boolean;
+              };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -23230,7 +23511,11 @@ export type DeleteClientFileMutation = {
       enrollmentId?: string | null;
       dateCreated?: string | null;
       dateUpdated?: string | null;
-      access: { __typename?: 'FileAccess'; canManage: boolean };
+      access: {
+        __typename?: 'FileAccess';
+        canEditFile: boolean;
+        canDeleteFile: boolean;
+      };
       enrollment?: { __typename?: 'Enrollment'; id: string } | null;
       uploadedBy?: {
         __typename?: 'ApplicationUser';
@@ -23432,7 +23717,11 @@ export type GetFileQuery = {
     enrollmentId?: string | null;
     dateCreated?: string | null;
     dateUpdated?: string | null;
-    access: { __typename?: 'FileAccess'; canManage: boolean };
+    access: {
+      __typename?: 'FileAccess';
+      canEditFile: boolean;
+      canDeleteFile: boolean;
+    };
     enrollment?: { __typename?: 'Enrollment'; id: string } | null;
     uploadedBy?: {
       __typename?: 'ApplicationUser';
@@ -23506,7 +23795,11 @@ export type GetClientFilesQuery = {
             canViewEnrollmentDetails: boolean;
           };
         } | null;
-        access: { __typename?: 'FileAccess'; canManage: boolean };
+        access: {
+          __typename?: 'FileAccess';
+          canEditFile: boolean;
+          canDeleteFile: boolean;
+        };
         uploadedBy?: {
           __typename?: 'ApplicationUser';
           id: string;
@@ -24308,7 +24601,11 @@ export type MergeClientsMutation = {
             enrollmentId?: string | null;
             dateCreated?: string | null;
             dateUpdated?: string | null;
-            access: { __typename?: 'FileAccess'; canManage: boolean };
+            access: {
+              __typename?: 'FileAccess';
+              canEditFile: boolean;
+              canDeleteFile: boolean;
+            };
             enrollment?: { __typename?: 'Enrollment'; id: string } | null;
             uploadedBy?: {
               __typename?: 'ApplicationUser';
@@ -24364,7 +24661,11 @@ export type MergeClientsMutation = {
             enrollmentId?: string | null;
             dateCreated?: string | null;
             dateUpdated?: string | null;
-            access: { __typename?: 'FileAccess'; canManage: boolean };
+            access: {
+              __typename?: 'FileAccess';
+              canEditFile: boolean;
+              canDeleteFile: boolean;
+            };
             enrollment?: { __typename?: 'Enrollment'; id: string } | null;
             uploadedBy?: {
               __typename?: 'ApplicationUser';
@@ -25044,7 +25345,11 @@ export type CurrentLivingSituationFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
-        access: { __typename?: 'FileAccess'; canManage: boolean };
+        access: {
+          __typename?: 'FileAccess';
+          canEditFile: boolean;
+          canDeleteFile: boolean;
+        };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -25100,7 +25405,11 @@ export type CurrentLivingSituationFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
-        access: { __typename?: 'FileAccess'; canManage: boolean };
+        access: {
+          __typename?: 'FileAccess';
+          canEditFile: boolean;
+          canDeleteFile: boolean;
+        };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -25217,7 +25526,11 @@ export type ProjectCurrentLivingSituationFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
-        access: { __typename?: 'FileAccess'; canManage: boolean };
+        access: {
+          __typename?: 'FileAccess';
+          canEditFile: boolean;
+          canDeleteFile: boolean;
+        };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -25273,7 +25586,11 @@ export type ProjectCurrentLivingSituationFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
-        access: { __typename?: 'FileAccess'; canManage: boolean };
+        access: {
+          __typename?: 'FileAccess';
+          canEditFile: boolean;
+          canDeleteFile: boolean;
+        };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -25390,7 +25707,11 @@ export type GetEnrollmentCurrentLivingSituationsQuery = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
-              access: { __typename?: 'FileAccess'; canManage: boolean };
+              access: {
+                __typename?: 'FileAccess';
+                canEditFile: boolean;
+                canDeleteFile: boolean;
+              };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -25446,7 +25767,11 @@ export type GetEnrollmentCurrentLivingSituationsQuery = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
-              access: { __typename?: 'FileAccess'; canManage: boolean };
+              access: {
+                __typename?: 'FileAccess';
+                canEditFile: boolean;
+                canDeleteFile: boolean;
+              };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -25582,7 +25907,11 @@ export type GetProjectCurrentLivingSituationsQuery = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
-              access: { __typename?: 'FileAccess'; canManage: boolean };
+              access: {
+                __typename?: 'FileAccess';
+                canEditFile: boolean;
+                canDeleteFile: boolean;
+              };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -25638,7 +25967,11 @@ export type GetProjectCurrentLivingSituationsQuery = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
-              access: { __typename?: 'FileAccess'; canManage: boolean };
+              access: {
+                __typename?: 'FileAccess';
+                canEditFile: boolean;
+                canDeleteFile: boolean;
+              };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -25742,7 +26075,11 @@ export type CustomCaseNoteFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
-        access: { __typename?: 'FileAccess'; canManage: boolean };
+        access: {
+          __typename?: 'FileAccess';
+          canEditFile: boolean;
+          canDeleteFile: boolean;
+        };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -25798,7 +26135,11 @@ export type CustomCaseNoteFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
-        access: { __typename?: 'FileAccess'; canManage: boolean };
+        access: {
+          __typename?: 'FileAccess';
+          canEditFile: boolean;
+          canDeleteFile: boolean;
+        };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -25906,7 +26247,11 @@ export type GetEnrollmentCustomCaseNotesQuery = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
-              access: { __typename?: 'FileAccess'; canManage: boolean };
+              access: {
+                __typename?: 'FileAccess';
+                canEditFile: boolean;
+                canDeleteFile: boolean;
+              };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -25962,7 +26307,11 @@ export type GetEnrollmentCustomCaseNotesQuery = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
-              access: { __typename?: 'FileAccess'; canManage: boolean };
+              access: {
+                __typename?: 'FileAccess';
+                canEditFile: boolean;
+                canDeleteFile: boolean;
+              };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -26120,7 +26469,11 @@ export type GetClientCaseNotesQuery = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
-              access: { __typename?: 'FileAccess'; canManage: boolean };
+              access: {
+                __typename?: 'FileAccess';
+                canEditFile: boolean;
+                canDeleteFile: boolean;
+              };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -26176,7 +26529,11 @@ export type GetClientCaseNotesQuery = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
-              access: { __typename?: 'FileAccess'; canManage: boolean };
+              access: {
+                __typename?: 'FileAccess';
+                canEditFile: boolean;
+                canDeleteFile: boolean;
+              };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -26238,7 +26595,11 @@ export type CustomDataElementValueFieldsFragment = {
     enrollmentId?: string | null;
     dateCreated?: string | null;
     dateUpdated?: string | null;
-    access: { __typename?: 'FileAccess'; canManage: boolean };
+    access: {
+      __typename?: 'FileAccess';
+      canEditFile: boolean;
+      canDeleteFile: boolean;
+    };
     enrollment?: { __typename?: 'Enrollment'; id: string } | null;
     uploadedBy?: {
       __typename?: 'ApplicationUser';
@@ -26303,7 +26664,11 @@ export type CustomDataElementFieldsFragment = {
       enrollmentId?: string | null;
       dateCreated?: string | null;
       dateUpdated?: string | null;
-      access: { __typename?: 'FileAccess'; canManage: boolean };
+      access: {
+        __typename?: 'FileAccess';
+        canEditFile: boolean;
+        canDeleteFile: boolean;
+      };
       enrollment?: { __typename?: 'Enrollment'; id: string } | null;
       uploadedBy?: {
         __typename?: 'ApplicationUser';
@@ -26359,7 +26724,11 @@ export type CustomDataElementFieldsFragment = {
       enrollmentId?: string | null;
       dateCreated?: string | null;
       dateUpdated?: string | null;
-      access: { __typename?: 'FileAccess'; canManage: boolean };
+      access: {
+        __typename?: 'FileAccess';
+        canEditFile: boolean;
+        canDeleteFile: boolean;
+      };
       enrollment?: { __typename?: 'Enrollment'; id: string } | null;
       uploadedBy?: {
         __typename?: 'ApplicationUser';
@@ -27540,7 +27909,11 @@ export type EnrolledClientFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
-        access: { __typename?: 'FileAccess'; canManage: boolean };
+        access: {
+          __typename?: 'FileAccess';
+          canEditFile: boolean;
+          canDeleteFile: boolean;
+        };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -27596,7 +27969,11 @@ export type EnrolledClientFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
-        access: { __typename?: 'FileAccess'; canManage: boolean };
+        access: {
+          __typename?: 'FileAccess';
+          canEditFile: boolean;
+          canDeleteFile: boolean;
+        };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -27691,7 +28068,11 @@ export type AllEnrollmentDetailsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
-        access: { __typename?: 'FileAccess'; canManage: boolean };
+        access: {
+          __typename?: 'FileAccess';
+          canEditFile: boolean;
+          canDeleteFile: boolean;
+        };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -27747,7 +28128,11 @@ export type AllEnrollmentDetailsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
-        access: { __typename?: 'FileAccess'; canManage: boolean };
+        access: {
+          __typename?: 'FileAccess';
+          canEditFile: boolean;
+          canDeleteFile: boolean;
+        };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -27825,7 +28210,11 @@ export type AllEnrollmentDetailsFragment = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
-          access: { __typename?: 'FileAccess'; canManage: boolean };
+          access: {
+            __typename?: 'FileAccess';
+            canEditFile: boolean;
+            canDeleteFile: boolean;
+          };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -27881,7 +28270,11 @@ export type AllEnrollmentDetailsFragment = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
-          access: { __typename?: 'FileAccess'; canManage: boolean };
+          access: {
+            __typename?: 'FileAccess';
+            canEditFile: boolean;
+            canDeleteFile: boolean;
+          };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -28678,7 +29071,11 @@ export type SubmittedEnrollmentResultFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
-        access: { __typename?: 'FileAccess'; canManage: boolean };
+        access: {
+          __typename?: 'FileAccess';
+          canEditFile: boolean;
+          canDeleteFile: boolean;
+        };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -28734,7 +29131,11 @@ export type SubmittedEnrollmentResultFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
-        access: { __typename?: 'FileAccess'; canManage: boolean };
+        access: {
+          __typename?: 'FileAccess';
+          canEditFile: boolean;
+          canDeleteFile: boolean;
+        };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -29152,7 +29553,11 @@ export type GetEnrollmentDetailsQuery = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
-          access: { __typename?: 'FileAccess'; canManage: boolean };
+          access: {
+            __typename?: 'FileAccess';
+            canEditFile: boolean;
+            canDeleteFile: boolean;
+          };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -29208,7 +29613,11 @@ export type GetEnrollmentDetailsQuery = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
-          access: { __typename?: 'FileAccess'; canManage: boolean };
+          access: {
+            __typename?: 'FileAccess';
+            canEditFile: boolean;
+            canDeleteFile: boolean;
+          };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -29286,7 +29695,11 @@ export type GetEnrollmentDetailsQuery = {
             enrollmentId?: string | null;
             dateCreated?: string | null;
             dateUpdated?: string | null;
-            access: { __typename?: 'FileAccess'; canManage: boolean };
+            access: {
+              __typename?: 'FileAccess';
+              canEditFile: boolean;
+              canDeleteFile: boolean;
+            };
             enrollment?: { __typename?: 'Enrollment'; id: string } | null;
             uploadedBy?: {
               __typename?: 'ApplicationUser';
@@ -29342,7 +29755,11 @@ export type GetEnrollmentDetailsQuery = {
             enrollmentId?: string | null;
             dateCreated?: string | null;
             dateUpdated?: string | null;
-            access: { __typename?: 'FileAccess'; canManage: boolean };
+            access: {
+              __typename?: 'FileAccess';
+              canEditFile: boolean;
+              canDeleteFile: boolean;
+            };
             enrollment?: { __typename?: 'Enrollment'; id: string } | null;
             uploadedBy?: {
               __typename?: 'ApplicationUser';
@@ -31672,7 +32089,11 @@ export type FileFieldsFragment = {
   enrollmentId?: string | null;
   dateCreated?: string | null;
   dateUpdated?: string | null;
-  access: { __typename?: 'FileAccess'; canManage: boolean };
+  access: {
+    __typename?: 'FileAccess';
+    canEditFile: boolean;
+    canDeleteFile: boolean;
+  };
   enrollment?: { __typename?: 'Enrollment'; id: string } | null;
   uploadedBy?: {
     __typename?: 'ApplicationUser';
@@ -37745,7 +38166,11 @@ export type SubmitFormMutation = {
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
                 dateUpdated?: string | null;
-                access: { __typename?: 'FileAccess'; canManage: boolean };
+                access: {
+                  __typename?: 'FileAccess';
+                  canEditFile: boolean;
+                  canDeleteFile: boolean;
+                };
                 enrollment?: { __typename?: 'Enrollment'; id: string } | null;
                 uploadedBy?: {
                   __typename?: 'ApplicationUser';
@@ -37801,7 +38226,11 @@ export type SubmitFormMutation = {
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
                 dateUpdated?: string | null;
-                access: { __typename?: 'FileAccess'; canManage: boolean };
+                access: {
+                  __typename?: 'FileAccess';
+                  canEditFile: boolean;
+                  canDeleteFile: boolean;
+                };
                 enrollment?: { __typename?: 'Enrollment'; id: string } | null;
                 uploadedBy?: {
                   __typename?: 'ApplicationUser';
@@ -37957,7 +38386,11 @@ export type SubmitFormMutation = {
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
                 dateUpdated?: string | null;
-                access: { __typename?: 'FileAccess'; canManage: boolean };
+                access: {
+                  __typename?: 'FileAccess';
+                  canEditFile: boolean;
+                  canDeleteFile: boolean;
+                };
                 enrollment?: { __typename?: 'Enrollment'; id: string } | null;
                 uploadedBy?: {
                   __typename?: 'ApplicationUser';
@@ -38013,7 +38446,11 @@ export type SubmitFormMutation = {
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
                 dateUpdated?: string | null;
-                access: { __typename?: 'FileAccess'; canManage: boolean };
+                access: {
+                  __typename?: 'FileAccess';
+                  canEditFile: boolean;
+                  canDeleteFile: boolean;
+                };
                 enrollment?: { __typename?: 'Enrollment'; id: string } | null;
                 uploadedBy?: {
                   __typename?: 'ApplicationUser';
@@ -38113,7 +38550,11 @@ export type SubmitFormMutation = {
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
                 dateUpdated?: string | null;
-                access: { __typename?: 'FileAccess'; canManage: boolean };
+                access: {
+                  __typename?: 'FileAccess';
+                  canEditFile: boolean;
+                  canDeleteFile: boolean;
+                };
                 enrollment?: { __typename?: 'Enrollment'; id: string } | null;
                 uploadedBy?: {
                   __typename?: 'ApplicationUser';
@@ -38169,7 +38610,11 @@ export type SubmitFormMutation = {
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
                 dateUpdated?: string | null;
-                access: { __typename?: 'FileAccess'; canManage: boolean };
+                access: {
+                  __typename?: 'FileAccess';
+                  canEditFile: boolean;
+                  canDeleteFile: boolean;
+                };
                 enrollment?: { __typename?: 'Enrollment'; id: string } | null;
                 uploadedBy?: {
                   __typename?: 'ApplicationUser';
@@ -38259,7 +38704,11 @@ export type SubmitFormMutation = {
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
                 dateUpdated?: string | null;
-                access: { __typename?: 'FileAccess'; canManage: boolean };
+                access: {
+                  __typename?: 'FileAccess';
+                  canEditFile: boolean;
+                  canDeleteFile: boolean;
+                };
                 enrollment?: { __typename?: 'Enrollment'; id: string } | null;
                 uploadedBy?: {
                   __typename?: 'ApplicationUser';
@@ -38315,7 +38764,11 @@ export type SubmitFormMutation = {
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
                 dateUpdated?: string | null;
-                access: { __typename?: 'FileAccess'; canManage: boolean };
+                access: {
+                  __typename?: 'FileAccess';
+                  canEditFile: boolean;
+                  canDeleteFile: boolean;
+                };
                 enrollment?: { __typename?: 'Enrollment'; id: string } | null;
                 uploadedBy?: {
                   __typename?: 'ApplicationUser';
@@ -38430,7 +38883,11 @@ export type SubmitFormMutation = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
-          access: { __typename?: 'FileAccess'; canManage: boolean };
+          access: {
+            __typename?: 'FileAccess';
+            canEditFile: boolean;
+            canDeleteFile: boolean;
+          };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -38504,7 +38961,11 @@ export type SubmitFormMutation = {
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
                 dateUpdated?: string | null;
-                access: { __typename?: 'FileAccess'; canManage: boolean };
+                access: {
+                  __typename?: 'FileAccess';
+                  canEditFile: boolean;
+                  canDeleteFile: boolean;
+                };
                 enrollment?: { __typename?: 'Enrollment'; id: string } | null;
                 uploadedBy?: {
                   __typename?: 'ApplicationUser';
@@ -38560,7 +39021,11 @@ export type SubmitFormMutation = {
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
                 dateUpdated?: string | null;
-                access: { __typename?: 'FileAccess'; canManage: boolean };
+                access: {
+                  __typename?: 'FileAccess';
+                  canEditFile: boolean;
+                  canDeleteFile: boolean;
+                };
                 enrollment?: { __typename?: 'Enrollment'; id: string } | null;
                 uploadedBy?: {
                   __typename?: 'ApplicationUser';
@@ -38672,7 +39137,11 @@ export type SubmitFormMutation = {
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
                 dateUpdated?: string | null;
-                access: { __typename?: 'FileAccess'; canManage: boolean };
+                access: {
+                  __typename?: 'FileAccess';
+                  canEditFile: boolean;
+                  canDeleteFile: boolean;
+                };
                 enrollment?: { __typename?: 'Enrollment'; id: string } | null;
                 uploadedBy?: {
                   __typename?: 'ApplicationUser';
@@ -38728,7 +39197,11 @@ export type SubmitFormMutation = {
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
                 dateUpdated?: string | null;
-                access: { __typename?: 'FileAccess'; canManage: boolean };
+                access: {
+                  __typename?: 'FileAccess';
+                  canEditFile: boolean;
+                  canDeleteFile: boolean;
+                };
                 enrollment?: { __typename?: 'Enrollment'; id: string } | null;
                 uploadedBy?: {
                   __typename?: 'ApplicationUser';
@@ -38813,7 +39286,11 @@ export type SubmitFormMutation = {
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
                 dateUpdated?: string | null;
-                access: { __typename?: 'FileAccess'; canManage: boolean };
+                access: {
+                  __typename?: 'FileAccess';
+                  canEditFile: boolean;
+                  canDeleteFile: boolean;
+                };
                 enrollment?: { __typename?: 'Enrollment'; id: string } | null;
                 uploadedBy?: {
                   __typename?: 'ApplicationUser';
@@ -38869,7 +39346,11 @@ export type SubmitFormMutation = {
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
                 dateUpdated?: string | null;
-                access: { __typename?: 'FileAccess'; canManage: boolean };
+                access: {
+                  __typename?: 'FileAccess';
+                  canEditFile: boolean;
+                  canDeleteFile: boolean;
+                };
                 enrollment?: { __typename?: 'Enrollment'; id: string } | null;
                 uploadedBy?: {
                   __typename?: 'ApplicationUser';
@@ -38990,7 +39471,11 @@ export type SubmitFormMutation = {
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
                 dateUpdated?: string | null;
-                access: { __typename?: 'FileAccess'; canManage: boolean };
+                access: {
+                  __typename?: 'FileAccess';
+                  canEditFile: boolean;
+                  canDeleteFile: boolean;
+                };
                 enrollment?: { __typename?: 'Enrollment'; id: string } | null;
                 uploadedBy?: {
                   __typename?: 'ApplicationUser';
@@ -39046,7 +39531,11 @@ export type SubmitFormMutation = {
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
                 dateUpdated?: string | null;
-                access: { __typename?: 'FileAccess'; canManage: boolean };
+                access: {
+                  __typename?: 'FileAccess';
+                  canEditFile: boolean;
+                  canDeleteFile: boolean;
+                };
                 enrollment?: { __typename?: 'Enrollment'; id: string } | null;
                 uploadedBy?: {
                   __typename?: 'ApplicationUser';
@@ -39250,7 +39739,11 @@ export type SubmitFormMutation = {
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
                 dateUpdated?: string | null;
-                access: { __typename?: 'FileAccess'; canManage: boolean };
+                access: {
+                  __typename?: 'FileAccess';
+                  canEditFile: boolean;
+                  canDeleteFile: boolean;
+                };
                 enrollment?: { __typename?: 'Enrollment'; id: string } | null;
                 uploadedBy?: {
                   __typename?: 'ApplicationUser';
@@ -39306,7 +39799,11 @@ export type SubmitFormMutation = {
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
                 dateUpdated?: string | null;
-                access: { __typename?: 'FileAccess'; canManage: boolean };
+                access: {
+                  __typename?: 'FileAccess';
+                  canEditFile: boolean;
+                  canDeleteFile: boolean;
+                };
                 enrollment?: { __typename?: 'Enrollment'; id: string } | null;
                 uploadedBy?: {
                   __typename?: 'ApplicationUser';
@@ -41844,7 +42341,11 @@ export type InventoryFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
-        access: { __typename?: 'FileAccess'; canManage: boolean };
+        access: {
+          __typename?: 'FileAccess';
+          canEditFile: boolean;
+          canDeleteFile: boolean;
+        };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -41900,7 +42401,11 @@ export type InventoryFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
-        access: { __typename?: 'FileAccess'; canManage: boolean };
+        access: {
+          __typename?: 'FileAccess';
+          canEditFile: boolean;
+          canDeleteFile: boolean;
+        };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -42177,7 +42682,11 @@ export type OrganizationDetailFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
-        access: { __typename?: 'FileAccess'; canManage: boolean };
+        access: {
+          __typename?: 'FileAccess';
+          canEditFile: boolean;
+          canDeleteFile: boolean;
+        };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -42233,7 +42742,11 @@ export type OrganizationDetailFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
-        access: { __typename?: 'FileAccess'; canManage: boolean };
+        access: {
+          __typename?: 'FileAccess';
+          canEditFile: boolean;
+          canDeleteFile: boolean;
+        };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -42319,7 +42832,11 @@ export type OrganizationFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
-        access: { __typename?: 'FileAccess'; canManage: boolean };
+        access: {
+          __typename?: 'FileAccess';
+          canEditFile: boolean;
+          canDeleteFile: boolean;
+        };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -42375,7 +42892,11 @@ export type OrganizationFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
-        access: { __typename?: 'FileAccess'; canManage: boolean };
+        access: {
+          __typename?: 'FileAccess';
+          canEditFile: boolean;
+          canDeleteFile: boolean;
+        };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -42494,7 +43015,11 @@ export type GetOrganizationQuery = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
-          access: { __typename?: 'FileAccess'; canManage: boolean };
+          access: {
+            __typename?: 'FileAccess';
+            canEditFile: boolean;
+            canDeleteFile: boolean;
+          };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -42550,7 +43075,11 @@ export type GetOrganizationQuery = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
-          access: { __typename?: 'FileAccess'; canManage: boolean };
+          access: {
+            __typename?: 'FileAccess';
+            canEditFile: boolean;
+            canDeleteFile: boolean;
+          };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -42749,7 +43278,11 @@ export type ProjectAllFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
-        access: { __typename?: 'FileAccess'; canManage: boolean };
+        access: {
+          __typename?: 'FileAccess';
+          canEditFile: boolean;
+          canDeleteFile: boolean;
+        };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -42805,7 +43338,11 @@ export type ProjectAllFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
-        access: { __typename?: 'FileAccess'; canManage: boolean };
+        access: {
+          __typename?: 'FileAccess';
+          canEditFile: boolean;
+          canDeleteFile: boolean;
+        };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -43535,7 +44072,11 @@ export type FunderFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
-        access: { __typename?: 'FileAccess'; canManage: boolean };
+        access: {
+          __typename?: 'FileAccess';
+          canEditFile: boolean;
+          canDeleteFile: boolean;
+        };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -43591,7 +44132,11 @@ export type FunderFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
-        access: { __typename?: 'FileAccess'; canManage: boolean };
+        access: {
+          __typename?: 'FileAccess';
+          canEditFile: boolean;
+          canDeleteFile: boolean;
+        };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -43831,7 +44376,11 @@ export type GetProjectQuery = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
-          access: { __typename?: 'FileAccess'; canManage: boolean };
+          access: {
+            __typename?: 'FileAccess';
+            canEditFile: boolean;
+            canDeleteFile: boolean;
+          };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -43887,7 +44436,11 @@ export type GetProjectQuery = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
-          access: { __typename?: 'FileAccess'; canManage: boolean };
+          access: {
+            __typename?: 'FileAccess';
+            canEditFile: boolean;
+            canDeleteFile: boolean;
+          };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -44336,7 +44889,11 @@ export type GetProjectAssessmentsQuery = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
-              access: { __typename?: 'FileAccess'; canManage: boolean };
+              access: {
+                __typename?: 'FileAccess';
+                canEditFile: boolean;
+                canDeleteFile: boolean;
+              };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -44392,7 +44949,11 @@ export type GetProjectAssessmentsQuery = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
-              access: { __typename?: 'FileAccess'; canManage: boolean };
+              access: {
+                __typename?: 'FileAccess';
+                canEditFile: boolean;
+                canDeleteFile: boolean;
+              };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -44536,7 +45097,11 @@ export type GetFunderQuery = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
-          access: { __typename?: 'FileAccess'; canManage: boolean };
+          access: {
+            __typename?: 'FileAccess';
+            canEditFile: boolean;
+            canDeleteFile: boolean;
+          };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -44592,7 +45157,11 @@ export type GetFunderQuery = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
-          access: { __typename?: 'FileAccess'; canManage: boolean };
+          access: {
+            __typename?: 'FileAccess';
+            canEditFile: boolean;
+            canDeleteFile: boolean;
+          };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -44695,7 +45264,11 @@ export type GetInventoryQuery = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
-          access: { __typename?: 'FileAccess'; canManage: boolean };
+          access: {
+            __typename?: 'FileAccess';
+            canEditFile: boolean;
+            canDeleteFile: boolean;
+          };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -44751,7 +45324,11 @@ export type GetInventoryQuery = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
-          access: { __typename?: 'FileAccess'; canManage: boolean };
+          access: {
+            __typename?: 'FileAccess';
+            canEditFile: boolean;
+            canDeleteFile: boolean;
+          };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -44895,7 +45472,11 @@ export type GetProjectInventoriesQuery = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
-              access: { __typename?: 'FileAccess'; canManage: boolean };
+              access: {
+                __typename?: 'FileAccess';
+                canEditFile: boolean;
+                canDeleteFile: boolean;
+              };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -44951,7 +45532,11 @@ export type GetProjectInventoriesQuery = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
-              access: { __typename?: 'FileAccess'; canManage: boolean };
+              access: {
+                __typename?: 'FileAccess';
+                canEditFile: boolean;
+                canDeleteFile: boolean;
+              };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -45200,7 +45785,11 @@ export type GetProjectFundersQuery = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
-              access: { __typename?: 'FileAccess'; canManage: boolean };
+              access: {
+                __typename?: 'FileAccess';
+                canEditFile: boolean;
+                canDeleteFile: boolean;
+              };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -45256,7 +45845,11 @@ export type GetProjectFundersQuery = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
-              access: { __typename?: 'FileAccess'; canManage: boolean };
+              access: {
+                __typename?: 'FileAccess';
+                canEditFile: boolean;
+                canDeleteFile: boolean;
+              };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -45812,7 +46405,11 @@ export type UpdateReferralPostingMutation = {
             enrollmentId?: string | null;
             dateCreated?: string | null;
             dateUpdated?: string | null;
-            access: { __typename?: 'FileAccess'; canManage: boolean };
+            access: {
+              __typename?: 'FileAccess';
+              canEditFile: boolean;
+              canDeleteFile: boolean;
+            };
             enrollment?: { __typename?: 'Enrollment'; id: string } | null;
             uploadedBy?: {
               __typename?: 'ApplicationUser';
@@ -45868,7 +46465,11 @@ export type UpdateReferralPostingMutation = {
             enrollmentId?: string | null;
             dateCreated?: string | null;
             dateUpdated?: string | null;
-            access: { __typename?: 'FileAccess'; canManage: boolean };
+            access: {
+              __typename?: 'FileAccess';
+              canEditFile: boolean;
+              canDeleteFile: boolean;
+            };
             enrollment?: { __typename?: 'Enrollment'; id: string } | null;
             uploadedBy?: {
               __typename?: 'ApplicationUser';
@@ -46052,7 +46653,11 @@ export type GetReferralPostingQuery = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
-          access: { __typename?: 'FileAccess'; canManage: boolean };
+          access: {
+            __typename?: 'FileAccess';
+            canEditFile: boolean;
+            canDeleteFile: boolean;
+          };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -46108,7 +46713,11 @@ export type GetReferralPostingQuery = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
-          access: { __typename?: 'FileAccess'; canManage: boolean };
+          access: {
+            __typename?: 'FileAccess';
+            canEditFile: boolean;
+            canDeleteFile: boolean;
+          };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -46331,7 +46940,11 @@ export type ReferralPostingDetailFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
-        access: { __typename?: 'FileAccess'; canManage: boolean };
+        access: {
+          __typename?: 'FileAccess';
+          canEditFile: boolean;
+          canDeleteFile: boolean;
+        };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -46387,7 +47000,11 @@ export type ReferralPostingDetailFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
-        access: { __typename?: 'FileAccess'; canManage: boolean };
+        access: {
+          __typename?: 'FileAccess';
+          canEditFile: boolean;
+          canDeleteFile: boolean;
+        };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -46504,7 +47121,11 @@ export type EsgFundingServiceFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
-        access: { __typename?: 'FileAccess'; canManage: boolean };
+        access: {
+          __typename?: 'FileAccess';
+          canEditFile: boolean;
+          canDeleteFile: boolean;
+        };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -46560,7 +47181,11 @@ export type EsgFundingServiceFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
-        access: { __typename?: 'FileAccess'; canManage: boolean };
+        access: {
+          __typename?: 'FileAccess';
+          canEditFile: boolean;
+          canDeleteFile: boolean;
+        };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -46655,7 +47280,11 @@ export type GetEsgFundingReportQuery = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
-          access: { __typename?: 'FileAccess'; canManage: boolean };
+          access: {
+            __typename?: 'FileAccess';
+            canEditFile: boolean;
+            canDeleteFile: boolean;
+          };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -46711,7 +47340,11 @@ export type GetEsgFundingReportQuery = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
-          access: { __typename?: 'FileAccess'; canManage: boolean };
+          access: {
+            __typename?: 'FileAccess';
+            canEditFile: boolean;
+            canDeleteFile: boolean;
+          };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -47068,7 +47701,11 @@ export type ServiceDetailFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
-        access: { __typename?: 'FileAccess'; canManage: boolean };
+        access: {
+          __typename?: 'FileAccess';
+          canEditFile: boolean;
+          canDeleteFile: boolean;
+        };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -47124,7 +47761,11 @@ export type ServiceDetailFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
-        access: { __typename?: 'FileAccess'; canManage: boolean };
+        access: {
+          __typename?: 'FileAccess';
+          canEditFile: boolean;
+          canDeleteFile: boolean;
+        };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -47230,7 +47871,11 @@ export type ServiceFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
-        access: { __typename?: 'FileAccess'; canManage: boolean };
+        access: {
+          __typename?: 'FileAccess';
+          canEditFile: boolean;
+          canDeleteFile: boolean;
+        };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -47286,7 +47931,11 @@ export type ServiceFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
-        access: { __typename?: 'FileAccess'; canManage: boolean };
+        access: {
+          __typename?: 'FileAccess';
+          canEditFile: boolean;
+          canDeleteFile: boolean;
+        };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -47392,7 +48041,11 @@ export type ClientServiceFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
-        access: { __typename?: 'FileAccess'; canManage: boolean };
+        access: {
+          __typename?: 'FileAccess';
+          canEditFile: boolean;
+          canDeleteFile: boolean;
+        };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -47448,7 +48101,11 @@ export type ClientServiceFieldsFragment = {
         enrollmentId?: string | null;
         dateCreated?: string | null;
         dateUpdated?: string | null;
-        access: { __typename?: 'FileAccess'; canManage: boolean };
+        access: {
+          __typename?: 'FileAccess';
+          canEditFile: boolean;
+          canDeleteFile: boolean;
+        };
         enrollment?: { __typename?: 'Enrollment'; id: string } | null;
         uploadedBy?: {
           __typename?: 'ApplicationUser';
@@ -47573,7 +48230,11 @@ export type GetServiceQuery = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
-          access: { __typename?: 'FileAccess'; canManage: boolean };
+          access: {
+            __typename?: 'FileAccess';
+            canEditFile: boolean;
+            canDeleteFile: boolean;
+          };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -47629,7 +48290,11 @@ export type GetServiceQuery = {
           enrollmentId?: string | null;
           dateCreated?: string | null;
           dateUpdated?: string | null;
-          access: { __typename?: 'FileAccess'; canManage: boolean };
+          access: {
+            __typename?: 'FileAccess';
+            canEditFile: boolean;
+            canDeleteFile: boolean;
+          };
           enrollment?: { __typename?: 'Enrollment'; id: string } | null;
           uploadedBy?: {
             __typename?: 'ApplicationUser';
@@ -47769,7 +48434,11 @@ export type DeleteServiceMutation = {
             enrollmentId?: string | null;
             dateCreated?: string | null;
             dateUpdated?: string | null;
-            access: { __typename?: 'FileAccess'; canManage: boolean };
+            access: {
+              __typename?: 'FileAccess';
+              canEditFile: boolean;
+              canDeleteFile: boolean;
+            };
             enrollment?: { __typename?: 'Enrollment'; id: string } | null;
             uploadedBy?: {
               __typename?: 'ApplicationUser';
@@ -47825,7 +48494,11 @@ export type DeleteServiceMutation = {
             enrollmentId?: string | null;
             dateCreated?: string | null;
             dateUpdated?: string | null;
-            access: { __typename?: 'FileAccess'; canManage: boolean };
+            access: {
+              __typename?: 'FileAccess';
+              canEditFile: boolean;
+              canDeleteFile: boolean;
+            };
             enrollment?: { __typename?: 'Enrollment'; id: string } | null;
             uploadedBy?: {
               __typename?: 'ApplicationUser';
@@ -47964,7 +48637,11 @@ export type GetEnrollmentServicesQuery = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
-              access: { __typename?: 'FileAccess'; canManage: boolean };
+              access: {
+                __typename?: 'FileAccess';
+                canEditFile: boolean;
+                canDeleteFile: boolean;
+              };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -48020,7 +48697,11 @@ export type GetEnrollmentServicesQuery = {
               enrollmentId?: string | null;
               dateCreated?: string | null;
               dateUpdated?: string | null;
-              access: { __typename?: 'FileAccess'; canManage: boolean };
+              access: {
+                __typename?: 'FileAccess';
+                canEditFile: boolean;
+                canDeleteFile: boolean;
+              };
               enrollment?: { __typename?: 'Enrollment'; id: string } | null;
               uploadedBy?: {
                 __typename?: 'ApplicationUser';
@@ -49953,7 +50634,8 @@ export const FileFieldsFragmentDoc = gql`
     url
     tags
     access {
-      canManage
+      canEditFile
+      canDeleteFile
     }
     redacted
     enrollmentId

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -9594,7 +9594,6 @@ export type AssessmentWithRecordsFragment = {
           name: string;
           url?: string | null;
           tags: Array<string>;
-          ownFile: boolean;
           redacted: boolean;
           enrollmentId?: string | null;
           dateCreated?: string | null;
@@ -9651,7 +9650,6 @@ export type AssessmentWithRecordsFragment = {
           name: string;
           url?: string | null;
           tags: Array<string>;
-          ownFile: boolean;
           redacted: boolean;
           enrollmentId?: string | null;
           dateCreated?: string | null;
@@ -9838,7 +9836,6 @@ export type AssessmentWithRecordsFragment = {
           name: string;
           url?: string | null;
           tags: Array<string>;
-          ownFile: boolean;
           redacted: boolean;
           enrollmentId?: string | null;
           dateCreated?: string | null;
@@ -9895,7 +9892,6 @@ export type AssessmentWithRecordsFragment = {
           name: string;
           url?: string | null;
           tags: Array<string>;
-          ownFile: boolean;
           redacted: boolean;
           enrollmentId?: string | null;
           dateCreated?: string | null;
@@ -10042,7 +10038,6 @@ export type AssessmentWithRecordsFragment = {
           name: string;
           url?: string | null;
           tags: Array<string>;
-          ownFile: boolean;
           redacted: boolean;
           enrollmentId?: string | null;
           dateCreated?: string | null;
@@ -10099,7 +10094,6 @@ export type AssessmentWithRecordsFragment = {
           name: string;
           url?: string | null;
           tags: Array<string>;
-          ownFile: boolean;
           redacted: boolean;
           enrollmentId?: string | null;
           dateCreated?: string | null;
@@ -10191,7 +10185,6 @@ export type AssessmentWithRecordsFragment = {
         name: string;
         url?: string | null;
         tags: Array<string>;
-        ownFile: boolean;
         redacted: boolean;
         enrollmentId?: string | null;
         dateCreated?: string | null;
@@ -10248,7 +10241,6 @@ export type AssessmentWithRecordsFragment = {
         name: string;
         url?: string | null;
         tags: Array<string>;
-        ownFile: boolean;
         redacted: boolean;
         enrollmentId?: string | null;
         dateCreated?: string | null;
@@ -10470,7 +10462,6 @@ export type FullAssessmentFragment = {
           name: string;
           url?: string | null;
           tags: Array<string>;
-          ownFile: boolean;
           redacted: boolean;
           enrollmentId?: string | null;
           dateCreated?: string | null;
@@ -10527,7 +10518,6 @@ export type FullAssessmentFragment = {
           name: string;
           url?: string | null;
           tags: Array<string>;
-          ownFile: boolean;
           redacted: boolean;
           enrollmentId?: string | null;
           dateCreated?: string | null;
@@ -10714,7 +10704,6 @@ export type FullAssessmentFragment = {
           name: string;
           url?: string | null;
           tags: Array<string>;
-          ownFile: boolean;
           redacted: boolean;
           enrollmentId?: string | null;
           dateCreated?: string | null;
@@ -10771,7 +10760,6 @@ export type FullAssessmentFragment = {
           name: string;
           url?: string | null;
           tags: Array<string>;
-          ownFile: boolean;
           redacted: boolean;
           enrollmentId?: string | null;
           dateCreated?: string | null;
@@ -10918,7 +10906,6 @@ export type FullAssessmentFragment = {
           name: string;
           url?: string | null;
           tags: Array<string>;
-          ownFile: boolean;
           redacted: boolean;
           enrollmentId?: string | null;
           dateCreated?: string | null;
@@ -10975,7 +10962,6 @@ export type FullAssessmentFragment = {
           name: string;
           url?: string | null;
           tags: Array<string>;
-          ownFile: boolean;
           redacted: boolean;
           enrollmentId?: string | null;
           dateCreated?: string | null;
@@ -11067,7 +11053,6 @@ export type FullAssessmentFragment = {
         name: string;
         url?: string | null;
         tags: Array<string>;
-        ownFile: boolean;
         redacted: boolean;
         enrollmentId?: string | null;
         dateCreated?: string | null;
@@ -11124,7 +11109,6 @@ export type FullAssessmentFragment = {
         name: string;
         url?: string | null;
         tags: Array<string>;
-        ownFile: boolean;
         redacted: boolean;
         enrollmentId?: string | null;
         dateCreated?: string | null;
@@ -11242,7 +11226,6 @@ export type AssessmentWithCdesFragment = {
         name: string;
         url?: string | null;
         tags: Array<string>;
-        ownFile: boolean;
         redacted: boolean;
         enrollmentId?: string | null;
         dateCreated?: string | null;
@@ -11299,7 +11282,6 @@ export type AssessmentWithCdesFragment = {
         name: string;
         url?: string | null;
         tags: Array<string>;
-        ownFile: boolean;
         redacted: boolean;
         enrollmentId?: string | null;
         dateCreated?: string | null;
@@ -12516,7 +12498,6 @@ export type GetAssessmentQuery = {
             name: string;
             url?: string | null;
             tags: Array<string>;
-            ownFile: boolean;
             redacted: boolean;
             enrollmentId?: string | null;
             dateCreated?: string | null;
@@ -12573,7 +12554,6 @@ export type GetAssessmentQuery = {
             name: string;
             url?: string | null;
             tags: Array<string>;
-            ownFile: boolean;
             redacted: boolean;
             enrollmentId?: string | null;
             dateCreated?: string | null;
@@ -12760,7 +12740,6 @@ export type GetAssessmentQuery = {
             name: string;
             url?: string | null;
             tags: Array<string>;
-            ownFile: boolean;
             redacted: boolean;
             enrollmentId?: string | null;
             dateCreated?: string | null;
@@ -12817,7 +12796,6 @@ export type GetAssessmentQuery = {
             name: string;
             url?: string | null;
             tags: Array<string>;
-            ownFile: boolean;
             redacted: boolean;
             enrollmentId?: string | null;
             dateCreated?: string | null;
@@ -12964,7 +12942,6 @@ export type GetAssessmentQuery = {
             name: string;
             url?: string | null;
             tags: Array<string>;
-            ownFile: boolean;
             redacted: boolean;
             enrollmentId?: string | null;
             dateCreated?: string | null;
@@ -13021,7 +12998,6 @@ export type GetAssessmentQuery = {
             name: string;
             url?: string | null;
             tags: Array<string>;
-            ownFile: boolean;
             redacted: boolean;
             enrollmentId?: string | null;
             dateCreated?: string | null;
@@ -13113,7 +13089,6 @@ export type GetAssessmentQuery = {
           name: string;
           url?: string | null;
           tags: Array<string>;
-          ownFile: boolean;
           redacted: boolean;
           enrollmentId?: string | null;
           dateCreated?: string | null;
@@ -13170,7 +13145,6 @@ export type GetAssessmentQuery = {
           name: string;
           url?: string | null;
           tags: Array<string>;
-          ownFile: boolean;
           redacted: boolean;
           enrollmentId?: string | null;
           dateCreated?: string | null;
@@ -13323,7 +13297,6 @@ export type GetClientAssessmentsQuery = {
               name: string;
               url?: string | null;
               tags: Array<string>;
-              ownFile: boolean;
               redacted: boolean;
               enrollmentId?: string | null;
               dateCreated?: string | null;
@@ -13380,7 +13353,6 @@ export type GetClientAssessmentsQuery = {
               name: string;
               url?: string | null;
               tags: Array<string>;
-              ownFile: boolean;
               redacted: boolean;
               enrollmentId?: string | null;
               dateCreated?: string | null;
@@ -13504,7 +13476,6 @@ export type GetEnrollmentAssessmentsQuery = {
               name: string;
               url?: string | null;
               tags: Array<string>;
-              ownFile: boolean;
               redacted: boolean;
               enrollmentId?: string | null;
               dateCreated?: string | null;
@@ -13561,7 +13532,6 @@ export type GetEnrollmentAssessmentsQuery = {
               name: string;
               url?: string | null;
               tags: Array<string>;
-              ownFile: boolean;
               redacted: boolean;
               enrollmentId?: string | null;
               dateCreated?: string | null;
@@ -13699,7 +13669,6 @@ export type GetHouseholdAssessmentsQuery = {
               name: string;
               url?: string | null;
               tags: Array<string>;
-              ownFile: boolean;
               redacted: boolean;
               enrollmentId?: string | null;
               dateCreated?: string | null;
@@ -13756,7 +13725,6 @@ export type GetHouseholdAssessmentsQuery = {
               name: string;
               url?: string | null;
               tags: Array<string>;
-              ownFile: boolean;
               redacted: boolean;
               enrollmentId?: string | null;
               dateCreated?: string | null;
@@ -14023,7 +13991,6 @@ export type SubmitAssessmentMutation = {
               name: string;
               url?: string | null;
               tags: Array<string>;
-              ownFile: boolean;
               redacted: boolean;
               enrollmentId?: string | null;
               dateCreated?: string | null;
@@ -14080,7 +14047,6 @@ export type SubmitAssessmentMutation = {
               name: string;
               url?: string | null;
               tags: Array<string>;
-              ownFile: boolean;
               redacted: boolean;
               enrollmentId?: string | null;
               dateCreated?: string | null;
@@ -14267,7 +14233,6 @@ export type SubmitAssessmentMutation = {
               name: string;
               url?: string | null;
               tags: Array<string>;
-              ownFile: boolean;
               redacted: boolean;
               enrollmentId?: string | null;
               dateCreated?: string | null;
@@ -14324,7 +14289,6 @@ export type SubmitAssessmentMutation = {
               name: string;
               url?: string | null;
               tags: Array<string>;
-              ownFile: boolean;
               redacted: boolean;
               enrollmentId?: string | null;
               dateCreated?: string | null;
@@ -14471,7 +14435,6 @@ export type SubmitAssessmentMutation = {
               name: string;
               url?: string | null;
               tags: Array<string>;
-              ownFile: boolean;
               redacted: boolean;
               enrollmentId?: string | null;
               dateCreated?: string | null;
@@ -14528,7 +14491,6 @@ export type SubmitAssessmentMutation = {
               name: string;
               url?: string | null;
               tags: Array<string>;
-              ownFile: boolean;
               redacted: boolean;
               enrollmentId?: string | null;
               dateCreated?: string | null;
@@ -14620,7 +14582,6 @@ export type SubmitAssessmentMutation = {
             name: string;
             url?: string | null;
             tags: Array<string>;
-            ownFile: boolean;
             redacted: boolean;
             enrollmentId?: string | null;
             dateCreated?: string | null;
@@ -14677,7 +14638,6 @@ export type SubmitAssessmentMutation = {
             name: string;
             url?: string | null;
             tags: Array<string>;
-            ownFile: boolean;
             redacted: boolean;
             enrollmentId?: string | null;
             dateCreated?: string | null;
@@ -14886,7 +14846,6 @@ export type SubmitHouseholdAssessmentsMutation = {
               name: string;
               url?: string | null;
               tags: Array<string>;
-              ownFile: boolean;
               redacted: boolean;
               enrollmentId?: string | null;
               dateCreated?: string | null;
@@ -14943,7 +14902,6 @@ export type SubmitHouseholdAssessmentsMutation = {
               name: string;
               url?: string | null;
               tags: Array<string>;
-              ownFile: boolean;
               redacted: boolean;
               enrollmentId?: string | null;
               dateCreated?: string | null;
@@ -15130,7 +15088,6 @@ export type SubmitHouseholdAssessmentsMutation = {
               name: string;
               url?: string | null;
               tags: Array<string>;
-              ownFile: boolean;
               redacted: boolean;
               enrollmentId?: string | null;
               dateCreated?: string | null;
@@ -15187,7 +15144,6 @@ export type SubmitHouseholdAssessmentsMutation = {
               name: string;
               url?: string | null;
               tags: Array<string>;
-              ownFile: boolean;
               redacted: boolean;
               enrollmentId?: string | null;
               dateCreated?: string | null;
@@ -15334,7 +15290,6 @@ export type SubmitHouseholdAssessmentsMutation = {
               name: string;
               url?: string | null;
               tags: Array<string>;
-              ownFile: boolean;
               redacted: boolean;
               enrollmentId?: string | null;
               dateCreated?: string | null;
@@ -15391,7 +15346,6 @@ export type SubmitHouseholdAssessmentsMutation = {
               name: string;
               url?: string | null;
               tags: Array<string>;
-              ownFile: boolean;
               redacted: boolean;
               enrollmentId?: string | null;
               dateCreated?: string | null;
@@ -15483,7 +15437,6 @@ export type SubmitHouseholdAssessmentsMutation = {
             name: string;
             url?: string | null;
             tags: Array<string>;
-            ownFile: boolean;
             redacted: boolean;
             enrollmentId?: string | null;
             dateCreated?: string | null;
@@ -15540,7 +15493,6 @@ export type SubmitHouseholdAssessmentsMutation = {
             name: string;
             url?: string | null;
             tags: Array<string>;
-            ownFile: boolean;
             redacted: boolean;
             enrollmentId?: string | null;
             dateCreated?: string | null;
@@ -15766,7 +15718,6 @@ export type GetAssessmentsForPopulationQuery = {
                 name: string;
                 url?: string | null;
                 tags: Array<string>;
-                ownFile: boolean;
                 redacted: boolean;
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
@@ -15823,7 +15774,6 @@ export type GetAssessmentsForPopulationQuery = {
                 name: string;
                 url?: string | null;
                 tags: Array<string>;
-                ownFile: boolean;
                 redacted: boolean;
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
@@ -16010,7 +15960,6 @@ export type GetAssessmentsForPopulationQuery = {
                 name: string;
                 url?: string | null;
                 tags: Array<string>;
-                ownFile: boolean;
                 redacted: boolean;
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
@@ -16067,7 +16016,6 @@ export type GetAssessmentsForPopulationQuery = {
                 name: string;
                 url?: string | null;
                 tags: Array<string>;
-                ownFile: boolean;
                 redacted: boolean;
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
@@ -16214,7 +16162,6 @@ export type GetAssessmentsForPopulationQuery = {
                 name: string;
                 url?: string | null;
                 tags: Array<string>;
-                ownFile: boolean;
                 redacted: boolean;
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
@@ -16271,7 +16218,6 @@ export type GetAssessmentsForPopulationQuery = {
                 name: string;
                 url?: string | null;
                 tags: Array<string>;
-                ownFile: boolean;
                 redacted: boolean;
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
@@ -16363,7 +16309,6 @@ export type GetAssessmentsForPopulationQuery = {
               name: string;
               url?: string | null;
               tags: Array<string>;
-              ownFile: boolean;
               redacted: boolean;
               enrollmentId?: string | null;
               dateCreated?: string | null;
@@ -16420,7 +16365,6 @@ export type GetAssessmentsForPopulationQuery = {
               name: string;
               url?: string | null;
               tags: Array<string>;
-              ownFile: boolean;
               redacted: boolean;
               enrollmentId?: string | null;
               dateCreated?: string | null;
@@ -18518,7 +18462,6 @@ export type CeReferralStepFieldsFragment = {
         name: string;
         url?: string | null;
         tags: Array<string>;
-        ownFile: boolean;
         redacted: boolean;
         enrollmentId?: string | null;
         dateCreated?: string | null;
@@ -18575,7 +18518,6 @@ export type CeReferralStepFieldsFragment = {
         name: string;
         url?: string | null;
         tags: Array<string>;
-        ownFile: boolean;
         redacted: boolean;
         enrollmentId?: string | null;
         dateCreated?: string | null;
@@ -19327,7 +19269,6 @@ export type StartCeReferralStepMutation = {
             name: string;
             url?: string | null;
             tags: Array<string>;
-            ownFile: boolean;
             redacted: boolean;
             enrollmentId?: string | null;
             dateCreated?: string | null;
@@ -19384,7 +19325,6 @@ export type StartCeReferralStepMutation = {
             name: string;
             url?: string | null;
             tags: Array<string>;
-            ownFile: boolean;
             redacted: boolean;
             enrollmentId?: string | null;
             dateCreated?: string | null;
@@ -20022,7 +19962,6 @@ export type SubmitCeReferralStepMutation = {
             name: string;
             url?: string | null;
             tags: Array<string>;
-            ownFile: boolean;
             redacted: boolean;
             enrollmentId?: string | null;
             dateCreated?: string | null;
@@ -20079,7 +20018,6 @@ export type SubmitCeReferralStepMutation = {
             name: string;
             url?: string | null;
             tags: Array<string>;
-            ownFile: boolean;
             redacted: boolean;
             enrollmentId?: string | null;
             dateCreated?: string | null;
@@ -21593,7 +21531,6 @@ export type GetCeReferralStepQuery = {
           name: string;
           url?: string | null;
           tags: Array<string>;
-          ownFile: boolean;
           redacted: boolean;
           enrollmentId?: string | null;
           dateCreated?: string | null;
@@ -21650,7 +21587,6 @@ export type GetCeReferralStepQuery = {
           name: string;
           url?: string | null;
           tags: Array<string>;
-          ownFile: boolean;
           redacted: boolean;
           enrollmentId?: string | null;
           dateCreated?: string | null;
@@ -22154,7 +22090,6 @@ export type ClientFieldsFragment = {
         name: string;
         url?: string | null;
         tags: Array<string>;
-        ownFile: boolean;
         redacted: boolean;
         enrollmentId?: string | null;
         dateCreated?: string | null;
@@ -22211,7 +22146,6 @@ export type ClientFieldsFragment = {
         name: string;
         url?: string | null;
         tags: Array<string>;
-        ownFile: boolean;
         redacted: boolean;
         enrollmentId?: string | null;
         dateCreated?: string | null;
@@ -22643,7 +22577,6 @@ export type GetClientQuery = {
           name: string;
           url?: string | null;
           tags: Array<string>;
-          ownFile: boolean;
           redacted: boolean;
           enrollmentId?: string | null;
           dateCreated?: string | null;
@@ -22700,7 +22633,6 @@ export type GetClientQuery = {
           name: string;
           url?: string | null;
           tags: Array<string>;
-          ownFile: boolean;
           redacted: boolean;
           enrollmentId?: string | null;
           dateCreated?: string | null;
@@ -23048,7 +22980,6 @@ export type GetClientServicesQuery = {
               name: string;
               url?: string | null;
               tags: Array<string>;
-              ownFile: boolean;
               redacted: boolean;
               enrollmentId?: string | null;
               dateCreated?: string | null;
@@ -23105,7 +23036,6 @@ export type GetClientServicesQuery = {
               name: string;
               url?: string | null;
               tags: Array<string>;
-              ownFile: boolean;
               redacted: boolean;
               enrollmentId?: string | null;
               dateCreated?: string | null;
@@ -23250,7 +23180,6 @@ export type DeleteClientFileMutation = {
       name: string;
       url?: string | null;
       tags: Array<string>;
-      ownFile: boolean;
       redacted: boolean;
       enrollmentId?: string | null;
       dateCreated?: string | null;
@@ -23454,7 +23383,6 @@ export type GetFileQuery = {
     name: string;
     url?: string | null;
     tags: Array<string>;
-    ownFile: boolean;
     redacted: boolean;
     enrollmentId?: string | null;
     dateCreated?: string | null;
@@ -23509,7 +23437,6 @@ export type GetClientFilesQuery = {
         name: string;
         url?: string | null;
         tags: Array<string>;
-        ownFile: boolean;
         redacted: boolean;
         enrollmentId?: string | null;
         dateCreated?: string | null;
@@ -24333,7 +24260,6 @@ export type MergeClientsMutation = {
             name: string;
             url?: string | null;
             tags: Array<string>;
-            ownFile: boolean;
             redacted: boolean;
             enrollmentId?: string | null;
             dateCreated?: string | null;
@@ -24390,7 +24316,6 @@ export type MergeClientsMutation = {
             name: string;
             url?: string | null;
             tags: Array<string>;
-            ownFile: boolean;
             redacted: boolean;
             enrollmentId?: string | null;
             dateCreated?: string | null;
@@ -25071,7 +24996,6 @@ export type CurrentLivingSituationFieldsFragment = {
         name: string;
         url?: string | null;
         tags: Array<string>;
-        ownFile: boolean;
         redacted: boolean;
         enrollmentId?: string | null;
         dateCreated?: string | null;
@@ -25128,7 +25052,6 @@ export type CurrentLivingSituationFieldsFragment = {
         name: string;
         url?: string | null;
         tags: Array<string>;
-        ownFile: boolean;
         redacted: boolean;
         enrollmentId?: string | null;
         dateCreated?: string | null;
@@ -25246,7 +25169,6 @@ export type ProjectCurrentLivingSituationFieldsFragment = {
         name: string;
         url?: string | null;
         tags: Array<string>;
-        ownFile: boolean;
         redacted: boolean;
         enrollmentId?: string | null;
         dateCreated?: string | null;
@@ -25303,7 +25225,6 @@ export type ProjectCurrentLivingSituationFieldsFragment = {
         name: string;
         url?: string | null;
         tags: Array<string>;
-        ownFile: boolean;
         redacted: boolean;
         enrollmentId?: string | null;
         dateCreated?: string | null;
@@ -25421,7 +25342,6 @@ export type GetEnrollmentCurrentLivingSituationsQuery = {
               name: string;
               url?: string | null;
               tags: Array<string>;
-              ownFile: boolean;
               redacted: boolean;
               enrollmentId?: string | null;
               dateCreated?: string | null;
@@ -25478,7 +25398,6 @@ export type GetEnrollmentCurrentLivingSituationsQuery = {
               name: string;
               url?: string | null;
               tags: Array<string>;
-              ownFile: boolean;
               redacted: boolean;
               enrollmentId?: string | null;
               dateCreated?: string | null;
@@ -25615,7 +25534,6 @@ export type GetProjectCurrentLivingSituationsQuery = {
               name: string;
               url?: string | null;
               tags: Array<string>;
-              ownFile: boolean;
               redacted: boolean;
               enrollmentId?: string | null;
               dateCreated?: string | null;
@@ -25672,7 +25590,6 @@ export type GetProjectCurrentLivingSituationsQuery = {
               name: string;
               url?: string | null;
               tags: Array<string>;
-              ownFile: boolean;
               redacted: boolean;
               enrollmentId?: string | null;
               dateCreated?: string | null;
@@ -25777,7 +25694,6 @@ export type CustomCaseNoteFieldsFragment = {
         name: string;
         url?: string | null;
         tags: Array<string>;
-        ownFile: boolean;
         redacted: boolean;
         enrollmentId?: string | null;
         dateCreated?: string | null;
@@ -25834,7 +25750,6 @@ export type CustomCaseNoteFieldsFragment = {
         name: string;
         url?: string | null;
         tags: Array<string>;
-        ownFile: boolean;
         redacted: boolean;
         enrollmentId?: string | null;
         dateCreated?: string | null;
@@ -25943,7 +25858,6 @@ export type GetEnrollmentCustomCaseNotesQuery = {
               name: string;
               url?: string | null;
               tags: Array<string>;
-              ownFile: boolean;
               redacted: boolean;
               enrollmentId?: string | null;
               dateCreated?: string | null;
@@ -26000,7 +25914,6 @@ export type GetEnrollmentCustomCaseNotesQuery = {
               name: string;
               url?: string | null;
               tags: Array<string>;
-              ownFile: boolean;
               redacted: boolean;
               enrollmentId?: string | null;
               dateCreated?: string | null;
@@ -26159,7 +26072,6 @@ export type GetClientCaseNotesQuery = {
               name: string;
               url?: string | null;
               tags: Array<string>;
-              ownFile: boolean;
               redacted: boolean;
               enrollmentId?: string | null;
               dateCreated?: string | null;
@@ -26216,7 +26128,6 @@ export type GetClientCaseNotesQuery = {
               name: string;
               url?: string | null;
               tags: Array<string>;
-              ownFile: boolean;
               redacted: boolean;
               enrollmentId?: string | null;
               dateCreated?: string | null;
@@ -26279,7 +26190,6 @@ export type CustomDataElementValueFieldsFragment = {
     name: string;
     url?: string | null;
     tags: Array<string>;
-    ownFile: boolean;
     redacted: boolean;
     enrollmentId?: string | null;
     dateCreated?: string | null;
@@ -26345,7 +26255,6 @@ export type CustomDataElementFieldsFragment = {
       name: string;
       url?: string | null;
       tags: Array<string>;
-      ownFile: boolean;
       redacted: boolean;
       enrollmentId?: string | null;
       dateCreated?: string | null;
@@ -26402,7 +26311,6 @@ export type CustomDataElementFieldsFragment = {
       name: string;
       url?: string | null;
       tags: Array<string>;
-      ownFile: boolean;
       redacted: boolean;
       enrollmentId?: string | null;
       dateCreated?: string | null;
@@ -27584,7 +27492,6 @@ export type EnrolledClientFieldsFragment = {
         name: string;
         url?: string | null;
         tags: Array<string>;
-        ownFile: boolean;
         redacted: boolean;
         enrollmentId?: string | null;
         dateCreated?: string | null;
@@ -27641,7 +27548,6 @@ export type EnrolledClientFieldsFragment = {
         name: string;
         url?: string | null;
         tags: Array<string>;
-        ownFile: boolean;
         redacted: boolean;
         enrollmentId?: string | null;
         dateCreated?: string | null;
@@ -27737,7 +27643,6 @@ export type AllEnrollmentDetailsFragment = {
         name: string;
         url?: string | null;
         tags: Array<string>;
-        ownFile: boolean;
         redacted: boolean;
         enrollmentId?: string | null;
         dateCreated?: string | null;
@@ -27794,7 +27699,6 @@ export type AllEnrollmentDetailsFragment = {
         name: string;
         url?: string | null;
         tags: Array<string>;
-        ownFile: boolean;
         redacted: boolean;
         enrollmentId?: string | null;
         dateCreated?: string | null;
@@ -27873,7 +27777,6 @@ export type AllEnrollmentDetailsFragment = {
           name: string;
           url?: string | null;
           tags: Array<string>;
-          ownFile: boolean;
           redacted: boolean;
           enrollmentId?: string | null;
           dateCreated?: string | null;
@@ -27930,7 +27833,6 @@ export type AllEnrollmentDetailsFragment = {
           name: string;
           url?: string | null;
           tags: Array<string>;
-          ownFile: boolean;
           redacted: boolean;
           enrollmentId?: string | null;
           dateCreated?: string | null;
@@ -28728,7 +28630,6 @@ export type SubmittedEnrollmentResultFieldsFragment = {
         name: string;
         url?: string | null;
         tags: Array<string>;
-        ownFile: boolean;
         redacted: boolean;
         enrollmentId?: string | null;
         dateCreated?: string | null;
@@ -28785,7 +28686,6 @@ export type SubmittedEnrollmentResultFieldsFragment = {
         name: string;
         url?: string | null;
         tags: Array<string>;
-        ownFile: boolean;
         redacted: boolean;
         enrollmentId?: string | null;
         dateCreated?: string | null;
@@ -29205,7 +29105,6 @@ export type GetEnrollmentDetailsQuery = {
           name: string;
           url?: string | null;
           tags: Array<string>;
-          ownFile: boolean;
           redacted: boolean;
           enrollmentId?: string | null;
           dateCreated?: string | null;
@@ -29262,7 +29161,6 @@ export type GetEnrollmentDetailsQuery = {
           name: string;
           url?: string | null;
           tags: Array<string>;
-          ownFile: boolean;
           redacted: boolean;
           enrollmentId?: string | null;
           dateCreated?: string | null;
@@ -29341,7 +29239,6 @@ export type GetEnrollmentDetailsQuery = {
             name: string;
             url?: string | null;
             tags: Array<string>;
-            ownFile: boolean;
             redacted: boolean;
             enrollmentId?: string | null;
             dateCreated?: string | null;
@@ -29398,7 +29295,6 @@ export type GetEnrollmentDetailsQuery = {
             name: string;
             url?: string | null;
             tags: Array<string>;
-            ownFile: boolean;
             redacted: boolean;
             enrollmentId?: string | null;
             dateCreated?: string | null;
@@ -31730,7 +31626,6 @@ export type FileFieldsFragment = {
   name: string;
   url?: string | null;
   tags: Array<string>;
-  ownFile: boolean;
   redacted: boolean;
   enrollmentId?: string | null;
   dateCreated?: string | null;
@@ -37805,7 +37700,6 @@ export type SubmitFormMutation = {
                 name: string;
                 url?: string | null;
                 tags: Array<string>;
-                ownFile: boolean;
                 redacted: boolean;
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
@@ -37862,7 +37756,6 @@ export type SubmitFormMutation = {
                 name: string;
                 url?: string | null;
                 tags: Array<string>;
-                ownFile: boolean;
                 redacted: boolean;
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
@@ -38019,7 +37912,6 @@ export type SubmitFormMutation = {
                 name: string;
                 url?: string | null;
                 tags: Array<string>;
-                ownFile: boolean;
                 redacted: boolean;
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
@@ -38076,7 +37968,6 @@ export type SubmitFormMutation = {
                 name: string;
                 url?: string | null;
                 tags: Array<string>;
-                ownFile: boolean;
                 redacted: boolean;
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
@@ -38177,7 +38068,6 @@ export type SubmitFormMutation = {
                 name: string;
                 url?: string | null;
                 tags: Array<string>;
-                ownFile: boolean;
                 redacted: boolean;
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
@@ -38234,7 +38124,6 @@ export type SubmitFormMutation = {
                 name: string;
                 url?: string | null;
                 tags: Array<string>;
-                ownFile: boolean;
                 redacted: boolean;
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
@@ -38325,7 +38214,6 @@ export type SubmitFormMutation = {
                 name: string;
                 url?: string | null;
                 tags: Array<string>;
-                ownFile: boolean;
                 redacted: boolean;
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
@@ -38382,7 +38270,6 @@ export type SubmitFormMutation = {
                 name: string;
                 url?: string | null;
                 tags: Array<string>;
-                ownFile: boolean;
                 redacted: boolean;
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
@@ -38498,7 +38385,6 @@ export type SubmitFormMutation = {
           name: string;
           url?: string | null;
           tags: Array<string>;
-          ownFile: boolean;
           redacted: boolean;
           enrollmentId?: string | null;
           dateCreated?: string | null;
@@ -38573,7 +38459,6 @@ export type SubmitFormMutation = {
                 name: string;
                 url?: string | null;
                 tags: Array<string>;
-                ownFile: boolean;
                 redacted: boolean;
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
@@ -38630,7 +38515,6 @@ export type SubmitFormMutation = {
                 name: string;
                 url?: string | null;
                 tags: Array<string>;
-                ownFile: boolean;
                 redacted: boolean;
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
@@ -38743,7 +38627,6 @@ export type SubmitFormMutation = {
                 name: string;
                 url?: string | null;
                 tags: Array<string>;
-                ownFile: boolean;
                 redacted: boolean;
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
@@ -38800,7 +38683,6 @@ export type SubmitFormMutation = {
                 name: string;
                 url?: string | null;
                 tags: Array<string>;
-                ownFile: boolean;
                 redacted: boolean;
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
@@ -38886,7 +38768,6 @@ export type SubmitFormMutation = {
                 name: string;
                 url?: string | null;
                 tags: Array<string>;
-                ownFile: boolean;
                 redacted: boolean;
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
@@ -38943,7 +38824,6 @@ export type SubmitFormMutation = {
                 name: string;
                 url?: string | null;
                 tags: Array<string>;
-                ownFile: boolean;
                 redacted: boolean;
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
@@ -39065,7 +38945,6 @@ export type SubmitFormMutation = {
                 name: string;
                 url?: string | null;
                 tags: Array<string>;
-                ownFile: boolean;
                 redacted: boolean;
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
@@ -39122,7 +39001,6 @@ export type SubmitFormMutation = {
                 name: string;
                 url?: string | null;
                 tags: Array<string>;
-                ownFile: boolean;
                 redacted: boolean;
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
@@ -39327,7 +39205,6 @@ export type SubmitFormMutation = {
                 name: string;
                 url?: string | null;
                 tags: Array<string>;
-                ownFile: boolean;
                 redacted: boolean;
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
@@ -39384,7 +39261,6 @@ export type SubmitFormMutation = {
                 name: string;
                 url?: string | null;
                 tags: Array<string>;
-                ownFile: boolean;
                 redacted: boolean;
                 enrollmentId?: string | null;
                 dateCreated?: string | null;
@@ -41930,7 +41806,6 @@ export type InventoryFieldsFragment = {
         name: string;
         url?: string | null;
         tags: Array<string>;
-        ownFile: boolean;
         redacted: boolean;
         enrollmentId?: string | null;
         dateCreated?: string | null;
@@ -41987,7 +41862,6 @@ export type InventoryFieldsFragment = {
         name: string;
         url?: string | null;
         tags: Array<string>;
-        ownFile: boolean;
         redacted: boolean;
         enrollmentId?: string | null;
         dateCreated?: string | null;
@@ -42265,7 +42139,6 @@ export type OrganizationDetailFieldsFragment = {
         name: string;
         url?: string | null;
         tags: Array<string>;
-        ownFile: boolean;
         redacted: boolean;
         enrollmentId?: string | null;
         dateCreated?: string | null;
@@ -42322,7 +42195,6 @@ export type OrganizationDetailFieldsFragment = {
         name: string;
         url?: string | null;
         tags: Array<string>;
-        ownFile: boolean;
         redacted: boolean;
         enrollmentId?: string | null;
         dateCreated?: string | null;
@@ -42409,7 +42281,6 @@ export type OrganizationFieldsFragment = {
         name: string;
         url?: string | null;
         tags: Array<string>;
-        ownFile: boolean;
         redacted: boolean;
         enrollmentId?: string | null;
         dateCreated?: string | null;
@@ -42466,7 +42337,6 @@ export type OrganizationFieldsFragment = {
         name: string;
         url?: string | null;
         tags: Array<string>;
-        ownFile: boolean;
         redacted: boolean;
         enrollmentId?: string | null;
         dateCreated?: string | null;
@@ -42586,7 +42456,6 @@ export type GetOrganizationQuery = {
           name: string;
           url?: string | null;
           tags: Array<string>;
-          ownFile: boolean;
           redacted: boolean;
           enrollmentId?: string | null;
           dateCreated?: string | null;
@@ -42643,7 +42512,6 @@ export type GetOrganizationQuery = {
           name: string;
           url?: string | null;
           tags: Array<string>;
-          ownFile: boolean;
           redacted: boolean;
           enrollmentId?: string | null;
           dateCreated?: string | null;
@@ -42843,7 +42711,6 @@ export type ProjectAllFieldsFragment = {
         name: string;
         url?: string | null;
         tags: Array<string>;
-        ownFile: boolean;
         redacted: boolean;
         enrollmentId?: string | null;
         dateCreated?: string | null;
@@ -42900,7 +42767,6 @@ export type ProjectAllFieldsFragment = {
         name: string;
         url?: string | null;
         tags: Array<string>;
-        ownFile: boolean;
         redacted: boolean;
         enrollmentId?: string | null;
         dateCreated?: string | null;
@@ -43631,7 +43497,6 @@ export type FunderFieldsFragment = {
         name: string;
         url?: string | null;
         tags: Array<string>;
-        ownFile: boolean;
         redacted: boolean;
         enrollmentId?: string | null;
         dateCreated?: string | null;
@@ -43688,7 +43553,6 @@ export type FunderFieldsFragment = {
         name: string;
         url?: string | null;
         tags: Array<string>;
-        ownFile: boolean;
         redacted: boolean;
         enrollmentId?: string | null;
         dateCreated?: string | null;
@@ -43929,7 +43793,6 @@ export type GetProjectQuery = {
           name: string;
           url?: string | null;
           tags: Array<string>;
-          ownFile: boolean;
           redacted: boolean;
           enrollmentId?: string | null;
           dateCreated?: string | null;
@@ -43986,7 +43849,6 @@ export type GetProjectQuery = {
           name: string;
           url?: string | null;
           tags: Array<string>;
-          ownFile: boolean;
           redacted: boolean;
           enrollmentId?: string | null;
           dateCreated?: string | null;
@@ -44436,7 +44298,6 @@ export type GetProjectAssessmentsQuery = {
               name: string;
               url?: string | null;
               tags: Array<string>;
-              ownFile: boolean;
               redacted: boolean;
               enrollmentId?: string | null;
               dateCreated?: string | null;
@@ -44493,7 +44354,6 @@ export type GetProjectAssessmentsQuery = {
               name: string;
               url?: string | null;
               tags: Array<string>;
-              ownFile: boolean;
               redacted: boolean;
               enrollmentId?: string | null;
               dateCreated?: string | null;
@@ -44638,7 +44498,6 @@ export type GetFunderQuery = {
           name: string;
           url?: string | null;
           tags: Array<string>;
-          ownFile: boolean;
           redacted: boolean;
           enrollmentId?: string | null;
           dateCreated?: string | null;
@@ -44695,7 +44554,6 @@ export type GetFunderQuery = {
           name: string;
           url?: string | null;
           tags: Array<string>;
-          ownFile: boolean;
           redacted: boolean;
           enrollmentId?: string | null;
           dateCreated?: string | null;
@@ -44799,7 +44657,6 @@ export type GetInventoryQuery = {
           name: string;
           url?: string | null;
           tags: Array<string>;
-          ownFile: boolean;
           redacted: boolean;
           enrollmentId?: string | null;
           dateCreated?: string | null;
@@ -44856,7 +44713,6 @@ export type GetInventoryQuery = {
           name: string;
           url?: string | null;
           tags: Array<string>;
-          ownFile: boolean;
           redacted: boolean;
           enrollmentId?: string | null;
           dateCreated?: string | null;
@@ -45001,7 +44857,6 @@ export type GetProjectInventoriesQuery = {
               name: string;
               url?: string | null;
               tags: Array<string>;
-              ownFile: boolean;
               redacted: boolean;
               enrollmentId?: string | null;
               dateCreated?: string | null;
@@ -45058,7 +44913,6 @@ export type GetProjectInventoriesQuery = {
               name: string;
               url?: string | null;
               tags: Array<string>;
-              ownFile: boolean;
               redacted: boolean;
               enrollmentId?: string | null;
               dateCreated?: string | null;
@@ -45308,7 +45162,6 @@ export type GetProjectFundersQuery = {
               name: string;
               url?: string | null;
               tags: Array<string>;
-              ownFile: boolean;
               redacted: boolean;
               enrollmentId?: string | null;
               dateCreated?: string | null;
@@ -45365,7 +45218,6 @@ export type GetProjectFundersQuery = {
               name: string;
               url?: string | null;
               tags: Array<string>;
-              ownFile: boolean;
               redacted: boolean;
               enrollmentId?: string | null;
               dateCreated?: string | null;
@@ -45922,7 +45774,6 @@ export type UpdateReferralPostingMutation = {
             name: string;
             url?: string | null;
             tags: Array<string>;
-            ownFile: boolean;
             redacted: boolean;
             enrollmentId?: string | null;
             dateCreated?: string | null;
@@ -45979,7 +45830,6 @@ export type UpdateReferralPostingMutation = {
             name: string;
             url?: string | null;
             tags: Array<string>;
-            ownFile: boolean;
             redacted: boolean;
             enrollmentId?: string | null;
             dateCreated?: string | null;
@@ -46164,7 +46014,6 @@ export type GetReferralPostingQuery = {
           name: string;
           url?: string | null;
           tags: Array<string>;
-          ownFile: boolean;
           redacted: boolean;
           enrollmentId?: string | null;
           dateCreated?: string | null;
@@ -46221,7 +46070,6 @@ export type GetReferralPostingQuery = {
           name: string;
           url?: string | null;
           tags: Array<string>;
-          ownFile: boolean;
           redacted: boolean;
           enrollmentId?: string | null;
           dateCreated?: string | null;
@@ -46445,7 +46293,6 @@ export type ReferralPostingDetailFieldsFragment = {
         name: string;
         url?: string | null;
         tags: Array<string>;
-        ownFile: boolean;
         redacted: boolean;
         enrollmentId?: string | null;
         dateCreated?: string | null;
@@ -46502,7 +46349,6 @@ export type ReferralPostingDetailFieldsFragment = {
         name: string;
         url?: string | null;
         tags: Array<string>;
-        ownFile: boolean;
         redacted: boolean;
         enrollmentId?: string | null;
         dateCreated?: string | null;
@@ -46620,7 +46466,6 @@ export type EsgFundingServiceFieldsFragment = {
         name: string;
         url?: string | null;
         tags: Array<string>;
-        ownFile: boolean;
         redacted: boolean;
         enrollmentId?: string | null;
         dateCreated?: string | null;
@@ -46677,7 +46522,6 @@ export type EsgFundingServiceFieldsFragment = {
         name: string;
         url?: string | null;
         tags: Array<string>;
-        ownFile: boolean;
         redacted: boolean;
         enrollmentId?: string | null;
         dateCreated?: string | null;
@@ -46773,7 +46617,6 @@ export type GetEsgFundingReportQuery = {
           name: string;
           url?: string | null;
           tags: Array<string>;
-          ownFile: boolean;
           redacted: boolean;
           enrollmentId?: string | null;
           dateCreated?: string | null;
@@ -46830,7 +46673,6 @@ export type GetEsgFundingReportQuery = {
           name: string;
           url?: string | null;
           tags: Array<string>;
-          ownFile: boolean;
           redacted: boolean;
           enrollmentId?: string | null;
           dateCreated?: string | null;
@@ -47188,7 +47030,6 @@ export type ServiceDetailFieldsFragment = {
         name: string;
         url?: string | null;
         tags: Array<string>;
-        ownFile: boolean;
         redacted: boolean;
         enrollmentId?: string | null;
         dateCreated?: string | null;
@@ -47245,7 +47086,6 @@ export type ServiceDetailFieldsFragment = {
         name: string;
         url?: string | null;
         tags: Array<string>;
-        ownFile: boolean;
         redacted: boolean;
         enrollmentId?: string | null;
         dateCreated?: string | null;
@@ -47352,7 +47192,6 @@ export type ServiceFieldsFragment = {
         name: string;
         url?: string | null;
         tags: Array<string>;
-        ownFile: boolean;
         redacted: boolean;
         enrollmentId?: string | null;
         dateCreated?: string | null;
@@ -47409,7 +47248,6 @@ export type ServiceFieldsFragment = {
         name: string;
         url?: string | null;
         tags: Array<string>;
-        ownFile: boolean;
         redacted: boolean;
         enrollmentId?: string | null;
         dateCreated?: string | null;
@@ -47516,7 +47354,6 @@ export type ClientServiceFieldsFragment = {
         name: string;
         url?: string | null;
         tags: Array<string>;
-        ownFile: boolean;
         redacted: boolean;
         enrollmentId?: string | null;
         dateCreated?: string | null;
@@ -47573,7 +47410,6 @@ export type ClientServiceFieldsFragment = {
         name: string;
         url?: string | null;
         tags: Array<string>;
-        ownFile: boolean;
         redacted: boolean;
         enrollmentId?: string | null;
         dateCreated?: string | null;
@@ -47699,7 +47535,6 @@ export type GetServiceQuery = {
           name: string;
           url?: string | null;
           tags: Array<string>;
-          ownFile: boolean;
           redacted: boolean;
           enrollmentId?: string | null;
           dateCreated?: string | null;
@@ -47756,7 +47591,6 @@ export type GetServiceQuery = {
           name: string;
           url?: string | null;
           tags: Array<string>;
-          ownFile: boolean;
           redacted: boolean;
           enrollmentId?: string | null;
           dateCreated?: string | null;
@@ -47897,7 +47731,6 @@ export type DeleteServiceMutation = {
             name: string;
             url?: string | null;
             tags: Array<string>;
-            ownFile: boolean;
             redacted: boolean;
             enrollmentId?: string | null;
             dateCreated?: string | null;
@@ -47954,7 +47787,6 @@ export type DeleteServiceMutation = {
             name: string;
             url?: string | null;
             tags: Array<string>;
-            ownFile: boolean;
             redacted: boolean;
             enrollmentId?: string | null;
             dateCreated?: string | null;
@@ -48094,7 +47926,6 @@ export type GetEnrollmentServicesQuery = {
               name: string;
               url?: string | null;
               tags: Array<string>;
-              ownFile: boolean;
               redacted: boolean;
               enrollmentId?: string | null;
               dateCreated?: string | null;
@@ -48151,7 +47982,6 @@ export type GetEnrollmentServicesQuery = {
               name: string;
               url?: string | null;
               tags: Array<string>;
-              ownFile: boolean;
               redacted: boolean;
               enrollmentId?: string | null;
               dateCreated?: string | null;
@@ -50059,7 +49889,6 @@ export const FileFieldsFragmentDoc = gql`
     name
     url
     tags
-    ownFile
     access {
       canManage
     }


### PR DESCRIPTION
## Description

Summary of changes:
- Resolve the new File access object, and use its `canManage` field when determining whether to show the Edit/Delete buttons for a given file
- Resolve the new `canIndexFiles` on the Client access object, and use it for determining whether to show the Client Files page
- While I was touching this code, I pulled in the perf improvement cleanup previously mentioned in a comment on `src/api/operations/access.fragments.graphql:57`, so that file-specific client permissions (other than `canIndexFiles`) are only resolved on the Client Files page, not on the root Client permission object.

[//]: # 'remove if not applicable'
Depends on hmis-warehouse PR: https://github.com/greenriver/hmis-warehouse/pull/6485

[//]: # 'remove if not applicable'
How to test: See ticket instructions

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Code clean-up

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have used Axe DevTools to scan for accessibility issues (or not applicable)
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
