### PR TITLE
Update codegen to get OPEN_ORGANIZATION_NAMES

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -39790,6 +39790,12 @@
             "deprecationReason": null
           },
           {
+            "name": "OPEN_ORGANIZATION_NAMES",
+            "description": "Names of organizations with open projects",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "OPEN_PROJECTS",
             "description": "Open Projects that the user can see",
             "isDeprecated": false,

--- a/src/types/gqlEnums.ts
+++ b/src/types/gqlEnums.ts
@@ -1017,6 +1017,7 @@ export const HmisEnums = {
     HUD_SERVICE_CATEGORIES: 'HUD_SERVICE_CATEGORIES',
     HUD_SERVICE_TYPES: 'HUD_SERVICE_TYPES',
     OPEN_HOH_ENROLLMENTS_FOR_PROJECT: 'Open HoH enrollments at the project.',
+    OPEN_ORGANIZATION_NAMES: 'Names of organizations with open projects',
     OPEN_PROJECTS: 'Open Projects that the user can see',
     ORGANIZATION: 'All Organizations that the User can see',
     OTHER_FUNDERS: 'OtherFunder values for all Funders across the installation',

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -5637,6 +5637,8 @@ export enum PickListType {
   HudServiceTypes = 'HUD_SERVICE_TYPES',
   /** Open HoH enrollments at the project. */
   OpenHohEnrollmentsForProject = 'OPEN_HOH_ENROLLMENTS_FOR_PROJECT',
+  /** Names of organizations with open projects */
+  OpenOrganizationNames = 'OPEN_ORGANIZATION_NAMES',
   /** Open Projects that the user can see */
   OpenProjects = 'OPEN_PROJECTS',
   /** All Organizations that the User can see */


### PR DESCRIPTION
## Description
Ticket: https://github.com/open-path/Green-River/issues/9281

Update codegen based on `staging` branch of hmis-warehouse. 
The picklist change made its way into 217 on the backend but not the frontend.

Will open a PR to merge staging=>main after this

## Type of change
new feature

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have used Axe DevTools to scan for accessibility issues (or not applicable)
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
