### PR TITLE
Remove unused code

### DIFF
--- a/src/modules/form/hooks/useServiceFormDefinition.tsx
+++ b/src/modules/form/hooks/useServiceFormDefinition.tsx
@@ -1,4 +1,3 @@
-import { ApolloError } from '@apollo/client';
 import { useMemo } from 'react';
 
 import { getItemMap } from '../util/formUtil';
@@ -9,13 +8,11 @@ interface Args {
   projectId: string;
   serviceTypeId?: string;
   formDefinitionId?: string | null; // provided when editing existing service
-  onError?: (error: ApolloError) => void;
 }
 const useServiceFormDefinition = ({
   serviceTypeId,
   projectId,
   formDefinitionId,
-  onError,
 }: Args) => {
   const { data, loading } = useGetServiceFormDefinitionQuery({
     variables: {
@@ -24,7 +21,6 @@ const useServiceFormDefinition = ({
       formDefinitionId,
     },
     skip: !serviceTypeId,
-    onError,
   });
 
   const { formDefinition, itemMap } = useMemo(() => {


### PR DESCRIPTION
## Description

Remove unused code. Removing this because it flagged in https://github.com/open-path/Green-River/issues/8958#issuecomment-4674559420. We will have to remove usages of onError/onComplete with`useQuery` when migration to Apollo client v4.

## Type of change
Code clean-up

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have used Axe DevTools to scan for accessibility issues (or not applicable)
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
