### PR TITLE
Enable attaching Funder and Project Type applicability to CE Match Rules

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -6058,15 +6058,19 @@
             "name": "funders",
             "description": null,
             "type": {
-              "kind": "LIST",
+              "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
+                "kind": "LIST",
                 "name": null,
                 "ofType": {
-                  "kind": "ENUM",
-                  "name": "FundingSource",
-                  "ofType": null
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "FundingSource",
+                    "ofType": null
+                  }
                 }
               }
             },
@@ -6126,15 +6130,19 @@
             "name": "projectTypes",
             "description": null,
             "type": {
-              "kind": "LIST",
+              "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "NON_NULL",
+                "kind": "LIST",
                 "name": null,
                 "ofType": {
-                  "kind": "ENUM",
-                  "name": "ProjectType",
-                  "ofType": null
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "ProjectType",
+                    "ofType": null
+                  }
                 }
               }
             },

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -6055,6 +6055,26 @@
             "deprecationReason": null
           },
           {
+            "name": "funders",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "FundingSource",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "name",
             "description": null,
             "type": {
@@ -6097,6 +6117,26 @@
               "kind": "SCALAR",
               "name": "Int",
               "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "projectTypes",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "ProjectType",
+                  "ofType": null
+                }
+              }
             },
             "defaultValue": null,
             "isDeprecated": false,

--- a/src/modules/admin/components/ceMatchRules/editor/CeMatchRuleForm.tsx
+++ b/src/modules/admin/components/ceMatchRules/editor/CeMatchRuleForm.tsx
@@ -29,6 +29,7 @@ import { getRequiredLabel } from '@/modules/form/components/RequiredLabel';
 import ControlledMultiSelect from '@/modules/form/components/rhf/ControlledMultiSelect';
 import ControlledTextInput from '@/modules/form/components/rhf/ControlledTextInput';
 import { localResolvePickList } from '@/modules/form/util/formUtil';
