### PR TITLE
Expose PSDE fields in CE Match Rule editor

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -47035,8 +47035,8 @@
                 }
               }
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "Use ceMatchFields(fieldSource: CLIENT)"
           },
           {
             "name": "ceMatchCustomAssessmentFields",
@@ -47104,9 +47104,26 @@
             "deprecationReason": null
           },
           {
-            "name": "ceMatchPsdeFields",
-            "description": "HUD Program Specific Data Element fields available for CE Match Rule expressions.",
-            "args": [],
+            "name": "ceMatchFields",
+            "description": "Fields available for CE Match Rule expressions. CUSTOM_DATA_ELEMENT fields are\nscoped to a form, so request those through ceMatchCustomAssessmentFields instead.",
+            "args": [
+              {
+                "name": "fieldSource",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "CeMatchRuleFieldSource",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
             "type": {
               "kind": "NON_NULL",
               "name": null,

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -6015,6 +6015,12 @@
             "description": "Custom",
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "PSDE",
+            "description": "HUD",
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "possibleTypes": null
@@ -47089,6 +47095,30 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "FormDefinition",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ceMatchPsdeFields",
+            "description": "HUD Program Specific Data Element fields available for CE Match Rule expressions.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "CeMatchField",
                     "ofType": null
                   }
                 }

--- a/src/api/operations/ceMatchRules.queries.graphql
+++ b/src/api/operations/ceMatchRules.queries.graphql
@@ -1,15 +1,8 @@
-# Client-level fields (current_age, veteran_status, days_since_last_exit) available
-# for CE Match Rule expressions.
-query GetCeMatchClientFields {
-  ceMatchClientFields {
-    ...CeMatchFieldDetails
-  }
-}
-
-# HUD Program Specific Data Element fields exposed through the static PSDE
-# registry for CE Match Rule expressions.
-query GetCeMatchPsdeFields {
-  ceMatchPsdeFields {
+# CE Match Rule expression fields for one field source: client-level fields such
+# as current_age, or HUD Program Specific Data Elements. Custom data element
+# fields are scoped to a form, so they use GetCeMatchCustomAssessmentFields.
+query GetCeMatchFields($fieldSource: CeMatchRuleFieldSource!) {
+  ceMatchFields(fieldSource: $fieldSource) {
     ...CeMatchFieldDetails
   }
 }

--- a/src/api/operations/ceMatchRules.queries.graphql
+++ b/src/api/operations/ceMatchRules.queries.graphql
@@ -6,6 +6,14 @@ query GetCeMatchClientFields {
   }
 }
 
+# HUD Program Specific Data Element fields exposed through the static PSDE
+# registry for CE Match Rule expressions.
+query GetCeMatchPsdeFields {
+  ceMatchPsdeFields {
+    ...CeMatchFieldDetails
+  }
+}
+
 # Published/retired custom assessment forms in the user's data source that have at
 # least one usable CDED field for CE Match Rule expressions.
 query GetCeMatchCustomAssessmentForms {

--- a/src/modules/admin/components/ceMatchRules/editor/CeMatchStructuredExpressionBuilder.tsx
+++ b/src/modules/admin/components/ceMatchRules/editor/CeMatchStructuredExpressionBuilder.tsx
@@ -22,9 +22,9 @@ import CardGroup, { RemovableCard } from '@/components/elements/CardGroup';
 import Loading from '@/components/elements/Loading';
 import {
   CeMatchRuleBooleanOperator,
-  useGetCeMatchClientFieldsQuery,
+  CeMatchRuleFieldSource,
   useGetCeMatchCustomAssessmentFormsQuery,
-  useGetCeMatchPsdeFieldsQuery,
+  useGetCeMatchFieldsQuery,
 } from '@/types/gqlTypes';
 
 interface Props {
@@ -61,7 +61,9 @@ const CeMatchStructuredExpressionBuilder: React.FC<Props> = ({
     data: clientItemsData,
     loading: clientItemsLoading,
     error: clientItemsError,
-  } = useGetCeMatchClientFieldsQuery();
+  } = useGetCeMatchFieldsQuery({
+    variables: { fieldSource: CeMatchRuleFieldSource.Client },
+  });
   const {
     data: customAssessmentFormsData,
     loading: customAssessmentFormsLoading,
@@ -73,12 +75,14 @@ const CeMatchStructuredExpressionBuilder: React.FC<Props> = ({
     data: psdeFieldsData,
     loading: psdeFieldsLoading,
     error: psdeFieldsError,
-  } = useGetCeMatchPsdeFieldsQuery();
+  } = useGetCeMatchFieldsQuery({
+    variables: { fieldSource: CeMatchRuleFieldSource.Psde },
+  });
 
   const loading =
     clientItemsLoading || customAssessmentFormsLoading || psdeFieldsLoading;
-  const clientItems = clientItemsData?.ceMatchClientFields || [];
-  const psdeFields = psdeFieldsData?.ceMatchPsdeFields || [];
+  const clientItems = clientItemsData?.ceMatchFields || [];
+  const psdeFields = psdeFieldsData?.ceMatchFields || [];
   const customAssessmentForms =
     customAssessmentFormsData?.ceMatchCustomAssessmentForms || [];
 

--- a/src/modules/admin/components/ceMatchRules/editor/CeMatchStructuredExpressionBuilder.tsx
+++ b/src/modules/admin/components/ceMatchRules/editor/CeMatchStructuredExpressionBuilder.tsx
@@ -24,6 +24,7 @@ import {
   CeMatchRuleBooleanOperator,
   useGetCeMatchClientFieldsQuery,
   useGetCeMatchCustomAssessmentFormsQuery,
+  useGetCeMatchPsdeFieldsQuery,
 } from '@/types/gqlTypes';
 
 interface Props {
@@ -66,14 +67,24 @@ const CeMatchStructuredExpressionBuilder: React.FC<Props> = ({
     loading: customAssessmentFormsLoading,
     error: customAssessmentFormsError,
   } = useGetCeMatchCustomAssessmentFormsQuery();
+  // PSDE fields come from a static backend registry, so they can be loaded once
+  // for the whole builder and shared by every requirement clause.
+  const {
+    data: psdeFieldsData,
+    loading: psdeFieldsLoading,
+    error: psdeFieldsError,
+  } = useGetCeMatchPsdeFieldsQuery();
 
-  const loading = clientItemsLoading || customAssessmentFormsLoading;
+  const loading =
+    clientItemsLoading || customAssessmentFormsLoading || psdeFieldsLoading;
   const clientItems = clientItemsData?.ceMatchClientFields || [];
+  const psdeFields = psdeFieldsData?.ceMatchPsdeFields || [];
   const customAssessmentForms =
     customAssessmentFormsData?.ceMatchCustomAssessmentForms || [];
 
   if (clientItemsError) throw clientItemsError;
   if (customAssessmentFormsError) throw customAssessmentFormsError;
+  if (psdeFieldsError) throw psdeFieldsError;
 
   return (
     <Stack gap={2}>
@@ -136,6 +147,7 @@ const CeMatchStructuredExpressionBuilder: React.FC<Props> = ({
                     setValue={setValue}
                     index={index}
                     clientItems={clientItems}
+                    psdeFields={psdeFields}
                     customAssessmentForms={customAssessmentForms}
                   />
                 </Stack>

--- a/src/modules/admin/components/ceMatchRules/editor/clause/CeMatchClause.tsx
+++ b/src/modules/admin/components/ceMatchRules/editor/clause/CeMatchClause.tsx
@@ -86,8 +86,6 @@ const CeMatchClause: React.FC<Props> = ({
 
   const fields = useMemo(() => {
     if (source === CeMatchRuleFieldSource.Client) return clientItems;
-    // PSDE metadata already has the common field shape, so the existing field,
-    // comparator, and value controls can consume it without special handling.
     if (source === CeMatchRuleFieldSource.Psde) return psdeFields;
     if (source === CeMatchRuleFieldSource.CustomDataElement)
       return customAssessmentFields;

--- a/src/modules/admin/components/ceMatchRules/editor/clause/CeMatchClause.tsx
+++ b/src/modules/admin/components/ceMatchRules/editor/clause/CeMatchClause.tsx
@@ -26,6 +26,7 @@ interface Props {
   setValue: UseFormSetValue<CeMatchRuleFormValues>;
   index: number;
   clientItems: CeMatchFieldDetailsFragment[];
+  psdeFields: CeMatchFieldDetailsFragment[];
   customAssessmentForms: CeMatchCustomAssessmentFormFieldsFragment[];
 }
 
@@ -37,6 +38,7 @@ const CeMatchClause: React.FC<Props> = ({
   setValue,
   index,
   clientItems,
+  psdeFields,
   customAssessmentForms,
 }) => {
   // Path to the current clause in the RHF form state
@@ -84,10 +86,13 @@ const CeMatchClause: React.FC<Props> = ({
 
   const fields = useMemo(() => {
     if (source === CeMatchRuleFieldSource.Client) return clientItems;
+    // PSDE metadata already has the common field shape, so the existing field,
+    // comparator, and value controls can consume it without special handling.
+    if (source === CeMatchRuleFieldSource.Psde) return psdeFields;
     if (source === CeMatchRuleFieldSource.CustomDataElement)
       return customAssessmentFields;
     return [];
-  }, [clientItems, source, customAssessmentFields]);
+  }, [clientItems, psdeFields, source, customAssessmentFields]);
 
   const selectedField = useMemo(
     () => fields.find((field) => field.expressionField === fieldValue),

--- a/src/types/gqlEnums.ts
+++ b/src/types/gqlEnums.ts
@@ -91,7 +91,11 @@ export const HmisEnums = {
     LTE: 'LTE',
     NOT_EQ: 'NOT_EQ',
   },
-  CeMatchRuleFieldSource: { CLIENT: 'Client', CUSTOM_DATA_ELEMENT: 'Custom' },
+  CeMatchRuleFieldSource: {
+    CLIENT: 'Client',
+    CUSTOM_DATA_ELEMENT: 'Custom',
+    PSDE: 'HUD',
+  },
   CeMatchRuleOwnerType: {
     DATA_SOURCE: 'Global',
     ORGANIZATION: 'Organization',

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -858,6 +858,8 @@ export enum CeMatchRuleFieldSource {
   Client = 'CLIENT',
   /** Custom */
   CustomDataElement = 'CUSTOM_DATA_ELEMENT',
+  /** HUD */
+  Psde = 'PSDE',
 }
 
 export type CeMatchRuleFilterOptions = {
@@ -6978,6 +6980,8 @@ export type Query = {
   ceMatchCustomAssessmentFields: Array<CeMatchField>;
   /** Custom assessment form definitions for use in CE match rule management. */
   ceMatchCustomAssessmentForms: Array<FormDefinition>;
+  /** HUD Program Specific Data Element fields available for CE Match Rule expressions. */
+  ceMatchPsdeFields: Array<CeMatchField>;
   ceMatchRule?: Maybe<CeMatchRule>;
   /** Coordinated Entry Match Rules in the current data source. */
   ceMatchRules: CeMatchRulesPaginated;
@@ -22979,6 +22983,36 @@ export type GetCeMatchClientFieldsQueryVariables = Exact<{
 export type GetCeMatchClientFieldsQuery = {
   __typename?: 'Query';
   ceMatchClientFields: Array<{
+    __typename?: 'CeMatchField';
+    id: string;
+    key: string;
+    label: string;
+    itemType: ItemType;
+    multiple: boolean;
+    expressionField: string;
+    pickListReference?: string | null;
+    pickListOptions?: Array<{
+      __typename?: 'PickListOption';
+      code: string;
+      label?: string | null;
+      secondaryLabel?: string | null;
+      groupLabel?: string | null;
+      groupCode?: string | null;
+      initialSelected?: boolean | null;
+      helperText?: string | null;
+      numericValue?: number | null;
+      disabled?: boolean | null;
+    }> | null;
+  }>;
+};
+
+export type GetCeMatchPsdeFieldsQueryVariables = Exact<{
+  [key: string]: never;
+}>;
+
+export type GetCeMatchPsdeFieldsQuery = {
+  __typename?: 'Query';
+  ceMatchPsdeFields: Array<{
     __typename?: 'CeMatchField';
     id: string;
     key: string;
@@ -59437,6 +59471,105 @@ export type GetCeMatchClientFieldsSuspenseQueryHookResult = ReturnType<
 export type GetCeMatchClientFieldsQueryResult = Apollo.QueryResult<
   GetCeMatchClientFieldsQuery,
   GetCeMatchClientFieldsQueryVariables
+>;
+export const GetCeMatchPsdeFieldsDocument = gql`
+  query GetCeMatchPsdeFields {
+    ceMatchPsdeFields {
+      ...CeMatchFieldDetails
+    }
+  }
+  ${CeMatchFieldDetailsFragmentDoc}
+`;
+
+/**
+ * __useGetCeMatchPsdeFieldsQuery__
+ *
+ * To run a query within a React component, call `useGetCeMatchPsdeFieldsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetCeMatchPsdeFieldsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetCeMatchPsdeFieldsQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useGetCeMatchPsdeFieldsQuery(
+  baseOptions?: Apollo.QueryHookOptions<
+    GetCeMatchPsdeFieldsQuery,
+    GetCeMatchPsdeFieldsQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    GetCeMatchPsdeFieldsQuery,
+    GetCeMatchPsdeFieldsQueryVariables
+  >(GetCeMatchPsdeFieldsDocument, options);
+}
+export function useGetCeMatchPsdeFieldsLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GetCeMatchPsdeFieldsQuery,
+    GetCeMatchPsdeFieldsQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    GetCeMatchPsdeFieldsQuery,
+    GetCeMatchPsdeFieldsQueryVariables
+  >(GetCeMatchPsdeFieldsDocument, options);
+}
+// @ts-ignore
+export function useGetCeMatchPsdeFieldsSuspenseQuery(
+  baseOptions?: Apollo.SuspenseQueryHookOptions<
+    GetCeMatchPsdeFieldsQuery,
+    GetCeMatchPsdeFieldsQueryVariables
+  >
+): Apollo.UseSuspenseQueryResult<
+  GetCeMatchPsdeFieldsQuery,
+  GetCeMatchPsdeFieldsQueryVariables
+>;
+export function useGetCeMatchPsdeFieldsSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        GetCeMatchPsdeFieldsQuery,
+        GetCeMatchPsdeFieldsQueryVariables
+      >
+): Apollo.UseSuspenseQueryResult<
+  GetCeMatchPsdeFieldsQuery | undefined,
+  GetCeMatchPsdeFieldsQueryVariables
+>;
+export function useGetCeMatchPsdeFieldsSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<
+        GetCeMatchPsdeFieldsQuery,
+        GetCeMatchPsdeFieldsQueryVariables
+      >
+) {
+  const options =
+    baseOptions === Apollo.skipToken
+      ? baseOptions
+      : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<
+    GetCeMatchPsdeFieldsQuery,
+    GetCeMatchPsdeFieldsQueryVariables
+  >(GetCeMatchPsdeFieldsDocument, options);
+}
+export type GetCeMatchPsdeFieldsQueryHookResult = ReturnType<
+  typeof useGetCeMatchPsdeFieldsQuery
+>;
+export type GetCeMatchPsdeFieldsLazyQueryHookResult = ReturnType<
+  typeof useGetCeMatchPsdeFieldsLazyQuery
+>;
+export type GetCeMatchPsdeFieldsSuspenseQueryHookResult = ReturnType<
+  typeof useGetCeMatchPsdeFieldsSuspenseQuery
+>;
+export type GetCeMatchPsdeFieldsQueryResult = Apollo.QueryResult<
+  GetCeMatchPsdeFieldsQuery,
+  GetCeMatchPsdeFieldsQueryVariables
 >;
 export const GetCeMatchCustomAssessmentFormsDocument = gql`
   query GetCeMatchCustomAssessmentForms {

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -6974,14 +6974,20 @@ export type Query = {
   ceClient?: Maybe<CeClient>;
   /** Clients who belong to at least one CE candidate pool */
   ceClients: CeClientsPaginated;
-  /** Client fields available for CE Match Rule expressions. */
+  /**
+   * Client fields available for CE Match Rule expressions.
+   * @deprecated Use ceMatchFields(fieldSource: CLIENT)
+   */
   ceMatchClientFields: Array<CeMatchField>;
   /** Fields on the form that are usable as CE Match Rule condition fields. */
   ceMatchCustomAssessmentFields: Array<CeMatchField>;
   /** Custom assessment form definitions for use in CE match rule management. */
   ceMatchCustomAssessmentForms: Array<FormDefinition>;
-  /** HUD Program Specific Data Element fields available for CE Match Rule expressions. */
-  ceMatchPsdeFields: Array<CeMatchField>;
+  /**
+   * Fields available for CE Match Rule expressions. CUSTOM_DATA_ELEMENT fields are
+   * scoped to a form, so request those through ceMatchCustomAssessmentFields instead.
+   */
+  ceMatchFields: Array<CeMatchField>;
   ceMatchRule?: Maybe<CeMatchRule>;
   /** Coordinated Entry Match Rules in the current data source. */
   ceMatchRules: CeMatchRulesPaginated;
@@ -7094,6 +7100,10 @@ export type QueryCeClientsArgs = {
 
 export type QueryCeMatchCustomAssessmentFieldsArgs = {
   formDefinitionIdentifier: Scalars['String']['input'];
+};
+
+export type QueryCeMatchFieldsArgs = {
+  fieldSource: CeMatchRuleFieldSource;
 };
 
 export type QueryCeMatchRuleArgs = {
@@ -22976,43 +22986,13 @@ export type DeleteCeMatchRuleMutation = {
   } | null;
 };
 
-export type GetCeMatchClientFieldsQueryVariables = Exact<{
-  [key: string]: never;
+export type GetCeMatchFieldsQueryVariables = Exact<{
+  fieldSource: CeMatchRuleFieldSource;
 }>;
 
-export type GetCeMatchClientFieldsQuery = {
+export type GetCeMatchFieldsQuery = {
   __typename?: 'Query';
-  ceMatchClientFields: Array<{
-    __typename?: 'CeMatchField';
-    id: string;
-    key: string;
-    label: string;
-    itemType: ItemType;
-    multiple: boolean;
-    expressionField: string;
-    pickListReference?: string | null;
-    pickListOptions?: Array<{
-      __typename?: 'PickListOption';
-      code: string;
-      label?: string | null;
-      secondaryLabel?: string | null;
-      groupLabel?: string | null;
-      groupCode?: string | null;
-      initialSelected?: boolean | null;
-      helperText?: string | null;
-      numericValue?: number | null;
-      disabled?: boolean | null;
-    }> | null;
-  }>;
-};
-
-export type GetCeMatchPsdeFieldsQueryVariables = Exact<{
-  [key: string]: never;
-}>;
-
-export type GetCeMatchPsdeFieldsQuery = {
-  __typename?: 'Query';
-  ceMatchPsdeFields: Array<{
+  ceMatchFields: Array<{
     __typename?: 'CeMatchField';
     id: string;
     key: string;
@@ -59373,9 +59353,9 @@ export type DeleteCeMatchRuleMutationOptions = Apollo.BaseMutationOptions<
   DeleteCeMatchRuleMutation,
   DeleteCeMatchRuleMutationVariables
 >;
-export const GetCeMatchClientFieldsDocument = gql`
-  query GetCeMatchClientFields {
-    ceMatchClientFields {
+export const GetCeMatchFieldsDocument = gql`
+  query GetCeMatchFields($fieldSource: CeMatchRuleFieldSource!) {
+    ceMatchFields(fieldSource: $fieldSource) {
       ...CeMatchFieldDetails
     }
   }
@@ -59383,71 +59363,76 @@ export const GetCeMatchClientFieldsDocument = gql`
 `;
 
 /**
- * __useGetCeMatchClientFieldsQuery__
+ * __useGetCeMatchFieldsQuery__
  *
- * To run a query within a React component, call `useGetCeMatchClientFieldsQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetCeMatchClientFieldsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useGetCeMatchFieldsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetCeMatchFieldsQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useGetCeMatchClientFieldsQuery({
+ * const { data, loading, error } = useGetCeMatchFieldsQuery({
  *   variables: {
+ *      fieldSource: // value for 'fieldSource'
  *   },
  * });
  */
-export function useGetCeMatchClientFieldsQuery(
-  baseOptions?: Apollo.QueryHookOptions<
-    GetCeMatchClientFieldsQuery,
-    GetCeMatchClientFieldsQueryVariables
-  >
+export function useGetCeMatchFieldsQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    GetCeMatchFieldsQuery,
+    GetCeMatchFieldsQueryVariables
+  > &
+    (
+      | { variables: GetCeMatchFieldsQueryVariables; skip?: boolean }
+      | { skip: boolean }
+    )
 ) {
   const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<
-    GetCeMatchClientFieldsQuery,
-    GetCeMatchClientFieldsQueryVariables
-  >(GetCeMatchClientFieldsDocument, options);
+  return Apollo.useQuery<GetCeMatchFieldsQuery, GetCeMatchFieldsQueryVariables>(
+    GetCeMatchFieldsDocument,
+    options
+  );
 }
-export function useGetCeMatchClientFieldsLazyQuery(
+export function useGetCeMatchFieldsLazyQuery(
   baseOptions?: Apollo.LazyQueryHookOptions<
-    GetCeMatchClientFieldsQuery,
-    GetCeMatchClientFieldsQueryVariables
+    GetCeMatchFieldsQuery,
+    GetCeMatchFieldsQueryVariables
   >
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useLazyQuery<
-    GetCeMatchClientFieldsQuery,
-    GetCeMatchClientFieldsQueryVariables
-  >(GetCeMatchClientFieldsDocument, options);
+    GetCeMatchFieldsQuery,
+    GetCeMatchFieldsQueryVariables
+  >(GetCeMatchFieldsDocument, options);
 }
 // @ts-ignore
-export function useGetCeMatchClientFieldsSuspenseQuery(
+export function useGetCeMatchFieldsSuspenseQuery(
   baseOptions?: Apollo.SuspenseQueryHookOptions<
-    GetCeMatchClientFieldsQuery,
-    GetCeMatchClientFieldsQueryVariables
+    GetCeMatchFieldsQuery,
+    GetCeMatchFieldsQueryVariables
   >
 ): Apollo.UseSuspenseQueryResult<
-  GetCeMatchClientFieldsQuery,
-  GetCeMatchClientFieldsQueryVariables
+  GetCeMatchFieldsQuery,
+  GetCeMatchFieldsQueryVariables
 >;
-export function useGetCeMatchClientFieldsSuspenseQuery(
+export function useGetCeMatchFieldsSuspenseQuery(
   baseOptions?:
     | Apollo.SkipToken
     | Apollo.SuspenseQueryHookOptions<
-        GetCeMatchClientFieldsQuery,
-        GetCeMatchClientFieldsQueryVariables
+        GetCeMatchFieldsQuery,
+        GetCeMatchFieldsQueryVariables
       >
 ): Apollo.UseSuspenseQueryResult<
-  GetCeMatchClientFieldsQuery | undefined,
-  GetCeMatchClientFieldsQueryVariables
+  GetCeMatchFieldsQuery | undefined,
+  GetCeMatchFieldsQueryVariables
 >;
-export function useGetCeMatchClientFieldsSuspenseQuery(
+export function useGetCeMatchFieldsSuspenseQuery(
   baseOptions?:
     | Apollo.SkipToken
     | Apollo.SuspenseQueryHookOptions<
-        GetCeMatchClientFieldsQuery,
-        GetCeMatchClientFieldsQueryVariables
+        GetCeMatchFieldsQuery,
+        GetCeMatchFieldsQueryVariables
       >
 ) {
   const options =
@@ -59455,121 +59440,22 @@ export function useGetCeMatchClientFieldsSuspenseQuery(
       ? baseOptions
       : { ...defaultOptions, ...baseOptions };
   return Apollo.useSuspenseQuery<
-    GetCeMatchClientFieldsQuery,
-    GetCeMatchClientFieldsQueryVariables
-  >(GetCeMatchClientFieldsDocument, options);
+    GetCeMatchFieldsQuery,
+    GetCeMatchFieldsQueryVariables
+  >(GetCeMatchFieldsDocument, options);
 }
-export type GetCeMatchClientFieldsQueryHookResult = ReturnType<
-  typeof useGetCeMatchClientFieldsQuery
+export type GetCeMatchFieldsQueryHookResult = ReturnType<
+  typeof useGetCeMatchFieldsQuery
 >;
-export type GetCeMatchClientFieldsLazyQueryHookResult = ReturnType<
-  typeof useGetCeMatchClientFieldsLazyQuery
+export type GetCeMatchFieldsLazyQueryHookResult = ReturnType<
+  typeof useGetCeMatchFieldsLazyQuery
 >;
-export type GetCeMatchClientFieldsSuspenseQueryHookResult = ReturnType<
-  typeof useGetCeMatchClientFieldsSuspenseQuery
+export type GetCeMatchFieldsSuspenseQueryHookResult = ReturnType<
+  typeof useGetCeMatchFieldsSuspenseQuery
 >;
-export type GetCeMatchClientFieldsQueryResult = Apollo.QueryResult<
-  GetCeMatchClientFieldsQuery,
-  GetCeMatchClientFieldsQueryVariables
->;
-export const GetCeMatchPsdeFieldsDocument = gql`
-  query GetCeMatchPsdeFields {
-    ceMatchPsdeFields {
-      ...CeMatchFieldDetails
-    }
-  }
-  ${CeMatchFieldDetailsFragmentDoc}
-`;
-
-/**
- * __useGetCeMatchPsdeFieldsQuery__
- *
- * To run a query within a React component, call `useGetCeMatchPsdeFieldsQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetCeMatchPsdeFieldsQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetCeMatchPsdeFieldsQuery({
- *   variables: {
- *   },
- * });
- */
-export function useGetCeMatchPsdeFieldsQuery(
-  baseOptions?: Apollo.QueryHookOptions<
-    GetCeMatchPsdeFieldsQuery,
-    GetCeMatchPsdeFieldsQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useQuery<
-    GetCeMatchPsdeFieldsQuery,
-    GetCeMatchPsdeFieldsQueryVariables
-  >(GetCeMatchPsdeFieldsDocument, options);
-}
-export function useGetCeMatchPsdeFieldsLazyQuery(
-  baseOptions?: Apollo.LazyQueryHookOptions<
-    GetCeMatchPsdeFieldsQuery,
-    GetCeMatchPsdeFieldsQueryVariables
-  >
-) {
-  const options = { ...defaultOptions, ...baseOptions };
-  return Apollo.useLazyQuery<
-    GetCeMatchPsdeFieldsQuery,
-    GetCeMatchPsdeFieldsQueryVariables
-  >(GetCeMatchPsdeFieldsDocument, options);
-}
-// @ts-ignore
-export function useGetCeMatchPsdeFieldsSuspenseQuery(
-  baseOptions?: Apollo.SuspenseQueryHookOptions<
-    GetCeMatchPsdeFieldsQuery,
-    GetCeMatchPsdeFieldsQueryVariables
-  >
-): Apollo.UseSuspenseQueryResult<
-  GetCeMatchPsdeFieldsQuery,
-  GetCeMatchPsdeFieldsQueryVariables
->;
-export function useGetCeMatchPsdeFieldsSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<
-        GetCeMatchPsdeFieldsQuery,
-        GetCeMatchPsdeFieldsQueryVariables
-      >
-): Apollo.UseSuspenseQueryResult<
-  GetCeMatchPsdeFieldsQuery | undefined,
-  GetCeMatchPsdeFieldsQueryVariables
->;
-export function useGetCeMatchPsdeFieldsSuspenseQuery(
-  baseOptions?:
-    | Apollo.SkipToken
-    | Apollo.SuspenseQueryHookOptions<
-        GetCeMatchPsdeFieldsQuery,
-        GetCeMatchPsdeFieldsQueryVariables
-      >
-) {
-  const options =
-    baseOptions === Apollo.skipToken
-      ? baseOptions
-      : { ...defaultOptions, ...baseOptions };
-  return Apollo.useSuspenseQuery<
-    GetCeMatchPsdeFieldsQuery,
-    GetCeMatchPsdeFieldsQueryVariables
-  >(GetCeMatchPsdeFieldsDocument, options);
-}
-export type GetCeMatchPsdeFieldsQueryHookResult = ReturnType<
-  typeof useGetCeMatchPsdeFieldsQuery
->;
-export type GetCeMatchPsdeFieldsLazyQueryHookResult = ReturnType<
-  typeof useGetCeMatchPsdeFieldsLazyQuery
->;
-export type GetCeMatchPsdeFieldsSuspenseQueryHookResult = ReturnType<
-  typeof useGetCeMatchPsdeFieldsSuspenseQuery
->;
-export type GetCeMatchPsdeFieldsQueryResult = Apollo.QueryResult<
-  GetCeMatchPsdeFieldsQuery,
-  GetCeMatchPsdeFieldsQueryVariables
+export type GetCeMatchFieldsQueryResult = Apollo.QueryResult<
+  GetCeMatchFieldsQuery,
+  GetCeMatchFieldsQueryVariables
 >;
 export const GetCeMatchCustomAssessmentFormsDocument = gql`
   query GetCeMatchCustomAssessmentForms {


### PR DESCRIPTION
## Description

Summary of changes:

Part of [#9413](https://github.com/open-path/Green-River/issues/9413).

- Adds the `GetCeMatchPsdeFields` query.
- Loads PSDE field metadata in the structured CE match rule builder.
- Adds “HUD” to the Source dropdown.
- Supplies the registered PSDE fields to the existing field, comparator, and value controls.
- Supports numeric, boolean, and null-check PSDE conditions without adding PSDE-specific controls.
- Regenerates GraphQL types, enum descriptions, and query hooks.

Depends on hmis-warehouse PR: TODO

How to test:

1. Open `9413 PSDE Development Fixture Rule`.
2. Confirm it hydrates into three structured requirements.
3. Confirm each clause uses the “HUD” source.
4. Create an unsaved requirement and confirm all eight HUD fields are available.
5. Confirm Total Monthly Income offers numeric comparisons.
6. Confirm logical PSDE fields offer True/False and null comparisons.
7. Save and reopen a PSDE rule and confirm its structured representation is preserved.
8. Confirm Client and Custom field sources still work.

## Type of change
New feature

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have used Axe DevTools to scan for accessibility issues (or not applicable)
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue