### PR TITLE
Remove usages of apollo onCompleted in queries

### DIFF
--- a/src/components/elements/tableFilters/filters/items/PickListWrapper.tsx
+++ b/src/components/elements/tableFilters/filters/items/PickListWrapper.tsx
@@ -1,10 +1,8 @@
-import { QueryHookOptions } from '@apollo/client';
 import React from 'react';
 
+import { PickListFetchOptions } from '@/modules/form/hooks/usePickList';
 import { PickListArgs } from '@/modules/form/types';
 import {
-  GetPickListQuery,
-  GetPickListQueryVariables,
   PickListOption,
   PickListType,
   useGetPickListQuery,
@@ -13,7 +11,7 @@ import {
 export type PickListWrapperProps = {
   pickListType: PickListType;
   pickListArgs?: PickListArgs;
-  fetchOptions?: QueryHookOptions<GetPickListQuery, GetPickListQueryVariables>;
+  fetchOptions?: PickListFetchOptions;
   children: (options: PickListOption[], loading: boolean) => JSX.Element;
 };
 

--- a/src/modules/bulkServices/components/BulkServicesPage.tsx
+++ b/src/modules/bulkServices/components/BulkServicesPage.tsx
@@ -340,7 +340,7 @@ const BulkServicesPage: React.FC<Props> = ({
                     action={addNewClientMenuButton}
                   />
                 }
-                onCompleted={handleSearchCompleted}
+                onNetworkDataReady={handleSearchCompleted}
               />
             </Paper>
           ) : (

--- a/src/modules/bulkServices/components/BulkServicesTable.tsx
+++ b/src/modules/bulkServices/components/BulkServicesTable.tsx
@@ -40,7 +40,7 @@ interface Props {
   servicePeriod?: ServicePeriod;
   cocCode?: string;
   title: ReactNode;
-  onCompleted: (data: BulkServicesClientSearchQuery) => void;
+  onNetworkDataReady: (data: BulkServicesClientSearchQuery) => void;
 }
 
 type RowType = BulkServicesClientSearchQuery['clientSearch']['nodes'][0];
@@ -54,7 +54,7 @@ const BulkServicesTable: React.FC<Props> = ({
   servicePeriod,
   title,
   cocCode,
-  onCompleted,
+  onNetworkDataReady,
 }) => {
   const [anyRowsSelected, setAnyRowsSelected] = useState<boolean>(false);
 
@@ -220,7 +220,7 @@ const BulkServicesTable: React.FC<Props> = ({
             />
           ),
         }}
-        onCompleted={onCompleted}
+        onNetworkDataReady={onNetworkDataReady}
       />
     </SsnDobShowContextProvider>
   );

--- a/src/modules/dataFetching/components/GenericTableWithData.tsx
+++ b/src/modules/dataFetching/components/GenericTableWithData.tsx
@@ -21,6 +21,7 @@ import TableControls, {
 } from '@/components/elements/tableFilters/TableControls';
 import useHasRefetched from '@/hooks/useHasRefetched';
 import usePrevious from '@/hooks/usePrevious';
+import { useNetworkDataReady } from '@/modules/dataFetching/hooks/useNetworkDataReady';
 import { useOptionalColumns } from '@/modules/dataFetching/hooks/useOptionalColumns';
 import SentryErrorBoundary from '@/modules/errors/components/SentryErrorBoundary';
 import { hasMeaningfulValue } from '@/modules/form/util/formUtil';
@@ -88,8 +89,8 @@ export interface Props<
   >['tableDisplayOptionButtons'];
   /** Fires when data is available (network or cache). Use to gate actions until results are shown, e.g. to reduce duplicate client record creation. */
   onDataReady?: (data: Query) => void;
-  /** Fires when data is fetched from network */
-  onCompleted?: (data: Query) => void;
+  /** Fires when data is available after a network fetch completes. */
+  onNetworkDataReady?: (data: Query) => void;
   filterRows?: (rows: RowDataType) => boolean; // Client-side row filtering
   loading?: boolean;
 }
@@ -138,7 +139,7 @@ const GenericTableWithData = <
   rowsPerPageOptions,
   tableDisplayOptionButtons,
   onDataReady,
-  onCompleted,
+  onNetworkDataReady,
   paginationItemName,
   filterRows,
   vertical,
@@ -223,14 +224,16 @@ const GenericTableWithData = <
     },
     notifyOnNetworkStatusChange: true,
     fetchPolicy,
-    onCompleted,
   });
 
   const hasRefetched = useHasRefetched(networkStatus);
 
-  // Fire onDataReady when data is available (from network or cache). Apollo's onCompleted
-  // only runs for network completions, so we use this effect to run the callback whenever
-  // the table has data to show.
+  // Fire onNetworkDataReady after the query moves from an in-flight networkStatus to ready.
+  // Only runs the callback when the table has data to show from a network call, not a cache hit.
+  useNetworkDataReady({ data, networkStatus, callback: onNetworkDataReady });
+
+  // Fire onDataReady when data is available from either cache or network.
+  // Runs the callback whenever the table has data to show.
   useEffect(() => {
     if (onDataReady && data) onDataReady(data);
   }, [onDataReady, data]);

