### PR TITLE
Add CE match field description to helper text

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -5434,6 +5434,18 @@
         "isOneOf": null,
         "fields": [
           {
+            "name": "description",
+            "description": "Additional detail about what this field represents and how its value is resolved",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "expressionField",
             "description": "The full-length identifier used in CE Match Rule expressions, such as\n\"current_age\" or \"cde.custom_assessment.my_field_key\".",
             "args": [],

--- a/src/api/operations/ceMatchRules.fragments.graphql
+++ b/src/api/operations/ceMatchRules.fragments.graphql
@@ -2,6 +2,7 @@ fragment CeMatchFieldDetails on CeMatchField {
   id
   key
   label
+  description
   itemType
   multiple
   expressionField

--- a/src/modules/admin/components/ceMatchRules/editor/clause/CeMatchClause.tsx
+++ b/src/modules/admin/components/ceMatchRules/editor/clause/CeMatchClause.tsx
@@ -129,7 +129,8 @@ const CeMatchClause: React.FC<Props> = ({
       fieldSelectDisabled
     )
       return 'Choose an assessment first.';
-  }, [source, fieldSelectDisabled]);
+    return selectedField?.description || undefined;
+  }, [source, fieldSelectDisabled, selectedField]);
 
   return (
     <Stack gap={2}>

--- a/src/types/gqlObjects.ts
+++ b/src/types/gqlObjects.ts
@@ -841,6 +841,10 @@ export const HmisObjectSchemas: GqlSchema[] = [
     name: 'CeMatchField',
     fields: [
       {
+        name: 'description',
+        type: { kind: 'SCALAR', name: 'String', ofType: null },
+      },
+      {
         name: 'expressionField',
         type: {
           kind: 'NON_NULL',

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -772,6 +772,8 @@ export type CeEligibleUnitGroupsPaginated = {
 /** Field metadata for CE Match Rule expressions */
 export type CeMatchField = {
   __typename?: 'CeMatchField';
+  /** Additional detail about what this field represents and how its value is resolved */
+  description?: Maybe<Scalars['String']['output']>;
   /**
    * The full-length identifier used in CE Match Rule expressions, such as
    * "current_age" or "cde.custom_assessment.my_field_key".
@@ -23252,6 +23254,7 @@ export type CeMatchFieldDetailsFragment = {
   id: string;
   key: string;
   label: string;
+  description?: string | null;
   itemType: ItemType;
   multiple: boolean;
   expressionField: string;
@@ -23652,6 +23655,7 @@ export type GetCeMatchFieldsQuery = {
     id: string;
     key: string;
     label: string;
+    description?: string | null;
     itemType: ItemType;
     multiple: boolean;
     expressionField: string;
@@ -23696,6 +23700,7 @@ export type GetCeMatchCustomAssessmentFieldsQuery = {
     id: string;
     key: string;
     label: string;
+    description?: string | null;
     itemType: ItemType;
     multiple: boolean;
     expressionField: string;
@@ -53708,6 +53713,7 @@ export const CeMatchFieldDetailsFragmentDoc = gql`
     id
     key
     label
+    description
     itemType
     multiple
     expressionField


### PR DESCRIPTION
## Description

Summary of changes: Resolve CE match field descriptions and add them to the Field dropdown helper text.

[//]: # 'remove if not applicable'
Depends on hmis-warehouse PR: https://github.com/greenriver/hmis-warehouse/pull/6901

[//]: # 'remove if not applicable'
How to test: See ticket screenshots

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)
New feature

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have used Axe DevTools to scan for accessibility issues (or not applicable)
- [ ] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
