### PR TITLE
Disable changing project config type

### DIFF
--- a/src/modules/admin/components/projectConfig/ProjectConfigDialog.tsx
+++ b/src/modules/admin/components/projectConfig/ProjectConfigDialog.tsx
@@ -40,6 +40,8 @@ const ProjectConfigDialog: React.FC<ProjectDialogProps> = ({
               UpdateProjectConfigMutationVariables
             >
               role={StaticFormRole.ProjectConfig}
+              // In edit mode, pass the config ID as a local constant so the form definition knows we are editing an existing record
+              localConstants={{ projectConfigId: config.id }}
               initialValues={{
                 lengthOfAbsenceDays: configOptions.length_of_absence_days,
                 receivesDirectReferrals:


### PR DESCRIPTION
## Description

Summary of changes: Pass existing config ID as a local constant to the Project Config static form.

[//]: # 'remove if not applicable'
Depends on hmis-warehouse PR: https://github.com/greenriver/hmis-warehouse/pull/6651

[//]: # 'remove if not applicable'
How to test: Locally, re-seed forms. Then, see QA instructions on ticket

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have used Axe DevTools to scan for accessibility issues (or not applicable)
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
