### PR TITLE
fix: 9542 unhandled rejection when app settings

### DIFF
--- a/src/modules/hmisAppSettings/Provider.tsx
+++ b/src/modules/hmisAppSettings/Provider.tsx
@@ -241,6 +241,9 @@ export const HmisAppSettingsProvider: React.FC<Props> = ({ children }) => {
         const userPromise: Promise<CurrentUserResult> = cachedUser
           ? Promise.resolve({ user: cachedUser })
           : fetchCurrentUser();
+        // If loadSettings rejects first, the await below never runs and this
+        // rejection would go unhandled. The await still gets it if reached.
+        userPromise.catch(() => {});
 
         await loadSettings();
 

--- a/src/modules/hmisAppSettings/Provider.tsx
+++ b/src/modules/hmisAppSettings/Provider.tsx
@@ -236,20 +236,20 @@ export const HmisAppSettingsProvider: React.FC<Props> = ({ children }) => {
 
     (async () => {
       try {
-        // Start this fetch before awaiting loadSettings, so the two requests
-        // overlap instead of costing two serial round-trips.
         const userPromise: Promise<CurrentUserResult> = cachedUser
           ? Promise.resolve({ user: cachedUser })
           : fetchCurrentUser();
-        // If loadSettings rejects first, the await below never runs and this
-        // rejection would go unhandled. The await still gets it if reached.
-        userPromise.catch(() => {});
 
-        await loadSettings();
+        // Awaited together so the requests overlap instead of costing two
+        // serial round-trips, and so neither rejection is left unhandled when
+        // the other loses the race.
+        const [, { user: fetchedUser, accountError }] = await Promise.all([
+          loadSettings(),
+          userPromise,
+        ]);
 
         // accountError does not go through `error`: that dialog offers only a
         // reload, and every reload fetches the same accountError back.
-        const { user: fetchedUser, accountError } = await userPromise;
         if (fetchedUser) setUser(fetchedUser);
         else if (accountError) setAccountError(accountError);
       } catch (err) {


### PR DESCRIPTION
## Description
    
Fix regression from the JWT/SSO auth change, which replaced the old Promise.all().catch(setError). No user-visible effect

## Type of change
Bug fix

## Checklist before requesting review
- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [ ] I have used Axe DevTools to scan for accessibility issues (or not applicable)
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [ ] I have updated the documentation (or not applicable)
- [ ] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
