### PR TITLE
Enable CE Match Rule editor for admin users

### DIFF
--- a/src/modules/admin/hooks/useAdminDashboardNavItems.tsx
+++ b/src/modules/admin/hooks/useAdminDashboardNavItems.tsx
@@ -40,8 +40,7 @@ export const useAdminDashboardNavItems = () => {
             id: 'eligibility-rules',
             title: 'Eligibility Rules',
             path: AdminDashboardRoutes.CE_RULES_ROOT,
-            // TODO(#7544): swap to canAdministrateCoordinatedEntry
-            permissions: ['canAdministrateConfig'],
+            permissions: ['canManageCeMatchRules'],
             hide: !globalFeatureFlags?.coordinatedEntryEnabled,
           },
         ],

--- a/src/routes/protected.tsx
+++ b/src/routes/protected.tsx
@@ -1141,8 +1141,7 @@ export const protectedRoutes: RouteNode[] = [
             path: AdminDashboardRoutes.CE_RULES_ROOT,
             element: (
               <RootPermissionsFilter
-                // TODO(#7544): swap to canAdministrateCoordinatedEntry
-                permissions='canAdministrateConfig'
+                permissions='canManageCeMatchRules'
                 otherwise={<NotFound />}
               >
                 <Navigate to={AdminDashboardRoutes.CE_RULES} replace />
@@ -1153,8 +1152,7 @@ export const protectedRoutes: RouteNode[] = [
             path: AdminDashboardRoutes.CE_RULES,
             element: (
               <RootPermissionsFilter
-                // TODO(#7544): swap to canAdministrateCoordinatedEntry
-                permissions='canAdministrateConfig'
+                permissions='canManageCeMatchRules'
                 otherwise={<NotFound />}
               >
                 <CeMatchRulesPage ownerLevel='global' />
@@ -1165,8 +1163,7 @@ export const protectedRoutes: RouteNode[] = [
             path: AdminDashboardRoutes.CE_RULE_ORGANIZATIONS,
             element: (
               <RootPermissionsFilter
-                // TODO(#7544): swap to canAdministrateCoordinatedEntry
-                permissions='canAdministrateConfig'
+                permissions='canManageCeMatchRules'
                 otherwise={<NotFound />}
               >
                 <CeMatchRulesPage ownerLevel='organization' />
@@ -1177,8 +1174,7 @@ export const protectedRoutes: RouteNode[] = [
             path: AdminDashboardRoutes.CE_RULE_PROJECTS,
             element: (
               <RootPermissionsFilter
-                // TODO(#7544): swap to canAdministrateCoordinatedEntry
-                permissions='canAdministrateConfig'
+                permissions='canManageCeMatchRules'
                 otherwise={<NotFound />}
               >
                 <CeMatchRulesPage ownerLevel='project' />
@@ -1189,8 +1185,7 @@ export const protectedRoutes: RouteNode[] = [
             path: AdminDashboardRoutes.CE_RULE_UNIT_GROUPS,
             element: (
               <RootPermissionsFilter
-                // TODO(#7544): swap to canAdministrateCoordinatedEntry
-                permissions='canAdministrateConfig'
+                permissions='canManageCeMatchRules'
                 otherwise={<NotFound />}
               >
                 <CeMatchRulesPage ownerLevel='unit-group' />
@@ -1201,8 +1196,7 @@ export const protectedRoutes: RouteNode[] = [
             path: AdminDashboardRoutes.CE_RULE_GLOBAL_NEW,
             element: (
               <RootPermissionsFilter
-                // TODO(#7544): swap to canAdministrateCoordinatedEntry
-                permissions='canAdministrateConfig'
+                permissions='canManageCeMatchRules'
                 otherwise={<NotFound />}
               >
                 <CeMatchRuleGlobalEditorPage />
@@ -1213,8 +1207,7 @@ export const protectedRoutes: RouteNode[] = [
             path: AdminDashboardRoutes.CE_RULE_GLOBAL_DETAIL,
             element: (
               <RootPermissionsFilter
-                // TODO(#7544): swap to canAdministrateCoordinatedEntry
-                permissions='canAdministrateConfig'
+                permissions='canManageCeMatchRules'
                 otherwise={<NotFound />}
               >
                 <CeMatchRuleDetailPage />
@@ -1225,8 +1218,7 @@ export const protectedRoutes: RouteNode[] = [
             path: AdminDashboardRoutes.CE_RULE_ORGANIZATION_NEW,
             element: (
               <RootPermissionsFilter
-                // TODO(#7544): swap to canAdministrateCoordinatedEntry
-                permissions='canAdministrateConfig'
+                permissions='canManageCeMatchRules'
                 otherwise={<NotFound />}
               >
                 <CeMatchRuleOrganizationEditorPage />
@@ -1237,8 +1229,7 @@ export const protectedRoutes: RouteNode[] = [
             path: AdminDashboardRoutes.CE_RULE_ORGANIZATION_DETAIL,
             element: (
               <RootPermissionsFilter
-                // TODO(#7544): swap to canAdministrateCoordinatedEntry
-                permissions='canAdministrateConfig'
+                permissions='canManageCeMatchRules'
                 otherwise={<NotFound />}
               >
                 <CeMatchRuleDetailPage />
@@ -1249,8 +1240,7 @@ export const protectedRoutes: RouteNode[] = [
             path: AdminDashboardRoutes.CE_RULE_PROJECT_NEW,
             element: (
               <RootPermissionsFilter
-                // TODO(#7544): swap to canAdministrateCoordinatedEntry
-                permissions='canAdministrateConfig'
+                permissions='canManageCeMatchRules'
                 otherwise={<NotFound />}
               >
                 <CeMatchRuleProjectEditorPage />
@@ -1261,8 +1251,7 @@ export const protectedRoutes: RouteNode[] = [
             path: AdminDashboardRoutes.CE_RULE_PROJECT_DETAIL,
             element: (
               <RootPermissionsFilter
-                // TODO(#7544): swap to canAdministrateCoordinatedEntry
-                permissions='canAdministrateConfig'
+                permissions='canManageCeMatchRules'
                 otherwise={<NotFound />}
               >
                 <CeMatchRuleDetailPage />
@@ -1273,8 +1262,7 @@ export const protectedRoutes: RouteNode[] = [
             path: AdminDashboardRoutes.CE_RULE_UNIT_GROUP_NEW,
             element: (
               <RootPermissionsFilter
-                // TODO(#7544): swap to canAdministrateCoordinatedEntry
-                permissions='canAdministrateConfig'
+                permissions='canManageCeMatchRules'
                 otherwise={<NotFound />}
               >
                 <CeMatchRuleUnitGroupEditorPage />
@@ -1285,8 +1273,7 @@ export const protectedRoutes: RouteNode[] = [
             path: AdminDashboardRoutes.CE_RULE_UNIT_GROUP_DETAIL,
             element: (
               <RootPermissionsFilter
-                // TODO(#7544): swap to canAdministrateCoordinatedEntry
-                permissions='canAdministrateConfig'
+                permissions='canManageCeMatchRules'
                 otherwise={<NotFound />}
               >
                 <CeMatchRuleDetailPage />
@@ -1297,8 +1284,7 @@ export const protectedRoutes: RouteNode[] = [
             path: AdminDashboardRoutes.CE_RULE_ORGANIZATION,
             element: (
               <RootPermissionsFilter
-                // TODO(#7544): swap to canAdministrateCoordinatedEntry
-                permissions='canAdministrateConfig'
+                permissions='canManageCeMatchRules'
                 otherwise={<NotFound />}
               >
                 <CeMatchOrganizationRulesPage />
@@ -1309,8 +1295,7 @@ export const protectedRoutes: RouteNode[] = [
             path: AdminDashboardRoutes.CE_RULE_UNIT_GROUP,
             element: (
               <RootPermissionsFilter
-                // TODO(#7544): swap to canAdministrateCoordinatedEntry
-                permissions='canAdministrateConfig'
+                permissions='canManageCeMatchRules'
                 otherwise={<NotFound />}
               >
                 <CeMatchUnitGroupRulesPage />
@@ -1321,8 +1306,7 @@ export const protectedRoutes: RouteNode[] = [
             path: AdminDashboardRoutes.CE_RULE_PROJECT,
             element: (
               <RootPermissionsFilter
-                // TODO(#7544): swap to canAdministrateCoordinatedEntry
-                permissions='canAdministrateConfig'
+                permissions='canManageCeMatchRules'
                 otherwise={<NotFound />}
               >
                 <CeMatchProjectRulesPage />


### PR DESCRIPTION
## Description

Summary of changes:

- Gate the Eligibility Rules admin navigation on `canManageCeMatchRules`.
- Apply the same permission to all CE match rule editor routes.
- Resolve the remaining `TODO(#7544)` comments.
- Preserve CE-disabled navigation and route behavior.

This aligns the frontend with the existing backend policy, which already requires `can_administrate_coordinated_entry`. It does not expand backend authorization.

Resolves https://github.com/open-path/Green-River/issues/9447

How to test:

1. Impersonate a user with `canManageCeMatchRules` but without `canAdministrateConfig`.
2. Confirm Admin → Eligibility Rules is visible.
3. Confirm Global, Organization, Project, and Unit Group rule pages load.
4. Create, view, edit, and delete rules at each level.
5. Disable CE and confirm Eligibility Rules is hidden and `/admin/rules` does not render the editor.

Validation completed:

- `yarn check-types`
- `yarn lint:check`
- Manual QA with CE enabled and disabled

## Type of change

Bug fix

## Checklist before requesting review

- [x] I have performed a self-review of my code
- [x] I have run the code that is being changed under ideal conditions, and it doesn't fail
- [x] I have used Axe DevTools to scan for accessibility issues (or not applicable)
- [x] My code includes comments and/or descriptive variable names to help other engineers understand the intent (or not applicable)
- [x] I have updated the documentation (or not applicable)
- [x] If it's not obvious how to test this change, I have provided testing instructions in this PR or the related issue
