### PR TITLE
Support Project Group-based Table Configuration

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -55688,6 +55688,31 @@
         "isOneOf": null,
         "fields": [
           {
+            "name": "ceClientsConfig",
+            "description": null,
+            "args": [
+              {
+                "name": "projectGroupId",
+                "description": "Optional project group ID to use for detecting the best config. Falls back\nto global config if not provided, or if no project group config exists.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "TableConfig",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "ceClientsGlobalConfig",
             "description": null,
             "args": [],

--- a/src/api/operations/tableConfig.queries.graphql
+++ b/src/api/operations/tableConfig.queries.graphql
@@ -1,6 +1,6 @@
-query GetCeClientsGlobalTableConfig {
+query GetCeClientsTableConfig($projectGroupId: ID) {
   tableConfigLookup {
-    ceClientsGlobalConfig {
+    ceClientsConfig(projectGroupId: $projectGroupId) {
       columns {
         ...TableColumnConfigFields
       }

--- a/src/modules/ce/components/admin/AdminCeClientsTable.tsx
+++ b/src/modules/ce/components/admin/AdminCeClientsTable.tsx
@@ -23,7 +23,7 @@ import {
   GetCeClientsQueryVariables,
   TableColumnConfigFieldsFragment,
   TableColumnConfigType,
-  useGetCeClientsGlobalTableConfigQuery,
+  useGetCeClientsTableConfigQuery,
 } from '@/types/gqlTypes';
 import { ensureArray } from '@/utils/arrays';
 import { generateSafePath } from '@/utils/pathEncoding';
@@ -65,12 +65,14 @@ interface Props {
 const AdminCeClientsTable: React.FC<Props> = ({ projectGroupId }) => {
   // Feature flags to check whether to show MCI ID column
   const { globalFeatureFlags: { mciIdEnabled } = {} } = useGlobalFeatureFlags();
-  // Fetch column configuration for global ce client list
+  // Fetch column configuration
   const {
     data: { tableConfigLookup } = {},
     loading,
     error,
-  } = useGetCeClientsGlobalTableConfigQuery();
+  } = useGetCeClientsTableConfigQuery({
+    variables: { projectGroupId: projectGroupId || null },
+  });
 
   // Internal state for search and dialog
   const [search, setSearch, debouncedSearch] = useDebouncedState<string>('');
@@ -78,7 +80,7 @@ const AdminCeClientsTable: React.FC<Props> = ({ projectGroupId }) => {
     React.useState<CeClientFieldsFragment | null>(null);
 
   const tableColumnConfig = useMemo(
-    () => tableConfigLookup?.ceClientsGlobalConfig?.columns,
+    () => tableConfigLookup?.ceClientsConfig?.columns,
     [tableConfigLookup]
   );
 
@@ -104,7 +106,7 @@ const AdminCeClientsTable: React.FC<Props> = ({ projectGroupId }) => {
 
   const { filters, filterValues, setFilterValues } = useTableFilters({
     type: 'CeClientFilterOptions',
-    dynamicFilters: tableConfigLookup?.ceClientsGlobalConfig?.filters,
+    dynamicFilters: tableConfigLookup?.ceClientsConfig?.filters,
     omit: ['projectGroupId'], // only exposed via Workspaces
   });
   const pagination = useTablePagination();

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -8560,8 +8560,13 @@ export type TableConfig = {
 
 export type TableConfigLookup = {
   __typename?: 'TableConfigLookup';
+  ceClientsConfig?: Maybe<TableConfig>;
   ceClientsGlobalConfig?: Maybe<TableConfig>;
   ceClientsUnitGroupConfig?: Maybe<TableConfig>;
+};
+
+export type TableConfigLookupCeClientsConfigArgs = {
+  projectGroupId?: InputMaybe<Scalars['ID']['input']>;
 };
 
 export type TableConfigLookupCeClientsUnitGroupConfigArgs = {
@@ -49996,15 +50001,15 @@ export type TableColumnConfigFieldsFragment = {
   label: string;
 };
 
-export type GetCeClientsGlobalTableConfigQueryVariables = Exact<{
-  [key: string]: never;
+export type GetCeClientsTableConfigQueryVariables = Exact<{
+  projectGroupId?: InputMaybe<Scalars['ID']['input']>;
 }>;
 
-export type GetCeClientsGlobalTableConfigQuery = {
+export type GetCeClientsTableConfigQuery = {
   __typename?: 'Query';
   tableConfigLookup: {
     __typename?: 'TableConfigLookup';
-    ceClientsGlobalConfig?: {
+    ceClientsConfig?: {
       __typename?: 'TableConfig';
       columns: Array<{
         __typename?: 'TableColumnConfig';
@@ -73522,10 +73527,10 @@ export type GetHouseholdStaffAssignmentHistoryQueryResult = Apollo.QueryResult<
   GetHouseholdStaffAssignmentHistoryQuery,
   GetHouseholdStaffAssignmentHistoryQueryVariables
 >;
-export const GetCeClientsGlobalTableConfigDocument = gql`
-  query GetCeClientsGlobalTableConfig {
+export const GetCeClientsTableConfigDocument = gql`
+  query GetCeClientsTableConfig($projectGroupId: ID) {
     tableConfigLookup {
-      ceClientsGlobalConfig {
+      ceClientsConfig(projectGroupId: $projectGroupId) {
         columns {
           ...TableColumnConfigFields
         }
@@ -73540,71 +73545,72 @@ export const GetCeClientsGlobalTableConfigDocument = gql`
 `;
 
 /**
- * __useGetCeClientsGlobalTableConfigQuery__
+ * __useGetCeClientsTableConfigQuery__
  *
- * To run a query within a React component, call `useGetCeClientsGlobalTableConfigQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetCeClientsGlobalTableConfigQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useGetCeClientsTableConfigQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetCeClientsTableConfigQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useGetCeClientsGlobalTableConfigQuery({
+ * const { data, loading, error } = useGetCeClientsTableConfigQuery({
  *   variables: {
+ *      projectGroupId: // value for 'projectGroupId'
  *   },
  * });
  */
-export function useGetCeClientsGlobalTableConfigQuery(
+export function useGetCeClientsTableConfigQuery(
   baseOptions?: Apollo.QueryHookOptions<
-    GetCeClientsGlobalTableConfigQuery,
-    GetCeClientsGlobalTableConfigQueryVariables
+    GetCeClientsTableConfigQuery,
+    GetCeClientsTableConfigQueryVariables
   >
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<
-    GetCeClientsGlobalTableConfigQuery,
-    GetCeClientsGlobalTableConfigQueryVariables
-  >(GetCeClientsGlobalTableConfigDocument, options);
+    GetCeClientsTableConfigQuery,
+    GetCeClientsTableConfigQueryVariables
+  >(GetCeClientsTableConfigDocument, options);
 }
-export function useGetCeClientsGlobalTableConfigLazyQuery(
+export function useGetCeClientsTableConfigLazyQuery(
   baseOptions?: Apollo.LazyQueryHookOptions<
-    GetCeClientsGlobalTableConfigQuery,
-    GetCeClientsGlobalTableConfigQueryVariables
+    GetCeClientsTableConfigQuery,
+    GetCeClientsTableConfigQueryVariables
   >
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useLazyQuery<
-    GetCeClientsGlobalTableConfigQuery,
-    GetCeClientsGlobalTableConfigQueryVariables
-  >(GetCeClientsGlobalTableConfigDocument, options);
+    GetCeClientsTableConfigQuery,
+    GetCeClientsTableConfigQueryVariables
+  >(GetCeClientsTableConfigDocument, options);
 }
 // @ts-ignore
-export function useGetCeClientsGlobalTableConfigSuspenseQuery(
+export function useGetCeClientsTableConfigSuspenseQuery(
   baseOptions?: Apollo.SuspenseQueryHookOptions<
-    GetCeClientsGlobalTableConfigQuery,
-    GetCeClientsGlobalTableConfigQueryVariables
+    GetCeClientsTableConfigQuery,
+    GetCeClientsTableConfigQueryVariables
   >
 ): Apollo.UseSuspenseQueryResult<
-  GetCeClientsGlobalTableConfigQuery,
-  GetCeClientsGlobalTableConfigQueryVariables
+  GetCeClientsTableConfigQuery,
+  GetCeClientsTableConfigQueryVariables
 >;
-export function useGetCeClientsGlobalTableConfigSuspenseQuery(
+export function useGetCeClientsTableConfigSuspenseQuery(
   baseOptions?:
     | Apollo.SkipToken
     | Apollo.SuspenseQueryHookOptions<
-        GetCeClientsGlobalTableConfigQuery,
-        GetCeClientsGlobalTableConfigQueryVariables
+        GetCeClientsTableConfigQuery,
+        GetCeClientsTableConfigQueryVariables
       >
 ): Apollo.UseSuspenseQueryResult<
-  GetCeClientsGlobalTableConfigQuery | undefined,
-  GetCeClientsGlobalTableConfigQueryVariables
+  GetCeClientsTableConfigQuery | undefined,
+  GetCeClientsTableConfigQueryVariables
 >;
-export function useGetCeClientsGlobalTableConfigSuspenseQuery(
+export function useGetCeClientsTableConfigSuspenseQuery(
   baseOptions?:
     | Apollo.SkipToken
     | Apollo.SuspenseQueryHookOptions<
-        GetCeClientsGlobalTableConfigQuery,
-        GetCeClientsGlobalTableConfigQueryVariables
+        GetCeClientsTableConfigQuery,
+        GetCeClientsTableConfigQueryVariables
       >
 ) {
   const options =
@@ -73612,22 +73618,22 @@ export function useGetCeClientsGlobalTableConfigSuspenseQuery(
       ? baseOptions
       : { ...defaultOptions, ...baseOptions };
   return Apollo.useSuspenseQuery<
-    GetCeClientsGlobalTableConfigQuery,
-    GetCeClientsGlobalTableConfigQueryVariables
-  >(GetCeClientsGlobalTableConfigDocument, options);
+    GetCeClientsTableConfigQuery,
+    GetCeClientsTableConfigQueryVariables
+  >(GetCeClientsTableConfigDocument, options);
 }
-export type GetCeClientsGlobalTableConfigQueryHookResult = ReturnType<
-  typeof useGetCeClientsGlobalTableConfigQuery
+export type GetCeClientsTableConfigQueryHookResult = ReturnType<
+  typeof useGetCeClientsTableConfigQuery
 >;
-export type GetCeClientsGlobalTableConfigLazyQueryHookResult = ReturnType<
-  typeof useGetCeClientsGlobalTableConfigLazyQuery
+export type GetCeClientsTableConfigLazyQueryHookResult = ReturnType<
+  typeof useGetCeClientsTableConfigLazyQuery
 >;
-export type GetCeClientsGlobalTableConfigSuspenseQueryHookResult = ReturnType<
-  typeof useGetCeClientsGlobalTableConfigSuspenseQuery
+export type GetCeClientsTableConfigSuspenseQueryHookResult = ReturnType<
+  typeof useGetCeClientsTableConfigSuspenseQuery
 >;
-export type GetCeClientsGlobalTableConfigQueryResult = Apollo.QueryResult<
-  GetCeClientsGlobalTableConfigQuery,
-  GetCeClientsGlobalTableConfigQueryVariables
+export type GetCeClientsTableConfigQueryResult = Apollo.QueryResult<
+  GetCeClientsTableConfigQuery,
+  GetCeClientsTableConfigQueryVariables
 >;
 export const GetCeClientsUnitGroupTableConfigDocument = gql`
   query GetCeClientsUnitGroupTableConfig($unitGroupId: ID!) {


### PR DESCRIPTION
## Description

Summary of changes:
- On the global Eligible Clients table, pass the project group ID of the currently selected workspace when querying for table config.
- Use the returned config for dynamic columns, dynamic filters, and requested client attribute keys.
- No change to the frontend Unit Eligible Clients tables. Internally on the backend we now check for project group ID-level config, but no change is needed to the API

Depends on hmis-warehouse PR:
https://github.com/greenriver/hmis-warehouse/pull/6699

[//]: # 'remove if not applicable'
How to test: See QA instructions on ticket

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
New feature

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have used Axe DevTools to scan for accessibility issues (or not applicable)
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
