### PR TITLE
Lock and visually flag HUD-linked fields

### DIFF
--- a/src/components/elements/CommonMenuButton.tsx
+++ b/src/components/elements/CommonMenuButton.tsx
@@ -165,7 +165,7 @@ const CommonMenuButton = ({
                       variant={'caption'}
                       sx={{ fontStyle: 'italic' }}
                     >
-                      {helperText }
+                      {helperText}
                     </Typography>
                   )}
                 </Stack>

--- a/src/components/elements/CommonMenuButton.tsx
+++ b/src/components/elements/CommonMenuButton.tsx
@@ -28,6 +28,7 @@ export type CommonMenuItem = {
   divider?: boolean;
   disabled?: boolean;
   disabledReason?: string;
+  helperText?: string;
   ariaLabel?: string;
   linkState?: LocationState;
   openInNew?: boolean;
@@ -126,6 +127,7 @@ const CommonMenuButton = ({
             onClick,
             disabled,
             disabledReason,
+            helperText,
             ariaLabel,
             openInNew,
             linkState,
@@ -156,6 +158,14 @@ const CommonMenuButton = ({
                       sx={{ fontStyle: 'italic' }}
                     >
                       {disabledReason}
+                    </Typography>
+                  )}
+                  {helperText && (
+                    <Typography
+                      variant={'caption'}
+                      sx={{ fontStyle: 'italic' }}
+                    >
+                      {helperText || 'hello'}
                     </Typography>
                   )}
                 </Stack>

--- a/src/components/elements/CommonMenuButton.tsx
+++ b/src/components/elements/CommonMenuButton.tsx
@@ -165,7 +165,7 @@ const CommonMenuButton = ({
                       variant={'caption'}
                       sx={{ fontStyle: 'italic' }}
                     >
-                      {helperText || 'hello'}
+                      {helperText }
                     </Typography>
                   )}
                 </Stack>

--- a/src/modules/formBuilder/components/HudChip.tsx
+++ b/src/modules/formBuilder/components/HudChip.tsx
@@ -1,0 +1,16 @@
+import { Chip } from '@mui/material';
+
+const HudChip: React.FC = ({}) => {
+  return (
+    <Chip
+      label='HUD'
+      size='small'
+      variant='outlined'
+      color='primary'
+      aria-label='HUD field'
+      sx={{ fontWeight: 600, height: '20px' }}
+    />
+  );
+};
+
+export default HudChip;

--- a/src/modules/formBuilder/components/SystemFieldChip.tsx
+++ b/src/modules/formBuilder/components/SystemFieldChip.tsx
@@ -1,16 +1,16 @@
 import { Chip } from '@mui/material';
 
-const HudChip: React.FC = ({}) => {
+const SystemFieldChip: React.FC = ({}) => {
   return (
     <Chip
-      label='HUD'
+      label='System Field'
       size='small'
       variant='outlined'
       color='primary'
-      aria-label='HUD field'
+      aria-label='System field'
       sx={{ fontWeight: 600, height: '20px' }}
     />
   );
 };
 
-export default HudChip;
+export default SystemFieldChip;

--- a/src/modules/formBuilder/components/formTree/FormTreeLabel.tsx
+++ b/src/modules/formBuilder/components/formTree/FormTreeLabel.tsx
@@ -5,7 +5,7 @@ import { useTreeItem2 } from '@mui/x-tree-view/useTreeItem2/useTreeItem2';
 import { UseTreeItem2LabelSlotProps } from '@mui/x-tree-view/useTreeItem2/useTreeItem2.types';
 import React, { useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { useFormContext, useFormState } from 'react-hook-form';
-import HudChip from '../HudChip';
+import SystemFieldChip from '../SystemFieldChip';
 import { FormTreeContext } from './FormTreeContext';
 import useUpdateFormStructure from './useUpdateFormStructure';
 import CommonMenuButton from '@/components/elements/CommonMenuButton';
@@ -63,7 +63,10 @@ const FormTreeLabel: React.FC<FormTreeLabelProps> = ({
 
   const item = useMemo(() => itemMap[itemId], [itemMap, itemId]);
 
-  const isHudItem = !!item?.mapping?.fieldName;
+  // If the item maps to a fieldName (as opposed to customFieldKey),
+  // it is a "system" field. Many of these are HUD fields, but not all.
+  // Restrict deletion for users who are not super-admins.
+  const isSystemField = !!item?.mapping?.fieldName;
   const [canAdministrateConfig] = useHasRootPermissions([
     'canAdministrateConfig',
   ]);
@@ -109,21 +112,20 @@ const FormTreeLabel: React.FC<FormTreeLabelProps> = ({
     const groupHasChildren =
       item?.type === ItemType.Group && !!item?.item && item.item.length > 0;
 
-    // Disable deletion (for non-super-admins) if this is a HUD-mapped field,
-    // to prevent the user from deleting the field and breaking the form's HUD data collection.
-    const disableDeleteHudItem = isHudItem && !canAdministrateConfig;
+    // Disable deletion (for non-super-admins) if this is a system-mapped field.
+    const disableDeleteSystemField = isSystemField && !canAdministrateConfig;
 
     let disabledReason = undefined;
     if (groupHasChildren) {
       disabledReason = 'Groups with items cannot be deleted.';
-    } else if (disableDeleteHudItem) {
-      disabledReason = 'This item maps to a HUD field.';
+    } else if (disableDeleteSystemField) {
+      disabledReason = 'This item maps to a system field.';
     }
 
     // For super-admins, show a helper text but don't disable the delete action.
     const helperText =
-      isHudItem && canAdministrateConfig
-        ? 'Caution: This item maps to a HUD field.'
+      isSystemField && canAdministrateConfig
+        ? 'Caution: This item maps to a system field.'
         : undefined;
 
     return [
@@ -136,12 +138,18 @@ const FormTreeLabel: React.FC<FormTreeLabelProps> = ({
         key: 'delete',
         title: 'Delete',
         onClick: () => onDelete(setDeletionBlockers),
-        disabled: groupHasChildren || disableDeleteHudItem,
+        disabled: groupHasChildren || disableDeleteSystemField,
         disabledReason: disabledReason,
         helperText,
       },
     ];
-  }, [canAdministrateConfig, isHudItem, item, onDelete, openFormItemEditor]);
+  }, [
+    canAdministrateConfig,
+    isSystemField,
+    item,
+    onDelete,
+    openFormItemEditor,
+  ]);
 
   return (
     <TreeItem2Label
@@ -193,7 +201,7 @@ const FormTreeLabel: React.FC<FormTreeLabelProps> = ({
           </Box>
 
           {item.required && <Typography color='red'>*</Typography>}
-          {isHudItem && <HudChip />}
+          {isSystemField && <SystemFieldChip />}
           {item.enableWhen && item.enableWhen?.length > 0 && (
             <ConditionalIcon
               fontSize='inherit'

--- a/src/modules/formBuilder/components/formTree/FormTreeLabel.tsx
+++ b/src/modules/formBuilder/components/formTree/FormTreeLabel.tsx
@@ -5,6 +5,7 @@ import { useTreeItem2 } from '@mui/x-tree-view/useTreeItem2/useTreeItem2';
 import { UseTreeItem2LabelSlotProps } from '@mui/x-tree-view/useTreeItem2/useTreeItem2.types';
 import React, { useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { useFormContext, useFormState } from 'react-hook-form';
+import HudChip from '../HudChip';
 import { FormTreeContext } from './FormTreeContext';
 import useUpdateFormStructure from './useUpdateFormStructure';
 import CommonMenuButton from '@/components/elements/CommonMenuButton';
@@ -19,6 +20,7 @@ import {
   FormItemPaletteType,
   ItemDependents,
 } from '@/modules/formBuilder/types';
+import { useHasRootPermissions } from '@/modules/permissions/useHasPermissionsHooks';
 import { ItemType } from '@/types/gqlTypes';
 
 export const getItemDisplayAttrs = (type: ItemType): FormItemPaletteType => {
@@ -61,6 +63,12 @@ const FormTreeLabel: React.FC<FormTreeLabelProps> = ({
 
   const item = useMemo(() => itemMap[itemId], [itemMap, itemId]);
 
+  const isHudItem = !!item?.mapping?.fieldName;
+  const isRequiredHudItem = isHudItem && !!item?.required;
+  const [canAdministrateConfig] = useHasRootPermissions([
+    'canAdministrateConfig',
+  ]);
+
   const displayAttrs = useMemo(
     () => getItemDisplayAttrs(item?.type),
     [item?.type]
@@ -97,8 +105,30 @@ const FormTreeLabel: React.FC<FormTreeLabelProps> = ({
     ItemDependents | undefined
   >(undefined);
 
-  const menuItems = useMemo(
-    () => [
+  const menuItems = useMemo(() => {
+    // Disable deletion for groups that have children.
+    const groupHasChildren =
+      item?.type === ItemType.Group && !!item?.item && item.item.length > 0;
+
+    // Disable deletion (for non-super-admins) if this is a HUD field that is required,
+    // to prevent the user from deleting the field and breaking the form's HUD data collection.
+    // This relies on the form being configured to correctly require HUD fields when the underlying HUD record requires them.
+    const disableDeleteHudItem = isRequiredHudItem && !canAdministrateConfig;
+
+    let disabledReason = undefined;
+    if (groupHasChildren) {
+      disabledReason = 'Groups with items cannot be deleted.';
+    } else if (disableDeleteHudItem) {
+      disabledReason = 'This item maps to a required HUD field.';
+    }
+
+    // For super-admins, show a helper text but don't disable the delete action.
+    const helperText =
+      isRequiredHudItem && canAdministrateConfig
+        ? 'Caution: This item maps to a required HUD field.'
+        : undefined;
+
+    return [
       {
         key: 'edit',
         title: 'Edit',
@@ -108,13 +138,18 @@ const FormTreeLabel: React.FC<FormTreeLabelProps> = ({
         key: 'delete',
         title: 'Delete',
         onClick: () => onDelete(setDeletionBlockers),
-        // disable deletion for groups that contain items
-        disabled:
-          item?.type === ItemType.Group && !!item?.item && item.item.length > 0,
+        disabled: groupHasChildren || disableDeleteHudItem,
+        disabledReason: disabledReason,
+        helperText,
       },
-    ],
-    [item, openFormItemEditor, onDelete]
-  );
+    ];
+  }, [
+    canAdministrateConfig,
+    isRequiredHudItem,
+    item,
+    onDelete,
+    openFormItemEditor,
+  ]);
 
   return (
     <TreeItem2Label
@@ -166,6 +201,7 @@ const FormTreeLabel: React.FC<FormTreeLabelProps> = ({
           </Box>
 
           {item.required && <Typography color='red'>*</Typography>}
+          {isHudItem && <HudChip />}
           {item.enableWhen && item.enableWhen?.length > 0 && (
             <ConditionalIcon
               fontSize='inherit'

--- a/src/modules/formBuilder/components/formTree/FormTreeLabel.tsx
+++ b/src/modules/formBuilder/components/formTree/FormTreeLabel.tsx
@@ -64,7 +64,6 @@ const FormTreeLabel: React.FC<FormTreeLabelProps> = ({
   const item = useMemo(() => itemMap[itemId], [itemMap, itemId]);
 
   const isHudItem = !!item?.mapping?.fieldName;
-  const isRequiredHudItem = isHudItem && !!item?.required;
   const [canAdministrateConfig] = useHasRootPermissions([
     'canAdministrateConfig',
   ]);
@@ -110,22 +109,21 @@ const FormTreeLabel: React.FC<FormTreeLabelProps> = ({
     const groupHasChildren =
       item?.type === ItemType.Group && !!item?.item && item.item.length > 0;
 
-    // Disable deletion (for non-super-admins) if this is a HUD field that is required,
+    // Disable deletion (for non-super-admins) if this is a HUD-mapped field,
     // to prevent the user from deleting the field and breaking the form's HUD data collection.
-    // This relies on the form being configured to correctly require HUD fields when the underlying HUD record requires them.
-    const disableDeleteHudItem = isRequiredHudItem && !canAdministrateConfig;
+    const disableDeleteHudItem = isHudItem && !canAdministrateConfig;
 
     let disabledReason = undefined;
     if (groupHasChildren) {
       disabledReason = 'Groups with items cannot be deleted.';
     } else if (disableDeleteHudItem) {
-      disabledReason = 'This item maps to a required HUD field.';
+      disabledReason = 'This item maps to a HUD field.';
     }
 
     // For super-admins, show a helper text but don't disable the delete action.
     const helperText =
-      isRequiredHudItem && canAdministrateConfig
-        ? 'Caution: This item maps to a required HUD field.'
+      isHudItem && canAdministrateConfig
+        ? 'Caution: This item maps to a HUD field.'
         : undefined;
 
     return [
@@ -143,13 +141,7 @@ const FormTreeLabel: React.FC<FormTreeLabelProps> = ({
         helperText,
       },
     ];
-  }, [
-    canAdministrateConfig,
-    isRequiredHudItem,
-    item,
-    onDelete,
-    openFormItemEditor,
-  ]);
+  }, [canAdministrateConfig, isHudItem, item, onDelete, openFormItemEditor]);
 
   return (
     <TreeItem2Label

--- a/src/modules/formBuilder/components/itemEditor/FormItemEditor.tsx
+++ b/src/modules/formBuilder/components/itemEditor/FormItemEditor.tsx
@@ -410,13 +410,20 @@ const FormItemEditor: React.FC<Props> = ({
                 />
               )}
           </Section>
-          {// Disable changing choices for HUD items
-          !lockHudItemControls &&
-            [ItemType.Choice, ItemType.OpenChoice].includes(itemTypeValue) && (
-              <Section title='Choices'>
-                <ManagePickListOptions control={control} setValue={setValue} />
-              </Section>
-            )}
+          {
+            // Disable changing choices for HUD items
+            !lockHudItemControls &&
+              [ItemType.Choice, ItemType.OpenChoice].includes(
+                itemTypeValue
+              ) && (
+                <Section title='Choices'>
+                  <ManagePickListOptions
+                    control={control}
+                    setValue={setValue}
+                  />
+                </Section>
+              )
+          }
           {
             // Disable changing visibility for HUD items
             !lockHudItemControls && (

--- a/src/modules/formBuilder/components/itemEditor/FormItemEditor.tsx
+++ b/src/modules/formBuilder/components/itemEditor/FormItemEditor.tsx
@@ -323,8 +323,8 @@ const FormItemEditor: React.FC<Props> = ({
                 {canAdministrateConfig && (
                   <>
                     As a super-admin, you can edit all properties, but be
-                    cautious about changing properties that may affect system
-                    field data collection.
+                    cautious about changing properties that may affect data
+                    collection, such as choices or visibility.
                   </>
                 )}
               </Alert>

--- a/src/modules/formBuilder/components/itemEditor/FormItemEditor.tsx
+++ b/src/modules/formBuilder/components/itemEditor/FormItemEditor.tsx
@@ -11,7 +11,7 @@ import React, {
 import { DeepPartial, useForm } from 'react-hook-form';
 import { v4 } from 'uuid';
 import FormEditorItemPreview from '../FormEditorItemPreview';
-import HudChip from '../HudChip';
+import SystemFieldChip from '../SystemFieldChip';
 import AutofillProperties from './conditionals/AutofillProperties';
 import InitialValue from './conditionals/InitialValue';
 import ManageEnableWhen from './conditionals/ManageEnableWhen';
@@ -161,11 +161,14 @@ const FormItemEditor: React.FC<Props> = ({
     [definition.role]
   );
 
-  const isHudItem = !!initialItem.mapping?.fieldName;
+  // If the item maps to a fieldName (as opposed to customFieldKey),
+  // it is a "system" field. Many of these are HUD fields, but not all.
+  // Lock down editing for users who are not super-admins.
+  const isSystemField = !!initialItem.mapping?.fieldName;
   const [canAdministrateConfig] = useHasRootPermissions([
     'canAdministrateConfig',
   ]);
-  const lockHudItemControls = isHudItem && !canAdministrateConfig;
+  const lockSystemFieldControls = isSystemField && !canAdministrateConfig;
 
   const componentOverridePicklist = useMemo(() => {
     if (!itemTypeValue) return [];
@@ -311,22 +314,22 @@ const FormItemEditor: React.FC<Props> = ({
                 <ErrorAlert key='errors' errors={errorState.errors} />
               </Stack>
             )}
-            {isHudItem && (
+            {isSystemField && (
               <Alert severity='info' sx={{ mb: 2 }}>
-                This question collects a HUD field.{' '}
+                This question collects a system field.{' '}
                 {!canAdministrateConfig && (
                   <>Only display text and layout controls are editable.</>
                 )}
                 {canAdministrateConfig && (
                   <>
                     As a super-admin, you can edit all properties, but be
-                    cautious about changing properties that may affect HUD data
-                    collection.
+                    cautious about changing properties that may affect system
+                    field data collection.
                   </>
                 )}
               </Alert>
             )}
-            {!lockHudItemControls &&
+            {!lockSystemFieldControls &&
               itemTypeValue === ItemType.Date &&
               isAssessment && (
                 <ControlledCheckbox
@@ -336,7 +339,7 @@ const FormItemEditor: React.FC<Props> = ({
                   helperText='If checked, this date will be recorded as the Assessment Date on the assessment'
                 />
               )}
-            {isQuestionItem && !lockHudItemControls && (
+            {isQuestionItem && !lockSystemFieldControls && (
               <RequiredOptionalRadio control={control} setValue={setValue} />
             )}
             <ControlledTextInput
@@ -392,7 +395,7 @@ const FormItemEditor: React.FC<Props> = ({
                 options={inputSizePickList}
               />
             )}
-            {!lockHudItemControls &&
+            {!lockSystemFieldControls &&
               ([
                 ItemType.Choice,
                 ItemType.OpenChoice,
@@ -411,8 +414,8 @@ const FormItemEditor: React.FC<Props> = ({
               )}
           </Section>
           {
-            // Disable changing choices for HUD items
-            !lockHudItemControls &&
+            // Disable changing choices for system fields
+            !lockSystemFieldControls &&
               [ItemType.Choice, ItemType.OpenChoice].includes(
                 itemTypeValue
               ) && (
@@ -425,8 +428,8 @@ const FormItemEditor: React.FC<Props> = ({
               )
           }
           {
-            // Disable changing visibility for HUD items
-            !lockHudItemControls && (
+            // Disable changing visibility for system fields
+            !lockSystemFieldControls && (
               <Section title='Visibility'>
                 {isAssessment && (
                   <ControlledSelect
@@ -548,7 +551,7 @@ const FormItemEditor: React.FC<Props> = ({
                   title={
                     <Stack direction='row' gap={1} alignItems='center'>
                       Field Key
-                      {initialItem.mapping?.fieldName && <HudChip />}
+                      {initialItem.mapping?.fieldName && <SystemFieldChip />}
                     </Stack>
                   }
                 >

--- a/src/modules/formBuilder/components/itemEditor/FormItemEditor.tsx
+++ b/src/modules/formBuilder/components/itemEditor/FormItemEditor.tsx
@@ -1,5 +1,5 @@
 import { LoadingButton } from '@mui/lab';
-import { Box, Button, Divider, Stack, Typography } from '@mui/material';
+import { Alert, Box, Button, Divider, Stack, Typography } from '@mui/material';
 import { isNil, omitBy, startCase } from 'lodash-es';
 import React, {
   Dispatch,
@@ -11,6 +11,7 @@ import React, {
 import { DeepPartial, useForm } from 'react-hook-form';
 import { v4 } from 'uuid';
 import FormEditorItemPreview from '../FormEditorItemPreview';
+import HudChip from '../HudChip';
 import AutofillProperties from './conditionals/AutofillProperties';
 import InitialValue from './conditionals/InitialValue';
 import ManageEnableWhen from './conditionals/ManageEnableWhen';
@@ -45,6 +46,7 @@ import {
   validComponentsForType,
 } from '@/modules/formBuilder/formBuilderUtil';
 import { RootPermissionsFilter } from '@/modules/permissions/PermissionsFilters';
+import { useHasRootPermissions } from '@/modules/permissions/useHasPermissionsHooks';
 import { HmisEnums } from '@/types/gqlEnums';
 import {
   AssessmentRole,
@@ -158,6 +160,12 @@ const FormItemEditor: React.FC<Props> = ({
     () => (Object.values(AssessmentRole) as [string]).includes(definition.role),
     [definition.role]
   );
+
+  const isHudItem = !!initialItem.mapping?.fieldName;
+  const [canAdministrateConfig] = useHasRootPermissions([
+    'canAdministrateConfig',
+  ]);
+  const lockHudItemControls = isHudItem && !canAdministrateConfig;
 
   const componentOverridePicklist = useMemo(() => {
     if (!itemTypeValue) return [];
@@ -303,15 +311,32 @@ const FormItemEditor: React.FC<Props> = ({
                 <ErrorAlert key='errors' errors={errorState.errors} />
               </Stack>
             )}
-            {itemTypeValue === ItemType.Date && isAssessment && (
-              <ControlledCheckbox
-                name='assessmentDate'
-                control={control}
-                label='Assessment Date'
-                helperText='If checked, this date will be recorded as the Assessment Date on the assessment'
-              />
+            {isHudItem && (
+              <Alert severity='info' sx={{ mb: 2 }}>
+                This question collects a HUD field.{' '}
+                {!canAdministrateConfig && (
+                  <>Only display text and layout controls are editable.</>
+                )}
+                {canAdministrateConfig && (
+                  <>
+                    As a super-admin, you can edit all properties, but be
+                    cautious about changing properties that may affect HUD data
+                    collection.
+                  </>
+                )}
+              </Alert>
             )}
-            {isQuestionItem && (
+            {!lockHudItemControls &&
+              itemTypeValue === ItemType.Date &&
+              isAssessment && (
+                <ControlledCheckbox
+                  name='assessmentDate'
+                  control={control}
+                  label='Assessment Date'
+                  helperText='If checked, this date will be recorded as the Assessment Date on the assessment'
+                />
+              )}
+            {isQuestionItem && !lockHudItemControls && (
               <RequiredOptionalRadio control={control} setValue={setValue} />
             )}
             <ControlledTextInput
@@ -367,78 +392,87 @@ const FormItemEditor: React.FC<Props> = ({
                 options={inputSizePickList}
               />
             )}
-            {([
-              ItemType.Choice,
-              ItemType.OpenChoice,
-              ItemType.File,
-              ItemType.Image,
-            ].includes(itemTypeValue) ||
-              (itemTypeValue === ItemType.Object &&
-                itemComponentValue === Component.Address)) && (
-              <ControlledCheckbox
-                name='repeats'
-                label='Allow multiple responses'
-                control={control}
-                disabled={disableRepeats}
-                helperText={repeatsHelperText}
-              />
-            )}
-          </Section>
-          {[ItemType.Choice, ItemType.OpenChoice].includes(itemTypeValue) && (
-            <Section title='Choices'>
-              <ManagePickListOptions control={control} setValue={setValue} />
-            </Section>
-          )}
-          <Section title='Visibility'>
-            {isAssessment && (
-              <ControlledSelect
-                name='dataCollectedAbout'
-                control={control}
-                label='Client Applicability'
-                placeholder='Select client applicability'
-                options={dataCollectedAboutPickList}
-                helperText='Select the client(s) to which this item applies. If left blank, the item will be shown for all clients.'
-              />
-            )}
-            <ControlledCheckbox
-              name='hidden'
-              control={control}
-              label='Always hide this item'
-              sx={{ width: 'fit-content' }}
-            />
-            {!hiddenValue && (
-              <>
-                <ManageEnableWhen
+            {!lockHudItemControls &&
+              ([
+                ItemType.Choice,
+                ItemType.OpenChoice,
+                ItemType.File,
+                ItemType.Image,
+              ].includes(itemTypeValue) ||
+                (itemTypeValue === ItemType.Object &&
+                  itemComponentValue === Component.Address)) && (
+                <ControlledCheckbox
+                  name='repeats'
+                  label='Allow multiple responses'
                   control={control}
-                  itemMap={itemMap}
-                  setValue={setValue}
+                  disabled={disableRepeats}
+                  helperText={repeatsHelperText}
                 />
-                {hasEnableWhen && !(itemTypeValue === ItemType.Group) && (
+              )}
+          </Section>
+          {// Disable changing choices for HUD items
+          !lockHudItemControls &&
+            [ItemType.Choice, ItemType.OpenChoice].includes(itemTypeValue) && (
+              <Section title='Choices'>
+                <ManagePickListOptions control={control} setValue={setValue} />
+              </Section>
+            )}
+          {
+            // Disable changing visibility for HUD items
+            !lockHudItemControls && (
+              <Section title='Visibility'>
+                {isAssessment && (
                   <ControlledSelect
-                    name='disabledDisplay'
+                    name='dataCollectedAbout'
                     control={control}
-                    label='Disabled Display'
-                    placeholder='Select disabled display'
-                    options={disabledDisplayPickList}
-                    helperText={
-                      <>
-                        <b>Hidden</b>: When this item is disabled, it will be
-                        completely hidden from view.
-                        <br />
-                        {/* TODO: Protected is only used in a few instances (Disability and some others). Should we hide it from the UI (or hide DIsabledDisplay altogether) since it's an advanced feature? */}
-                        <b>Protected</b>: When this item is disabled, it will
-                        still appear but not be interactable.
-                        <br />
-                        <b>Protected with Value</b>: When this item is disabled,
-                        it will still appear and its value will be visible but
-                        not interactible. Its value will be submitted.
-                      </>
-                    }
+                    label='Client Applicability'
+                    placeholder='Select client applicability'
+                    options={dataCollectedAboutPickList}
+                    helperText='Select the client(s) to which this item applies. If left blank, the item will be shown for all clients.'
                   />
                 )}
-              </>
-            )}
-          </Section>
+                <ControlledCheckbox
+                  name='hidden'
+                  control={control}
+                  label='Always hide this item'
+                  sx={{ width: 'fit-content' }}
+                />
+                {!hiddenValue && (
+                  <>
+                    <ManageEnableWhen
+                      control={control}
+                      itemMap={itemMap}
+                      setValue={setValue}
+                    />
+                    {hasEnableWhen && !(itemTypeValue === ItemType.Group) && (
+                      <ControlledSelect
+                        name='disabledDisplay'
+                        control={control}
+                        label='Disabled Display'
+                        placeholder='Select disabled display'
+                        options={disabledDisplayPickList}
+                        helperText={
+                          <>
+                            <b>Hidden</b>: When this item is disabled, it will
+                            be completely hidden from view.
+                            <br />
+                            {/* TODO: Protected is only used in a few instances (Disability and some others). Should we hide it from the UI (or hide DIsabledDisplay altogether) since it's an advanced feature? */}
+                            <b>Protected</b>: When this item is disabled, it
+                            will still appear but not be interactable.
+                            <br />
+                            <b>Protected with Value</b>: When this item is
+                            disabled, it will still appear and its value will be
+                            visible but not interactible. Its value will be
+                            submitted.
+                          </>
+                        }
+                      />
+                    )}
+                  </>
+                )}
+              </Section>
+            )
+          }
           <RootPermissionsFilter permissions='canAdministrateConfig'>
             <Section
               title='Initial Value'
@@ -503,7 +537,14 @@ const FormItemEditor: React.FC<Props> = ({
             {!isNewItem &&
               (initialItem.mapping?.customFieldKey ||
                 initialItem.mapping?.fieldName) && (
-                <CommonLabeledTextBlock title='Field Key'>
+                <CommonLabeledTextBlock
+                  title={
+                    <Stack direction='row' gap={1} alignItems='center'>
+                      Field Key
+                      {initialItem.mapping?.fieldName && <HudChip />}
+                    </Stack>
+                  }
+                >
                   {initialItem.mapping?.customFieldKey ||
                     initialItem.mapping?.fieldName}
                 </CommonLabeledTextBlock>


### PR DESCRIPTION
## Description

Summary of changes:
- Add helper text to common menu items. This looks similar to the existing disabled-reason, but is available when the field is enabled.
<img width="1442" height="372" alt="Screenshot 2026-06-24 at 2 48 35 PM" src="https://github.com/user-attachments/assets/3370823c-0eed-462d-99ef-c5415f387cf2" />

- Visually flag HUD-linked fields on the form builder tree, and disable deletion of these fields for non-super-admins.
<img width="1708" height="1592" alt="Screenshot 2026-06-24 at 2 44 52 PM" src="https://github.com/user-attachments/assets/87741f5c-4f8d-4416-b82f-7617469dc621" />

- In the form item editor, lock certain fields so they can only be edited by super-admins. We can discuss these choices more -- my guess was that for properties like label and helper text, it's not harmful to allow broader editing. But if it would be preferable to just fully lock the item and disallow editing, I can make that change.
<img width="1346" height="1712" alt="Screenshot 2026-06-24 at 2 45 41 PM" src="https://github.com/user-attachments/assets/eb998d9d-6ef9-4d53-85b6-a23abf9b1944" />

[//]: # 'remove if not applicable'
Depends on hmis-warehouse PR: N/A. In plan mode, AI also suggested backend changes to prevent super-admins from changing the locked fields, but my intuition was that we can descope the backend changes. My reasoning: Since this is already an admin-only UI backed by admin-only endpoints, we are just trying to add better UX affordances that will help the user not trip up or get into a weird state.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have used Axe DevTools to scan for accessibility issues (or not applicable)
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
