### PR TITLE
fix: improvements to JWT/SSO logout failure handling

### DIFF
--- a/src/modules/auth/components/LogoutFailedDialog.stories.tsx
+++ b/src/modules/auth/components/LogoutFailedDialog.stories.tsx
@@ -13,40 +13,23 @@ const args = {
   loading: false,
   onRetry: fn(),
   onDismiss: fn(),
-  authMethod: 'jwt' as const,
 };
 
 // The dialog renders in a portal, so queries go through document.body rather
 // than the story canvas.
 const dialog = () => within(document.body);
 
-export const JwtSso: Story = {
+export const Default: Story = {
   args,
   play: async () => {
     await expect(
       dialog().getByText('You are still signed in')
     ).toBeInTheDocument();
     await expect(
-      dialog().getByText(/still signed in here and with your identity provider/)
+      dialog().getByText(/you are still signed in\. Anyone using this computer/)
     ).toBeInTheDocument();
     await expect(
-      dialog().getByText(/close every browser window/)
-    ).toBeInTheDocument();
-  },
-};
-
-export const DeviseOkta: Story = {
-  args: { ...args, authMethod: 'devise' },
-  play: async () => {
-    // A Devise/Okta sign-out never ends the IdP session, so the copy must not
-    // mention one.
-    await expect(
-      dialog().queryByText(/identity provider/)
-    ).not.toBeInTheDocument();
-    await expect(
-      dialog().getByText(
-        /You are still signed in, so anyone using this computer/
-      )
+      dialog().getByText(/close all of your browser windows to make sure/)
     ).toBeInTheDocument();
   },
 };

--- a/src/modules/auth/components/LogoutFailedDialog.tsx
+++ b/src/modules/auth/components/LogoutFailedDialog.tsx
@@ -6,17 +6,12 @@ interface Props {
   loading: boolean;
   onRetry: VoidFunction;
   onDismiss: VoidFunction;
-  // Selects the copy: a 'jwt' sign-out also ends the IdP session, so its failure
-  // leaves that session live and the user has to be told. A Devise/Okta sign-out
-  // never ends the IdP session, so naming one there would be noise.
-  authMethod: 'devise' | 'jwt';
 }
 
 const LogoutFailedDialog: React.FC<Props> = ({
   loading,
   onRetry,
   onDismiss,
-  authMethod,
 }) => (
   <ConfirmationDialog
     open={true}
@@ -28,15 +23,13 @@ const LogoutFailedDialog: React.FC<Props> = ({
     onCancel={onDismiss}
   >
     <Typography>
-      Signing out did not complete.{' '}
-      {authMethod === 'jwt'
-        ? 'You are still signed in here and with your identity provider, so anyone using this computer next could still reach your account.'
-        : 'You are still signed in, so anyone using this computer next could still reach your account.'}
+      Signing out did not finish, so you are still signed in. Anyone using this
+      computer next could still get into your account.
     </Typography>
     <Typography sx={{ mt: 2 }}>
-      Try signing out again. If it keeps failing, quitting your browser
-      completely will usually end the session. Let your administrator know if it
-      persists.
+      Try signing out again. If that does not work, close all of your browser
+      windows to make sure you are fully signed out. Let your administrator know
+      if it keeps happening.
     </Typography>
   </ConfirmationDialog>
 );

--- a/src/modules/hmisAppSettings/Provider.tsx
+++ b/src/modules/hmisAppSettings/Provider.tsx
@@ -21,7 +21,6 @@ import StopImpersonatingFailedDialog from '@/modules/auth/components/StopImperso
 import { TerminalAccountErrorType } from '@/modules/auth/events';
 import { useSessionTrackingObserver } from '@/modules/auth/hooks/useSessionTrackingObserver';
 import { fetchHmisAppSettings } from '@/modules/hmisAppSettings/api';
-import { resolveAuthMethod } from '@/modules/hmisAppSettings/authMethod';
 import { HmisAppSettingsContext } from '@/modules/hmisAppSettings/Context';
 import { HmisAppSettings } from '@/modules/hmisAppSettings/types';
 import { HttpError } from '@/utils/HttpError';
@@ -170,10 +169,15 @@ export const HmisAppSettingsProvider: React.FC<Props> = ({ children }) => {
     attemptLogout(false);
   }, [attemptLogout]);
 
-  // A sign-out can fail for a transient reason, and the session it failed to end
-  // is still usable, so dismissing and going back to work is a legitimate choice.
-  // Sign out stays in the user menu for a later attempt.
-  const dismissLogoutFailure = useCallback(() => setLogoutFailed(false), []);
+  // Reload rather than just hide the dialog: a failed logout() has already run
+  // resetLocalSession, which clears stored app settings and clears the Apollo
+  // cache without refetching it. Dismissing would leave the app mounted against
+  // that emptied state; reloading re-bootstraps settings, user, and cache against
+  // the still-live session.
+  const dismissLogoutFailure = useCallback(() => {
+    setLoading(true);
+    reloadWindow();
+  }, []);
 
   const dismissStopImpersonatingFailure = useCallback(
     () => setStopImpersonatingFailed(false),
@@ -282,7 +286,6 @@ export const HmisAppSettingsProvider: React.FC<Props> = ({ children }) => {
           loading={logoutInFlight}
           onRetry={retryLogout}
           onDismiss={dismissLogoutFailure}
-          authMethod={resolveAuthMethod(appSettings?.authMethod)}
         />
       )}
       {stopImpersonatingFailed && (


### PR DESCRIPTION

## Description
- Reload the app when a failed sign-out is dismissed
- Simplify the "still signed in" dialog copy to plain language

