### PR TITLE
Simplify Assessment deletion permission checks

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -1881,7 +1881,7 @@
         "fields": [
           {
             "name": "canDeleteAssessments",
-            "description": null,
+            "description": "Whether the user can delete this assessment",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -1908,8 +1908,8 @@
                 "ofType": null
               }
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "Use assessment.access.canDeleteAssessments for delete checks"
           },
           {
             "name": "canEditEnrollments",
@@ -1924,8 +1924,8 @@
                 "ofType": null
               }
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "Use enrollment.access.canEditEnrollments for enrollment edit checks"
           },
           {
             "name": "id",

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -1880,7 +1880,7 @@
         "isOneOf": null,
         "fields": [
           {
-            "name": "canDeleteAssessments",
+            "name": "canDelete",
             "description": "Whether the user can delete this assessment",
             "args": [],
             "type": {
@@ -1896,6 +1896,22 @@
             "deprecationReason": null
           },
           {
+            "name": "canDeleteAssessments",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": true,
+            "deprecationReason": "Use assessment.access.canDelete"
+          },
+          {
             "name": "canDeleteEnrollments",
             "description": null,
             "args": [],
@@ -1909,7 +1925,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use assessment.access.canDeleteAssessments for delete checks"
+            "deprecationReason": "Use assessment.access.canDelete"
           },
           {
             "name": "canEditEnrollments",

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -1880,7 +1880,7 @@
         "isOneOf": null,
         "fields": [
           {
-            "name": "canDelete",
+            "name": "canDeleteAssessment",
             "description": "Whether the user can delete this assessment",
             "args": [],
             "type": {
@@ -1909,7 +1909,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use assessment.access.canDelete"
+            "deprecationReason": "Use assessment.access.canDeleteAssessment"
           },
           {
             "name": "canDeleteEnrollments",
@@ -1925,7 +1925,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "Use assessment.access.canDelete"
+            "deprecationReason": "Use assessment.access.canDeleteAssessment"
           },
           {
             "name": "canEditEnrollments",

--- a/src/api/operations/access.fragments.graphql
+++ b/src/api/operations/access.fragments.graphql
@@ -76,8 +76,6 @@ fragment EnrollmentAccessFields on EnrollmentAccess {
 fragment AssessmentAccessFields on AssessmentAccess {
   id
   canDeleteAssessments
-  canDeleteEnrollments
-  canEditEnrollments
 }
 
 fragment ProjectAccessFields on ProjectAccess {

--- a/src/api/operations/access.fragments.graphql
+++ b/src/api/operations/access.fragments.graphql
@@ -75,7 +75,7 @@ fragment EnrollmentAccessFields on EnrollmentAccess {
 
 fragment AssessmentAccessFields on AssessmentAccess {
   id
-  canDeleteAssessments
+  canDelete
 }
 
 fragment ProjectAccessFields on ProjectAccess {

--- a/src/api/operations/access.fragments.graphql
+++ b/src/api/operations/access.fragments.graphql
@@ -75,7 +75,7 @@ fragment EnrollmentAccessFields on EnrollmentAccess {
 
 fragment AssessmentAccessFields on AssessmentAccess {
   id
-  canDelete
+  canDeleteAssessment
 }
 
 fragment ProjectAccessFields on ProjectAccess {

--- a/src/modules/assessments/components/AssessmentFormActions.tsx
+++ b/src/modules/assessments/components/AssessmentFormActions.tsx
@@ -43,7 +43,7 @@ const AssessmentFormActions: React.FC<Props> = ({
     [enrollment, navigate]
   );
 
-  const showDeleteAssessmentButton = assessment?.access.canDelete;
+  const showDeleteAssessmentButton = assessment?.access.canDeleteAssessment;
 
   const showPrintViewButton = !isPrintView && locked && assessment;
 

--- a/src/modules/assessments/components/AssessmentFormActions.tsx
+++ b/src/modules/assessments/components/AssessmentFormActions.tsx
@@ -43,7 +43,7 @@ const AssessmentFormActions: React.FC<Props> = ({
     [enrollment, navigate]
   );
 
-  const showDeleteAssessmentButton = assessment?.access.canDeleteAssessments;
+  const showDeleteAssessmentButton = assessment?.access.canDelete;
 
   const showPrintViewButton = !isPrintView && locked && assessment;
 

--- a/src/modules/assessments/components/AssessmentFormActions.tsx
+++ b/src/modules/assessments/components/AssessmentFormActions.tsx
@@ -9,7 +9,6 @@ import AssessmentAutofillButton from '@/modules/assessments/components/Assessmen
 import { isHeadOfMultiMemberHousehold } from '@/modules/hmis/hmisUtil';
 import { EnrollmentDashboardRoutes } from '@/routes/routes';
 import {
-  AssessmentRole,
   EnrollmentFieldsFragment,
   FullAssessmentFragment,
 } from '@/types/gqlTypes';
@@ -44,27 +43,7 @@ const AssessmentFormActions: React.FC<Props> = ({
     [enrollment, navigate]
   );
 
-  const showDeleteAssessmentButton = useMemo(() => {
-    if (!assessment) return false;
-
-    const { canDeleteAssessments, canEditEnrollments, canDeleteEnrollments } =
-      assessment.access;
-
-    // canEditEnrollments is required for deleting WIP or Submitted assessments
-    if (!canEditEnrollments) return false;
-
-    const isSubmitted = !assessment.inProgress;
-    const deletesEnrollment = assessment.role === AssessmentRole.Intake;
-    if (isSubmitted) {
-      // canDeleteAssessments is required for deleting submitted assessments
-      if (!canDeleteAssessments) return false;
-
-      // canDeleteEnrollments is required for deleting submitted INTAKE assessments
-      if (!canDeleteEnrollments && deletesEnrollment) return false;
-    }
-
-    return true;
-  }, [assessment]);
+  const showDeleteAssessmentButton = assessment?.access.canDeleteAssessments;
 
   const showPrintViewButton = !isPrintView && locked && assessment;
 

--- a/src/types/gqlObjects.ts
+++ b/src/types/gqlObjects.ts
@@ -316,7 +316,7 @@ export const HmisObjectSchemas: GqlSchema[] = [
     name: 'AssessmentAccess',
     fields: [
       {
-        name: 'canDelete',
+        name: 'canDeleteAssessment',
         type: {
           kind: 'NON_NULL',
           name: null,

--- a/src/types/gqlObjects.ts
+++ b/src/types/gqlObjects.ts
@@ -316,6 +316,14 @@ export const HmisObjectSchemas: GqlSchema[] = [
     name: 'AssessmentAccess',
     fields: [
       {
+        name: 'canDelete',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'Boolean', ofType: null },
+        },
+      },
+      {
         name: 'canDeleteAssessments',
         type: {
           kind: 'NON_NULL',

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -293,8 +293,11 @@ export type Assessment = {
 
 export type AssessmentAccess = {
   __typename?: 'AssessmentAccess';
+  /** Whether the user can delete this assessment */
   canDeleteAssessments: Scalars['Boolean']['output'];
+  /** @deprecated Use assessment.access.canDeleteAssessments for delete checks */
   canDeleteEnrollments: Scalars['Boolean']['output'];
+  /** @deprecated Use enrollment.access.canEditEnrollments for enrollment edit checks */
   canEditEnrollments: Scalars['Boolean']['output'];
   id: Scalars['ID']['output'];
 };
@@ -9166,8 +9169,6 @@ export type AssessmentAccessFieldsFragment = {
   __typename?: 'AssessmentAccess';
   id: string;
   canDeleteAssessments: boolean;
-  canDeleteEnrollments: boolean;
-  canEditEnrollments: boolean;
 };
 
 export type ProjectAccessFieldsFragment = {
@@ -10297,8 +10298,6 @@ export type AssessmentWithRecordsFragment = {
     __typename?: 'AssessmentAccess';
     id: string;
     canDeleteAssessments: boolean;
-    canDeleteEnrollments: boolean;
-    canEditEnrollments: boolean;
   };
   geolocation?: {
     __typename?: 'Geolocation';
@@ -11165,8 +11164,6 @@ export type FullAssessmentFragment = {
     __typename?: 'AssessmentAccess';
     id: string;
     canDeleteAssessments: boolean;
-    canDeleteEnrollments: boolean;
-    canEditEnrollments: boolean;
   };
   geolocation?: {
     __typename?: 'Geolocation';
@@ -13201,8 +13198,6 @@ export type GetAssessmentQuery = {
       __typename?: 'AssessmentAccess';
       id: string;
       canDeleteAssessments: boolean;
-      canDeleteEnrollments: boolean;
-      canEditEnrollments: boolean;
     };
     geolocation?: {
       __typename?: 'Geolocation';
@@ -14694,8 +14689,6 @@ export type SubmitAssessmentMutation = {
         __typename?: 'AssessmentAccess';
         id: string;
         canDeleteAssessments: boolean;
-        canDeleteEnrollments: boolean;
-        canEditEnrollments: boolean;
       };
       geolocation?: {
         __typename?: 'Geolocation';
@@ -15549,8 +15542,6 @@ export type SubmitHouseholdAssessmentsMutation = {
         __typename?: 'AssessmentAccess';
         id: string;
         canDeleteAssessments: boolean;
-        canDeleteEnrollments: boolean;
-        canEditEnrollments: boolean;
       };
       geolocation?: {
         __typename?: 'Geolocation';
@@ -16421,8 +16412,6 @@ export type GetAssessmentsForPopulationQuery = {
           __typename?: 'AssessmentAccess';
           id: string;
           canDeleteAssessments: boolean;
-          canDeleteEnrollments: boolean;
-          canEditEnrollments: boolean;
         };
         geolocation?: {
           __typename?: 'Geolocation';
@@ -50254,8 +50243,6 @@ export const AssessmentAccessFieldsFragmentDoc = gql`
   fragment AssessmentAccessFields on AssessmentAccess {
     id
     canDeleteAssessments
-    canDeleteEnrollments
-    canEditEnrollments
   }
 `;
 export const GeolocationFieldsFragmentDoc = gql`

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -294,10 +294,10 @@ export type Assessment = {
 export type AssessmentAccess = {
   __typename?: 'AssessmentAccess';
   /** Whether the user can delete this assessment */
-  canDelete: Scalars['Boolean']['output'];
-  /** @deprecated Use assessment.access.canDelete */
+  canDeleteAssessment: Scalars['Boolean']['output'];
+  /** @deprecated Use assessment.access.canDeleteAssessment */
   canDeleteAssessments: Scalars['Boolean']['output'];
-  /** @deprecated Use assessment.access.canDelete */
+  /** @deprecated Use assessment.access.canDeleteAssessment */
   canDeleteEnrollments: Scalars['Boolean']['output'];
   /** @deprecated Use enrollment.access.canEditEnrollments for enrollment edit checks */
   canEditEnrollments: Scalars['Boolean']['output'];
@@ -9171,7 +9171,7 @@ export type EnrollmentAccessFieldsFragment = {
 export type AssessmentAccessFieldsFragment = {
   __typename?: 'AssessmentAccess';
   id: string;
-  canDelete: boolean;
+  canDeleteAssessment: boolean;
 };
 
 export type ProjectAccessFieldsFragment = {
@@ -10297,7 +10297,11 @@ export type AssessmentWithRecordsFragment = {
       } | null;
     }> | null;
   }>;
-  access: { __typename?: 'AssessmentAccess'; id: string; canDelete: boolean };
+  access: {
+    __typename?: 'AssessmentAccess';
+    id: string;
+    canDeleteAssessment: boolean;
+  };
   geolocation?: {
     __typename?: 'Geolocation';
     id: string;
@@ -11159,7 +11163,11 @@ export type FullAssessmentFragment = {
       } | null;
     }> | null;
   }>;
-  access: { __typename?: 'AssessmentAccess'; id: string; canDelete: boolean };
+  access: {
+    __typename?: 'AssessmentAccess';
+    id: string;
+    canDeleteAssessment: boolean;
+  };
   geolocation?: {
     __typename?: 'Geolocation';
     id: string;
@@ -13189,7 +13197,11 @@ export type GetAssessmentQuery = {
         } | null;
       }> | null;
     }>;
-    access: { __typename?: 'AssessmentAccess'; id: string; canDelete: boolean };
+    access: {
+      __typename?: 'AssessmentAccess';
+      id: string;
+      canDeleteAssessment: boolean;
+    };
     geolocation?: {
       __typename?: 'Geolocation';
       id: string;
@@ -14679,7 +14691,7 @@ export type SubmitAssessmentMutation = {
       access: {
         __typename?: 'AssessmentAccess';
         id: string;
-        canDelete: boolean;
+        canDeleteAssessment: boolean;
       };
       geolocation?: {
         __typename?: 'Geolocation';
@@ -15532,7 +15544,7 @@ export type SubmitHouseholdAssessmentsMutation = {
       access: {
         __typename?: 'AssessmentAccess';
         id: string;
-        canDelete: boolean;
+        canDeleteAssessment: boolean;
       };
       geolocation?: {
         __typename?: 'Geolocation';
@@ -16402,7 +16414,7 @@ export type GetAssessmentsForPopulationQuery = {
         access: {
           __typename?: 'AssessmentAccess';
           id: string;
-          canDelete: boolean;
+          canDeleteAssessment: boolean;
         };
         geolocation?: {
           __typename?: 'Geolocation';
@@ -50233,7 +50245,7 @@ export const EmploymentEducationValuesFragmentDoc = gql`
 export const AssessmentAccessFieldsFragmentDoc = gql`
   fragment AssessmentAccessFields on AssessmentAccess {
     id
-    canDelete
+    canDeleteAssessment
   }
 `;
 export const GeolocationFieldsFragmentDoc = gql`

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -294,8 +294,10 @@ export type Assessment = {
 export type AssessmentAccess = {
   __typename?: 'AssessmentAccess';
   /** Whether the user can delete this assessment */
+  canDelete: Scalars['Boolean']['output'];
+  /** @deprecated Use assessment.access.canDelete */
   canDeleteAssessments: Scalars['Boolean']['output'];
-  /** @deprecated Use assessment.access.canDeleteAssessments for delete checks */
+  /** @deprecated Use assessment.access.canDelete */
   canDeleteEnrollments: Scalars['Boolean']['output'];
   /** @deprecated Use enrollment.access.canEditEnrollments for enrollment edit checks */
   canEditEnrollments: Scalars['Boolean']['output'];
@@ -9168,7 +9170,7 @@ export type EnrollmentAccessFieldsFragment = {
 export type AssessmentAccessFieldsFragment = {
   __typename?: 'AssessmentAccess';
   id: string;
-  canDeleteAssessments: boolean;
+  canDelete: boolean;
 };
 
 export type ProjectAccessFieldsFragment = {
@@ -10294,11 +10296,7 @@ export type AssessmentWithRecordsFragment = {
       } | null;
     }> | null;
   }>;
-  access: {
-    __typename?: 'AssessmentAccess';
-    id: string;
-    canDeleteAssessments: boolean;
-  };
+  access: { __typename?: 'AssessmentAccess'; id: string; canDelete: boolean };
   geolocation?: {
     __typename?: 'Geolocation';
     id: string;
@@ -11160,11 +11158,7 @@ export type FullAssessmentFragment = {
       } | null;
     }> | null;
   }>;
-  access: {
-    __typename?: 'AssessmentAccess';
-    id: string;
-    canDeleteAssessments: boolean;
-  };
+  access: { __typename?: 'AssessmentAccess'; id: string; canDelete: boolean };
   geolocation?: {
     __typename?: 'Geolocation';
     id: string;
@@ -13194,11 +13188,7 @@ export type GetAssessmentQuery = {
         } | null;
       }> | null;
     }>;
-    access: {
-      __typename?: 'AssessmentAccess';
-      id: string;
-      canDeleteAssessments: boolean;
-    };
+    access: { __typename?: 'AssessmentAccess'; id: string; canDelete: boolean };
     geolocation?: {
       __typename?: 'Geolocation';
       id: string;
@@ -14688,7 +14678,7 @@ export type SubmitAssessmentMutation = {
       access: {
         __typename?: 'AssessmentAccess';
         id: string;
-        canDeleteAssessments: boolean;
+        canDelete: boolean;
       };
       geolocation?: {
         __typename?: 'Geolocation';
@@ -15541,7 +15531,7 @@ export type SubmitHouseholdAssessmentsMutation = {
       access: {
         __typename?: 'AssessmentAccess';
         id: string;
-        canDeleteAssessments: boolean;
+        canDelete: boolean;
       };
       geolocation?: {
         __typename?: 'Geolocation';
@@ -16411,7 +16401,7 @@ export type GetAssessmentsForPopulationQuery = {
         access: {
           __typename?: 'AssessmentAccess';
           id: string;
-          canDeleteAssessments: boolean;
+          canDelete: boolean;
         };
         geolocation?: {
           __typename?: 'Geolocation';
@@ -50242,7 +50232,7 @@ export const EmploymentEducationValuesFragmentDoc = gql`
 export const AssessmentAccessFieldsFragmentDoc = gql`
   fragment AssessmentAccessFields on AssessmentAccess {
     id
-    canDeleteAssessments
+    canDelete
   }
 `;
 export const GeolocationFieldsFragmentDoc = gql`


### PR DESCRIPTION
## Description

Summary of changes:
- Replace the frontend logic for determining whether to show the Delete Assessment button, with one permission check that relies on the backend policy.
- **Note that this is a logical change from before!**
  - Previously: The backend required only `can_delete_enrollments` to delete a completed Intake, but the frontend required `can_delete_enrollments` AND `can_delete_assessments`.
  - After this PR: Frontend is aligned with backend on the _less strict_ version. You only need `can_delete_enrollments` to delete a completed Intake.

[//]: # 'remove if not applicable'
Depends on hmis-warehouse PR: https://github.com/greenriver/hmis-warehouse/pull/6505

[//]: # 'remove if not applicable'
How to test: See QA instructions on ticket

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Code clean-up

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have used Axe DevTools to scan for accessibility issues (or not applicable)
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
