### PR TITLE
Add summary CDEs to Referral task card

### DIFF
--- a/src/api/operations/ce.fragments.graphql
+++ b/src/api/operations/ce.fragments.graphql
@@ -305,15 +305,15 @@ fragment CeReferralStepSummaryFields on CeReferralStep {
   access {
     canPerformStep
   }
+  customDataElements {
+    ...CustomDataElementFields
+  }
 }
 
 fragment CeReferralStepFields on CeReferralStep {
   ...CeReferralStepSummaryFields
   formDefinition {
     ...FormDefinitionFields
-  }
-  customDataElements {
-    ...CustomDataElementFields
   }
 }
 

--- a/src/modules/ce/components/referral/ReferralStepCard.stories.tsx
+++ b/src/modules/ce/components/referral/ReferralStepCard.stories.tsx
@@ -6,6 +6,9 @@ import {
   CeReferralOrigin,
   CeReferralStatus,
   CeReferralStepStatus,
+  CustomDataElementFieldsFragment,
+  CustomDataElementType,
+  DisplayHook,
 } from '@/types/gqlTypes';
 
 export default {
@@ -39,7 +42,35 @@ const mockStep = {
   access: {
     canPerformStep: true,
   },
+  customDataElements: [],
 };
+
+const summaryCustomDataElements: CustomDataElementFieldsFragment[] = [
+  {
+    id: 'cde-1',
+    key: 'denial_reason',
+    label: 'Denial Reason',
+    fieldType: CustomDataElementType.String,
+    repeats: false,
+    displayHooks: [DisplayHook.TableSummary],
+    value: {
+      id: 'v-1',
+      valueString: 'Missing documentation',
+    },
+  },
+  {
+    id: 'cde-2',
+    key: 'follow_up_items',
+    label: 'Follow-up Items',
+    fieldType: CustomDataElementType.String,
+    repeats: true,
+    displayHooks: [DisplayHook.TableSummary],
+    values: [
+      { id: 'v-2a', valueString: 'Call client' },
+      { id: 'v-2b', valueString: 'Verify income' },
+    ],
+  },
+];
 
 const mockReferral: CeReferralFieldsFragment = {
   id: '1',
@@ -102,7 +133,11 @@ export const Locked: Story = {
 
 export const Done: Story = {
   args: {
-    step: { ...mockStep, status: CeReferralStepStatus.Completed },
+    step: {
+      ...mockStep,
+      status: CeReferralStepStatus.Completed,
+      customDataElements: summaryCustomDataElements,
+    },
     referral: mockReferral,
   },
 };

--- a/src/modules/ce/components/referral/ReferralStepCard.stories.tsx
+++ b/src/modules/ce/components/referral/ReferralStepCard.stories.tsx
@@ -70,6 +70,15 @@ const summaryCustomDataElements: CustomDataElementFieldsFragment[] = [
       { id: 'v-2b', valueString: 'Verify income' },
     ],
   },
+  {
+    id: 'cde-3',
+    key: 'item_with_no_value',
+    label: 'Item With No Value',
+    fieldType: CustomDataElementType.String,
+    repeats: false,
+    displayHooks: [DisplayHook.TableSummary],
+    value: null,
+  },
 ];
 
 const mockReferral: CeReferralFieldsFragment = {

--- a/src/modules/ce/components/referral/ReferralStepCard.tsx
+++ b/src/modules/ce/components/referral/ReferralStepCard.tsx
@@ -2,6 +2,7 @@ import { Box, Paper, Stack, Typography } from '@mui/material';
 import React from 'react';
 import ReferralStepDetails from './ReferralStepDetails';
 import ReferralStepAction from '@/modules/ce/components/referral/ReferralStepAction';
+import ReferralStepSummaryDetails from '@/modules/ce/components/referral/ReferralStepSummaryDetails';
 import {
   CeReferralFieldsFragment,
   CeReferralStepStatus,
@@ -32,6 +33,7 @@ const ReferralStepCard: React.FC<Props> = ({ step, referral, path }) => {
             {name}
           </Typography>
           <ReferralStepDetails step={step} />
+          <ReferralStepSummaryDetails step={step} />
         </Stack>
         <Box>
           <ReferralStepAction

--- a/src/modules/ce/components/referral/ReferralStepCard.tsx
+++ b/src/modules/ce/components/referral/ReferralStepCard.tsx
@@ -2,7 +2,7 @@ import { Box, Paper, Stack, Typography } from '@mui/material';
 import React from 'react';
 import ReferralStepDetails from './ReferralStepDetails';
 import ReferralStepAction from '@/modules/ce/components/referral/ReferralStepAction';
-import ReferralStepSummaryDetails from '@/modules/ce/components/referral/ReferralStepSummaryDetails';
+import ReferralStepCdeSummary from '@/modules/ce/components/referral/ReferralStepCdeSummary';
 import {
   CeReferralFieldsFragment,
   CeReferralStepStatus,
@@ -33,7 +33,7 @@ const ReferralStepCard: React.FC<Props> = ({ step, referral, path }) => {
             {name}
           </Typography>
           <ReferralStepDetails step={step} />
-          <ReferralStepSummaryDetails step={step} />
+          <ReferralStepCdeSummary step={step} />
         </Stack>
         <Box>
           <ReferralStepAction

--- a/src/modules/ce/components/referral/ReferralStepCdeSummary.tsx
+++ b/src/modules/ce/components/referral/ReferralStepCdeSummary.tsx
@@ -1,5 +1,5 @@
 import { Stack } from '@mui/material';
-import React from 'react';
+import React, { useMemo } from 'react';
 
 import { CommonLabeledTextBlock } from '@/components/elements/CommonLabeledTextBlock';
 import { customDataElementValueAsString } from '@/modules/hmis/hmisUtil';
@@ -13,18 +13,21 @@ interface Props {
   step: CeReferralStepSummaryFieldsFragment;
 }
 
-const ReferralStepSummaryDetails: React.FC<Props> = ({ step }) => {
+const ReferralStepCdeSummary: React.FC<Props> = ({ step }) => {
+  const summaryRows = useMemo(
+    () =>
+      step.customDataElements
+        .filter((cde) => cde.displayHooks.includes(DisplayHook.TableSummary))
+        .map((cde) => ({
+          key: cde.key,
+          label: cde.label,
+          value: customDataElementValueAsString(cde),
+        }))
+        .filter((row) => !!row.value),
+    [step.customDataElements]
+  );
+
   if (step.status !== CeReferralStepStatus.Completed) return null;
-
-  const summaryRows = step.customDataElements
-    .filter((cde) => cde.displayHooks.includes(DisplayHook.TableSummary))
-    .map((cde) => ({
-      key: cde.key,
-      label: cde.label,
-      value: customDataElementValueAsString(cde),
-    }))
-    .filter((row) => !!row.value);
-
   if (summaryRows.length === 0) return null;
 
   return (
@@ -38,4 +41,4 @@ const ReferralStepSummaryDetails: React.FC<Props> = ({ step }) => {
   );
 };
 
-export default ReferralStepSummaryDetails;
+export default ReferralStepCdeSummary;

--- a/src/modules/ce/components/referral/ReferralStepSummaryDetails.tsx
+++ b/src/modules/ce/components/referral/ReferralStepSummaryDetails.tsx
@@ -19,6 +19,7 @@ const ReferralStepSummaryDetails: React.FC<Props> = ({ step }) => {
   const summaryRows = step.customDataElements
     .filter((cde) => cde.displayHooks.includes(DisplayHook.TableSummary))
     .map((cde) => ({
+      key: cde.key,
       label: cde.label,
       value: customDataElementValueAsString(cde),
     }))
@@ -29,7 +30,7 @@ const ReferralStepSummaryDetails: React.FC<Props> = ({ step }) => {
   return (
     <Stack gap={1}>
       {summaryRows.map((row) => (
-        <CommonLabeledTextBlock key={row.label} title={`${row.label}:`}>
+        <CommonLabeledTextBlock key={row.key} title={`${row.label}:`}>
           {row.value}
         </CommonLabeledTextBlock>
       ))}

--- a/src/modules/ce/components/referral/ReferralStepSummaryDetails.tsx
+++ b/src/modules/ce/components/referral/ReferralStepSummaryDetails.tsx
@@ -1,0 +1,40 @@
+import { Stack } from '@mui/material';
+import React from 'react';
+
+import { CommonLabeledTextBlock } from '@/components/elements/CommonLabeledTextBlock';
+import { customDataElementValueAsString } from '@/modules/hmis/hmisUtil';
+import {
+  CeReferralStepStatus,
+  CeReferralStepSummaryFieldsFragment,
+  DisplayHook,
+} from '@/types/gqlTypes';
+
+interface Props {
+  step: CeReferralStepSummaryFieldsFragment;
+}
+
+const ReferralStepSummaryDetails: React.FC<Props> = ({ step }) => {
+  if (step.status !== CeReferralStepStatus.Completed) return null;
+
+  const summaryRows = step.customDataElements
+    .filter((cde) => cde.displayHooks.includes(DisplayHook.TableSummary))
+    .map((cde) => ({
+      label: cde.label,
+      value: customDataElementValueAsString(cde),
+    }))
+    .filter((row) => !!row.value);
+
+  if (summaryRows.length === 0) return null;
+
+  return (
+    <Stack gap={1}>
+      {summaryRows.map((row) => (
+        <CommonLabeledTextBlock key={row.label} title={`${row.label}:`}>
+          {row.value}
+        </CommonLabeledTextBlock>
+      ))}
+    </Stack>
+  );
+};
+
+export default ReferralStepSummaryDetails;

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -18298,6 +18298,135 @@ export type CeReferralFieldsFragment = {
       name: string;
     } | null;
     access: { __typename?: 'CeReferralStepAccess'; canPerformStep: boolean };
+    customDataElements: Array<{
+      __typename?: 'CustomDataElement';
+      id: string;
+      key: string;
+      label: string;
+      fieldType: CustomDataElementType;
+      repeats: boolean;
+      displayHooks: Array<DisplayHook>;
+      value?: {
+        __typename?: 'CustomDataElementValue';
+        id: string;
+        valueBoolean?: boolean | null;
+        valueDate?: string | null;
+        valueFloat?: number | null;
+        valueInteger?: number | null;
+        valueJson?: any | null;
+        valueString?: string | null;
+        valueText?: string | null;
+        dateCreated?: string | null;
+        dateUpdated?: string | null;
+        valueFile?: {
+          __typename?: 'File';
+          confidential?: boolean | null;
+          contentType?: string | null;
+          effectiveDate?: string | null;
+          expirationDate?: string | null;
+          id: string;
+          name: string;
+          url?: string | null;
+          tags: Array<string>;
+          redacted: boolean;
+          enrollmentId?: string | null;
+          dateCreated?: string | null;
+          dateUpdated?: string | null;
+          access: {
+            __typename?: 'FileAccess';
+            canEditFile: boolean;
+            canDeleteFile: boolean;
+          };
+          enrollment?: { __typename?: 'Enrollment'; id: string } | null;
+          uploadedBy?: {
+            __typename?: 'ApplicationUser';
+            id: string;
+            name: string;
+          } | null;
+          updatedBy?: {
+            __typename?: 'ApplicationUser';
+            id: string;
+            name: string;
+          } | null;
+          user?: {
+            __typename: 'ApplicationUser';
+            id: string;
+            name: string;
+            firstName?: string | null;
+            lastName?: string | null;
+            email: string;
+          } | null;
+        } | null;
+        user?: {
+          __typename: 'ApplicationUser';
+          id: string;
+          name: string;
+          firstName?: string | null;
+          lastName?: string | null;
+          email: string;
+        } | null;
+      } | null;
+      values?: Array<{
+        __typename?: 'CustomDataElementValue';
+        id: string;
+        valueBoolean?: boolean | null;
+        valueDate?: string | null;
+        valueFloat?: number | null;
+        valueInteger?: number | null;
+        valueJson?: any | null;
+        valueString?: string | null;
+        valueText?: string | null;
+        dateCreated?: string | null;
+        dateUpdated?: string | null;
+        valueFile?: {
+          __typename?: 'File';
+          confidential?: boolean | null;
+          contentType?: string | null;
+          effectiveDate?: string | null;
+          expirationDate?: string | null;
+          id: string;
+          name: string;
+          url?: string | null;
+          tags: Array<string>;
+          redacted: boolean;
+          enrollmentId?: string | null;
+          dateCreated?: string | null;
+          dateUpdated?: string | null;
+          access: {
+            __typename?: 'FileAccess';
+            canEditFile: boolean;
+            canDeleteFile: boolean;
+          };
+          enrollment?: { __typename?: 'Enrollment'; id: string } | null;
+          uploadedBy?: {
+            __typename?: 'ApplicationUser';
+            id: string;
+            name: string;
+          } | null;
+          updatedBy?: {
+            __typename?: 'ApplicationUser';
+            id: string;
+            name: string;
+          } | null;
+          user?: {
+            __typename: 'ApplicationUser';
+            id: string;
+            name: string;
+            firstName?: string | null;
+            lastName?: string | null;
+            email: string;
+          } | null;
+        } | null;
+        user?: {
+          __typename: 'ApplicationUser';
+          id: string;
+          name: string;
+          firstName?: string | null;
+          lastName?: string | null;
+          email: string;
+        } | null;
+      }> | null;
+    }>;
   }> | null;
   opportunity?: {
     __typename?: 'CeOpportunity';
@@ -18512,6 +18641,135 @@ export type CeReferralStepSummaryFieldsFragment = {
     name: string;
   } | null;
   access: { __typename?: 'CeReferralStepAccess'; canPerformStep: boolean };
+  customDataElements: Array<{
+    __typename?: 'CustomDataElement';
+    id: string;
+    key: string;
+    label: string;
+    fieldType: CustomDataElementType;
+    repeats: boolean;
+    displayHooks: Array<DisplayHook>;
+    value?: {
+      __typename?: 'CustomDataElementValue';
+      id: string;
+      valueBoolean?: boolean | null;
+      valueDate?: string | null;
+      valueFloat?: number | null;
+      valueInteger?: number | null;
+      valueJson?: any | null;
+      valueString?: string | null;
+      valueText?: string | null;
+      dateCreated?: string | null;
+      dateUpdated?: string | null;
+      valueFile?: {
+        __typename?: 'File';
+        confidential?: boolean | null;
+        contentType?: string | null;
+        effectiveDate?: string | null;
+        expirationDate?: string | null;
+        id: string;
+        name: string;
+        url?: string | null;
+        tags: Array<string>;
+        redacted: boolean;
+        enrollmentId?: string | null;
+        dateCreated?: string | null;
+        dateUpdated?: string | null;
+        access: {
+          __typename?: 'FileAccess';
+          canEditFile: boolean;
+          canDeleteFile: boolean;
+        };
+        enrollment?: { __typename?: 'Enrollment'; id: string } | null;
+        uploadedBy?: {
+          __typename?: 'ApplicationUser';
+          id: string;
+          name: string;
+        } | null;
+        updatedBy?: {
+          __typename?: 'ApplicationUser';
+          id: string;
+          name: string;
+        } | null;
+        user?: {
+          __typename: 'ApplicationUser';
+          id: string;
+          name: string;
+          firstName?: string | null;
+          lastName?: string | null;
+          email: string;
+        } | null;
+      } | null;
+      user?: {
+        __typename: 'ApplicationUser';
+        id: string;
+        name: string;
+        firstName?: string | null;
+        lastName?: string | null;
+        email: string;
+      } | null;
+    } | null;
+    values?: Array<{
+      __typename?: 'CustomDataElementValue';
+      id: string;
+      valueBoolean?: boolean | null;
+      valueDate?: string | null;
+      valueFloat?: number | null;
+      valueInteger?: number | null;
+      valueJson?: any | null;
+      valueString?: string | null;
+      valueText?: string | null;
+      dateCreated?: string | null;
+      dateUpdated?: string | null;
+      valueFile?: {
+        __typename?: 'File';
+        confidential?: boolean | null;
+        contentType?: string | null;
+        effectiveDate?: string | null;
+        expirationDate?: string | null;
+        id: string;
+        name: string;
+        url?: string | null;
+        tags: Array<string>;
+        redacted: boolean;
+        enrollmentId?: string | null;
+        dateCreated?: string | null;
+        dateUpdated?: string | null;
+        access: {
+          __typename?: 'FileAccess';
+          canEditFile: boolean;
+          canDeleteFile: boolean;
+        };
+        enrollment?: { __typename?: 'Enrollment'; id: string } | null;
+        uploadedBy?: {
+          __typename?: 'ApplicationUser';
+          id: string;
+          name: string;
+        } | null;
+        updatedBy?: {
+          __typename?: 'ApplicationUser';
+          id: string;
+          name: string;
+        } | null;
+        user?: {
+          __typename: 'ApplicationUser';
+          id: string;
+          name: string;
+          firstName?: string | null;
+          lastName?: string | null;
+          email: string;
+        } | null;
+      } | null;
+      user?: {
+        __typename: 'ApplicationUser';
+        id: string;
+        name: string;
+        firstName?: string | null;
+        lastName?: string | null;
+        email: string;
+      } | null;
+    }> | null;
+  }>;
 };
 
 export type CeReferralStepFieldsFragment = {
@@ -19044,6 +19302,17 @@ export type CeReferralStepFieldsFragment = {
       canDuplicateForm: boolean;
     };
   };
+  assignees: Array<{
+    __typename?: 'ApplicationUser';
+    id: string;
+    name: string;
+  }>;
+  updatedBy?: {
+    __typename?: 'ApplicationUser';
+    id: string;
+    name: string;
+  } | null;
+  access: { __typename?: 'CeReferralStepAccess'; canPerformStep: boolean };
   customDataElements: Array<{
     __typename?: 'CustomDataElement';
     id: string;
@@ -19173,17 +19442,6 @@ export type CeReferralStepFieldsFragment = {
       } | null;
     }> | null;
   }>;
-  assignees: Array<{
-    __typename?: 'ApplicationUser';
-    id: string;
-    name: string;
-  }>;
-  updatedBy?: {
-    __typename?: 'ApplicationUser';
-    id: string;
-    name: string;
-  } | null;
-  access: { __typename?: 'CeReferralStepAccess'; canPerformStep: boolean };
 };
 
 export type UserCeReferralStepFieldsFragment = {
@@ -19859,6 +20117,17 @@ export type StartCeReferralStepMutation = {
           canDuplicateForm: boolean;
         };
       };
+      assignees: Array<{
+        __typename?: 'ApplicationUser';
+        id: string;
+        name: string;
+      }>;
+      updatedBy?: {
+        __typename?: 'ApplicationUser';
+        id: string;
+        name: string;
+      } | null;
+      access: { __typename?: 'CeReferralStepAccess'; canPerformStep: boolean };
       customDataElements: Array<{
         __typename?: 'CustomDataElement';
         id: string;
@@ -19988,17 +20257,6 @@ export type StartCeReferralStepMutation = {
           } | null;
         }> | null;
       }>;
-      assignees: Array<{
-        __typename?: 'ApplicationUser';
-        id: string;
-        name: string;
-      }>;
-      updatedBy?: {
-        __typename?: 'ApplicationUser';
-        id: string;
-        name: string;
-      } | null;
-      access: { __typename?: 'CeReferralStepAccess'; canPerformStep: boolean };
     } | null;
     errors: Array<{
       __typename?: 'ValidationError';
@@ -20560,6 +20818,17 @@ export type SubmitCeReferralStepMutation = {
           canDuplicateForm: boolean;
         };
       };
+      assignees: Array<{
+        __typename?: 'ApplicationUser';
+        id: string;
+        name: string;
+      }>;
+      updatedBy?: {
+        __typename?: 'ApplicationUser';
+        id: string;
+        name: string;
+      } | null;
+      access: { __typename?: 'CeReferralStepAccess'; canPerformStep: boolean };
       customDataElements: Array<{
         __typename?: 'CustomDataElement';
         id: string;
@@ -20689,17 +20958,6 @@ export type SubmitCeReferralStepMutation = {
           } | null;
         }> | null;
       }>;
-      assignees: Array<{
-        __typename?: 'ApplicationUser';
-        id: string;
-        name: string;
-      }>;
-      updatedBy?: {
-        __typename?: 'ApplicationUser';
-        id: string;
-        name: string;
-      } | null;
-      access: { __typename?: 'CeReferralStepAccess'; canPerformStep: boolean };
     } | null;
     referral?: {
       __typename?: 'CeReferral';
@@ -20784,6 +21042,135 @@ export type SubmitCeReferralStepMutation = {
           __typename?: 'CeReferralStepAccess';
           canPerformStep: boolean;
         };
+        customDataElements: Array<{
+          __typename?: 'CustomDataElement';
+          id: string;
+          key: string;
+          label: string;
+          fieldType: CustomDataElementType;
+          repeats: boolean;
+          displayHooks: Array<DisplayHook>;
+          value?: {
+            __typename?: 'CustomDataElementValue';
+            id: string;
+            valueBoolean?: boolean | null;
+            valueDate?: string | null;
+            valueFloat?: number | null;
+            valueInteger?: number | null;
+            valueJson?: any | null;
+            valueString?: string | null;
+            valueText?: string | null;
+            dateCreated?: string | null;
+            dateUpdated?: string | null;
+            valueFile?: {
+              __typename?: 'File';
+              confidential?: boolean | null;
+              contentType?: string | null;
+              effectiveDate?: string | null;
+              expirationDate?: string | null;
+              id: string;
+              name: string;
+              url?: string | null;
+              tags: Array<string>;
+              redacted: boolean;
+              enrollmentId?: string | null;
+              dateCreated?: string | null;
+              dateUpdated?: string | null;
+              access: {
+                __typename?: 'FileAccess';
+                canEditFile: boolean;
+                canDeleteFile: boolean;
+              };
+              enrollment?: { __typename?: 'Enrollment'; id: string } | null;
+              uploadedBy?: {
+                __typename?: 'ApplicationUser';
+                id: string;
+                name: string;
+              } | null;
+              updatedBy?: {
+                __typename?: 'ApplicationUser';
+                id: string;
+                name: string;
+              } | null;
+              user?: {
+                __typename: 'ApplicationUser';
+                id: string;
+                name: string;
+                firstName?: string | null;
+                lastName?: string | null;
+                email: string;
+              } | null;
+            } | null;
+            user?: {
+              __typename: 'ApplicationUser';
+              id: string;
+              name: string;
+              firstName?: string | null;
+              lastName?: string | null;
+              email: string;
+            } | null;
+          } | null;
+          values?: Array<{
+            __typename?: 'CustomDataElementValue';
+            id: string;
+            valueBoolean?: boolean | null;
+            valueDate?: string | null;
+            valueFloat?: number | null;
+            valueInteger?: number | null;
+            valueJson?: any | null;
+            valueString?: string | null;
+            valueText?: string | null;
+            dateCreated?: string | null;
+            dateUpdated?: string | null;
+            valueFile?: {
+              __typename?: 'File';
+              confidential?: boolean | null;
+              contentType?: string | null;
+              effectiveDate?: string | null;
+              expirationDate?: string | null;
+              id: string;
+              name: string;
+              url?: string | null;
+              tags: Array<string>;
+              redacted: boolean;
+              enrollmentId?: string | null;
+              dateCreated?: string | null;
+              dateUpdated?: string | null;
+              access: {
+                __typename?: 'FileAccess';
+                canEditFile: boolean;
+                canDeleteFile: boolean;
+              };
+              enrollment?: { __typename?: 'Enrollment'; id: string } | null;
+              uploadedBy?: {
+                __typename?: 'ApplicationUser';
+                id: string;
+                name: string;
+              } | null;
+              updatedBy?: {
+                __typename?: 'ApplicationUser';
+                id: string;
+                name: string;
+              } | null;
+              user?: {
+                __typename: 'ApplicationUser';
+                id: string;
+                name: string;
+                firstName?: string | null;
+                lastName?: string | null;
+                email: string;
+              } | null;
+            } | null;
+            user?: {
+              __typename: 'ApplicationUser';
+              id: string;
+              name: string;
+              firstName?: string | null;
+              lastName?: string | null;
+              email: string;
+            } | null;
+          }> | null;
+        }>;
       }> | null;
       access: {
         __typename?: 'CeReferralAccess';
@@ -21137,6 +21524,135 @@ export type AssignParticipantsMutation = {
           __typename?: 'CeReferralStepAccess';
           canPerformStep: boolean;
         };
+        customDataElements: Array<{
+          __typename?: 'CustomDataElement';
+          id: string;
+          key: string;
+          label: string;
+          fieldType: CustomDataElementType;
+          repeats: boolean;
+          displayHooks: Array<DisplayHook>;
+          value?: {
+            __typename?: 'CustomDataElementValue';
+            id: string;
+            valueBoolean?: boolean | null;
+            valueDate?: string | null;
+            valueFloat?: number | null;
+            valueInteger?: number | null;
+            valueJson?: any | null;
+            valueString?: string | null;
+            valueText?: string | null;
+            dateCreated?: string | null;
+            dateUpdated?: string | null;
+            valueFile?: {
+              __typename?: 'File';
+              confidential?: boolean | null;
+              contentType?: string | null;
+              effectiveDate?: string | null;
+              expirationDate?: string | null;
+              id: string;
+              name: string;
+              url?: string | null;
+              tags: Array<string>;
+              redacted: boolean;
+              enrollmentId?: string | null;
+              dateCreated?: string | null;
+              dateUpdated?: string | null;
+              access: {
+                __typename?: 'FileAccess';
+                canEditFile: boolean;
+                canDeleteFile: boolean;
+              };
+              enrollment?: { __typename?: 'Enrollment'; id: string } | null;
+              uploadedBy?: {
+                __typename?: 'ApplicationUser';
+                id: string;
+                name: string;
+              } | null;
+              updatedBy?: {
+                __typename?: 'ApplicationUser';
+                id: string;
+                name: string;
+              } | null;
+              user?: {
+                __typename: 'ApplicationUser';
+                id: string;
+                name: string;
+                firstName?: string | null;
+                lastName?: string | null;
+                email: string;
+              } | null;
+            } | null;
+            user?: {
+              __typename: 'ApplicationUser';
+              id: string;
+              name: string;
+              firstName?: string | null;
+              lastName?: string | null;
+              email: string;
+            } | null;
+          } | null;
+          values?: Array<{
+            __typename?: 'CustomDataElementValue';
+            id: string;
+            valueBoolean?: boolean | null;
+            valueDate?: string | null;
+            valueFloat?: number | null;
+            valueInteger?: number | null;
+            valueJson?: any | null;
+            valueString?: string | null;
+            valueText?: string | null;
+            dateCreated?: string | null;
+            dateUpdated?: string | null;
+            valueFile?: {
+              __typename?: 'File';
+              confidential?: boolean | null;
+              contentType?: string | null;
+              effectiveDate?: string | null;
+              expirationDate?: string | null;
+              id: string;
+              name: string;
+              url?: string | null;
+              tags: Array<string>;
+              redacted: boolean;
+              enrollmentId?: string | null;
+              dateCreated?: string | null;
+              dateUpdated?: string | null;
+              access: {
+                __typename?: 'FileAccess';
+                canEditFile: boolean;
+                canDeleteFile: boolean;
+              };
+              enrollment?: { __typename?: 'Enrollment'; id: string } | null;
+              uploadedBy?: {
+                __typename?: 'ApplicationUser';
+                id: string;
+                name: string;
+              } | null;
+              updatedBy?: {
+                __typename?: 'ApplicationUser';
+                id: string;
+                name: string;
+              } | null;
+              user?: {
+                __typename: 'ApplicationUser';
+                id: string;
+                name: string;
+                firstName?: string | null;
+                lastName?: string | null;
+                email: string;
+              } | null;
+            } | null;
+            user?: {
+              __typename: 'ApplicationUser';
+              id: string;
+              name: string;
+              firstName?: string | null;
+              lastName?: string | null;
+              email: string;
+            } | null;
+          }> | null;
+        }>;
       }> | null;
       swimlanes?: Array<{
         __typename?: 'CeReferralSwimlane';
@@ -21467,6 +21983,135 @@ export type GetCeReferralQuery = {
         name: string;
       } | null;
       access: { __typename?: 'CeReferralStepAccess'; canPerformStep: boolean };
+      customDataElements: Array<{
+        __typename?: 'CustomDataElement';
+        id: string;
+        key: string;
+        label: string;
+        fieldType: CustomDataElementType;
+        repeats: boolean;
+        displayHooks: Array<DisplayHook>;
+        value?: {
+          __typename?: 'CustomDataElementValue';
+          id: string;
+          valueBoolean?: boolean | null;
+          valueDate?: string | null;
+          valueFloat?: number | null;
+          valueInteger?: number | null;
+          valueJson?: any | null;
+          valueString?: string | null;
+          valueText?: string | null;
+          dateCreated?: string | null;
+          dateUpdated?: string | null;
+          valueFile?: {
+            __typename?: 'File';
+            confidential?: boolean | null;
+            contentType?: string | null;
+            effectiveDate?: string | null;
+            expirationDate?: string | null;
+            id: string;
+            name: string;
+            url?: string | null;
+            tags: Array<string>;
+            redacted: boolean;
+            enrollmentId?: string | null;
+            dateCreated?: string | null;
+            dateUpdated?: string | null;
+            access: {
+              __typename?: 'FileAccess';
+              canEditFile: boolean;
+              canDeleteFile: boolean;
+            };
+            enrollment?: { __typename?: 'Enrollment'; id: string } | null;
+            uploadedBy?: {
+              __typename?: 'ApplicationUser';
+              id: string;
+              name: string;
+            } | null;
+            updatedBy?: {
+              __typename?: 'ApplicationUser';
+              id: string;
+              name: string;
+            } | null;
+            user?: {
+              __typename: 'ApplicationUser';
+              id: string;
+              name: string;
+              firstName?: string | null;
+              lastName?: string | null;
+              email: string;
+            } | null;
+          } | null;
+          user?: {
+            __typename: 'ApplicationUser';
+            id: string;
+            name: string;
+            firstName?: string | null;
+            lastName?: string | null;
+            email: string;
+          } | null;
+        } | null;
+        values?: Array<{
+          __typename?: 'CustomDataElementValue';
+          id: string;
+          valueBoolean?: boolean | null;
+          valueDate?: string | null;
+          valueFloat?: number | null;
+          valueInteger?: number | null;
+          valueJson?: any | null;
+          valueString?: string | null;
+          valueText?: string | null;
+          dateCreated?: string | null;
+          dateUpdated?: string | null;
+          valueFile?: {
+            __typename?: 'File';
+            confidential?: boolean | null;
+            contentType?: string | null;
+            effectiveDate?: string | null;
+            expirationDate?: string | null;
+            id: string;
+            name: string;
+            url?: string | null;
+            tags: Array<string>;
+            redacted: boolean;
+            enrollmentId?: string | null;
+            dateCreated?: string | null;
+            dateUpdated?: string | null;
+            access: {
+              __typename?: 'FileAccess';
+              canEditFile: boolean;
+              canDeleteFile: boolean;
+            };
+            enrollment?: { __typename?: 'Enrollment'; id: string } | null;
+            uploadedBy?: {
+              __typename?: 'ApplicationUser';
+              id: string;
+              name: string;
+            } | null;
+            updatedBy?: {
+              __typename?: 'ApplicationUser';
+              id: string;
+              name: string;
+            } | null;
+            user?: {
+              __typename: 'ApplicationUser';
+              id: string;
+              name: string;
+              firstName?: string | null;
+              lastName?: string | null;
+              email: string;
+            } | null;
+          } | null;
+          user?: {
+            __typename: 'ApplicationUser';
+            id: string;
+            name: string;
+            firstName?: string | null;
+            lastName?: string | null;
+            email: string;
+          } | null;
+        }> | null;
+      }>;
     }> | null;
     opportunity?: {
       __typename?: 'CeOpportunity';
@@ -22138,6 +22783,17 @@ export type GetCeReferralStepQuery = {
         canDuplicateForm: boolean;
       };
     };
+    assignees: Array<{
+      __typename?: 'ApplicationUser';
+      id: string;
+      name: string;
+    }>;
+    updatedBy?: {
+      __typename?: 'ApplicationUser';
+      id: string;
+      name: string;
+    } | null;
+    access: { __typename?: 'CeReferralStepAccess'; canPerformStep: boolean };
     customDataElements: Array<{
       __typename?: 'CustomDataElement';
       id: string;
@@ -22267,17 +22923,6 @@ export type GetCeReferralStepQuery = {
         } | null;
       }> | null;
     }>;
-    assignees: Array<{
-      __typename?: 'ApplicationUser';
-      id: string;
-      name: string;
-    }>;
-    updatedBy?: {
-      __typename?: 'ApplicationUser';
-      id: string;
-      name: string;
-    } | null;
-    access: { __typename?: 'CeReferralStepAccess'; canPerformStep: boolean };
   } | null;
 };
 
@@ -52678,7 +53323,11 @@ export const CeReferralStepSummaryFieldsFragmentDoc = gql`
     access {
       canPerformStep
     }
+    customDataElements {
+      ...CustomDataElementFields
+    }
   }
+  ${CustomDataElementFieldsFragmentDoc}
 `;
 export const CeReferralAuditEventFieldsFragmentDoc = gql`
   fragment CeReferralAuditEventFields on CeReferralAuditEvent {
@@ -52911,13 +53560,9 @@ export const CeReferralStepFieldsFragmentDoc = gql`
     formDefinition {
       ...FormDefinitionFields
     }
-    customDataElements {
-      ...CustomDataElementFields
-    }
   }
   ${CeReferralStepSummaryFieldsFragmentDoc}
   ${FormDefinitionFieldsFragmentDoc}
-  ${CustomDataElementFieldsFragmentDoc}
 `;
 export const UserCeReferralStepFieldsFragmentDoc = gql`
   fragment UserCeReferralStepFields on CeReferralStep {


### PR DESCRIPTION
## Description

* Add `ReferralStepSummaryDetails` to show custom data elements with the `TableSummary` display hook on completed referral step cards.
* Move `customDataElements` from `CeReferralStepFields` to `CeReferralStepSummaryFields` so summary CDEs are loaded with referral step cards.
* Render summary rows only when the step is completed and the CDE has a value; skip empty values.
* Update the `ReferralStepCard` Storybook `Done` story with sample summary CDEs, including repeating values and a CDE with no value.

[//]: # 'remove if not applicable'
Relates to https://github.com/greenriver/hmis-warehouse/pull/6847 (does not depend)

[//]: # 'remove if not applicable'
How to test: See issue

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
New feature

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have used Axe DevTools to scan for accessibility issues (or not applicable)
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
