### PR TITLE
Clarify referral exited household members

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -9570,6 +9570,18 @@
             "deprecationReason": null
           },
           {
+            "name": "exitDate",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "ISO8601Date",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "id",
             "description": null,
             "args": [],

--- a/src/api/operations/ce.fragments.graphql
+++ b/src/api/operations/ce.fragments.graphql
@@ -199,6 +199,7 @@ fragment CeReferralDetailFields on CeReferral {
       clientId
       clientName
       relationshipToHoH
+      exitDate
       access {
         canViewClients
       }

--- a/src/modules/ce/components/referral/ReferralDetailContent.tsx
+++ b/src/modules/ce/components/referral/ReferralDetailContent.tsx
@@ -209,11 +209,18 @@ const ReferralDetailContent: React.FC<Props> = ({
       value: (
         <Stack gap={1}>
           {referral.sourceEnrollment.householdMembers.map(
-            ({ id, clientId, clientName, relationshipToHoH, access }) => {
-              const nameAndRelationship = `${clientName} (${relationshipToHohForDisplay(
+            ({
+              id,
+              clientId,
+              clientName,
+              relationshipToHoH,
+              exitDate,
+              access,
+            }) => {
+              const nameRelationshipAndStatus = `${clientName} (${relationshipToHohForDisplay(
                 relationshipToHoH,
                 true
-              )})`;
+              )})${exitDate ? ' - Exited' : ''}`;
               if (access.canViewClients) {
                 return (
                   <RouterLink
@@ -223,11 +230,11 @@ const ReferralDetailContent: React.FC<Props> = ({
                     })}
                     openInNew
                   >
-                    {nameAndRelationship}
+                    {nameRelationshipAndStatus}
                   </RouterLink>
                 );
               }
-              return <span>{nameAndRelationship}</span>;
+              return <span>{nameRelationshipAndStatus}</span>;
             }
           )}
         </Stack>

--- a/src/types/gqlObjects.ts
+++ b/src/types/gqlObjects.ts
@@ -1668,6 +1668,10 @@ export const HmisObjectSchemas: GqlSchema[] = [
         },
       },
       {
+        name: 'exitDate',
+        type: { kind: 'SCALAR', name: 'ISO8601Date', ofType: null },
+      },
+      {
         name: 'id',
         type: {
           kind: 'NON_NULL',

--- a/src/types/gqlTypes.ts
+++ b/src/types/gqlTypes.ts
@@ -1259,6 +1259,7 @@ export type CeReferralSourceHouseholdMember = {
   clientId: Scalars['ID']['output'];
   /** The name of the client. Returns masked name if the user does not have permission to view the client name. */
   clientName: Scalars['String']['output'];
+  exitDate?: Maybe<Scalars['ISO8601Date']['output']>;
   id: Scalars['ID']['output'];
   relationshipToHoH: RelationshipToHoH;
 };
@@ -18246,6 +18247,7 @@ export type CeReferralDetailFieldsFragment = {
       clientId: string;
       clientName: string;
       relationshipToHoH: RelationshipToHoH;
+      exitDate?: string | null;
       access: {
         __typename?: 'CeReferralSourceHouseholdMemberAccess';
         canViewClients: boolean;
@@ -18515,6 +18517,7 @@ export type CeReferralFieldsFragment = {
       clientId: string;
       clientName: string;
       relationshipToHoH: RelationshipToHoH;
+      exitDate?: string | null;
       access: {
         __typename?: 'CeReferralSourceHouseholdMemberAccess';
         canViewClients: boolean;
@@ -21233,6 +21236,7 @@ export type SubmitCeReferralStepMutation = {
           clientId: string;
           clientName: string;
           relationshipToHoH: RelationshipToHoH;
+          exitDate?: string | null;
           access: {
             __typename?: 'CeReferralSourceHouseholdMemberAccess';
             canViewClients: boolean;
@@ -22204,6 +22208,7 @@ export type GetCeReferralQuery = {
         clientId: string;
         clientName: string;
         relationshipToHoH: RelationshipToHoH;
+        exitDate?: string | null;
         access: {
           __typename?: 'CeReferralSourceHouseholdMemberAccess';
           canViewClients: boolean;
@@ -53350,6 +53355,7 @@ export const CeReferralDetailFieldsFragmentDoc = gql`
         clientId
         clientName
         relationshipToHoH
+        exitDate
         access {
           canViewClients
         }


### PR DESCRIPTION
## Description

Related issue: [#9372](https://github.com/open-path/Green-River/issues/9372)

Summary of changes:

- Request household-member `exitDate` on Referral Details.
- Display exited members as `Name (Relationship) - Exited`.
- Continue displaying open members without a suffix.
- Preserve masked names and existing client links.

Depends on hmis-warehouse PR: https://github.com/greenriver/hmis-warehouse/pull/6939

How to test:

1. Send a Direct Referral for a mixed household.
2. Open the referral under **Outgoing Referrals**.
3. Open **Details** and expand **Source Enrollment Details**.
4. Confirm the exited member remains listed with `- Exited`.
5. Confirm open members have no suffix.
6. Confirm relationships remain visible.

Validation:

```bash
yarn check-types
yarn lint:check
```

Both commands pass.

Reviewer feedback requested:

The same household data appears in the waitlist source-enrollment selector. That UI summarizes hidden names with a `+N more` chip and lists all members in its tooltip. We explored adding `- Exited` there, but intentionally left it unchanged because the acceptance criteria only specify Referral Details.

Should exited members also receive a suffix in the waitlist tooltip as a follow-up improvement?

## Type of change

Bug fix

## Checklist before requesting review
- [ ] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have used Axe DevTools to scan for accessibility issues (or not applicable)
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
