### PR TITLE
Fix bug where client with masked DOB is considered adult

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.cursor/
 bundle_analysis*
 untracked
 docker-compose.yml

--- a/src/api/operations/client.fragments.graphql
+++ b/src/api/operations/client.fragments.graphql
@@ -75,7 +75,10 @@ fragment ClientName on Client {
 
 fragment ClientNameDobVet on Client {
   ...ClientName
+  # DOB can be null because it's unknown, OR because the user doesn't have permission to view DOB
   dob
+  # Age is always visible to the user on clients they can view, if it is known
+  age
   veteranStatus
 }
 

--- a/src/modules/form/util/formUtil.applyDataCollectedAbout.test.ts
+++ b/src/modules/form/util/formUtil.applyDataCollectedAbout.test.ts
@@ -66,6 +66,30 @@ describe('applyDataCollectedAbout', () => {
       )
     ).toMatchObject(items);
   });
+  it('includes HOH_AND_ADULTS if client has explicit adult age and masked DOB', () => {
+    const items = [
+      { linkId: '1', dataCollectedAbout: DataCollectedAbout.HohAndAdults },
+    ];
+    expect(
+      applyDataCollectedAbout(
+        items as FormDefinitionFieldsFragment['definition']['item'],
+        { ...client, age: 18 },
+        RelationshipToHoH.UnrelatedHouseholdMember
+      )
+    ).toMatchObject(items);
+  });
+  it('excludes non-HOH children from HOH_AND_ADULTS if DOB is masked', () => {
+    const items = [
+      { linkId: '1', dataCollectedAbout: DataCollectedAbout.HohAndAdults },
+    ];
+    expect(
+      applyDataCollectedAbout(
+        items as FormDefinitionFieldsFragment['definition']['item'],
+        { ...client, age: 10 },
+        RelationshipToHoH.UnrelatedHouseholdMember
+      )
+    ).toHaveLength(0);
+  });
   it('excludes non-HOH children from HOH_AND_ADULTS', () => {
     const items = [
       { linkId: '1', dataCollectedAbout: DataCollectedAbout.HohAndAdults },

--- a/src/modules/form/util/formUtil.ts
+++ b/src/modules/form/util/formUtil.ts
@@ -1117,6 +1117,7 @@ export const addDescendants = (
 export type ClientNameDobVeteranFields = {
   id: string;
   dob?: string | null;
+  age?: number | null;
   veteranStatus: NoYesReasonsForMissingData;
 };
 

--- a/src/modules/hmis/hmisUtil.ts
+++ b/src/modules/hmis/hmisUtil.ts
@@ -283,7 +283,10 @@ export const dob = (client: { dob?: string | null }) => {
   return parseAndFormatDate(client.dob);
 };
 
-export const age = (client: { dob?: string | null }) => {
+export const age = (client: { dob?: string | null; age?: number | null }) => {
+  // DOB may be null because it's unknown, OR because the user doesn't have permission to view DOB.
+  // Age is always present if it is known, so return age first if available.
+  if (!isNil(client.age)) return client.age;
   if (!client.dob) return null;
   const date = parseISO(client.dob);
   return differenceInYears(new Date(), date);
@@ -612,7 +615,7 @@ export const evaluateDataCollectedAbout = (
       const clientAge = age(client);
       return (
         relationshipToHoH === RelationshipToHoH.SelfHeadOfHousehold ||
-        isNil(client.dob) ||
+        isNil(clientAge) || // If we don't know the client's age, assume adult
         (!isNil(clientAge) && clientAge >= 18)
       );
     case DataCollectedAbout.VeteranHoh:

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -22972,6 +22972,7 @@ export type ClientNameFragment = {
 export type ClientNameDobVetFragment = {
   __typename?: 'Client';
   dob?: string | null;
+  age?: number | null;
   veteranStatus: NoYesReasonsForMissingData;
   id: string;
   lockVersion: number;
@@ -28169,9 +28170,9 @@ export type ProjectEnrollmentFieldsFragment = {
     __typename?: 'Client';
     id: string;
     dob?: string | null;
+    age?: number | null;
     veteranStatus: NoYesReasonsForMissingData;
     lockVersion: number;
-    age?: number | null;
     gender: Array<Gender>;
     pronouns: Array<string>;
     firstName?: string | null;
@@ -28243,6 +28244,7 @@ export type EnrollmentFieldsFragment = {
   client: {
     __typename?: 'Client';
     dob?: string | null;
+    age?: number | null;
     veteranStatus: NoYesReasonsForMissingData;
     id: string;
     lockVersion: number;
@@ -28267,6 +28269,7 @@ export type AssessedClientFieldsFragment = {
   ssn?: string | null;
   race: Array<Race>;
   dob?: string | null;
+  age?: number | null;
   veteranStatus: NoYesReasonsForMissingData;
   id: string;
   lockVersion: number;
@@ -28282,6 +28285,7 @@ export type EnrolledClientFieldsFragment = {
   ssn?: string | null;
   race: Array<Race>;
   dob?: string | null;
+  age?: number | null;
   veteranStatus: NoYesReasonsForMissingData;
   id: string;
   lockVersion: number;
@@ -28581,6 +28585,7 @@ export type AllEnrollmentDetailsFragment = {
     __typename?: 'Client';
     hudChronic?: boolean | null;
     dob?: string | null;
+    age?: number | null;
     veteranStatus: NoYesReasonsForMissingData;
     ssn?: string | null;
     race: Array<Race>;
@@ -29589,6 +29594,7 @@ export type SubmittedEnrollmentResultFieldsFragment = {
   client: {
     __typename?: 'Client';
     dob?: string | null;
+    age?: number | null;
     veteranStatus: NoYesReasonsForMissingData;
     id: string;
     lockVersion: number;
@@ -29772,6 +29778,7 @@ export type EnrollmentWithHouseholdFieldsFragment = {
   client: {
     __typename?: 'Client';
     dob?: string | null;
+    age?: number | null;
     veteranStatus: NoYesReasonsForMissingData;
     id: string;
     lockVersion: number;
@@ -29880,6 +29887,7 @@ export type GetEnrollmentQuery = {
     client: {
       __typename?: 'Client';
       dob?: string | null;
+      age?: number | null;
       veteranStatus: NoYesReasonsForMissingData;
       id: string;
       lockVersion: number;
@@ -30066,6 +30074,7 @@ export type GetEnrollmentDetailsQuery = {
       __typename?: 'Client';
       hudChronic?: boolean | null;
       dob?: string | null;
+      age?: number | null;
       veteranStatus: NoYesReasonsForMissingData;
       ssn?: string | null;
       race: Array<Race>;
@@ -30930,6 +30939,7 @@ export type GetEnrollmentWithHouseholdQuery = {
     client: {
       __typename?: 'Client';
       dob?: string | null;
+      age?: number | null;
       veteranStatus: NoYesReasonsForMissingData;
       id: string;
       lockVersion: number;
@@ -31063,6 +31073,7 @@ export type GetEnrollmentRemindersQuery = {
         __typename?: 'Client';
         id: string;
         dob?: string | null;
+        age?: number | null;
         veteranStatus: NoYesReasonsForMissingData;
         lockVersion: number;
         firstName?: string | null;
@@ -39222,6 +39233,7 @@ export type SubmitFormMutation = {
           client: {
             __typename?: 'Client';
             dob?: string | null;
+            age?: number | null;
             veteranStatus: NoYesReasonsForMissingData;
             id: string;
             lockVersion: number;
@@ -44640,9 +44652,9 @@ export type ProjectEnrollmentQueryEnrollmentFieldsFragment = {
     __typename?: 'Client';
     id: string;
     dob?: string | null;
+    age?: number | null;
     veteranStatus: NoYesReasonsForMissingData;
     lockVersion: number;
-    age?: number | null;
     gender: Array<Gender>;
     pronouns: Array<string>;
     firstName?: string | null;
@@ -45034,9 +45046,9 @@ export type GetProjectEnrollmentsQuery = {
           __typename?: 'Client';
           id: string;
           dob?: string | null;
+          age?: number | null;
           veteranStatus: NoYesReasonsForMissingData;
           lockVersion: number;
-          age?: number | null;
           gender: Array<Gender>;
           pronouns: Array<string>;
           firstName?: string | null;
@@ -45165,6 +45177,7 @@ export type GetProjectServicesQuery = {
           client: {
             __typename?: 'Client';
             dob?: string | null;
+            age?: number | null;
             veteranStatus: NoYesReasonsForMissingData;
             id: string;
             lockVersion: number;
@@ -45248,6 +45261,7 @@ export type GetProjectAssessmentsQuery = {
           client: {
             __typename?: 'Client';
             dob?: string | null;
+            age?: number | null;
             veteranStatus: NoYesReasonsForMissingData;
             id: string;
             lockVersion: number;
@@ -47471,6 +47485,7 @@ export type ReminderFieldsFragment = {
     __typename?: 'Client';
     id: string;
     dob?: string | null;
+    age?: number | null;
     veteranStatus: NoYesReasonsForMissingData;
     lockVersion: number;
     firstName?: string | null;
@@ -52646,6 +52661,7 @@ export const ClientNameDobVetFragmentDoc = gql`
   fragment ClientNameDobVet on Client {
     ...ClientName
     dob
+    age
     veteranStatus
   }
   ${ClientNameFragmentDoc}


### PR DESCRIPTION
## Description

Summary of changes:
- Add `age` to the `ClientNameDobVet` fragment.
  - Alternatives considered: add to the `AssessedClientFields` fragment. 
    - Why: This change would have had a smaller footprint, scoped only to assessments. 
    - Why not: Adding it to the more broadly-used `ClientNameDobVet` fragment helps guard against similar/future bugs in other contexts. The backend cost of querying this field is low, since `age` is an in-memory calculation from the already-loaded DOB.
- Update the `age(client)` helper used by `evaluateEnableWhen` to use the explicit `age` field first, and fallback to `dob` if unavailable (unexpected). 
  - This also fixes the other usage of the `age` helper, which is the client card at the top of the left-hand nav on the client dashboard. Previously, if DOB was masked, it would not display the client age; now it does.

[//]: # 'remove if not applicable'
Depends on hmis-warehouse PR: N/A

[//]: # 'remove if not applicable'
How to test: See ticket QA instructions

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have used Axe DevTools to scan for accessibility issues (or not applicable)
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
