### PR TITLE
[Bug] Optional Column selections no longer persisted

### DIFF
--- a/src/hooks/useTablePagination.ts
+++ b/src/hooks/useTablePagination.ts
@@ -52,13 +52,11 @@ const useTablePagination = ({
     [defaultPageSize, pageParam, pageSizeParam]
   );
 
-  // Populate missing params on first load so refresh/share links include the active pagination state.
+  // Use URL values when present and fall back to table defaults without seeding
+  // missing params on mount. Avoiding a mount-time URL write prevents this hook
+  // from overwriting params initialized by other table state, such as optional columns.
   const [paginationParams, setPaginationParams] = useSearchParamsState({
     paramsDefinition,
-    initial: {
-      [pageParam]: 1,
-      [pageSizeParam]: defaultPageSize,
-    },
   });
 
   // Convert the human-readable 1-indexed URL page into the 0-indexed value used by table components.


### PR DESCRIPTION
## Description

Summary of changes:

Fixes https://github.com/open-path/Green-River/issues/9406.

URL-backed pagination previously seeded its default `page` and `pageSize` parameters when mounting. This could overwrite URL parameters simultaneously initialized by optional-column state, causing persisted columns to briefly appear and then disappear.

This change removes pagination’s mount-time URL seed while retaining the same defaults through `paramsDefinition`. Explicit pagination URLs and user pagination changes remain URL-backed.

How to test:

Manual QA covered all four pagination-enabled tables:

- `/referrals`
- `/referrals/available-units`
- `/referrals/eligible-clients`
- `/projects/:projectId/enrollments/households`

Verified:

- Tables default to page 1 with 25 rows without writing pagination parameters on mount.
- Page changes update the URL.
- Refresh, direct links, and browser Back/Forward restore pagination.
- Page-size changes reset to page 1 and persist through refresh.
- Filters and pagination coexist and filter changes reset pagination.
- Optional columns persist across pagination, refresh, and tab navigation.
- Project/workspace navigation does not display stale records.
- Invalid pagination parameters safely fall back to defaults without console errors.

## Type of change

Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have used Axe DevTools to scan for accessibility issues (or not applicable)
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue