### PR TITLE
Pin js-yaml to ^4.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "lodash": "^4.18.0",
     "axios": "^1.18.0",
     "uuid": "^11.1.1",
-    "js-yaml": "^4.2.0",
+    "js-yaml": "^4.3.0",
     "postcss": "^8.5.18"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7950,10 +7950,10 @@ joi@^17.11.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^3.13.1, js-yaml@^4.1.0, js-yaml@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.2.0.tgz#2bd9e85682dd91bd469afb809d816043b3d49524"
-  integrity sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==
+js-yaml@^3.13.1, js-yaml@^4.1.0, js-yaml@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.0.tgz#d1900572a7f7cf0b5f540c83673e60bad3436592"
+  integrity sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==
   dependencies:
     argparse "^2.0.1"
 


### PR DESCRIPTION
## Description

Resolve GHSA-52cp-r559-cp3m

This package is only used by dev dependencies

```
=> Found "js-yaml@4.3.0"
info Reasons this module exists
   - "eslint" depends on it
   - Hoisted from "eslint#js-yaml"
   - Hoisted from "eslint#@eslint#eslintrc#js-yaml"
   - Hoisted from "@graphql-codegen#cli#cosmiconfig#js-yaml"
   - Hoisted from "@storybook#test-runner#nyc#@istanbuljs#load-nyc-config#js-yaml"
   - Hoisted from "@graphql-codegen#cli#graphql-config#cosmiconfig#js-yaml"
```

## Type of change
Dependency update

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have used Axe DevTools to scan for accessibility issues (or not applicable)
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
