### PR TITLE
Split HUD and Custom assmts in dropdown menu

### DIFF
--- a/src/modules/enrollment/components/EnrollmentAssessmentActionButtons.tsx
+++ b/src/modules/enrollment/components/EnrollmentAssessmentActionButtons.tsx
@@ -77,15 +77,40 @@ const NewAssessmentMenu: React.FC<
     [clientId, enrollmentId]
   );
 
-  const items: CommonMenuItem[] = useMemo(
-    () =>
-      assessmentEligibilities.map(({ id, title, role, formDefinitionId }) => ({
+  const items: CommonMenuItem[] = useMemo(() => {
+    const toMenuItem = ({
+      id,
+      title,
+      role,
+      formDefinitionId,
+    }: AssessmentEligibilityType): CommonMenuItem => {
+      const prefix = role === AssessmentRole.CustomAssessment ? '' : 'HUD ';
+
+      return {
         key: id,
         to: getPath(role, formDefinitionId),
-        title: title,
-      })),
-    [assessmentEligibilities, getPath]
-  );
+        title: `${prefix}${title}`,
+      };
+    };
+
+    const hudItems = assessmentEligibilities
+      .filter(({ role }) => role !== AssessmentRole.CustomAssessment)
+      .map(toMenuItem);
+    const customItems = assessmentEligibilities
+      .filter(({ role }) => role === AssessmentRole.CustomAssessment)
+      .map(toMenuItem);
+
+    if (hudItems.length === 0 || customItems.length === 0) {
+      return [...hudItems, ...customItems];
+    }
+
+    // If there are both HUD and custom assessments, add a divider between them
+    return [
+      ...hudItems,
+      { key: 'divider-custom-assessments', title: 'divider', divider: true },
+      ...customItems,
+    ];
+  }, [assessmentEligibilities, getPath]);
 
   if (items.length === 0) {
     // Assessment eligibilities will have length 0 for an exited enrollment where no post-exit assessments are enabled.


### PR DESCRIPTION
## Description

Issue: https://github.com/open-path/Green-River/issues/9544

Update UX of New Assessment Menu, so HUD and Custom assessments are differentiated.

- [x] Ensured system tests all pass on the backend


<img width="280" height="501" alt="Screenshot 2026-08-23 at 11 07 22 AM" src="https://github.com/user-attachments/assets/23e25f7b-9957-4fae-ab21-1ed1a0ff6a88" />

## Type of change
UX

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have used Axe DevTools to scan for accessibility issues (or not applicable)
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