--- a/src/modules/dataFetching/hooks/useNetworkDataReady.ts
+++ b/src/modules/dataFetching/hooks/useNetworkDataReady.ts
@@ -1,0 +1,37 @@
+import { NetworkStatus } from '@apollo/client';
+import { useEffect } from 'react';
+
+import usePrevious from '@/hooks/usePrevious';
+
+type UseNetworkDataReadyProps<Query> = {
+  data?: Query;
+  networkStatus: NetworkStatus;
+  callback?: (data: Query) => void;
+};
+
+/**
+ * Calls `callback` after an Apollo query moves from an in-flight networkStatus to ready.
+ */
+export function useNetworkDataReady<Query>({
+  data,
+  networkStatus,
+  callback,
+}: UseNetworkDataReadyProps<Query>) {
+  const previousNetworkStatus = usePrevious(networkStatus);
+
+  useEffect(() => {
+    if (
+      data &&
+      callback &&
+      // Previous network status was in-flight
+      !!previousNetworkStatus &&
+      ![NetworkStatus.ready, NetworkStatus.error].includes(
+        previousNetworkStatus
+      ) &&
+      // Current network status is ready
+      networkStatus === NetworkStatus.ready
+    ) {
+      callback(data);
+    }
+  }, [data, networkStatus, callback, previousNetworkStatus]);
+}

