### PR TITLE
Bump nginx CVE-2026-9256

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,7 +34,7 @@ RUN --mount=type=cache,target=/app/node_modules \
 #####################################################################
 # nginx container
 #####################################################################
-FROM nginx:1.28-alpine3.23
+FROM nginx:1.30-alpine3.23
 ARG USERID=${USERID:-10000}
 ARG GROUPID=${GROUPID:-10001}
 


### PR DESCRIPTION
## Description

Bump nginx version to resolve  CVE-2026-9256 causing trivy build failures.

Image used: https://hub.docker.com/layers/library/nginx/1.30-alpine3.23/images/sha256-7390e25a11474d8ce30e8b458289117c17c9fc07ece236204533c22070c4305b

Not tested locally, test image when deployed

## Type of change
Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have used Axe DevTools to scan for accessibility issues (or not applicable)
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