+import { MultiHmisEnum } from '@/modules/hmis/components/HmisEnum';
 import { HmisEnums } from '@/types/gqlEnums';
 import {
   CeMatchRuleDetailsFragment,
@@ -47,16 +48,6 @@ interface Props {
 
 const projectTypeOptions = localResolvePickList('ProjectType') || [];
 const funderOptions = localResolvePickList('FundingSource') || [];
-
-const formatApplicabilityValues = (
-  values: readonly string[],
-  labels: Record<string, string>,
-  emptyLabel: string
-) => {
-  if (!values.length) return emptyLabel;
-
-  return values.map((value) => labels[value] || value).join(', ');
-};
 
 /**
  * The top-level CE match rule form component.
@@ -130,8 +121,6 @@ const CeMatchRuleForm: React.FC<Props> = ({
   const showWarningDialog = hasOnlyWarnings(errorState);
   const expressionDirty =
     !!dirtyFields.freeTextExpression || !!dirtyFields.structuredExpression;
-  const applicabilityDirty =
-    !!dirtyFields.projectTypes || !!dirtyFields.funders;
   const showApplicabilityCard = ownerType === CeMatchRuleOwnerType.DataSource;
 
   const handleCancel = useCallback(() => {
@@ -185,8 +174,16 @@ const CeMatchRuleForm: React.FC<Props> = ({
         </Stack>
       </TitleCard>
       {showApplicabilityCard && (
-        <TitleCard title='Applies To' headerComponent='h2' padded>
-          <Typography variant='body2' mt={-2} mb={1}>
+        <TitleCard
+          title='Applies To'
+          headerComponent='h2'
+          headerSx={{
+            pb: 0,
+            '& > .MuiTypography-root': { pb: 0 },
+          }}
+          padded
+        >
+          <Typography variant='body2' mb={2}>
             This rule will only be evaluated for projects matching the selected
             funders and project types.
           </Typography>
@@ -212,18 +209,18 @@ const CeMatchRuleForm: React.FC<Props> = ({
             {!editing && (
               <>
                 <CommonLabeledTextBlock title='Funders'>
-                  {formatApplicabilityValues(
-                    displayValues.funders,
-                    HmisEnums.FundingSource,
-                    'All funders'
-                  )}
+                  <MultiHmisEnum
+                    values={displayValues.funders}
+                    enumMap={HmisEnums.FundingSource}
+                    noData='All funders'
+                  />
                 </CommonLabeledTextBlock>
                 <CommonLabeledTextBlock title='Project Types'>
-                  {formatApplicabilityValues(
-                    displayValues.projectTypes,
-                    HmisEnums.ProjectType,
-                    'All project types'
-                  )}
+                  <MultiHmisEnum
+                    values={displayValues.projectTypes}
+                    enumMap={HmisEnums.ProjectType}
+                    noData='All project types'
+                  />
                 </CommonLabeledTextBlock>
               </>
             )}
@@ -274,7 +271,7 @@ const CeMatchRuleForm: React.FC<Props> = ({
               loading={loading}
               variant='contained'
               onClick={handleSubmit((values) =>
-                submit(values, { expressionDirty, applicabilityDirty })
+                submit(values, { expressionDirty })
               )}
             >
               Save Rule
@@ -311,7 +308,6 @@ const CeMatchRuleForm: React.FC<Props> = ({
               submit(values, {
                 confirmed: true,
                 expressionDirty,
-                applicabilityDirty,
               })
             )()
           }

--- a/src/modules/admin/components/ceMatchRules/editor/CeMatchRuleForm.tsx
+++ b/src/modules/admin/components/ceMatchRules/editor/CeMatchRuleForm.tsx
@@ -1,5 +1,5 @@
 import UnlockIcon from '@mui/icons-material/Lock';
-import { Button, Stack } from '@mui/material';
+import { Button, Stack, Typography } from '@mui/material';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
@@ -26,7 +26,10 @@ import ApolloErrorAlert from '@/modules/errors/components/ApolloErrorAlert';
 import ErrorAlert from '@/modules/errors/components/ErrorAlert';
 import { hasErrors, hasOnlyWarnings } from '@/modules/errors/util';
 import { getRequiredLabel } from '@/modules/form/components/RequiredLabel';
+import ControlledMultiSelect from '@/modules/form/components/rhf/ControlledMultiSelect';
 import ControlledTextInput from '@/modules/form/components/rhf/ControlledTextInput';
+import { localResolvePickList } from '@/modules/form/util/formUtil';
+import { HmisEnums } from '@/types/gqlEnums';
 import {
   CeMatchRuleDetailsFragment,
   CeMatchRuleOwnerType,
@@ -41,6 +44,19 @@ interface Props {
   onCancel?: VoidFunction;
   onDelete?: VoidFunction;
 }
+
+const projectTypeOptions = localResolvePickList('ProjectType') || [];
+const funderOptions = localResolvePickList('FundingSource') || [];
+
+const formatApplicabilityValues = (
+  values: readonly string[],
+  labels: Record<string, string>,
+  emptyLabel: string
+) => {
+  if (!values.length) return emptyLabel;
+
+  return values.map((value) => labels[value] || value).join(', ');
+};
 
 /**
  * The top-level CE match rule form component.
@@ -114,6 +130,9 @@ const CeMatchRuleForm: React.FC<Props> = ({
   const showWarningDialog = hasOnlyWarnings(errorState);
   const expressionDirty =
     !!dirtyFields.freeTextExpression || !!dirtyFields.structuredExpression;
+  const applicabilityDirty =
+    !!dirtyFields.projectTypes || !!dirtyFields.funders;
+  const showApplicabilityCard = ownerType === CeMatchRuleOwnerType.DataSource;
 
   const handleCancel = useCallback(() => {
     // If this was a new rule, call the onCancel callback
@@ -165,6 +184,52 @@ const CeMatchRuleForm: React.FC<Props> = ({
           )}
         </Stack>
       </TitleCard>
+      {showApplicabilityCard && (
+        <TitleCard title='Applies To' headerComponent='h2' padded>
+          <Typography variant='body2' mt={-2} mb={1}>
+            This rule will only be evaluated for projects matching the selected
+            funders and project types.
+          </Typography>
+          <Stack gap={2}>
+            {editing && (
+              <>
+                <ControlledMultiSelect
+                  name='funders'
+                  control={control}
+                  label='Funders'
+                  options={funderOptions}
+                  placeholder='All funders'
+                />
+                <ControlledMultiSelect
+                  name='projectTypes'
+                  control={control}
+                  label='Project Types'
+                  options={projectTypeOptions}
+                  placeholder='All project types'
+                />
+              </>
+            )}
+            {!editing && (
+              <>
+                <CommonLabeledTextBlock title='Funders'>
+                  {formatApplicabilityValues(
+                    displayValues.funders,
+                    HmisEnums.FundingSource,
+                    'All funders'
+                  )}
+                </CommonLabeledTextBlock>
+                <CommonLabeledTextBlock title='Project Types'>
+                  {formatApplicabilityValues(
+                    displayValues.projectTypes,
+                    HmisEnums.ProjectType,
+                    'All project types'
+                  )}
+                </CommonLabeledTextBlock>
+              </>
+            )}
+          </Stack>
+        </TitleCard>
+      )}
       <TitleCard
         title='Eligibility Requirements'
         headerComponent='h2'
@@ -209,7 +274,7 @@ const CeMatchRuleForm: React.FC<Props> = ({
               loading={loading}
               variant='contained'
               onClick={handleSubmit((values) =>
-                submit(values, { expressionDirty })
+                submit(values, { expressionDirty, applicabilityDirty })
               )}
             >
               Save Rule
@@ -243,7 +308,11 @@ const CeMatchRuleForm: React.FC<Props> = ({
           onCancel={clearErrors}
           onConfirm={() =>
             handleSubmit((values) =>
-              submit(values, { confirmed: true, expressionDirty })
+              submit(values, {
+                confirmed: true,
+                expressionDirty,
+                applicabilityDirty,
+              })
             )()
           }
         />

--- a/src/modules/admin/components/ceMatchRules/editor/CeMatchRuleOwnerText.tsx
+++ b/src/modules/admin/components/ceMatchRules/editor/CeMatchRuleOwnerText.tsx
@@ -17,6 +17,9 @@ const CeMatchRuleOwnerText: React.FC<Props> = ({
   return (
     <Typography variant='body2'>
       This eligibility rule {ruleId ? 'applies' : 'will apply'} to all units
+      {ownerType === CeMatchRuleOwnerType.DataSource && (
+        <> unless constrained further by funder or project type</>
+      )}
       {ownerType !== CeMatchRuleOwnerType.DataSource && (
         <>
           {' '}

--- a/src/modules/admin/components/ceMatchRules/editor/ceMatchRuleFormUtil.ts
+++ b/src/modules/admin/components/ceMatchRules/editor/ceMatchRuleFormUtil.ts
@@ -59,7 +59,7 @@ export const ceMatchRuleToFormValues = (
       mode: 'freeText',
       structuredExpression: defaultCeMatchRuleFormValues().structuredExpression,
       freeTextExpression: rule.expression,
-      projectTypes: rule.projectTypes,
+      projectTypes: rule.projectTypes || [],
       funders: rule.funders || [],
     };
   }
@@ -90,7 +90,7 @@ export const ceMatchRuleToFormValues = (
       ),
     },
     freeTextExpression: rule.expression,
-    projectTypes: rule.projectTypes,
+    projectTypes: rule.projectTypes || [],
     funders: rule.funders || [],
   };
 };

--- a/src/modules/admin/components/ceMatchRules/editor/ceMatchRuleFormUtil.ts
+++ b/src/modules/admin/components/ceMatchRules/editor/ceMatchRuleFormUtil.ts
@@ -4,6 +4,8 @@ import {
   CeMatchRuleComparator,
   CeMatchRuleDetailsFragment,
   CeMatchRuleFieldSource,
+  FundingSource,
+  ProjectType,
 } from '@/types/gqlTypes';
 
 export type CeMatchExpressionMode = 'structured' | 'freeText';
@@ -23,6 +25,8 @@ export interface CeMatchRuleFormValues {
     clauses: CeMatchDraftClause[];
   };
   freeTextExpression: string;
+  projectTypes: ProjectType[];
+  funders: FundingSource[];
 }
 
 export const newDraftClause = (): CeMatchDraftClause => ({
@@ -41,6 +45,8 @@ export const defaultCeMatchRuleFormValues = (): CeMatchRuleFormValues => ({
     clauses: [newDraftClause()],
   },
   freeTextExpression: '',
+  projectTypes: [],
+  funders: [],
 });
 
 export const ceMatchRuleToFormValues = (
@@ -53,6 +59,8 @@ export const ceMatchRuleToFormValues = (
       mode: 'freeText',
       structuredExpression: defaultCeMatchRuleFormValues().structuredExpression,
       freeTextExpression: rule.expression,
+      projectTypes: rule.projectTypes,
+      funders: rule.funders || [],
     };
   }
 
@@ -82,5 +90,7 @@ export const ceMatchRuleToFormValues = (
       ),
     },
     freeTextExpression: rule.expression,
+    projectTypes: rule.projectTypes,
+    funders: rule.funders || [],
   };
 };

--- a/src/modules/admin/components/ceMatchRules/editor/useCeMatchRuleFormSubmission.ts
+++ b/src/modules/admin/components/ceMatchRules/editor/useCeMatchRuleFormSubmission.ts
@@ -67,7 +67,6 @@ const buildCreateCeMatchRuleInput = (
 
 interface BuildUpdateCeMatchRuleInputArgs {
   expressionDirty?: boolean;
-  applicabilityDirty?: boolean;
 }
 
 const buildUpdateCeMatchRuleInput = (
@@ -79,22 +78,16 @@ const buildUpdateCeMatchRuleInput = (
     projectTypes,
     funders,
   }: CeMatchRuleFormValues,
-  {
-    expressionDirty = false,
-    applicabilityDirty = false,
-  }: BuildUpdateCeMatchRuleInputArgs = {}
+  { expressionDirty = false }: BuildUpdateCeMatchRuleInputArgs = {}
 ): CeMatchRuleInput => {
   // Updates intentionally avoid create-only immutable fields (owner/type/ruleType).
   // Only send expression when the editor value changed, so switching modes or updating name
   // does not rewrite equivalent saved expressions or trigger impact preview.
   const input: CeMatchRuleInput = {
     name: name.trim(),
+    projectTypes,
+    funders,
   };
-
-  if (applicabilityDirty) {
-    input.projectTypes = projectTypes;
-    input.funders = funders;
-  }
 
   if (!expressionDirty) return input;
 
@@ -121,7 +114,6 @@ interface UseCeMatchRuleFormSubmissionArgs {
 interface SubmitCeMatchRuleArgs {
   confirmed?: boolean;
   expressionDirty?: boolean;
-  applicabilityDirty?: boolean;
 }
 
 const useCeMatchRuleFormSubmission = ({
@@ -170,11 +162,7 @@ const useCeMatchRuleFormSubmission = ({
   const submit = useCallback(
     (
       values: CeMatchRuleFormValues,
-      {
-        confirmed = false,
-        expressionDirty = false,
-        applicabilityDirty = false,
-      }: SubmitCeMatchRuleArgs = {}
+      { confirmed = false, expressionDirty = false }: SubmitCeMatchRuleArgs = {}
     ) => {
       if (ruleId) {
         updateCeMatchRule({
@@ -182,7 +170,6 @@ const useCeMatchRuleFormSubmission = ({
             id: ruleId,
             input: buildUpdateCeMatchRuleInput(values, {
               expressionDirty,
-              applicabilityDirty,
             }),
             confirmed,
           },

--- a/src/modules/admin/components/ceMatchRules/editor/useCeMatchRuleFormSubmission.ts
+++ b/src/modules/admin/components/ceMatchRules/editor/useCeMatchRuleFormSubmission.ts
@@ -37,6 +37,8 @@ const buildCreateCeMatchRuleInput = (
     mode,
     structuredExpression,
     freeTextExpression,
+    projectTypes,
+    funders,
   }: CeMatchRuleFormValues,
   ownerType?: CeMatchRuleOwnerType,
   ownerId?: string
@@ -46,6 +48,8 @@ const buildCreateCeMatchRuleInput = (
     ownerId,
     ownerType,
     ruleType: CeMatchRuleType.EligibilityRequirement,
+    projectTypes,
+    funders,
   };
 
   if (mode === 'freeText') {
@@ -63,6 +67,7 @@ const buildCreateCeMatchRuleInput = (
 
 interface BuildUpdateCeMatchRuleInputArgs {
   expressionDirty?: boolean;
+  applicabilityDirty?: boolean;
 }
 
 const buildUpdateCeMatchRuleInput = (
@@ -71,8 +76,13 @@ const buildUpdateCeMatchRuleInput = (
     mode,
     structuredExpression,
     freeTextExpression,
+    projectTypes,
+    funders,
   }: CeMatchRuleFormValues,
-  { expressionDirty = false }: BuildUpdateCeMatchRuleInputArgs = {}
+  {
+    expressionDirty = false,
+    applicabilityDirty = false,
+  }: BuildUpdateCeMatchRuleInputArgs = {}
 ): CeMatchRuleInput => {
   // Updates intentionally avoid create-only immutable fields (owner/type/ruleType).
   // Only send expression when the editor value changed, so switching modes or updating name
@@ -80,6 +90,11 @@ const buildUpdateCeMatchRuleInput = (
   const input: CeMatchRuleInput = {
     name: name.trim(),
   };
+
+  if (applicabilityDirty) {
+    input.projectTypes = projectTypes;
+    input.funders = funders;
+  }
 
   if (!expressionDirty) return input;
 
@@ -106,6 +121,7 @@ interface UseCeMatchRuleFormSubmissionArgs {
 interface SubmitCeMatchRuleArgs {
   confirmed?: boolean;
   expressionDirty?: boolean;
+  applicabilityDirty?: boolean;
 }
 
 const useCeMatchRuleFormSubmission = ({
@@ -154,13 +170,20 @@ const useCeMatchRuleFormSubmission = ({
   const submit = useCallback(
     (
       values: CeMatchRuleFormValues,
-      { confirmed = false, expressionDirty = false }: SubmitCeMatchRuleArgs = {}
+      {
+        confirmed = false,
+        expressionDirty = false,
+        applicabilityDirty = false,
+      }: SubmitCeMatchRuleArgs = {}
     ) => {
       if (ruleId) {
         updateCeMatchRule({
           variables: {
             id: ruleId,
-            input: buildUpdateCeMatchRuleInput(values, { expressionDirty }),
+            input: buildUpdateCeMatchRuleInput(values, {
+              expressionDirty,
+              applicabilityDirty,
+            }),
             confirmed,
           },
         });

--- a/src/modules/form/components/rhf/ControlledMultiSelect.tsx
+++ b/src/modules/form/components/rhf/ControlledMultiSelect.tsx
@@ -1,6 +1,12 @@
 import React, { ReactNode, useCallback, useMemo } from 'react';
 
-import { Control, useController } from 'react-hook-form';
+import {
+  Control,
+  FieldValues,
+  Path,
+  RegisterOptions,
+  useController,
+} from 'react-hook-form';
 import GenericSelect, {
   GenericSelectProps,
 } from '@/components/elements/input/GenericSelect';
@@ -9,22 +15,24 @@ import { RhfRules } from '@/modules/form/types';
 import { findOptionLabel } from '@/modules/form/util/formUtil';
 import { PickListOption } from '@/types/gqlTypes';
 
-export type ControlledMultiSelectProps = Omit<
-  GenericSelectProps<PickListOption, true, false>,
-  'value' | 'onChange' | 'onBlur' | 'multiple'
-> & {
-  name: string;
-  control?: Control; // Optional when using FormProvider
-  rules?: RhfRules;
-  required?: boolean;
-  helperText?: ReactNode;
-  placeholder?: string;
-  onChange?: (options: PickListOption[]) => void;
-};
+export type ControlledMultiSelectProps<T extends FieldValues = FieldValues> =
+  Omit<
+    GenericSelectProps<PickListOption, true, false>,
+    'value' | 'onChange' | 'onBlur' | 'multiple'
+  > & {
+    // Path<T> gives callers type checking for nested RHF paths.
+    name: Path<T>;
+    control?: Control<T>; // Optional when using FormProvider
+    rules?: RhfRules;
+    required?: boolean;
+    helperText?: ReactNode;
+    placeholder?: string;
+    onChange?: (options: PickListOption[]) => void;
+  };
 
 // React-Hook-Form wrapper around GenericSelect for multiple selection.
 // This component stores an array of strings as the field value, but passes a PickListOption[] to the GenericSelect.
-const ControlledMultiSelect: React.FC<ControlledMultiSelectProps> = ({
+const ControlledMultiSelect = <T extends FieldValues = FieldValues>({
   name,
   control,
   rules,
@@ -35,18 +43,18 @@ const ControlledMultiSelect: React.FC<ControlledMultiSelectProps> = ({
   helperText,
   onChange,
   ...props
-}) => {
+}: ControlledMultiSelectProps<T>) => {
   const {
     field,
     fieldState: { error },
-  } = useController({
+  } = useController<T>({
     name,
     control,
     shouldUnregister: true,
     rules: {
       required: required ? 'This field is required' : false,
       ...rules,
-    },
+    } as RegisterOptions<T, Path<T>>,
   });
 
   const isGrouped = !!options[0]?.groupLabel;

--- a/src/types/gqlObjects.ts
+++ b/src/types/gqlObjects.ts
@@ -8313,12 +8313,16 @@ export const HmisInputObjectSchemas: GqlInputObjectSchema[] = [
       {
         name: 'funders',
         type: {
-          kind: 'LIST',
+          kind: 'NON_NULL',
           name: null,
           ofType: {
-            kind: 'NON_NULL',
+            kind: 'LIST',
             name: null,
-            ofType: { kind: 'ENUM', name: 'FundingSource', ofType: null },
+            ofType: {
+              kind: 'NON_NULL',
+              name: null,
+              ofType: { kind: 'ENUM', name: 'FundingSource', ofType: null },
+            },
           },
         },
       },
@@ -8335,12 +8339,16 @@ export const HmisInputObjectSchemas: GqlInputObjectSchema[] = [
       {
         name: 'projectTypes',
         type: {
-          kind: 'LIST',
+          kind: 'NON_NULL',
           name: null,
           ofType: {
-            kind: 'NON_NULL',
+            kind: 'LIST',
             name: null,
-            ofType: { kind: 'ENUM', name: 'ProjectType', ofType: null },
+            ofType: {
+              kind: 'NON_NULL',
+              name: null,
+              ofType: { kind: 'ENUM', name: 'ProjectType', ofType: null },
+            },
           },
         },
       },

--- a/src/types/gqlObjects.ts
+++ b/src/types/gqlObjects.ts
@@ -8310,6 +8310,18 @@ export const HmisInputObjectSchemas: GqlInputObjectSchema[] = [
         name: 'expression',
         type: { kind: 'SCALAR', name: 'String', ofType: null },
       },
+      {
+        name: 'funders',
+        type: {
+          kind: 'LIST',
+          name: null,
+          ofType: {
+            kind: 'NON_NULL',
+            name: null,
+            ofType: { kind: 'ENUM', name: 'FundingSource', ofType: null },
+          },
+        },
+      },
       { name: 'name', type: { kind: 'SCALAR', name: 'String', ofType: null } },
       { name: 'ownerId', type: { kind: 'SCALAR', name: 'ID', ofType: null } },
       {
@@ -8319,6 +8331,18 @@ export const HmisInputObjectSchemas: GqlInputObjectSchema[] = [
       {
         name: 'priorityRank',
         type: { kind: 'SCALAR', name: 'Int', ofType: null },
+      },
+      {
+        name: 'projectTypes',
+        type: {
+          kind: 'LIST',
+          name: null,
+          ofType: {
+            kind: 'NON_NULL',
+            name: null,
+            ofType: { kind: 'ENUM', name: 'ProjectType', ofType: null },
+          },
+        },
       },
       {
         name: 'ruleType',

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -859,10 +859,12 @@ export type CeMatchRuleGroup = {
 
 export type CeMatchRuleInput = {
   expression?: InputMaybe<Scalars['String']['input']>;
+  funders?: InputMaybe<Array<FundingSource>>;
   name?: InputMaybe<Scalars['String']['input']>;
   ownerId?: InputMaybe<Scalars['ID']['input']>;
   ownerType?: InputMaybe<CeMatchRuleOwnerType>;
   priorityRank?: InputMaybe<Scalars['Int']['input']>;
+  projectTypes?: InputMaybe<Array<ProjectType>>;
   ruleType?: InputMaybe<CeMatchRuleType>;
   structuredExpression?: InputMaybe<CeMatchRuleStructuredExpressionInput>;
 };

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -859,12 +859,12 @@ export type CeMatchRuleGroup = {
 
 export type CeMatchRuleInput = {
   expression?: InputMaybe<Scalars['String']['input']>;
-  funders?: InputMaybe<Array<FundingSource>>;
+  funders: Array<FundingSource>;
   name?: InputMaybe<Scalars['String']['input']>;
   ownerId?: InputMaybe<Scalars['ID']['input']>;
   ownerType?: InputMaybe<CeMatchRuleOwnerType>;
   priorityRank?: InputMaybe<Scalars['Int']['input']>;
-  projectTypes?: InputMaybe<Array<ProjectType>>;
+  projectTypes: Array<ProjectType>;
   ruleType?: InputMaybe<CeMatchRuleType>;
   structuredExpression?: InputMaybe<CeMatchRuleStructuredExpressionInput>;
 };


### PR DESCRIPTION
## Description

Summary of changes:

Enables project type and funder filtering on global (DataSource-owned) CE match rules. This allows administrators to constrain when a rule is evaluated based on the project's funder or type.

- Adds an "Applies To" card to the CE match rule form with multi-selects for Funders and Project Types (only displayed for global rules)
- Updates the owner text to clarify that global rules can be further constrained by funder or project type
- Tracks `applicabilityDirty` state separately from expression changes to avoid unnecessary updates
- Improves TypeScript generics on `ControlledMultiSelect` for better type safety with react-hook-form paths

Depends on hmis-warehouse PR: https://github.com/greenriver/hmis-warehouse/pull/6717

How to test:
1. Navigate to a global CE match rule (DataSource-owned)
2. Verify the "Applies To" card appears with Funder and Project Type multi-selects
3. Select funders and/or project types and save the rule
4. Verify the selections persist on reload
5. Confirm the "Applies To" card does **not** appear for project-specific rules

## Type of change

New feature

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have used Axe DevTools to scan for accessibility issues (or not applicable)
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
