### PR TITLE
Support editing null/not-null conditions in CE Match Rule UI

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -5867,6 +5867,18 @@
             "deprecationReason": null
           },
           {
+            "name": "IS_NOT_NULL",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "IS_NULL",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "LT",
             "description": null,
             "isDeprecated": false,

--- a/src/modules/admin/components/ceMatchRules/editor/clause/CeMatchClause.tsx
+++ b/src/modules/admin/components/ceMatchRules/editor/clause/CeMatchClause.tsx
@@ -182,16 +182,15 @@ const CeMatchClause: React.FC<Props> = ({
             onComparatorChange={resetValueSelection}
           />
         </Grid>
-        {/* Hide and unmount the Value input if the comparator indicates we're checking for null/not null. */}
-        {!isNullCheck && (
-          <Grid item xs={12} md={4}>
-            <CeMatchClauseValueInput
-              clausePath={clausePath}
-              control={control}
-              selectedField={selectedField}
-            />
-          </Grid>
-        )}
+        <Grid item xs={12} md={4}>
+          <CeMatchClauseValueInput
+            clausePath={clausePath}
+            control={control}
+            selectedField={selectedField}
+            disabled={isNullCheck}
+            required={!isNullCheck}
+          />
+        </Grid>
       </Grid>
     </Stack>
   );

--- a/src/modules/admin/components/ceMatchRules/editor/clause/CeMatchClause.tsx
+++ b/src/modules/admin/components/ceMatchRules/editor/clause/CeMatchClause.tsx
@@ -182,15 +182,15 @@ const CeMatchClause: React.FC<Props> = ({
             onComparatorChange={resetValueSelection}
           />
         </Grid>
-        <Grid item xs={12} md={4}>
-          <CeMatchClauseValueInput
-            clausePath={clausePath}
-            control={control}
-            selectedField={selectedField}
-            disabled={isNullCheck}
-            required={!isNullCheck}
-          />
-        </Grid>
+        {!isNullCheck && (
+          <Grid item xs={12} md={4}>
+            <CeMatchClauseValueInput
+              clausePath={clausePath}
+              control={control}
+              selectedField={selectedField}
+            />
+          </Grid>
+        )}
       </Grid>
     </Stack>
   );

--- a/src/modules/admin/components/ceMatchRules/editor/clause/CeMatchClause.tsx
+++ b/src/modules/admin/components/ceMatchRules/editor/clause/CeMatchClause.tsx
@@ -56,6 +56,14 @@ const CeMatchClause: React.FC<Props> = ({
     control,
     name: `${clausePath}.field`,
   });
+  const comparator = useWatch({
+    control,
+    name: `${clausePath}.comparator`,
+  });
+  const isNullCheck = [
+    CeMatchRuleComparator.IsNull,
+    CeMatchRuleComparator.IsNotNull,
+  ].includes(comparator);
 
   // Query for custom assessment field at this level, rather than in the child CeMatchClauseFieldSelect,
   // because the selected field metadata also impacts the other child controls (comparator and value dropdowns).
@@ -174,13 +182,16 @@ const CeMatchClause: React.FC<Props> = ({
             onComparatorChange={resetValueSelection}
           />
         </Grid>
-        <Grid item xs={12} md={4}>
-          <CeMatchClauseValueInput
-            clausePath={clausePath}
-            control={control}
-            selectedField={selectedField}
-          />
-        </Grid>
+        {/* Hide and unmount the Value input if the comparator indicates we're checking for null/not null. */}
+        {!isNullCheck && (
+          <Grid item xs={12} md={4}>
+            <CeMatchClauseValueInput
+              clausePath={clausePath}
+              control={control}
+              selectedField={selectedField}
+            />
+          </Grid>
+        )}
       </Grid>
     </Stack>
   );

--- a/src/modules/admin/components/ceMatchRules/editor/clause/CeMatchClauseComparatorSelect.tsx
+++ b/src/modules/admin/components/ceMatchRules/editor/clause/CeMatchClauseComparatorSelect.tsx
@@ -38,6 +38,10 @@ const comparatorLabel = (comparator: CeMatchRuleComparator) => {
       return 'Includes';
     case CeMatchRuleComparator.Excludes:
       return 'Excludes';
+    case CeMatchRuleComparator.IsNotNull:
+      return 'Has a value';
+    case CeMatchRuleComparator.IsNull:
+      return 'Does not have a value';
     default:
       return comparator;
   }
@@ -53,9 +57,11 @@ const comparatorOptionsForField = (
     comparators.add(CeMatchRuleComparator.Includes);
     comparators.add(CeMatchRuleComparator.Excludes);
   } else {
-    // Otherwise, start with Equals/Not Equals
+    // Otherwise, start with Equals/Not Equals/null checks
     comparators.add(CeMatchRuleComparator.Eq);
     comparators.add(CeMatchRuleComparator.NotEq);
+    comparators.add(CeMatchRuleComparator.IsNotNull);
+    comparators.add(CeMatchRuleComparator.IsNull);
 
     // If the field type is comparable (numeric/date/etc), add the comparable operators
     if (field && COMPARABLE_ITEM_TYPES.includes(field.itemType)) {

--- a/src/modules/admin/components/ceMatchRules/editor/clause/CeMatchClauseComparatorSelect.tsx
+++ b/src/modules/admin/components/ceMatchRules/editor/clause/CeMatchClauseComparatorSelect.tsx
@@ -53,7 +53,9 @@ const comparatorOptionsForField = (
   const comparators = new Set<CeMatchRuleComparator>();
 
   if (field?.multiple) {
-    // For a multiple value (array), only allow Includes/Excludes
+    // For a multiple value (array), only allow Includes/Excludes.
+    // Null/Not Null comparisons don't currently work for array CDEs,
+    // since the backend CdeFieldMap uses a default of [], not null, when no values are present
     comparators.add(CeMatchRuleComparator.Includes);
     comparators.add(CeMatchRuleComparator.Excludes);
   } else {

--- a/src/modules/admin/components/ceMatchRules/editor/clause/CeMatchClauseValueInput.tsx
+++ b/src/modules/admin/components/ceMatchRules/editor/clause/CeMatchClauseValueInput.tsx
@@ -19,8 +19,6 @@ interface Props {
   control: Control<CeMatchRuleFormValues>;
   clausePath: ClausePath;
   selectedField?: CeMatchFieldDetailsFragment;
-  disabled?: boolean;
-  required?: boolean;
 }
 
 const pickListOptionsForField = (
@@ -65,24 +63,20 @@ const CeMatchClauseValueInput: React.FC<Props> = ({
   control,
   clausePath,
   selectedField,
-  disabled,
-  required,
 }) => {
   const valueOptions = pickListOptionsForField(selectedField);
   const valueType = valueInputType(selectedField, valueOptions);
-  const label = getRequiredLabel('Value', required);
-  const isDisabled = disabled || !selectedField;
 
   if (valueType === 'choice') {
     return (
       <ControlledSelect
         name={`${clausePath}.value`}
         control={control}
-        label={label}
+        label={getRequiredLabel('Value', true)}
         placeholder='Select value'
-        required={required}
+        required
         options={valueOptions}
-        disabled={isDisabled}
+        disabled={!selectedField}
       />
     );
   }
@@ -92,13 +86,13 @@ const CeMatchClauseValueInput: React.FC<Props> = ({
       <ControlledSelect
         name={`${clausePath}.value`}
         control={control}
-        label={label}
+        label={getRequiredLabel('Value', true)}
         placeholder='Select value'
         options={[
           { code: 'true', label: 'True' },
           { code: 'false', label: 'False' },
         ]}
-        disabled={isDisabled}
+        disabled={!selectedField}
         // Represent empty/unselected as '', otherwise clearing the select would become
         // `false`, which is a valid submitted JSON value.
         setValueAs={(option) => (option ? option.code === 'true' : '')}
@@ -115,10 +109,10 @@ const CeMatchClauseValueInput: React.FC<Props> = ({
     <ControlledTextInput
       name={`${clausePath}.value`}
       control={control}
-      label={label}
+      label={getRequiredLabel('Value', true)}
       type={valueType}
-      required={required}
-      disabled={isDisabled}
+      required
+      disabled={!selectedField}
     />
   );
 };

--- a/src/modules/admin/components/ceMatchRules/editor/clause/CeMatchClauseValueInput.tsx
+++ b/src/modules/admin/components/ceMatchRules/editor/clause/CeMatchClauseValueInput.tsx
@@ -19,6 +19,8 @@ interface Props {
   control: Control<CeMatchRuleFormValues>;
   clausePath: ClausePath;
   selectedField?: CeMatchFieldDetailsFragment;
+  disabled?: boolean;
+  required?: boolean;
 }
 
 const pickListOptionsForField = (
@@ -63,20 +65,24 @@ const CeMatchClauseValueInput: React.FC<Props> = ({
   control,
   clausePath,
   selectedField,
+  disabled,
+  required,
 }) => {
   const valueOptions = pickListOptionsForField(selectedField);
   const valueType = valueInputType(selectedField, valueOptions);
+  const label = getRequiredLabel('Value', required);
+  const isDisabled = disabled || !selectedField;
 
   if (valueType === 'choice') {
     return (
       <ControlledSelect
         name={`${clausePath}.value`}
         control={control}
-        label={getRequiredLabel('Value', true)}
+        label={label}
         placeholder='Select value'
-        required
+        required={required}
         options={valueOptions}
-        disabled={!selectedField}
+        disabled={isDisabled}
       />
     );
   }
@@ -86,13 +92,13 @@ const CeMatchClauseValueInput: React.FC<Props> = ({
       <ControlledSelect
         name={`${clausePath}.value`}
         control={control}
-        label={getRequiredLabel('Value', true)}
+        label={label}
         placeholder='Select value'
         options={[
           { code: 'true', label: 'True' },
           { code: 'false', label: 'False' },
         ]}
-        disabled={!selectedField}
+        disabled={isDisabled}
         // Represent empty/unselected as '', otherwise clearing the select would become
         // `false`, which is a valid submitted JSON value.
         setValueAs={(option) => (option ? option.code === 'true' : '')}
@@ -109,10 +115,10 @@ const CeMatchClauseValueInput: React.FC<Props> = ({
     <ControlledTextInput
       name={`${clausePath}.value`}
       control={control}
-      label={getRequiredLabel('Value', true)}
+      label={label}
       type={valueType}
-      required
-      disabled={!selectedField}
+      required={required}
+      disabled={isDisabled}
     />
   );
 };

--- a/src/modules/admin/components/ceMatchRules/editor/useCeMatchRuleFormSubmission.ts
+++ b/src/modules/admin/components/ceMatchRules/editor/useCeMatchRuleFormSubmission.ts
@@ -27,14 +27,15 @@ const buildStructuredExpressionInput = ({
   clauses,
 }: CeMatchRuleFormValues['structuredExpression']) => ({
   operator,
-  clauses: clauses.map(
-    // Strip out unneeded fields from the draft clause.
-    ({ field, comparator, value }) => ({
-      field,
-      comparator,
-      value: NULL_COMPARATORS.has(comparator) ? null : value,
-    })
-  ),
+  clauses: clauses.map(({ field, comparator, value }) => ({
+    field,
+    comparator,
+    // CeMatchClauseValueInput is not rendered for IS_NULL/IS_NOT_NULL, but we
+    // still coerce here because clauses live inside a useFieldArray, and RHF does not
+    // reliably clear nested field values on unmount when shouldUnregister is true.
+    // (See RHF docs for useFieldArray).
+    value: NULL_COMPARATORS.has(comparator) ? null : value,
+  })),
 });
 
 const buildCreateCeMatchRuleInput = (

--- a/src/modules/admin/components/ceMatchRules/editor/useCeMatchRuleFormSubmission.ts
+++ b/src/modules/admin/components/ceMatchRules/editor/useCeMatchRuleFormSubmission.ts
@@ -7,6 +7,7 @@ import {
   partitionValidations,
 } from '@/modules/errors/util';
 import {
+  CeMatchRuleComparator,
   CeMatchRuleDetailsFragment,
   CeMatchRuleInput,
   CeMatchRuleOwnerType,
@@ -15,6 +16,11 @@ import {
   useCreateCeMatchRuleMutation,
   useUpdateCeMatchRuleMutation,
 } from '@/types/gqlTypes';
+
+const NULL_COMPARATORS = new Set<CeMatchRuleComparator>([
+  CeMatchRuleComparator.IsNull,
+  CeMatchRuleComparator.IsNotNull,
+]);
 
 const buildStructuredExpressionInput = ({
   operator,
@@ -26,7 +32,7 @@ const buildStructuredExpressionInput = ({
     ({ field, comparator, value }) => ({
       field,
       comparator,
-      value,
+      value: NULL_COMPARATORS.has(comparator) ? null : value,
     })
   ),
 });

--- a/src/types/gqlEnums.ts
+++ b/src/types/gqlEnums.ts
@@ -85,6 +85,8 @@ export const HmisEnums = {
     GT: 'GT',
     GTE: 'GTE',
     INCLUDES: 'INCLUDES',
+    IS_NOT_NULL: 'IS_NOT_NULL',
+    IS_NULL: 'IS_NULL',
     LT: 'LT',
     LTE: 'LTE',
     NOT_EQ: 'NOT_EQ',

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -830,6 +830,8 @@ export enum CeMatchRuleComparator {
   Gt = 'GT',
   Gte = 'GTE',
   Includes = 'INCLUDES',
+  IsNotNull = 'IS_NOT_NULL',
+  IsNull = 'IS_NULL',
   Lt = 'LT',
   Lte = 'LTE',
   NotEq = 'NOT_EQ',


### PR DESCRIPTION
## Description

Summary of changes:
* Add the two comparators to `CeMatchClauseComparatorSelect` for non-multiple fields, labeled "Has a value" / "Does not have a value".
* Disable the value input and mark it optional when a null-check comparator is selected (`CeMatchClause`, `CeMatchClauseValueInput`).
* Force `value: null` when submitting a null-check clause in `useCeMatchRuleFormSubmission`, regardless of any stale form value.

Depends on hmis-warehouse PR: #6715

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
New feature

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have used Axe DevTools to scan for accessibility issues (or not applicable)
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
