### PR TITLE
Clarify CE waitlist UX language

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -4195,6 +4195,66 @@
       },
       {
         "kind": "OBJECT",
+        "name": "CeCandidatePoolSummary",
+        "description": null,
+        "isOneOf": null,
+        "fields": [
+          {
+            "name": "neverGeneratedCount",
+            "description": "Active pools that have never completed generation",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pendingRefreshCount",
+            "description": "Active pools whose pool-level change marker is dirty",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalCount",
+            "description": "Number of active CE candidate pools",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "CeCandidatesPaginated",
         "description": null,
         "isOneOf": null,
@@ -6823,6 +6883,22 @@
               "kind": "SCALAR",
               "name": "ISO8601DateTime",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "candidatesGenerating",
+            "description": "Whether the eligible client list for this unit is currently being\n(re)processed and may be temporarily incomplete or out of date",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -46761,6 +46837,35 @@
               "kind": "OBJECT",
               "name": "FormDefinition",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ceCandidatePoolSummary",
+            "description": "Generation and refresh status for active CE candidate pools",
+            "args": [
+              {
+                "name": "projectGroupId",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "CeCandidatePoolSummary",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -4200,24 +4200,8 @@
         "isOneOf": null,
         "fields": [
           {
-            "name": "neverGeneratedCount",
-            "description": "Active pools that have never completed generation",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "pendingRefreshCount",
-            "description": "Active pools whose pool-level change marker is dirty",
+            "name": "neverFullyGeneratedCount",
+            "description": "Active pools that have never completed a full generation",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -6876,8 +6860,8 @@
             "deprecationReason": null
           },
           {
-            "name": "candidatesGeneratedAt",
-            "description": null,
+            "name": "candidatesFullyGeneratedAt",
+            "description": "When this unit's eligible client list last completed a full generation against\nall destination clients. Null means it has never finished first-time setup.",
             "args": [],
             "type": {
               "kind": "SCALAR",
@@ -6888,17 +6872,13 @@
             "deprecationReason": null
           },
           {
-            "name": "candidatesGenerating",
-            "description": "Whether the eligible client list for this unit is currently being\n(re)processed and may be temporarily incomplete or out of date",
+            "name": "candidatesGeneratedAt",
+            "description": "When this unit's eligible client list was last updated by any processing (full refresh or individual client)",
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "ISO8601DateTime",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/src/api/operations/ce.fragments.graphql
+++ b/src/api/operations/ce.fragments.graphql
@@ -23,15 +23,14 @@ fragment CeOpportunitySummaryFields on CeOpportunity {
 fragment CeOpportunityFields on CeOpportunity {
   ...CeOpportunitySummaryFields
   candidatesGeneratedAt
-  candidatesGenerating
+  candidatesFullyGeneratedAt
   referral {
     ...CeReferralSummaryFields
   }
 }
 
 fragment CeCandidatePoolSummaryFields on CeCandidatePoolSummary {
-  # Only query neverGeneratedCount for now, although other summary fields are available for future improvement
-  neverGeneratedCount
+  neverFullyGeneratedCount
 }
 
 fragment CeOpportunityAdminFields on CeOpportunity {

--- a/src/api/operations/ce.fragments.graphql
+++ b/src/api/operations/ce.fragments.graphql
@@ -23,9 +23,15 @@ fragment CeOpportunitySummaryFields on CeOpportunity {
 fragment CeOpportunityFields on CeOpportunity {
   ...CeOpportunitySummaryFields
   candidatesGeneratedAt
+  candidatesGenerating
   referral {
     ...CeReferralSummaryFields
   }
+}
+
+fragment CeCandidatePoolSummaryFields on CeCandidatePoolSummary {
+  # Only query neverGeneratedCount for now, although other summary fields are available for future improvement
+  neverGeneratedCount
 }
 
 fragment CeOpportunityAdminFields on CeOpportunity {

--- a/src/api/operations/ce.queries.graphql
+++ b/src/api/operations/ce.queries.graphql
@@ -198,3 +198,9 @@ query GetCeClientEligibleUnitGroups(
     }
   }
 }
+
+query GetCeCandidatePoolSummary($projectGroupId: ID) {
+  ceCandidatePoolSummary(projectGroupId: $projectGroupId) {
+    ...CeCandidatePoolSummaryFields
+  }
+}

--- a/src/modules/ce/components/admin/AdminCeClientsTable.tsx
+++ b/src/modules/ce/components/admin/AdminCeClientsTable.tsx
@@ -71,8 +71,8 @@ const AdminCeClientsTable: React.FC<Props> = ({ projectGroupId }) => {
   const { data: poolSummaryData } = useGetCeCandidatePoolSummaryQuery({
     variables: { projectGroupId: projectGroupId || null },
   });
-  const neverGeneratedCount =
-    poolSummaryData?.ceCandidatePoolSummary?.neverGeneratedCount ?? 0;
+  const neverFullyGeneratedCount =
+    poolSummaryData?.ceCandidatePoolSummary?.neverFullyGeneratedCount ?? 0;
 
   // Fetch column configuration
   const {
@@ -146,8 +146,7 @@ const AdminCeClientsTable: React.FC<Props> = ({ projectGroupId }) => {
 
   return (
     <Stack spacing={2}>
-      {neverGeneratedCount > 0 && (
-        // todo @martha - interesting, maybe this actually IS correct. when does candidatesGeneratedAt get set?
+      {neverFullyGeneratedCount > 0 && (
         <Alert severity='info'>
           Eligible client lists are still being processed; not all eligible
           clients may be shown.

--- a/src/modules/ce/components/admin/AdminCeClientsTable.tsx
+++ b/src/modules/ce/components/admin/AdminCeClientsTable.tsx
@@ -148,8 +148,8 @@ const AdminCeClientsTable: React.FC<Props> = ({ projectGroupId }) => {
     <Stack spacing={2}>
       {neverFullyGeneratedCount > 0 && (
         <Alert severity='info'>
-          Eligible client lists are still being processed; not all eligible
-          clients may be shown.
+          Eligible clients are still being calculated for some projects. Client
+          list may be incomplete.
         </Alert>
       )}
       <CommonSearchInput

--- a/src/modules/ce/components/admin/AdminCeClientsTable.tsx
+++ b/src/modules/ce/components/admin/AdminCeClientsTable.tsx
@@ -1,4 +1,4 @@
-import { Paper, Stack } from '@mui/material';
+import { Alert, Paper, Stack } from '@mui/material';
 import React, { useCallback, useMemo } from 'react';
 
 import { externalIdColumn } from '@/components/elements/ExternalIdDisplay';
@@ -23,6 +23,7 @@ import {
   GetCeClientsQueryVariables,
   TableColumnConfigFieldsFragment,
   TableColumnConfigType,
+  useGetCeCandidatePoolSummaryQuery,
   useGetCeClientsTableConfigQuery,
 } from '@/types/gqlTypes';
 import { ensureArray } from '@/utils/arrays';
@@ -65,6 +66,14 @@ interface Props {
 const AdminCeClientsTable: React.FC<Props> = ({ projectGroupId }) => {
   // Feature flags to check whether to show MCI ID column
   const { globalFeatureFlags: { mciIdEnabled } = {} } = useGlobalFeatureFlags();
+
+  // Fetch summary in order to display warning if pools may be out-of-date
+  const { data: poolSummaryData } = useGetCeCandidatePoolSummaryQuery({
+    variables: { projectGroupId: projectGroupId || null },
+  });
+  const neverGeneratedCount =
+    poolSummaryData?.ceCandidatePoolSummary?.neverGeneratedCount ?? 0;
+
   // Fetch column configuration
   const {
     data: { tableConfigLookup } = {},
@@ -137,6 +146,13 @@ const AdminCeClientsTable: React.FC<Props> = ({ projectGroupId }) => {
 
   return (
     <Stack spacing={2}>
+      {neverGeneratedCount > 0 && (
+        // todo @martha - interesting, maybe this actually IS correct. when does candidatesGeneratedAt get set?
+        <Alert severity='info'>
+          Eligible client lists are still being processed; not all eligible
+          clients may be shown.
+        </Alert>
+      )}
       <CommonSearchInput
         label='Search clients'
         name='search clients'

--- a/src/modules/ce/components/unit/PrioritizedClientsTable.tsx
+++ b/src/modules/ce/components/unit/PrioritizedClientsTable.tsx
@@ -51,7 +51,8 @@ const PrioritizedClientsTable: React.FC<Props> = ({
   unitGroupId,
 }) => {
   const { project } = useProjectDashboardContext();
-  const { status, candidatesGeneratedAt, candidatesGenerating } = opportunity;
+  const { status, candidatesGeneratedAt, candidatesFullyGeneratedAt } =
+    opportunity;
 
   // Fetch column configuration
   const {
@@ -115,7 +116,7 @@ const PrioritizedClientsTable: React.FC<Props> = ({
 
   const [search, setSearch, debouncedSearch] = useDebouncedState<string>('');
 
-  if (!candidatesGeneratedAt) {
+  if (!candidatesFullyGeneratedAt) {
     return (
       <Alert severity='info'>
         The eligible client list is still being set up, either because it is
@@ -131,16 +132,6 @@ const PrioritizedClientsTable: React.FC<Props> = ({
 
   return (
     <Stack rowGap={2}>
-      {candidatesGenerating && (
-        // todo @martha- I wrote on the ticket,
-        //  If it's a brand-new candidate pool, and few clients are eligible (100s) relative to the total clients in the database (10000s), then for a long time the list will display no/few clients as eligible.
-        // is that true? AI doesn't seem to think so, but that was my observation
-        <Alert severity='warning'>
-          This list is currently being refreshed and may be temporarily
-          incomplete. Consider waiting until the refresh finishes before using
-          this list to select a client.
-        </Alert>
-      )}
       <CommonCard title='Eligible Clients'>
         This table lists clients who meet the eligibility requirements for this
         unit. Clients are sorted based on their priority score.
@@ -149,7 +140,7 @@ const PrioritizedClientsTable: React.FC<Props> = ({
             {' '}
             The eligible client list was last updated{' '}
             {formatRelativeDateTime(candidatesGeneratedAtDate)} (
-            {parseAndFormatDateTime(candidatesGeneratedAt)}).
+            {parseAndFormatDateTime(candidatesGeneratedAt || '')}).
           </>
         )}
         {/* May want to add additional explainer text about this list being deduplicated (i.e. it contains destination clients) */}

--- a/src/modules/ce/components/unit/PrioritizedClientsTable.tsx
+++ b/src/modules/ce/components/unit/PrioritizedClientsTable.tsx
@@ -119,8 +119,8 @@ const PrioritizedClientsTable: React.FC<Props> = ({
   if (!candidatesFullyGeneratedAt) {
     return (
       <Alert severity='info'>
-        The eligible client list is still being set up, either because it is
-        new, or because rules recently changed. Please check back later.
+        Eligible clients are still being calculated for this unit. Please check
+        back later.
       </Alert>
     );
   }

--- a/src/modules/ce/components/unit/PrioritizedClientsTable.tsx
+++ b/src/modules/ce/components/unit/PrioritizedClientsTable.tsx
@@ -51,7 +51,7 @@ const PrioritizedClientsTable: React.FC<Props> = ({
   unitGroupId,
 }) => {
   const { project } = useProjectDashboardContext();
-  const { status } = opportunity;
+  const { status, candidatesGeneratedAt, candidatesGenerating } = opportunity;
 
   // Fetch column configuration
   const {
@@ -115,33 +115,41 @@ const PrioritizedClientsTable: React.FC<Props> = ({
 
   const [search, setSearch, debouncedSearch] = useDebouncedState<string>('');
 
-  // If CandidatePool has not been generated yet (due to change in eligibility or prioritization requirements), show a message
-  if (!opportunity.candidatesGeneratedAt) {
+  if (!candidatesGeneratedAt) {
     return (
       <Alert severity='info'>
-        The eligible client list for this unit has not been generated yet.
-        Please check back later.
+        The eligible client list is still being set up, either because it is
+        new, or because rules recently changed. Please check back later.
       </Alert>
     );
   }
-  const candidatesGeneratedAt = parseHmisDateString(
-    opportunity.candidatesGeneratedAt
-  );
+
+  const candidatesGeneratedAtDate = parseHmisDateString(candidatesGeneratedAt);
 
   if (error) throw error;
   if (loading && !tableConfigLookup) return <Loading />;
 
   return (
     <Stack rowGap={2}>
+      {candidatesGenerating && (
+        // todo @martha- I wrote on the ticket,
+        //  If it's a brand-new candidate pool, and few clients are eligible (100s) relative to the total clients in the database (10000s), then for a long time the list will display no/few clients as eligible.
+        // is that true? AI doesn't seem to think so, but that was my observation
+        <Alert severity='warning'>
+          This list is currently being refreshed and may be temporarily
+          incomplete. Consider waiting until the refresh finishes before using
+          this list to select a client.
+        </Alert>
+      )}
       <CommonCard title='Eligible Clients'>
         This table lists clients who meet the eligibility requirements for this
         unit. Clients are sorted based on their priority score.
-        {candidatesGeneratedAt && (
+        {candidatesGeneratedAtDate && (
           <>
             {' '}
             The eligible client list was last updated{' '}
-            {formatRelativeDateTime(candidatesGeneratedAt)} (
-            {parseAndFormatDateTime(opportunity.candidatesGeneratedAt)}).
+            {formatRelativeDateTime(candidatesGeneratedAtDate)} (
+            {parseAndFormatDateTime(candidatesGeneratedAt)}).
           </>
         )}
         {/* May want to add additional explainer text about this list being deduplicated (i.e. it contains destination clients) */}

--- a/src/types/gqlObjects.ts
+++ b/src/types/gqlObjects.ts
@@ -602,15 +602,7 @@ export const HmisObjectSchemas: GqlSchema[] = [
     name: 'CeCandidatePoolSummary',
     fields: [
       {
-        name: 'neverGeneratedCount',
-        type: {
-          kind: 'NON_NULL',
-          name: null,
-          ofType: { kind: 'SCALAR', name: 'Int', ofType: null },
-        },
-      },
-      {
-        name: 'pendingRefreshCount',
+        name: 'neverFullyGeneratedCount',
         type: {
           kind: 'NON_NULL',
           name: null,
@@ -1152,16 +1144,12 @@ export const HmisObjectSchemas: GqlSchema[] = [
         },
       },
       {
-        name: 'candidatesGeneratedAt',
+        name: 'candidatesFullyGeneratedAt',
         type: { kind: 'SCALAR', name: 'ISO8601DateTime', ofType: null },
       },
       {
-        name: 'candidatesGenerating',
-        type: {
-          kind: 'NON_NULL',
-          name: null,
-          ofType: { kind: 'SCALAR', name: 'Boolean', ofType: null },
-        },
+        name: 'candidatesGeneratedAt',
+        type: { kind: 'SCALAR', name: 'ISO8601DateTime', ofType: null },
       },
       {
         name: 'categories',

--- a/src/types/gqlObjects.ts
+++ b/src/types/gqlObjects.ts
@@ -599,6 +599,35 @@ export const HmisObjectSchemas: GqlSchema[] = [
     ],
   },
   {
+    name: 'CeCandidatePoolSummary',
+    fields: [
+      {
+        name: 'neverGeneratedCount',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'Int', ofType: null },
+        },
+      },
+      {
+        name: 'pendingRefreshCount',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'Int', ofType: null },
+        },
+      },
+      {
+        name: 'totalCount',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'Int', ofType: null },
+        },
+      },
+    ],
+  },
+  {
     name: 'CeClient',
     fields: [
       {
@@ -1125,6 +1154,14 @@ export const HmisObjectSchemas: GqlSchema[] = [
       {
         name: 'candidatesGeneratedAt',
         type: { kind: 'SCALAR', name: 'ISO8601DateTime', ofType: null },
+      },
+      {
+        name: 'candidatesGenerating',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'Boolean', ofType: null },
+        },
       },
       {
         name: 'categories',

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -624,10 +624,8 @@ export type CeCandidateEnrollmentsArgs = {
 
 export type CeCandidatePoolSummary = {
   __typename?: 'CeCandidatePoolSummary';
-  /** Active pools that have never completed generation */
-  neverGeneratedCount: Scalars['Int']['output'];
-  /** Active pools whose pool-level change marker is dirty */
-  pendingRefreshCount: Scalars['Int']['output'];
+  /** Active pools that have never completed a full generation */
+  neverFullyGeneratedCount: Scalars['Int']['output'];
   /** Number of active CE candidate pools */
   totalCount: Scalars['Int']['output'];
 };
@@ -952,12 +950,13 @@ export type CeOpportunity = {
   active: Scalars['Boolean']['output'];
   candidateLookup?: Maybe<CeCandidate>;
   candidates: CeCandidatesPaginated;
-  candidatesGeneratedAt?: Maybe<Scalars['ISO8601DateTime']['output']>;
   /**
-   * Whether the eligible client list for this unit is currently being
-   * (re)processed and may be temporarily incomplete or out of date
+   * When this unit's eligible client list last completed a full generation against
+   * all destination clients. Null means it has never finished first-time setup.
    */
-  candidatesGenerating: Scalars['Boolean']['output'];
+  candidatesFullyGeneratedAt?: Maybe<Scalars['ISO8601DateTime']['output']>;
+  /** When this unit's eligible client list was last updated by any processing (full refresh or individual client) */
+  candidatesGeneratedAt?: Maybe<Scalars['ISO8601DateTime']['output']>;
   categories: Array<Scalars['String']['output']>;
   dateAvailable: Scalars['ISO8601Date']['output'];
   expiresAt?: Maybe<Scalars['ISO8601DateTime']['output']>;
@@ -17864,7 +17863,7 @@ export type CeOpportunitySummaryFieldsFragment = {
 export type CeOpportunityFieldsFragment = {
   __typename?: 'CeOpportunity';
   candidatesGeneratedAt?: string | null;
-  candidatesGenerating: boolean;
+  candidatesFullyGeneratedAt?: string | null;
   id: string;
   name: string;
   status: CeOpportunityStatus;
@@ -17902,7 +17901,7 @@ export type CeOpportunityFieldsFragment = {
 
 export type CeCandidatePoolSummaryFieldsFragment = {
   __typename?: 'CeCandidatePoolSummary';
-  neverGeneratedCount: number;
+  neverFullyGeneratedCount: number;
 };
 
 export type CeOpportunityAdminFieldsFragment = {
@@ -20698,7 +20697,7 @@ export type SubmitCeReferralStepMutation = {
       opportunity?: {
         __typename?: 'CeOpportunity';
         candidatesGeneratedAt?: string | null;
-        candidatesGenerating: boolean;
+        candidatesFullyGeneratedAt?: string | null;
         id: string;
         name: string;
         status: CeOpportunityStatus;
@@ -22569,7 +22568,7 @@ export type GetCeCandidatePoolSummaryQuery = {
   __typename?: 'Query';
   ceCandidatePoolSummary: {
     __typename?: 'CeCandidatePoolSummary';
-    neverGeneratedCount: number;
+    neverFullyGeneratedCount: number;
   };
 };
 
@@ -50308,7 +50307,7 @@ export type UnitDetailFieldsFragment = {
   latestOpportunity?: {
     __typename?: 'CeOpportunity';
     candidatesGeneratedAt?: string | null;
-    candidatesGenerating: boolean;
+    candidatesFullyGeneratedAt?: string | null;
     id: string;
     name: string;
     status: CeOpportunityStatus;
@@ -50729,7 +50728,7 @@ export type GetUnitQuery = {
     latestOpportunity?: {
       __typename?: 'CeOpportunity';
       candidatesGeneratedAt?: string | null;
-      candidatesGenerating: boolean;
+      candidatesFullyGeneratedAt?: string | null;
       id: string;
       name: string;
       status: CeOpportunityStatus;
@@ -52378,7 +52377,7 @@ export const UserAuditEventFieldsFragmentDoc = gql`
 `;
 export const CeCandidatePoolSummaryFieldsFragmentDoc = gql`
   fragment CeCandidatePoolSummaryFields on CeCandidatePoolSummary {
-    neverGeneratedCount
+    neverFullyGeneratedCount
   }
 `;
 export const CeOpportunitySummaryFieldsFragmentDoc = gql`
@@ -54660,7 +54659,7 @@ export const CeOpportunityFieldsFragmentDoc = gql`
   fragment CeOpportunityFields on CeOpportunity {
     ...CeOpportunitySummaryFields
     candidatesGeneratedAt
-    candidatesGenerating
+    candidatesFullyGeneratedAt
     referral {
       ...CeReferralSummaryFields
     }

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -622,6 +622,16 @@ export type CeCandidateEnrollmentsArgs = {
   offset?: InputMaybe<Scalars['Int']['input']>;
 };
 
+export type CeCandidatePoolSummary = {
+  __typename?: 'CeCandidatePoolSummary';
+  /** Active pools that have never completed generation */
+  neverGeneratedCount: Scalars['Int']['output'];
+  /** Active pools whose pool-level change marker is dirty */
+  pendingRefreshCount: Scalars['Int']['output'];
+  /** Number of active CE candidate pools */
+  totalCount: Scalars['Int']['output'];
+};
+
 export type CeCandidatesPaginated = {
   __typename?: 'CeCandidatesPaginated';
   hasMoreAfter: Scalars['Boolean']['output'];
@@ -943,6 +953,11 @@ export type CeOpportunity = {
   candidateLookup?: Maybe<CeCandidate>;
   candidates: CeCandidatesPaginated;
   candidatesGeneratedAt?: Maybe<Scalars['ISO8601DateTime']['output']>;
+  /**
+   * Whether the eligible client list for this unit is currently being
+   * (re)processed and may be temporarily incomplete or out of date
+   */
+  candidatesGenerating: Scalars['Boolean']['output'];
   categories: Array<Scalars['String']['output']>;
   dateAvailable: Scalars['ISO8601Date']['output'];
   expiresAt?: Maybe<Scalars['ISO8601DateTime']['output']>;
@@ -6947,6 +6962,8 @@ export type Query = {
   assessment?: Maybe<Assessment>;
   /** Get the correct Form Definition to use for an assessment, by Role or FormDefinition ID */
   assessmentFormDefinition?: Maybe<FormDefinition>;
+  /** Generation and refresh status for active CE candidate pools */
+  ceCandidatePoolSummary: CeCandidatePoolSummary;
   ceClient?: Maybe<CeClient>;
   /** Clients who belong to at least one CE candidate pool */
   ceClients: CeClientsPaginated;
@@ -7050,6 +7067,10 @@ export type QueryAssessmentFormDefinitionArgs = {
   id?: InputMaybe<Scalars['ID']['input']>;
   projectId: Scalars['ID']['input'];
   role?: InputMaybe<AssessmentRole>;
+};
+
+export type QueryCeCandidatePoolSummaryArgs = {
+  projectGroupId?: InputMaybe<Scalars['ID']['input']>;
 };
 
 export type QueryCeClientArgs = {
@@ -17843,6 +17864,7 @@ export type CeOpportunitySummaryFieldsFragment = {
 export type CeOpportunityFieldsFragment = {
   __typename?: 'CeOpportunity';
   candidatesGeneratedAt?: string | null;
+  candidatesGenerating: boolean;
   id: string;
   name: string;
   status: CeOpportunityStatus;
@@ -17876,6 +17898,11 @@ export type CeOpportunityFieldsFragment = {
     } | null;
     unitGroup?: { __typename?: 'UnitGroup'; id: string; name: string } | null;
   } | null;
+};
+
+export type CeCandidatePoolSummaryFieldsFragment = {
+  __typename?: 'CeCandidatePoolSummary';
+  neverGeneratedCount: number;
 };
 
 export type CeOpportunityAdminFieldsFragment = {
@@ -20671,6 +20698,7 @@ export type SubmitCeReferralStepMutation = {
       opportunity?: {
         __typename?: 'CeOpportunity';
         candidatesGeneratedAt?: string | null;
+        candidatesGenerating: boolean;
         id: string;
         name: string;
         status: CeOpportunityStatus;
@@ -22531,6 +22559,18 @@ export type GetCeClientEligibleUnitGroupsQuery = {
       }>;
     };
   } | null;
+};
+
+export type GetCeCandidatePoolSummaryQueryVariables = Exact<{
+  projectGroupId?: InputMaybe<Scalars['ID']['input']>;
+}>;
+
+export type GetCeCandidatePoolSummaryQuery = {
+  __typename?: 'Query';
+  ceCandidatePoolSummary: {
+    __typename?: 'CeCandidatePoolSummary';
+    neverGeneratedCount: number;
+  };
 };
 
 export type CeMatchFieldDetailsFragment = {
@@ -50268,6 +50308,7 @@ export type UnitDetailFieldsFragment = {
   latestOpportunity?: {
     __typename?: 'CeOpportunity';
     candidatesGeneratedAt?: string | null;
+    candidatesGenerating: boolean;
     id: string;
     name: string;
     status: CeOpportunityStatus;
@@ -50688,6 +50729,7 @@ export type GetUnitQuery = {
     latestOpportunity?: {
       __typename?: 'CeOpportunity';
       candidatesGeneratedAt?: string | null;
+      candidatesGenerating: boolean;
       id: string;
       name: string;
       status: CeOpportunityStatus;
@@ -52332,6 +52374,11 @@ export const UserAuditEventFieldsFragmentDoc = gql`
       id
       name
     }
+  }
+`;
+export const CeCandidatePoolSummaryFieldsFragmentDoc = gql`
+  fragment CeCandidatePoolSummaryFields on CeCandidatePoolSummary {
+    neverGeneratedCount
   }
 `;
 export const CeOpportunitySummaryFieldsFragmentDoc = gql`
@@ -54613,6 +54660,7 @@ export const CeOpportunityFieldsFragmentDoc = gql`
   fragment CeOpportunityFields on CeOpportunity {
     ...CeOpportunitySummaryFields
     candidatesGeneratedAt
+    candidatesGenerating
     referral {
       ...CeReferralSummaryFields
     }
@@ -59004,6 +59052,106 @@ export type GetCeClientEligibleUnitGroupsSuspenseQueryHookResult = ReturnType<
 export type GetCeClientEligibleUnitGroupsQueryResult = Apollo.QueryResult<
   GetCeClientEligibleUnitGroupsQuery,
   GetCeClientEligibleUnitGroupsQueryVariables
+>;
+export const GetCeCandidatePoolSummaryDocument = gql`
+  query GetCeCandidatePoolSummary($projectGroupId: ID) {
+    ceCandidatePoolSummary(projectGroupId: $projectGroupId) {
+      ...CeCandidatePoolSummaryFields
+    }
+  }
+  ${CeCandidatePoolSummaryFieldsFragmentDoc}
+`;
+
+/**
+ * __useGetCeCandidatePoolSummaryQuery__
+ *
+ * To run a query within a React component, call `useGetCeCandidatePoolSummaryQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetCeCandidatePoolSummaryQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetCeCandidatePoolSummaryQuery({
+ *   variables: {
+ *      projectGroupId: // value for 'projectGroupId'
+ *   },
+ * });
+ */
+export function useGetCeCandidatePoolSummaryQuery(
+  baseOptions?: Apollo.QueryHookOptions<
+    GetCeCandidatePoolSummaryQuery,
+    GetCeCandidatePoolSummaryQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    GetCeCandidatePoolSummaryQuery,
+    GetCeCandidatePoolSummaryQueryVariables
+  >(GetCeCandidatePoolSummaryDocument, options);
+}
+export function useGetCeCandidatePoolSummaryLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GetCeCandidatePoolSummaryQuery,
+    GetCeCandidatePoolSummaryQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    GetCeCandidatePoolSummaryQuery,
+    GetCeCandidatePoolSummaryQueryVariables
+  >(GetCeCandidatePoolSummaryDocument, options);
+}
+// @ts-ignore
+export function useGetCeCandidatePoolSummarySuspenseQuery(
+  baseOptions?: Apollo.SuspenseQueryHookOptions<
+    GetCeCandidatePoolSummaryQuery,
+    GetCeCandidatePoolSummaryQueryVariables
+  >
+): Apollo.UseSuspenseQueryResult<
+  GetCeCandidatePoolSummaryQuery,
+  GetCeCandidatePoolSummaryQueryVariables
+>;
+export function useGetCeCandidatePoolSummarySuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        GetCeCandidatePoolSummaryQuery,
+        GetCeCandidatePoolSummaryQueryVariables
+      >
+): Apollo.UseSuspenseQueryResult<
+  GetCeCandidatePoolSummaryQuery | undefined,
+  GetCeCandidatePoolSummaryQueryVariables
+>;
+export function useGetCeCandidatePoolSummarySuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        GetCeCandidatePoolSummaryQuery,
+        GetCeCandidatePoolSummaryQueryVariables
+      >
+) {
+  const options =
+    baseOptions === Apollo.skipToken
+      ? baseOptions
+      : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<
+    GetCeCandidatePoolSummaryQuery,
+    GetCeCandidatePoolSummaryQueryVariables
+  >(GetCeCandidatePoolSummaryDocument, options);
+}
+export type GetCeCandidatePoolSummaryQueryHookResult = ReturnType<
+  typeof useGetCeCandidatePoolSummaryQuery
+>;
+export type GetCeCandidatePoolSummaryLazyQueryHookResult = ReturnType<
+  typeof useGetCeCandidatePoolSummaryLazyQuery
+>;
+export type GetCeCandidatePoolSummarySuspenseQueryHookResult = ReturnType<
+  typeof useGetCeCandidatePoolSummarySuspenseQuery
+>;
+export type GetCeCandidatePoolSummaryQueryResult = Apollo.QueryResult<
+  GetCeCandidatePoolSummaryQuery,
+  GetCeCandidatePoolSummaryQueryVariables
 >;
 export const CreateCeMatchRuleDocument = gql`
   mutation CreateCeMatchRule($input: CeMatchRuleInput!, $confirmed: Boolean) {


### PR DESCRIPTION
## Description

Summary of changes:
- See backend PR description for more detail on the newly added `candidatesFullyGeneratedAt` field.
- Gate `PrioritizedClientsTable` on `candidatesFullyGeneratedAt` instead of `candidatesGeneratedAt`.
- Keep the "last updated" caption sourced from `candidatesGeneratedAt`.
- Show an info banner on `AdminCeClientsTable` when `ceCandidatePoolSummary.neverFullyGeneratedCount > 0`.

Depends on hmis-warehouse PR: greenriver/hmis-warehouse#6729.

## Type of change
New feature / UX language improvement

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [ ] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have used Axe DevTools to scan for accessibility issues (or not applicable)
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