--- a/src/modules/dataFetching/hooks/useNetworkDataReady.ts
+++ b/src/modules/dataFetching/hooks/useNetworkDataReady.ts
@@ -11,6 +11,7 @@ type UseNetworkDataReadyProps<Query> = {
 
 /**
  * Calls `callback` after an Apollo query moves from an in-flight networkStatus to ready.
+ * The query must pass `notifyOnNetworkStatusChange: true` so status transitions are observable. 
  */
 export function useNetworkDataReady<Query>({
   data,

--- a/src/modules/dataFetching/hooks/useNetworkDataReady.ts
+++ b/src/modules/dataFetching/hooks/useNetworkDataReady.ts
@@ -11,7 +11,7 @@ type UseNetworkDataReadyProps<Query> = {
 
 /**
  * Calls `callback` after an Apollo query moves from an in-flight networkStatus to ready.
- * The query must pass `notifyOnNetworkStatusChange: true` so status transitions are observable. 
+ * The query must pass `notifyOnNetworkStatusChange: true` so status transitions are observable.
  */
 export function useNetworkDataReady<Query>({
   data,

--- a/src/modules/form/hooks/usePickList.tsx
+++ b/src/modules/form/hooks/usePickList.tsx
@@ -12,13 +12,19 @@ import {
   useGetPickListQuery,
 } from '@/types/gqlTypes';
 
+export type PickListFetchOptions = Omit<
+  QueryHookOptions<GetPickListQuery, GetPickListQueryVariables>,
+  // Omit deprecated Apollo callbacks to make sure we don't re-introduce them.
+  'onCompleted' | 'onError'
+>;
+
 export function usePickList({
   item,
   fetchOptions,
   ...pickListArgs
 }: {
   item: FormItem;
-  fetchOptions?: QueryHookOptions<GetPickListQuery, GetPickListQueryVariables>;
+  fetchOptions?: PickListFetchOptions;
 } & PickListArgs) {
   const resolved = useMemo(() => resolveOptionList(item), [item]);
   const isKnownType = useMemo(

--- a/src/modules/household/components/householdActions/JoinHouseholdDialog.tsx
+++ b/src/modules/household/components/householdActions/JoinHouseholdDialog.tsx
@@ -1,5 +1,11 @@
 import { Typography } from '@mui/material';
-import React, { useCallback, useMemo, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { generatePath } from 'react-router-dom';
 import Loading from '@/components/elements/Loading';
 import Wayfinder from '@/components/elements/navigation/Wayfinder';
@@ -71,32 +77,42 @@ const JoinHouseholdDialog = ({
     error: fetchError,
   } = useGetEnrollmentWithHouseholdQuery({
     variables: { id: initiatorEnrollmentId },
-    onCompleted: (data) => {
-      const household = data?.enrollment?.household;
-
-      const initiator = household?.householdClients.find(
-        (hc) => hc.enrollment.id === initiatorEnrollmentId
-      );
-
-      if (!household || !initiator) {
-        throw new Error(`Enrollment ${initiatorEnrollmentId} not found`);
-      }
-
-      // Set the joining clients list to the initiator client, plus, if they are the HoH, all their household members.
-      if (
-        initiator.relationshipToHoH === RelationshipToHoH.SelfHeadOfHousehold
-      ) {
-        setJoiningClients(sortHouseholdMembers(household.householdClients));
-      } else {
-        setJoiningClients([initiator]);
-      }
-    },
   });
 
   const donorHousehold = useMemo(
     () => initiatorEnrollment?.household,
     [initiatorEnrollment]
   );
+
+  const initiator = useMemo(
+    () =>
+      donorHousehold?.householdClients.find(
+        (hc) => hc.enrollment.id === initiatorEnrollmentId
+      ),
+    [donorHousehold?.householdClients, initiatorEnrollmentId]
+  );
+
+  // Track initiator enrollment in a ref to avoid re-running the effect
+  const initializedEnrollmentId = useRef<string | null>(null);
+
+  // This effect could be avoided by splitting the component into
+  // an outer query-loading component and an inner component that holds the state.
+  // We're avoiding that refactor for now; see comments on #8958
+  useEffect(() => {
+    if (!initiatorEnrollment) return;
+    if (initiatorEnrollment.id !== initiatorEnrollmentId) return;
+    if (!donorHousehold || !initiator) return;
+    if (initializedEnrollmentId.current === initiatorEnrollmentId) return;
+
+    // Set the joining clients list to the initiator client, plus, if they are the HoH, all their household members.
+    if (initiator.relationshipToHoH === RelationshipToHoH.SelfHeadOfHousehold) {
+      setJoiningClients(sortHouseholdMembers(donorHousehold.householdClients));
+    } else {
+      setJoiningClients([initiator]);
+    }
+    setRelationships({});
+    initializedEnrollmentId.current = initiatorEnrollmentId;
+  }, [donorHousehold, initiator, initiatorEnrollment, initiatorEnrollmentId]);
 
   const receivingHoh = useMemo(
     () => findHohOrRep(receivingHousehold.householdClients),
@@ -273,6 +289,10 @@ const JoinHouseholdDialog = ({
   );
 
   if (fetchError) throw fetchError;
+  if (initiatorEnrollment && (!donorHousehold || !initiator)) {
+    // unexpected
+    throw new Error(`Enrollment ${initiatorEnrollmentId} not found`);
+  }
   if (joinError) throw joinError;
 
   return (

--- a/src/modules/search/components/ClientSearch.tsx
+++ b/src/modules/search/components/ClientSearch.tsx
@@ -247,7 +247,7 @@ const ClientSearch: React.FC<ClientSearchProps> = ({ searchType }) => {
   }, []);
 
   // When search data is returned, update the URL params and the apollo cache.
-  // Passed to GenericTable as onCompleted, NOT onDataReady, so we only update the search params
+  // Passed to GenericTable as onNetworkDataReady, NOT onDataReady, so we only update the search params
   // if this is the completion of a network call, not a cache hit.
   // This avoids buggy behavior with the back-button.
   const handleSearchCompleted = useCallback(
@@ -338,7 +338,7 @@ const ClientSearch: React.FC<ClientSearchProps> = ({ searchType }) => {
             queryVariables={{ input: searchInput }}
             queryDocument={SearchClientsDocument}
             onDataReady={() => setHasSearched(true)}
-            onCompleted={handleSearchCompleted}
+            onNetworkDataReady={handleSearchCompleted}
             columns={columns}
             rowLinkTo={(client) => getViewClientMenuItem(client).to}
             rowName={(row) => clientBriefName(row)}

--- a/src/modules/staffAssignment/components/NewStaffAssignmentForm.tsx
+++ b/src/modules/staffAssignment/components/NewStaffAssignmentForm.tsx
@@ -1,6 +1,6 @@
 import LoadingButton from '@mui/lab/LoadingButton';
 import { Alert, AlertTitle, Card, Grid, Typography } from '@mui/material';
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import theme from '@/config/theme';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import ValidationErrorList from '@/modules/errors/components/ValidationErrorList';
@@ -51,12 +51,17 @@ const NewStaffAssignmentForm: React.FC<NewStaffAssignmentFormProps> = ({
       pickListType: PickListType.StaffAssignmentRelationships,
       projectId: projectId,
     },
-    onCompleted: (data) => {
-      if (data.pickList?.length === 1) {
-        setRelationshipId(data.pickList[0].code);
-      }
-    },
   });
+
+  // This effect could be avoided by splitting the component into
+  // an outer query-loading component and an inner component that holds the state.
+  // We're avoiding that refactor for now; see comments on #8958
+  useEffect(() => {
+    if (relationshipPickList?.length !== 1) return;
+
+    // If the picklist returned has only 1 option, auto-select it.
+    setRelationshipId(relationshipPickList[0].code);
+  }, [relationshipPickList]);
 
   const [assignStaff, { error: assignmentError, loading: assignmentLoading }] =
     useAssignStaffMutation({


### PR DESCRIPTION
## Description

Summary of changes:
- Remove all current usages of `onCompleted` callbacks to apollo queries. 
- Replace usages with `useEffects` that watch for changed data, and/or watch `networkStatus`

[//]: # 'remove if not applicable'
Depends on hmis-warehouse PR: n/a

[//]: # 'remove if not applicable'
How to test: No functionality change; see QA instructions on ticket

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Code clean-up (preparation for Apollo migration)

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have used Axe DevTools to scan for accessibility issues (or not applicable)
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
