### PR TITLE
Use ESG funding report feature flag in frontend

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -31429,6 +31429,22 @@
             "deprecationReason": null
           },
           {
+            "name": "esgFundingReportEnabled",
+            "description": "Whether the ESG Funding Report is enabled",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "externalReferralsEnabled",
             "description": "Whether an external referral integration is enabled",
             "args": [],

--- a/src/api/operations/globalFeatureFlag.fragments.graphql
+++ b/src/api/operations/globalFeatureFlag.fragments.graphql
@@ -4,4 +4,5 @@ fragment GlobalFeatureFlagFields on GlobalFeatureFlags {
   bulkVoidEnabled
   externalReferralsEnabled
   mciIdEnabled
+  esgFundingReportEnabled
 }

--- a/src/modules/enrollment/components/EnrollmentQuickActions.tsx
+++ b/src/modules/enrollment/components/EnrollmentQuickActions.tsx
@@ -46,7 +46,7 @@ const EnrollmentQuickActions = ({
 
   const canViewEsgFundingReport =
     enrollment.project.access.canManageIncomingReferrals &&
-    globalFeatureFlags?.externalReferralsEnabled;
+    globalFeatureFlags?.esgFundingReportEnabled;
 
   if (
     ![canRecordService, canEditClient, canViewEsgFundingReport].some((b) => !!b)

--- a/src/modules/legacyReferrals/components/ProjectReferralPostingPage.tsx
+++ b/src/modules/legacyReferrals/components/ProjectReferralPostingPage.tsx
@@ -23,8 +23,12 @@ import {
 import { generateSafePath } from '@/utils/pathEncoding';
 
 const ProjectReferralPostingPage: React.FC = () => {
-  const { globalFeatureFlags: { externalReferralsEnabled } = {} } =
-    useGlobalFeatureFlags();
+  const {
+    globalFeatureFlags: {
+      externalReferralsEnabled,
+      esgFundingReportEnabled,
+    } = {},
+  } = useGlobalFeatureFlags();
   const { referralPostingId } = useSafeParams<{ referralPostingId: string }>();
   const { data, loading, error } = useGetReferralPostingQuery({
     variables: { id: referralPostingId as any as string },
@@ -61,7 +65,7 @@ const ProjectReferralPostingPage: React.FC = () => {
             />
           </TitleCard>
           <Stack gap={2}>
-            {externalReferralsEnabled && (
+            {esgFundingReportEnabled && (
               <ButtonLink
                 fullWidth
                 variant='outlined'

--- a/src/types/gqlObjects.ts
+++ b/src/types/gqlObjects.ts
@@ -5170,6 +5170,14 @@ export const HmisObjectSchemas: GqlSchema[] = [
         },
       },
       {
+        name: 'esgFundingReportEnabled',
+        type: {
+          kind: 'NON_NULL',
+          name: null,
+          ofType: { kind: 'SCALAR', name: 'Boolean', ofType: null },
+        },
+      },
+      {
         name: 'externalReferralsEnabled',
         type: {
           kind: 'NON_NULL',

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -4298,6 +4298,8 @@ export type GlobalFeatureFlags = {
   bulkVoidEnabled: Scalars['Boolean']['output'];
   /** Whether Coordinated Entry is enabled */
   coordinatedEntryEnabled: Scalars['Boolean']['output'];
+  /** Whether the ESG Funding Report is enabled */
+  esgFundingReportEnabled: Scalars['Boolean']['output'];
   /** Whether an external referral integration is enabled */
   externalReferralsEnabled: Scalars['Boolean']['output'];
   id: Scalars['ID']['output'];
@@ -42599,6 +42601,7 @@ export type GlobalFeatureFlagFieldsFragment = {
   bulkVoidEnabled: boolean;
   externalReferralsEnabled: boolean;
   mciIdEnabled: boolean;
+  esgFundingReportEnabled: boolean;
 };
 
 export type GetGlobalFeatureFlagsQueryVariables = Exact<{
@@ -42614,6 +42617,7 @@ export type GetGlobalFeatureFlagsQuery = {
     bulkVoidEnabled: boolean;
     externalReferralsEnabled: boolean;
     mciIdEnabled: boolean;
+    esgFundingReportEnabled: boolean;
   };
 };
 
@@ -53844,6 +53848,7 @@ export const GlobalFeatureFlagFieldsFragmentDoc = gql`
     bulkVoidEnabled
     externalReferralsEnabled
     mciIdEnabled
+    esgFundingReportEnabled
   }
 `;
 export const ProjectEnrollmentsHouseholdClientFieldsFragmentDoc = gql`


### PR DESCRIPTION
## Description

Summary of changes:
- Resolve `esgFundingReportEnabled` on the `GlobalFeatureFlagFields` fragment.
- Gate the ESG Funding Report entry points on the new `esgFundingReportEnabled` flag instead of overloading `externalReferralsEnabled`.

[//]: # 'remove if not applicable'
Depends on hmis-warehouse PR: https://github.com/greenriver/hmis-warehouse/pull/6752

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
New feature flag

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have used Axe DevTools to scan for accessibility issues (or not applicable)
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
