### PR TITLE
Update schema to allow nil CE rules

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -47119,13 +47119,9 @@
               }
             ],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "CeMatchRule",
-                "ofType": null
-              }
+              "kind": "OBJECT",
+              "name": "CeMatchRule",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/src/modules/admin/components/forms/JsonFormEditorPage.tsx
+++ b/src/modules/admin/components/forms/JsonFormEditorPage.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import JsonFormEditor from './JsonFormEditor';
 import Loading from '@/components/elements/Loading';
 import PageTitle from '@/components/layout/PageTitle';
+import NotFound from '@/components/pages/NotFound';
 import useSafeParams from '@/hooks/useSafeParams';
 import ApolloErrorAlert from '@/modules/errors/components/ApolloErrorAlert';
 import ErrorAlert from '@/modules/errors/components/ErrorAlert';
@@ -13,11 +14,14 @@ import {
 const JsonFormEditorPage = () => {
   const { formId } = useSafeParams() as { formId: string };
 
-  const { data: { formDefinition } = {}, error } =
-    useGetFormDefinitionFieldsForJsonEditorQuery({
-      variables: { id: formId },
-      fetchPolicy: 'network-only', // always get the latest form
-    });
+  const {
+    data: { formDefinition } = {},
+    loading: fetchLoading,
+    error,
+  } = useGetFormDefinitionFieldsForJsonEditorQuery({
+    variables: { id: formId },
+    fetchPolicy: 'network-only', // always get the latest form
+  });
 
   const [
     updateFormDefinition,
@@ -29,7 +33,8 @@ const JsonFormEditorPage = () => {
     [saveResponse]
   );
   if (error) throw error;
-  if (!formDefinition) return <Loading />;
+  if (!formDefinition && fetchLoading) return <Loading />;
+  if (!formDefinition) return <NotFound />;
 
   return (
     <>

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -6978,7 +6978,7 @@ export type Query = {
   ceMatchCustomAssessmentFields: Array<CeMatchField>;
   /** Custom assessment form definitions for use in CE match rule management. */
   ceMatchCustomAssessmentForms: Array<FormDefinition>;
-  ceMatchRule: CeMatchRule;
+  ceMatchRule?: Maybe<CeMatchRule>;
   /** Coordinated Entry Match Rules in the current data source. */
   ceMatchRules: CeMatchRulesPaginated;
   ceOpportunities: CeOpportunitiesPaginated;
@@ -23077,7 +23077,7 @@ export type GetCeMatchRuleQueryVariables = Exact<{
 
 export type GetCeMatchRuleQuery = {
   __typename?: 'Query';
-  ceMatchRule: {
+  ceMatchRule?: {
     __typename?: 'CeMatchRule';
     ownerId: string;
     ownerName: string;
@@ -23101,7 +23101,7 @@ export type GetCeMatchRuleQuery = {
         value?: any | null;
       }>;
     } | null;
-  };
+  } | null;
 };
 
 export type GetCeMatchRuleOrganizationsQueryVariables = Exact<{


### PR DESCRIPTION
## Description

Summary of changes: 
- Update the graphql schema alongside the backend updates to allow `null` to be returned for an unfound CE match rule.
- Update the `JsonFormEditorPage` to return `NotFound` if the definition is null and loading has finished

[//]: # 'remove if not applicable'
Depends on hmis-warehouse PR: https://github.com/greenriver/hmis-warehouse/pull/6754

[//]: # 'remove if not applicable'
How to test:
- Visit a url for a deleted form definition. You should see Not Found, not a red error
- Visit a url for a deleted CE match rule. You should see Not Found, not a red error

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
Schema update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have used Axe DevTools to scan for accessibility issues (or not applicable)
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
